### PR TITLE
WIP: Avoid making WMI calls to find the windows version on each symlink creation

### DIFF
--- a/lib/chef/win32/file.rb
+++ b/lib/chef/win32/file.rb
@@ -23,6 +23,7 @@ require_relative "api/security"
 require_relative "error"
 require_relative "unicode"
 require_relative "version"
+require "chef-utils" unless defined?(ChefUtils::CANARY)
 
 class Chef
   module ReservedNames::Win32
@@ -62,7 +63,7 @@ class Chef
         # TODO do a check for CreateSymbolicLinkW and
         # raise NotImplemented exception on older Windows
         flags = ::File.directory?(old_name) ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0
-        flags |= SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE if Chef::ReservedNames::Win32::Version.new.win_10_creators_or_higher?
+        flags |= SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE if ChefUtils.windows_nt_version >= "10.0.15063" # Windows 10 Creators Update or later
         old_name = encode_path(old_name)
         new_name = encode_path(new_name)
         unless CreateSymbolicLinkW(new_name, old_name, flags)

--- a/lib/chef/win32/version.rb
+++ b/lib/chef/win32/version.rb
@@ -22,6 +22,7 @@ require "wmi-lite/wmi"
 
 class Chef
   module ReservedNames::Win32
+    # @deprecated This isn't used anywhere in chef/chef and should be avoided if at all possible as each time it's used expensive WMI calls have to be made. Windows version should be fetched from chef-utils instead
     class Version
       class << self
         include Chef::ReservedNames::Win32::API::System


### PR DESCRIPTION
We can gather this information via ChefUtils which abstracts the Ohai data. That way we only make these WMI calls once.

Signed-off-by: Tim Smith <tsmith@chef.io>