### PR TITLE
Avoid a slow hash merge

### DIFF
--- a/lib/chef/provider/package/freebsd/base.rb
+++ b/lib/chef/provider/package/freebsd/base.rb
@@ -58,7 +58,8 @@ class Chef
 
           def makefile_variable_value(variable, dir = nil)
             options = dir ? { cwd: dir } : {}
-            options.merge!(env: nil, returns: [0, 1])
+            options[:env] = nil
+            options[:returns] = [0, 1]
             make_v = shell_out!("make", "-V", variable, **options)
             make_v.exitstatus == 0 ? make_v.stdout.strip.split($OUTPUT_RECORD_SEPARATOR).first : nil # $\ is the line separator, i.e. newline.
           end

--- a/lib/chef/provider/package/freebsd/base.rb
+++ b/lib/chef/provider/package/freebsd/base.rb
@@ -61,7 +61,7 @@ class Chef
             options[:env] = nil
             options[:returns] = [0, 1]
             make_v = shell_out!("make", "-V", variable, **options)
-            make_v.exitstatus == 0 ? make_v.stdout.strip.split($OUTPUT_RECORD_SEPARATOR).first : nil # $\ is the line separator, i.e. newline.
+            make_v.exitstatus == 0 ? make_v.stdout.strip.split($OUTPUT_RECORD_SEPARATOR).first : nil
           end
         end
 


### PR DESCRIPTION
This is 2.66X slower than just throwing the data in there.

Signed-off-by: Tim Smith <tsmith@chef.io>