### PR TITLE
Add bridge property to ifconfig for RHEL based systems

### DIFF
--- a/lib/chef/provider/ifconfig/redhat.rb
+++ b/lib/chef/provider/ifconfig/redhat.rb
@@ -78,10 +78,12 @@ VLAN=<%= new_resource.vlan %>
 <% if new_resource.gateway -%>
 GATEWAY=<%= new_resource.gateway %>
 <% end -%>
+<% if new_resource.bridge -%>
+BRIDGE=<%= new_resource.bridge %>
+<% end -%>
           }
           @config_path = "/etc/sysconfig/network-scripts/ifcfg-#{new_resource.device}"
         end
-
       end
     end
   end

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -102,6 +102,10 @@ class Chef
       property :gateway, String,
         introduced: "14.4",
         description: "The gateway to use for the interface."
+
+      property :bridge, String,
+        introduced: "16.7",
+        description: "The bridge interface this interface is a member of on Red Hat based systems."
     end
   end
 end


### PR DESCRIPTION
I don't see any documentation mentioning this being used on Debian, but
it's a thing in the legacy interface configs on RHEL

This wraps up https://github.com/chef/chef/issues/3509

Signed-off-by: Tim Smith <tsmith@chef.io>