### PR TITLE
Update docs generation task to handle Chef 16 required format

### DIFF
--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -159,7 +159,7 @@ namespace :docs_site do
         values = {}
         values["property"] = property["name"]
         values["ruby_type"] = friendly_types_list(property["is"])
-        values["required"] = property["required"]
+        values["required"] = !!property["required"] # right now we just want a boolean value here since the docs doesn't know what to do with an array of actions
         values["default_value"] = default_val unless default_val.nil?
         values["new_in"] = property["introduced"] unless property["introduced"].nil?
         values["allowed_values"] = property["equal_to"].join(", ") unless property["equal_to"].empty?


### PR DESCRIPTION
We need a boolean for the docs site here, but we get back an array now.
For now let's just treat it like a boolean.

Signed-off-by: Tim Smith <tsmith@chef.io>