### PR TITLE
Update to Ruby 2.7.2 / Rubygems 3.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       mixlib-log (>= 2.0, < 4.0)
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
-    cheffish (16.0.9)
+    cheffish (16.0.12)
       chef-zero (>= 14.0)
       net-ssh
     coderay (1.1.3)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 3e43293a0eff95c4175c983247b737a2ce137e35
+  revision: 447cd359cff2c6fe3e5785d711862100db78104a
   branch: master
   specs:
-    omnibus (7.0.27)
+    omnibus (7.0.30)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-sugar (>= 3.3)
@@ -11,14 +11,14 @@ GIT
       license_scout (~> 1.0)
       mixlib-shellout (>= 2.0, < 4.0)
       mixlib-versioning
-      ohai (>= 13, < 17)
+      ohai (>= 15)
       pedump
       ruby-progressbar (~> 1.7)
       thor (>= 0.18, < 2.0)
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 0e0686b82299ca2ddc6b9251319e4309142c4b7d
+  revision: e5ac48a1cd931b5f1931e9828713e32718fd36e6
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.378.0)
+    aws-partitions (1.380.0)
     aws-sdk-core (3.109.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -41,8 +41,8 @@ GEM
     aws-sdk-kms (1.39.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.81.1)
-      aws-sdk-core (~> 3, >= 3.104.3)
+    aws-sdk-s3 (1.83.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,7 +3,7 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "3.1.2" # pin to what ships in the ruby version
+override :rubygems, version: "3.1.4" # pin to what ships in the ruby version
 override :bundler, version: "2.1.4" # pin to what ships in the ruby version
 override "libarchive", version: "3.4.3"
 override "libffi", version: "3.3"
@@ -18,7 +18,7 @@ override "ncurses", version: "5.9"
 override "nokogiri", version: "1.10.10"
 override "openssl", version: "1.0.2w"
 override "pkg-config-lite", version: "0.28-1"
-override "ruby", version: "2.7.1"
+override "ruby", version: "2.7.2"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"


### PR DESCRIPTION
This resolves CVE-2020-25613 and a large number of misc bugs

Signed-off-by: Tim Smith <tsmith@chef.io>