### PR TITLE
Refactor ResourceGuardInterpreter

### DIFF
--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -76,7 +76,7 @@ class Chef
       # default for this resource, this method can be removed since
       # guard context and recipe resource context will have the
       # same behavior.
-      def self.get_default_attributes(opts)
+      def self.get_default_attributes
         { convert_boolean_return: true }
       end
     end

--- a/spec/support/shared/unit/script_resource.rb
+++ b/spec/support/shared/unit/script_resource.rb
@@ -56,7 +56,7 @@ shared_examples_for "a script resource" do
 
     it "when guard_interpreter is set to the default value, the guard command string should be evaluated by command execution and not through a resource" do
       expect_any_instance_of(Chef::Resource::Conditional).not_to receive(:evaluate_block)
-      expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).not_to receive(:evaluate_action)
+      expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).not_to receive(:evaluate)
       expect_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).to receive(:evaluate).and_return(true)
       script_resource.only_if "echo hi"
       expect(script_resource.should_skip?(:run)).to eq(nil)
@@ -65,7 +65,7 @@ shared_examples_for "a script resource" do
     it "when a valid guard_interpreter resource is specified, a block should be used to evaluate the guard" do
       expect_any_instance_of(Chef::Resource::Conditional).not_to receive(:evaluate_block)
       expect_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).not_to receive(:evaluate)
-      expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(true)
+      expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate).and_return(true)
       script_resource.guard_interpreter :script
       script_resource.only_if "echo hi"
       expect(script_resource.should_skip?(:run)).to eq(nil)

--- a/spec/support/shared/unit/windows_script_resource.rb
+++ b/spec/support/shared/unit/windows_script_resource.rb
@@ -35,7 +35,7 @@ shared_examples_for "a Windows script resource" do
     end
 
     it "should use a resource to evaluate the guard when guard_interpreter is not specified" do
-      expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(true)
+      expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate).and_return(true)
       expect_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).not_to receive(:evaluate)
       windows_script_resource.only_if "echo hi"
       expect(windows_script_resource.should_skip?(:run)).to eq(nil)

--- a/spec/unit/guard_interpreter/resource_guard_interpreter_spec.rb
+++ b/spec/unit/guard_interpreter/resource_guard_interpreter_spec.rb
@@ -93,8 +93,8 @@ describe Chef::GuardInterpreter::ResourceGuardInterpreter do
     end
 
     describe "script command opts switch" do
-      let(:command_opts) { {} }
-      let(:guard_interpreter) { Chef::GuardInterpreter::ResourceGuardInterpreter.new(parent_resource, "exit 0", command_opts) }
+      let(:guard_interpreter) { Chef::GuardInterpreter::ResourceGuardInterpreter.new(parent_resource, "exit 0", {}) }
+      let(:resource) { guard_interpreter.instance_variable_get("@resource") }
 
       context "resource is a Script" do
         context "and guard_interpreter is a :script" do
@@ -117,9 +117,9 @@ describe Chef::GuardInterpreter::ResourceGuardInterpreter do
             end
           end
 
-          it "merges to :code" do
-            expect(command_opts).to receive(:merge).with({ code: "exit 0" }).and_call_original
-            expect(guard_interpreter.evaluate).to eq(true)
+          it "assigns the comand to the resource's code property" do
+            guard_interpreter.evaluate
+            expect(resource.code).to eq("exit 0")
           end
         end
 
@@ -130,9 +130,9 @@ describe Chef::GuardInterpreter::ResourceGuardInterpreter do
             parent_resource
           end
 
-          it "merges to :code" do
-            expect(command_opts).to receive(:merge).with({ command: "exit 0" }).and_call_original
-            expect(guard_interpreter.evaluate).to eq(true)
+          it "assigns the comand to the resource's command property" do
+            guard_interpreter.evaluate
+            expect(resource.command).to eq("exit 0")
           end
         end
       end
@@ -144,9 +144,9 @@ describe Chef::GuardInterpreter::ResourceGuardInterpreter do
           parent_resource
         end
 
-        it "merges to :command" do
-          expect(command_opts).to receive(:merge).with({ command: "exit 0" }).and_call_original
-          expect(guard_interpreter.evaluate).to eq(true)
+        it "assigns the comand to the resource's command property" do
+          guard_interpreter.evaluate
+          expect(resource.command).to eq("exit 0")
         end
       end
 

