### PR TITLE
mount: Changes to fix creating multiple entries in fstab

### DIFF
--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -166,7 +166,7 @@ class Chef
             # The current options don't match what we have, so
             # update the last matching entry with current option
             # and order will remain the same.
-            update_or_delete_fs(true)
+            edit_fstab
           else
             ::File.open("/etc/fstab", "a") do |fstab|
               fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
@@ -176,7 +176,7 @@ class Chef
         end
 
         def disable_fs
-          update_or_delete_fs
+          edit_fstab(:remove)
         end
 
         def network_device?
@@ -248,7 +248,7 @@ class Chef
         end
 
         # It will update or delete the entry from fstab.
-        def update_or_delete_fs(update_fs = false)
+        def edit_fstab(action = :update)
           if @current_resource.enabled
             contents = []
 
@@ -256,7 +256,7 @@ class Chef
             ::File.readlines("/etc/fstab").reverse_each do |line|
               if !found && line =~ /^#{device_fstab_regex}\s+#{Regexp.escape(@new_resource.mount_point)}\s/
                 found = true
-                if update_fs
+                if action == :update
                   logger.trace("#{@new_resource} is updated with new content in fstab")
                   contents << ("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
                 else

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -166,7 +166,7 @@ class Chef
             # The current options don't match what we have, so
             # update the last matching entry with current option
             # and order will remain the same.
-            edit_fstab
+            edit_fstab(:update)
           else
             ::File.open("/etc/fstab", "a") do |fstab|
               fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
@@ -248,7 +248,7 @@ class Chef
         end
 
         # It will update or delete the entry from fstab.
-        def edit_fstab(action = :update)
+        def edit_fstab(action)
           if @current_resource.enabled
             contents = []
 

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -164,36 +164,19 @@ class Chef
 
           if @current_resource.enabled
             # The current options don't match what we have, so
-            # disable, then enable.
-            disable_fs
-          end
-          ::File.open("/etc/fstab", "a") do |fstab|
-            fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
-            logger.trace("#{@new_resource} is enabled at #{@new_resource.mount_point}")
+            # update the last matching entry with current option
+            # and order will remain the same.
+            update_or_delete_fs(true)
+          else  
+            ::File.open("/etc/fstab", "a") do |fstab|
+              fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
+              logger.trace("#{@new_resource} is enabled at #{@new_resource.mount_point}")
+            end
           end
         end
 
         def disable_fs
-          if @current_resource.enabled
-            contents = []
-
-            found = false
-            ::File.readlines("/etc/fstab").reverse_each do |line|
-              if !found && line =~ /^#{device_fstab_regex}\s+#{Regexp.escape(@new_resource.mount_point)}\s/
-                found = true
-                logger.trace("#{@new_resource} is removed from fstab")
-                next
-              else
-                contents << line
-              end
-            end
-
-            ::File.open("/etc/fstab", "w") do |fstab|
-              contents.reverse_each { |line| fstab.puts line }
-            end
-          else
-            logger.trace("#{@new_resource} is not enabled - nothing to do")
-          end
+          update_or_delete_fs
         end
 
         def network_device?
@@ -262,6 +245,35 @@ class Chef
             @current_resource.options == @new_resource.options &&
             @current_resource.dump == @new_resource.dump &&
             @current_resource.pass == @new_resource.pass
+        end
+
+        # It will update or delete the entry from fstab.
+        def update_or_delete_fs(update_fs=false)
+          if @current_resource.enabled
+            contents = []
+
+            found = false
+            ::File.readlines("/etc/fstab").reverse_each do |line|
+              if !found && line =~ /^#{device_fstab_regex}\s+#{Regexp.escape(@new_resource.mount_point)}\s/
+                found = true
+                if update_fs
+                  logger.trace("#{@new_resource} is updated with new content in fstab")
+                  contents << ("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
+                else
+                  logger.trace("#{@new_resource} is removed from fstab")
+                end
+                next
+              else
+                contents << line
+              end
+            end
+
+            ::File.open("/etc/fstab", "w") do |fstab|
+              contents.reverse_each { |line| fstab.puts line }
+            end
+          else
+            logger.trace("#{@new_resource} is not enabled - nothing to do")
+          end
         end
 
       end

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -166,7 +166,7 @@ class Chef
             # The current options don't match what we have, so
             # update the last matching entry with current option
             # and order will remain the same.
-            edit_fstab(:update)
+            edit_fstab
           else
             ::File.open("/etc/fstab", "a") do |fstab|
               fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
@@ -176,7 +176,7 @@ class Chef
         end
 
         def disable_fs
-          edit_fstab(:remove)
+          edit_fstab(remove: true)
         end
 
         def network_device?
@@ -248,7 +248,7 @@ class Chef
         end
 
         # It will update or delete the entry from fstab.
-        def edit_fstab(action)
+        def edit_fstab(remove: false)
           if @current_resource.enabled
             contents = []
 
@@ -256,11 +256,11 @@ class Chef
             ::File.readlines("/etc/fstab").reverse_each do |line|
               if !found && line =~ /^#{device_fstab_regex}\s+#{Regexp.escape(@new_resource.mount_point)}\s/
                 found = true
-                if action == :update
-                  logger.trace("#{@new_resource} is updated with new content in fstab")
-                  contents << ("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
-                else
+                if remove
                   logger.trace("#{@new_resource} is removed from fstab")
+                else
+                  contents << ("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
+                  logger.trace("#{@new_resource} is updated with new content in fstab")
                 end
                 next
               else

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -167,7 +167,7 @@ class Chef
             # update the last matching entry with current option
             # and order will remain the same.
             update_or_delete_fs(true)
-          else  
+          else
             ::File.open("/etc/fstab", "a") do |fstab|
               fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
               logger.trace("#{@new_resource} is enabled at #{@new_resource.mount_point}")
@@ -248,7 +248,7 @@ class Chef
         end
 
         # It will update or delete the entry from fstab.
-        def update_or_delete_fs(update_fs=false)
+        def update_or_delete_fs(update_fs = false)
           if @current_resource.enabled
             contents = []
 

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -70,10 +70,6 @@ class Chef
               @current_resource.dump($4.to_i)
               @current_resource.pass($5.to_i)
               logger.trace("Found mount #{device_fstab} to #{@new_resource.mount_point} in /etc/fstab")
-              next
-            when %r{^[/\w]+\s+#{Regexp.escape(@new_resource.mount_point)}\s+}
-              enabled = false
-              logger.trace("Found conflicting mount point #{@new_resource.mount_point} in /etc/fstab")
             end
           end
           @current_resource.enabled(enabled)

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -247,15 +247,6 @@ describe Chef::Provider::Mount::Mount do
       expect(@provider.current_resource.enabled).to be_falsey
     end
 
-    it "should set enabled to false if the mount point is not last in fstab" do
-      line_1 = "#{@new_resource.device} #{@new_resource.mount_point}  ext3  defaults  1 2\n"
-      line_2 = "/dev/sdy1 #{@new_resource.mount_point}  ext3  defaults  1 2\n"
-      allow(::File).to receive(:foreach).with("/etc/fstab").and_yield(line_1).and_yield(line_2)
-
-      @provider.load_current_resource
-      expect(@provider.current_resource.enabled).to be_falsey
-    end
-
     it "should not mangle the mount options if the device in fstab is a symlink" do
       # expand the target path to correct specs on Windows
       target = "/dev/mapper/target"


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
- Updated `enabled?` method in mount provider.
- Added `update_or_delete_fs` method to fix the order change
- Added spec for the changes
- Fixed test case failure.

## Related Issue
#2908 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
