### PR TITLE
Simplify the ifconfig provides statement on Ubuntu/Debian

### DIFF
--- a/lib/chef/provider/ifconfig/debian.rb
+++ b/lib/chef/provider/ifconfig/debian.rb
@@ -23,8 +23,7 @@ class Chef
   class Provider
     class Ifconfig
       class Debian < Chef::Provider::Ifconfig
-        provides :ifconfig, platform: %w{ubuntu}, platform_version: ">= 11.10"
-        provides :ifconfig, platform: %w{debian}, platform_version: ">= 7.0"
+        provides :ifconfig, platform_family: %w{debian}
 
         INTERFACES_FILE = "/etc/network/interfaces".freeze
         INTERFACES_DOT_D_DIR = "/etc/network/interfaces.d".freeze

--- a/lib/chef/provider/ifconfig/debian.rb
+++ b/lib/chef/provider/ifconfig/debian.rb
@@ -80,7 +80,7 @@ iface <%= new_resource.device %> <%= new_resource.family %> static
         protected
 
         def enforce_interfaces_dot_d_sanity
-          # on ubuntu 18.04 there's no interfaces file and it uses interfaces.d by default
+          # on ubuntu 18.04+ there's no interfaces file and it uses interfaces.d by default
           return if ::File.directory?(INTERFACES_DOT_D_DIR) && !::File.exist?(INTERFACES_FILE)
 
           # create /etc/network/interfaces.d via dir resource (to get reporting, etc)

--- a/spec/unit/resource/ifconfig_spec.rb
+++ b/spec/unit/resource/ifconfig_spec.rb
@@ -90,19 +90,11 @@ describe Chef::Resource::Ifconfig do
     it_should_behave_like "being a platform based on RedHat", "redhat", "4.0"
   end
 
-  describe "when it is an old Debian platform" do
-    it_should_behave_like "being a platform based on an old Debian", "debian", "6.0"
-  end
-
-  describe "when it is a new Debian platform" do
+  describe "when it is a Debian platform" do
     it_should_behave_like "being a platform based on a recent Debian", "debian", "7.0"
   end
 
-  describe "when it is an old Ubuntu platform" do
-    it_should_behave_like "being a platform based on an old Debian", "ubuntu", "11.04"
-  end
-
-  describe "when it is a new Ubuntu platform" do
+  describe "when it is a Ubuntu platform" do
     it_should_behave_like "being a platform based on a recent Debian", "ubuntu", "11.10"
   end
 


### PR DESCRIPTION
We don't need to check around ancient EOL versions that we don't provide packages for anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>