### PR TITLE
fix specs on powershell v4 and below

### DIFF
--- a/spec/functional/mixin/powershell_out_spec.rb
+++ b/spec/functional/mixin/powershell_out_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Mixin::PowershellOut, :windows_only do
     end
 
     it "uses :powershell by default" do
-      expect(powershell_out("$PSVersionTable").run_command.stdout).to match /Desktop/
+      expect(powershell_out("$PSVersionTable").run_command.stdout).to match /CLRVersion/
     end
 
     it ":pwsh interpreter uses core edition", :pwsh_installed do

--- a/spec/unit/mixin/powershell_exec_spec.rb
+++ b/spec/unit/mixin/powershell_exec_spec.rb
@@ -29,9 +29,9 @@ describe Chef::Mixin::PowershellExec, :windows_only, :windows_gte_10 do
         expect(object.powershell_exec("$PSVersionTable")).to be_kind_of(Chef::PowerShell)
       end
 
-      it "uses the Desktop edition" do
+      it "uses less than version 6" do
         execution = object.powershell_exec("$PSVersionTable")
-        expect(execution.result["PSEdition"]).to eql("Desktop")
+        expect(execution.result["PSVersion"].to_s.to_i).to be < 6
       end
     end
 
@@ -40,9 +40,9 @@ describe Chef::Mixin::PowershellExec, :windows_only, :windows_gte_10 do
         expect(object.powershell_exec("$PSVersionTable", :pwsh)).to be_kind_of(Chef::Pwsh)
       end
 
-      it "uses the Desktop edition" do
+      it "uses greater than version 6" do
         execution = object.powershell_exec("$PSVersionTable", :pwsh)
-        expect(execution.result["PSEdition"]).to eql("Core")
+        expect(execution.result["PSVersion"]["Major"]).to be > 6
       end
     end
 
@@ -51,9 +51,9 @@ describe Chef::Mixin::PowershellExec, :windows_only, :windows_gte_10 do
         expect(object.powershell_exec("$PSVersionTable", :powershell)).to be_kind_of(Chef::PowerShell)
       end
 
-      it "uses the Desktop edition" do
+      it "uses less than version 6" do
         execution = object.powershell_exec("$PSVersionTable", :powershell)
-        expect(execution.result["PSEdition"]).to eql("Desktop")
+        expect(execution.result["PSVersion"].to_s.to_i).to be < 6
       end
     end
 


### PR DESCRIPTION
Some of our tests are interrogating the `PSEdition` property of `$PSVersionTable`. This prop does not exist in versions of powershell under 5.1. So we either check the version of the existence of `CLRVersion`.

Signed-off-by: mwrock <matt@mattwrock.com>
