### PR TITLE
Fix bad formatting in a deprecation message

### DIFF
--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -88,7 +88,7 @@ class Chef
 
         # @deprecated
         def valid_actions(*args)
-          Chef::Log.warn("`valid_actions' is deprecated, please use allowed_actions `instead'!")
+          Chef::Log.warn("`valid_actions` is deprecated, please use `allowed_actions` instead!")
           allowed_actions(*args)
         end
 


### PR DESCRIPTION
This was all funky

Signed-off-by: Tim Smith <tsmith@chef.io>