### PR TITLE
Improve handling of multilib packages in yum_package

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -220,7 +220,8 @@ class Chef
           @available_version[index] ||= if new_resource.source
                                           resolve_source_to_version_obj
                                         else
-                                          python_helper.package_query(:whatavailable, package_name_array[index], version: safe_version_array[index], arch: safe_arch_array[index], options: options)
+                                          mc = (action == :install) || nil
+                                          python_helper.package_query(:whatavailable, package_name_array[index], version: safe_version_array[index], arch: safe_arch_array[index], options: options, multilibcompat: mc)
                                         end
 
           @available_version[index]

--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -113,8 +113,8 @@ class Chef
 
           # @return Array<Version>
           # NB: "options" here is the yum_package options hash and is deliberately not **opts
-          def package_query(action, provides, version: nil, arch: nil, options: {})
-            parameters = { "provides" => provides, "version" => version, "arch" => arch }
+          def package_query(action, provides, version: nil, arch: nil, options: {}, multilibcompat: nil)
+            parameters = { "provides" => provides, "version" => version, "arch" => arch, "multilibcompat" => multilibcompat }
             repo_opts = options_params(options || {})
             parameters.merge!(repo_opts)
             # XXX: for now we restart before and after every query with an enablerepo/disablerepo to clean the helpers internal state


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

When `yum_package` is used to install a package, and there is already a package with the same name but different architecture installed on the system, and the package version that `yum_package` chooses for the new package is different than the version of the already installed package, the `yum` command generates an multilib version error and `chef-client` aborts.  This PR makes two behavioral changes that help prevent `yum_package` from triggering errors regarding multilib version conflicts when calling out to `yum` in this situation.

1. When `yum_package` searches for candidates to satisfy an `:install` action that has no version constraints, it tries to install the latest version of the package available.  The first part of this PR makes `yum_package` prefer those candidates with versions that match any installed packages that have the same name (but different architectures).

1.  When `yum_package` is handling packages in the same `:install` action (i.e. `yum_package` [ 'pkg.arch1', 'pkg.arch2', 'other-packages...' ]), `yum_package` only passes those packages that are not installed on the system to `yum` for installation.  The second part of this PR identifies when the version chosen for the new package is incompatible with the version of the installed package and instructs `yum` to install both packages in this case.  When told to install both packages, `yum` responds by updating the installed package to the same version as the new package being installed, avoiding a conflict.

There is an edge case where if a user sets `protected_multilib=0` in their YUM configuration, `yum` will install different versions of multilib packages without generating an error.  The yum documentation discourages this configuration wherever `protected_multilib` is discussed.  If a user has this configuration, the first part of this PR will detect it and resort to always choosing the most recent version of installation candidates.  The second part of this PR, however, does not have visibility into the YUM configuration; it will sill update an installed package to maintain version consistency with new packages being installed when both packages are defined in the resource's package list.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Resolves #10485

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
