### PR TITLE
Avoid using complex regexes when we can use include?

### DIFF
--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -126,18 +126,18 @@ class Chef
               elsif line.match(addr_regex)[3] == ""
                 @int_name = line.match(addr_regex)[1]
                 @interfaces[@int_name] = {}
-                @interfaces[@int_name]["mtu"] = (line =~ /mtu (\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /mtu/ && @interfaces[@int_name]["mtu"].nil?
+                @interfaces[@int_name]["mtu"] = (line =~ /mtu (\S+)/ ? Regexp.last_match(1) : "nil") if line.include?("mtu") && @interfaces[@int_name]["mtu"].nil?
               else
                 @int_name = "#{line.match(addr_regex)[1]}:#{line.match(addr_regex)[3]}"
                 @interfaces[@int_name] = {}
-                @interfaces[@int_name]["mtu"] = (line =~ /mtu (\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /mtu/ && @interfaces[@int_name]["mtu"].nil?
+                @interfaces[@int_name]["mtu"] = (line =~ /mtu (\S+)/ ? Regexp.last_match(1) : "nil") if line.include?("mtu") && @interfaces[@int_name]["mtu"].nil?
               end
             else
-              @interfaces[@int_name]["inet_addr"] = (line =~ /inet (\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /inet/ && @interfaces[@int_name]["inet_addr"].nil?
-              @interfaces[@int_name]["bcast"] = (line =~ /broadcast (\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /broadcast/ && @interfaces[@int_name]["bcast"].nil?
-              @interfaces[@int_name]["mask"] = (line =~ /netmask (\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /netmask/ && @interfaces[@int_name]["mask"].nil?
-              @interfaces[@int_name]["hwaddr"] = (line =~ /ether (\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /ether/ && @interfaces[@int_name]["hwaddr"].nil?
-              @interfaces[@int_name]["metric"] = (line =~ /Metric:(\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /Metric:/ && @interfaces[@int_name]["metric"].nil?
+              @interfaces[@int_name]["inet_addr"] = (line =~ /inet (\S+)/ ? Regexp.last_match(1) : "nil") if line.include?("inet") && @interfaces[@int_name]["inet_addr"].nil?
+              @interfaces[@int_name]["bcast"] = (line =~ /broadcast (\S+)/ ? Regexp.last_match(1) : "nil") if line.include?("broadcast") && @interfaces[@int_name]["bcast"].nil?
+              @interfaces[@int_name]["mask"] = (line =~ /netmask (\S+)/ ? Regexp.last_match(1) : "nil") if line.include?("netmask") && @interfaces[@int_name]["mask"].nil?
+              @interfaces[@int_name]["hwaddr"] = (line =~ /ether (\S+)/ ? Regexp.last_match(1) : "nil") if line.include?("ether") && @interfaces[@int_name]["hwaddr"].nil?
+              @interfaces[@int_name]["metric"] = (line =~ /Metric:(\S+)/ ? Regexp.last_match(1) : "nil") if line.include?("Metric:") && @interfaces[@int_name]["metric"].nil?
             end
 
             next unless @interfaces.key?(new_resource.device)

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -201,7 +201,7 @@ class Chef
         end
 
         def network_device?
-          @new_resource.device =~ /:/ || @new_resource.device =~ %r{//}
+          @new_resource.device.include?(":") || @new_resource.device.include?("//")
         end
 
         def device_should_exist?

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -161,7 +161,7 @@ class Chef
 
         def config_file_options
           # If the user has specified config file options previously, respect those.
-          return if Array(options).any? { |opt| opt =~ /--force-conf/ }
+          return if Array(options).any? { |opt| opt.include?("--force-conf") }
 
           # It doesn't make sense to install packages in a scenario that can
           # result in a prompt. Have users decide up-front whether they want to

--- a/lib/chef/provider/user/aix.rb
+++ b/lib/chef/provider/user/aix.rb
@@ -68,7 +68,7 @@ class Chef
 
         def check_lock
           lock_info = shell_out!("lsuser", "-a", "account_locked", new_resource.username)
-          if whyrun_mode? && passwd_s.stdout.empty? && lock_info.stderr.match(/does not exist/)
+          if whyrun_mode? && passwd_s.stdout.empty? && lock_info.stderr.include?("does not exist")
             # if we're in whyrun mode and the user is not yet created we assume it would be
             return false
           end

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -224,7 +224,7 @@ class Chef
         else # windows
           WINDOWS_EC2_CONFIG = 'C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml'.freeze
 
-          raise "Windows hostnames cannot contain a period." if new_resource.hostname.match?(/\./)
+          raise "Windows hostnames cannot contain a period." if new_resource.hostname.include?(".")
 
           # suppress EC2 config service from setting our hostname
           if ::File.exist?(WINDOWS_EC2_CONFIG)

--- a/lib/chef/util/dsc/local_configuration_manager.rb
+++ b/lib/chef/util/dsc/local_configuration_manager.rb
@@ -105,7 +105,7 @@ class Chef::Util::DSC
 
     def dsc_module_import_failure?(command_output)
       !! (command_output =~ /\sCimException/ &&
-        command_output =~ /ProviderOperationExecutionFailure/ &&
+        command_output.include?("ProviderOperationExecutionFailure") &&
         command_output =~ /\smodule\s+is\s+installed/)
     end
 


### PR DESCRIPTION
The ifconfig part needs a complete rewrite, but this is better. At least it's not doing a regex twice for each thing it wants to match per line. It still does 5 regexes even if it matches on the first.

Signed-off-by: Tim Smith <tsmith@chef.io>