### PR TITLE
Remove the yard doc generation task / group

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -18,7 +18,7 @@ steps:
 - label: "Integration Ubuntu 18.04 :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -31,7 +31,7 @@ steps:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -42,7 +42,7 @@ steps:
 - label: "Unit Ubuntu 18.04 :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -53,7 +53,7 @@ steps:
 - label: "Integration Ubuntu 20.04 :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -66,7 +66,7 @@ steps:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -77,7 +77,7 @@ steps:
 - label: "Unit Ubuntu 20.04 :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -88,7 +88,7 @@ steps:
 - label: "Integration CentOS 7 :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -100,7 +100,7 @@ steps:
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - yum install -y crontabs e2fsprogs util-linux
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -111,7 +111,7 @@ steps:
 - label: "Unit CentOS 7 :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -123,7 +123,7 @@ steps:
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - zypper install -y cron insserv-compat
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -135,7 +135,7 @@ steps:
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - zypper install -y cronie insserv-compat
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -147,7 +147,7 @@ steps:
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - zypper install -y cron insserv-compat
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -158,7 +158,7 @@ steps:
 - label: "Integration Fedora :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -170,7 +170,7 @@ steps:
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - yum install -y crontabs e2fsprogs util-linux
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -184,7 +184,7 @@ steps:
 - label: "Unit Fedora :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -245,7 +245,7 @@ steps:
 - label: "Chefstyle :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake style
   expeditor:
     executor:
@@ -255,7 +255,7 @@ steps:
 - label: "Integration :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -268,7 +268,7 @@ steps:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales net-tools # needed for functional tests to pass
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -279,7 +279,7 @@ steps:
 - label: "Unit :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -294,7 +294,7 @@ steps:
 - label: "chef-sugar gem :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec tasks/bin/run_external_test chef/chef-sugar master rake
   expeditor:
     executor:
@@ -304,7 +304,7 @@ steps:
 - label: "chef-zero gem :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec tasks/bin/run_external_test chef/chef-zero master rake pedant
   expeditor:
     executor:
@@ -317,7 +317,7 @@ steps:
 - label: "cheffish gem :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec tasks/bin/run_external_test chef/cheffish master rake spec
   expeditor:
     executor:
@@ -327,7 +327,7 @@ steps:
 - label: "chefspec gem :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec tasks/bin/run_external_test chefspec/chefspec master rake
   expeditor:
     executor:
@@ -337,7 +337,7 @@ steps:
 - label: "knife-windows gem :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec tasks/bin/run_external_test chef/knife-windows master rake spec
   expeditor:
     executor:
@@ -349,7 +349,7 @@ steps:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y graphviz
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package docgen
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec tasks/bin/run_external_test berkshelf/berkshelf master rake
   expeditor:
     executor:

--- a/Gemfile
+++ b/Gemfile
@@ -41,10 +41,6 @@ group(:omnibus_package, :pry) do
   gem "pry-stack_explorer"
 end
 
-group(:docgen) do
-  gem "yard"
-end
-
 # Everything except AIX
 group(:ruby_prof) do
   # ruby-prof 1.3.0 does not compile on our centos6 builders/kitchen testers

--- a/Rakefile
+++ b/Rakefile
@@ -97,15 +97,3 @@ begin
 rescue LoadError
   puts "chefstyle/rubocop is not available. bundle install first to make sure all dependencies are installed."
 end
-
-begin
-  require "yard"
-  DOC_FILES = [ "spec/tiny_server.rb", "lib/**/*.rb" ].freeze
-
-  YARD::Rake::YardocTask.new(:docs) do |t|
-    t.files = DOC_FILES
-    t.options = ["--format", "html"]
-  end
-rescue LoadError
-  puts "yard is not available. bundle install first to make sure all dependencies are installed."
-end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
 
     - script: |
         cd kitchen-tests
-        sudo /opt/chef/embedded/bin/bundle config set without 'omnibus_package docgen ruby_prof'
+        sudo /opt/chef/embedded/bin/bundle config set without 'omnibus_package ruby_prof'
         sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3 --path=vendor/bundle
         sudo /opt/chef/embedded/bin/gem install berkshelf --no-doc
         sudo /opt/chef/embedded/bin/berks vendor cookbooks
@@ -77,7 +77,7 @@ jobs:
     - powershell: |
         cd kitchen-tests
         $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
-        bundle config set without 'omnibus_package docgen ruby_prof'
+        bundle config set without 'omnibus_package ruby_prof'
         bundle install --jobs=3 --retry=3 --path=vendor/bundle
         gem install berkshelf --no-doc
         # berks emits a ruby warning when it loads net/http due to a previously


### PR DESCRIPTION
If someone wants the yard docs locally they can just gem install yard and then run yard. This is way overthinking the problem and requires us to exclude the group all over the place.

Signed-off-by: Tim Smith <tsmith@chef.io>