### PR TITLE
Remove constantize method from Chef::Mixin::ConvertToClassName

### DIFF
--- a/lib/chef/mixin/convert_to_class_name.rb
+++ b/lib/chef/mixin/convert_to_class_name.rb
@@ -66,62 +66,6 @@ class Chef
         str = base.to_s + (file_base == "default" ? "" : "_#{file_base}")
         normalize_snake_case_name(str)
       end
-
-      # Copied from rails activesupport.  In ruby >= 2.0 const_get will just do this, so this can
-      # be deprecated and removed.
-      #
-      # MIT LICENSE is here: https://github.com/rails/rails/blob/master/activesupport/MIT-LICENSE
-
-      # Tries to find a constant with the name specified in the argument string.
-      #
-      #   'Module'.constantize     # => Module
-      #   'Test::Unit'.constantize # => Test::Unit
-      #
-      # The name is assumed to be the one of a top-level constant, no matter
-      # whether it starts with "::" or not. No lexical context is taken into
-      # account:
-      #
-      #   C = 'outside'
-      #   module M
-      #     C = 'inside'
-      #     C               # => 'inside'
-      #     'C'.constantize # => 'outside', same as ::C
-      #   end
-      #
-      # NameError is raised when the name is not in CamelCase or the constant is
-      # unknown.
-      def constantize(camel_cased_word)
-        names = camel_cased_word.split("::")
-
-        # Trigger a built-in NameError exception including the ill-formed constant in the message.
-        Object.const_get(camel_cased_word) if names.empty?
-
-        # Remove the first blank element in case of '::ClassName' notation.
-        names.shift if names.size > 1 && names.first.empty?
-
-        names.inject(Object) do |constant, name|
-          if constant == Object
-            constant.const_get(name)
-          else
-            candidate = constant.const_get(name)
-            next candidate if constant.const_defined?(name, false)
-            next candidate unless Object.const_defined?(name)
-
-            # Go down the ancestors to check if it is owned directly. The check
-            # stops when we reach Object or the end of ancestors tree.
-            constant = constant.ancestors.inject do |const, ancestor|
-              break const    if ancestor == Object
-              break ancestor if ancestor.const_defined?(name, false)
-
-              const
-            end
-
-            # owner is in Object, so raise
-            constant.const_get(name, false)
-          end
-        end
-      end
-
     end
   end
 end


### PR DESCRIPTION
It doesn't look like we're using this anymore and the comment states
that we wouldn't need the implementation after Ruby 2.0 anyways.

Signed-off-by: Tim Smith <tsmith@chef.io>