### PR TITLE
Changing ifconfig provider to reduce blank lines in redhat and debian ifconfigs

### DIFF
--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -236,7 +236,7 @@ class Chef
         return unless can_generate_config?
 
         b = binding
-        template = ::ERB.new(@config_template, nil, '-')
+        template = ::ERB.new(@config_template, nil, "-")
         config = resource_for_config(@config_path)
         config.content(template.result(b))
         config.run_action(:create)

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -236,7 +236,7 @@ class Chef
         return unless can_generate_config?
 
         b = binding
-        template = ::ERB.new(@config_template)
+        template = ::ERB.new(@config_template, nil, '-')
         config = resource_for_config(@config_path)
         config.content(template.result(b))
         config.run_action(:create)

--- a/lib/chef/provider/ifconfig/debian.rb
+++ b/lib/chef/provider/ifconfig/debian.rb
@@ -32,25 +32,43 @@ class Chef
         def initialize(new_resource, run_context)
           super(new_resource, run_context)
           @config_template = %{
-<% if new_resource.device %>
-<% if new_resource.onboot == "yes" %>auto <%= new_resource.device %><% end %>
+<% if new_resource.device -%>
+<% if new_resource.onboot == "yes" -%>
+auto <%= new_resource.device %>
+<% end -%>
 <% case new_resource.bootproto
-   when "dhcp" %>
+   when "dhcp" -%>
 iface <%= new_resource.device %> <%= new_resource.family %> dhcp
-<% when "bootp" %>
+<% when "bootp" -%>
 iface <%= new_resource.device %> <%= new_resource.family %> bootp
-<% else %>
+<% else -%>
 iface <%= new_resource.device %> <%= new_resource.family %> static
-    <% if new_resource.target %>address <%= new_resource.target %><% end %>
-    <% if new_resource.mask %>netmask <%= new_resource.mask %><% end %>
-    <% if new_resource.network %>network <%= new_resource.network %><% end %>
-    <% if new_resource.bcast %>broadcast <%= new_resource.bcast %><% end %>
-    <% if new_resource.metric %>metric <%= new_resource.metric %><% end %>
-    <% if new_resource.hwaddr %>hwaddress <%= new_resource.hwaddr %><% end %>
-    <% if new_resource.mtu %>mtu <%= new_resource.mtu %><% end %>
-    <% if new_resource.gateway %>gateway <%= new_resource.gateway %><% end %>
-<% end %>
-<% end %>
+    <% if new_resource.target -%>
+    address <%= new_resource.target %>
+    <% end -%>
+    <% if new_resource.mask -%>
+    netmask <%= new_resource.mask %>
+    <% end -%>
+    <% if new_resource.network -%>
+    network <%= new_resource.network %>
+    <% end -%>
+    <% if new_resource.bcast -%>
+    broadcast <%= new_resource.bcast %>
+    <% end -%>
+    <% if new_resource.metric -%>
+    metric <%= new_resource.metric %>
+    <% end -%>
+    <% if new_resource.hwaddr -%>
+    hwaddress <%= new_resource.hwaddr %>
+    <% end -%>
+    <% if new_resource.mtu -%>
+    mtu <%= new_resource.mtu %>
+    <% end -%>
+    <% if new_resource.gateway -%>
+    gateway <%= new_resource.gateway %>
+    <% end -%>
+<% end -%>
+<% end -%>
           }
           @config_path = "#{INTERFACES_DOT_D_DIR}/ifcfg-#{new_resource.device}"
         end

