### PR TITLE
Remove coderay and ffi-yajl-bench binstubs

### DIFF
--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -113,6 +113,8 @@ build do
       xmllint
       xslt-config
       xsltproc
+      coderay
+      ffi-yajl-bench
     }.each do |f|
       file_path = "#{install_dir}/embedded/bin/#{f}"
 


### PR DESCRIPTION
Nuke a few more binstubs that have nothing to do with chef and shouldn't
be shipped.

Signed-off-by: Tim Smith <tsmith@chef.io>