### PR TITLE
Fix LWRP build cache

### DIFF
--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -63,11 +63,11 @@ class Chef
 
           Chef::Log.trace("Loaded contents of #{filename} into resource #{resource_name} (#{resource_class})")
 
-          LWRPBase.loaded_lwrps[filename] = true
-
           # wire up the default resource name after the class is parsed only if we haven't declared one.
           # (this ordering is important for MapCollision deprecation warnings)
           resource_class.provides resource_name.to_sym unless Chef::ResourceResolver.includes_handler?(resource_name.to_sym, self)
+
+          LWRPBase.loaded_lwrps[filename] = resource_class
 
           resource_class
         end


### PR DESCRIPTION
## Description

In `lib/chef/provider/lwrp_base.rb` the `build_from_file` method tries to avoid rebuilding LWRPs, but incorrectly stores "true" instead of the built resource in the cache.

This way, two different data types are returned.

Return values are only used in the resource inspector, so impact is mimimal.

## Related Issue

-

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