--- a/lib/chef/provider/ifconfig/redhat.rb
+++ b/lib/chef/provider/ifconfig/redhat.rb
@@ -27,23 +27,57 @@ class Chef
         def initialize(new_resource, run_context)
           super(new_resource, run_context)
           @config_template = %{
-<% if new_resource.device %>DEVICE=<%= new_resource.device %><% end %>
-<% if new_resource.onboot == "yes" %>ONBOOT=<%= new_resource.onboot %><% end %>
-<% if new_resource.bootproto %>BOOTPROTO=<%= new_resource.bootproto %><% end %>
-<% if new_resource.target %>IPADDR=<%= new_resource.target %><% end %>
-<% if new_resource.mask %>NETMASK=<%= new_resource.mask %><% end %>
-<% if new_resource.network %>NETWORK=<%= new_resource.network %><% end %>
-<% if new_resource.bcast %>BROADCAST=<%= new_resource.bcast %><% end %>
-<% if new_resource.onparent %>ONPARENT=<%= new_resource.onparent %><% end %>
-<% if new_resource.hwaddr %>HWADDR=<%= new_resource.hwaddr %><% end %>
-<% if new_resource.metric %>METRIC=<%= new_resource.metric %><% end %>
-<% if new_resource.mtu %>MTU=<%= new_resource.mtu %><% end %>
-<% if new_resource.ethtool_opts %>ETHTOOL_OPTS="<%= new_resource.ethtool_opts %>"<% end %>
-<% if new_resource.bonding_opts %>BONDING_OPTS="<%= new_resource.bonding_opts %>"<% end %>
-<% if new_resource.master %>MASTER=<%= new_resource.master %><% end %>
-<% if new_resource.slave %>SLAVE=<%= new_resource.slave %><% end %>
-<% if new_resource.vlan %>VLAN=<%= new_resource.vlan %><% end %>
-<% if new_resource.gateway %>GATEWAY=<%= new_resource.gateway %><% end %>
+<% if new_resource.device -%>
+DEVICE=<%= new_resource.device %>
+<% end -%>
+<% if new_resource.onboot == "yes" -%>
+ONBOOT=<%= new_resource.onboot %>
+<% end -%>
+<% if new_resource.bootproto -%>
+BOOTPROTO=<%= new_resource.bootproto %>
+<% end -%>
+<% if new_resource.target -%>
+IPADDR=<%= new_resource.target %>
+<% end -%>
+<% if new_resource.mask -%>
+NETMASK=<%= new_resource.mask %>
+<% end -%>
+<% if new_resource.network -%>
+NETWORK=<%= new_resource.network %>
+<% end -%>
+<% if new_resource.bcast -%>
+BROADCAST=<%= new_resource.bcast %>
+<% end -%>
+<% if new_resource.onparent -%>
+ONPARENT=<%= new_resource.onparent %>
+<% end -%>
+<% if new_resource.hwaddr -%>
+HWADDR=<%= new_resource.hwaddr %>
+<% end -%>
+<% if new_resource.metric -%>
+METRIC=<%= new_resource.metric %>
+<% end -%>
+<% if new_resource.mtu -%>
+MTU=<%= new_resource.mtu %>
+<% end -%>
+<% if new_resource.ethtool_opts -%>
+ETHTOOL_OPTS="<%= new_resource.ethtool_opts %>"
+<% end -%>
+<% if new_resource.bonding_opts -%>
+BONDING_OPTS="<%= new_resource.bonding_opts %>"
+<% end -%>
+<% if new_resource.master -%>
+MASTER=<%= new_resource.master %>
+<% end -%>
+<% if new_resource.slave -%>
+SLAVE=<%= new_resource.slave %>
+<% end -%>
+<% if new_resource.vlan -%>
+VLAN=<%= new_resource.vlan %>
+<% end -%>
+<% if new_resource.gateway -%>
+GATEWAY=<%= new_resource.gateway %>
+<% end -%>
           }
           @config_path = "/etc/sysconfig/network-scripts/ifcfg-#{new_resource.device}"
         end


### PR DESCRIPTION
Changing ifconfig provider to use '-' trim_mode for its ERB templates and updating the redhat and debian ifconfigs to leverage the trim_mode so they are not constructed with any blank lines when nil values are encountered.

This addresses https://github.com/chef/chef/issues/10457

## Description
This improves the `ifconfig` templates defined for debian and redhat so that `nil` values do not generate blank lines in the resulting ifconfig file.

Ruby ERB supports a `trim_mode` parameter of `'-'` to `"-  omit blank lines ending in -%>"`

I've changed the ERB call in https://github.com/chef/chef/blob/master/lib/chef/provider/ifconfig.rb#L239 to leverage this trim mode.

I've also changed each of the distro's template generation scripts to generate a template that omits blank lines when a `nil` value is encountered 

## Related Issue
https://github.com/chef/chef/issues/10457

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