--- a/spec/unit/resource/powershell_script_spec.rb
+++ b/spec/unit/resource/powershell_script_spec.rb
@@ -47,81 +47,11 @@ describe Chef::Resource::PowershellScript do
     expect(resource.convert_boolean_return).to eq(false)
   end
 
-  context "when using guards" do
-    before(:each) do
-      allow(resource).to receive(:run_action)
-      allow(resource).to receive(:updated).and_return(true)
-    end
+  it "inherits exactly the :cwd, :environment, :group, :path, :user, :umask, :architecture, :elevated, :interpreter properties from a parent resource class" do
+    inherited_difference = Chef::Resource::PowershellScript.guard_inherited_attributes -
+      %i{cwd environment group path user umask architecture elevated interpreter}
 
-    it "inherits exactly the :cwd, :environment, :group, :path, :user, :umask, :architecture, :elevated, :interpreter properties from a parent resource class" do
-      inherited_difference = Chef::Resource::PowershellScript.guard_inherited_attributes -
-        %i{cwd environment group path user umask architecture elevated interpreter}
-
-      expect(inherited_difference).to eq([])
-    end
-
-    it "allows guard interpreter to be set to Chef::Resource::Script" do
-      resource.guard_interpreter(:script)
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(false)
-      resource.only_if("echo hi")
-    end
-
-    it "allows guard interpreter to be set to Chef::Resource::Bash derived from Chef::Resource::Script" do
-      resource.guard_interpreter(:bash)
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(false)
-      resource.only_if("echo hi")
-    end
-
-    it "allows guard interpreter to be set to Chef::Resource::PowershellScript derived indirectly from Chef::Resource::Script" do
-      resource.guard_interpreter(:powershell_script)
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(false)
-      resource.only_if("echo hi")
-    end
-
-    it "enables convert_boolean_return by default for guards in the context of powershell_script when no guard params are specified" do
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(true)
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
-        { convert_boolean_return: true, code: "$true" }
-      ).and_return(Proc.new {})
-      resource.only_if("$true")
-    end
-
-    it "enables convert_boolean_return by default for guards in non-Chef::Resource::Script derived resources when no guard params are specified" do
-      node = Chef::Node.new
-      run_context = Chef::RunContext.new(node, nil, nil)
-      file_resource = Chef::Resource::File.new("idontexist", run_context)
-      file_resource.guard_interpreter :powershell_script
-
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
-        { convert_boolean_return: true, code: "$true" }
-      ).and_return(Proc.new {})
-      resource.only_if("$true")
-    end
-
-    it "enables convert_boolean_return by default for guards in the context of powershell_script when guard params are specified" do
-      guard_parameters = { cwd: "/etc/chef", architecture: :x86_64 }
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
-        { convert_boolean_return: true, code: "$true" }.merge(guard_parameters)
-      ).and_return(Proc.new {})
-      resource.only_if("$true", guard_parameters)
-    end
-
-    it "passes convert_boolean_return as true if it was specified as true in a guard parameter" do
-      guard_parameters = { cwd: "/etc/chef", convert_boolean_return: true, architecture: :x86_64 }
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
-        { convert_boolean_return: true, code: "$true" }.merge(guard_parameters)
-      ).and_return(Proc.new {})
-      resource.only_if("$true", guard_parameters)
-    end
-
-    it "passes convert_boolean_return as false if it was specified as true in a guard parameter" do
-      other_guard_parameters = { cwd: "/etc/chef", architecture: :x86_64 }
-      parameters_with_boolean_disabled = other_guard_parameters.merge({ convert_boolean_return: false, code: "$true" })
-      allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
-        parameters_with_boolean_disabled
-      ).and_return(Proc.new {})
-      resource.only_if("$true", parameters_with_boolean_disabled)
-    end
+    expect(inherited_difference).to eq([])
   end
 
   context "as a script running in Windows-based scripting language" do


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

I started refactoring ResourceGuardInterpreter as part of a different PR a few months ago but moved the changes onto a different branch when I realized I didn't have to change it for that PR's behavior. This doesn't fix anything other than making the code a lot easier to follow (IMO).