### PR TITLE
Use a native resource in the ifconfig debian provider

### DIFF
--- a/lib/chef/provider/ifconfig/debian.rb
+++ b/lib/chef/provider/ifconfig/debian.rb
@@ -83,10 +83,9 @@ iface <%= new_resource.device %> <%= new_resource.family %> static
           # on ubuntu 18.04+ there's no interfaces file and it uses interfaces.d by default
           return if ::File.directory?(INTERFACES_DOT_D_DIR) && !::File.exist?(INTERFACES_FILE)
 
-          # create /etc/network/interfaces.d via dir resource (to get reporting, etc)
-          dir = Chef::Resource::Directory.new(INTERFACES_DOT_D_DIR, run_context)
-          dir.run_action(:create)
-          new_resource.updated_by_last_action(true) if dir.updated_by_last_action?
+          # create /etc/network/interfaces.d via dir if it's missing
+          directory INTERFACES_DOT_D_DIR
+
           # roll our own file_edit resource, this will not get reported until we have a file_edit resource
           interfaces_dot_d_for_regexp = INTERFACES_DOT_D_DIR.gsub(/\./, '\.') # escape dots for the regexp
           regexp = %r{^\s*source\s+#{interfaces_dot_d_for_regexp}/\*\s*$}


### PR DESCRIPTION
We're in unified mode. There's no need to work with classes when we can just use the DSL here.

Signed-off-by: Tim Smith <tsmith@chef.io>