### PR TITLE
Add required_ruby_version to chef-utils and chef-config

### DIFF
--- a/chef-config/chef-config.gemspec
+++ b/chef-config/chef-config.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/chef"
   spec.license       = "Apache-2.0"
 
+  spec.required_ruby_version = ">= 2.6.0"
+
   spec.require_paths = ["lib"]
 
   spec.add_dependency "chef-utils", "= #{ChefConfig::VERSION}"

--- a/chef-utils/chef-utils.gemspec
+++ b/chef-utils/chef-utils.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/chef/tree/master/chef-utils"
   spec.license       = "Apache-2.0"
 
+  spec.required_ruby_version = ">= 2.6.0"
+
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/chef/chef/issues",
     "changelog_uri" => "https://github.com/chef/chef/CHANGELOG.md",


### PR DESCRIPTION
These are getting pulled in all over and that's causing problems on
older Ruby releases.

Signed-off-by: Tim Smith <tsmith@chef.io>