### PR TITLE
Simplify some regexes by removing redundant character classes

### DIFF
--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -195,8 +195,8 @@ module ChefConfig
       message = ""
       message << "You have invalid ruby syntax in your config file #{config_file_path}\n\n"
       message << "#{e.class.name}: #{e.message}\n"
-      if file_line = e.message[/#{Regexp.escape(config_file_path)}:[\d]+/]
-        line = file_line[/:([\d]+)$/, 1].to_i
+      if file_line = e.message[/#{Regexp.escape(config_file_path)}:\d+/]
+        line = file_line[/:(\d+)$/, 1].to_i
         message << highlight_config_error(config_file_path, line)
       end
       raise ChefConfig::ConfigurationError, message
@@ -206,7 +206,7 @@ module ChefConfig
       filtered_trace = e.backtrace.grep(/#{Regexp.escape(config_file_path)}/)
       filtered_trace.each { |bt_line| message << "  " << bt_line << "\n" }
       unless filtered_trace.empty?
-        line_nr = filtered_trace.first[/#{Regexp.escape(config_file_path)}:([\d]+)/, 1]
+        line_nr = filtered_trace.first[/#{Regexp.escape(config_file_path)}:(\d+)/, 1]
         message << highlight_config_error(config_file_path, line_nr.to_i)
       end
       raise ChefConfig::ConfigurationError, message

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -35,7 +35,7 @@ class Chef
     include Chef::Mixin::ParamsValidate
     include Chef::Mixin::FromFile
 
-    COMBINED_COOKBOOK_CONSTRAINT = /(.+)(?:[\s]+)((?:#{Chef::VersionConstraint::OPS.join('|')})(?:[\s]+).+)$/.freeze
+    COMBINED_COOKBOOK_CONSTRAINT = /(.+)(?:\s+)((?:#{Chef::VersionConstraint::OPS.join('|')})(?:\s+).+)$/.freeze
 
     def initialize(chef_server_rest: nil)
       @name = ""

--- a/lib/chef/formatters/error_inspectors/compile_error_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/compile_error_inspector.rb
@@ -115,14 +115,14 @@ class Chef
 
         def culprit_line
           @culprit_line ||= begin
-            line_number = culprit_backtrace_entry[/^(?:.\:)?[^:]+:([\d]+)/, 1].to_i
+            line_number = culprit_backtrace_entry[/^(?:.\:)?[^:]+:(\d+)/, 1].to_i
             Chef::Log.trace("Line number of compile error: '#{line_number}'")
             line_number
           end
         end
 
         def culprit_file
-          @culprit_file ||= culprit_backtrace_entry[/^((?:.\:)?[^:]+):([\d]+)/, 1]
+          @culprit_file ||= culprit_backtrace_entry[/^((?:.\:)?[^:]+):(\d+)/, 1]
         end
 
         def filtered_bt

--- a/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
@@ -79,8 +79,8 @@ class Chef
               loop do
 
                 # low rent parser. try to gracefully handle nested blocks in resources
-                nesting += 1 if /[\s]+do[\s]*/.match?(lines[current_line])
-                nesting -= 1 if /end[\s]*$/.match?(lines[current_line])
+                nesting += 1 if /\s+do\s*/.match?(lines[current_line])
+                nesting -= 1 if /end\s*$/.match?(lines[current_line])
 
                 relevant_lines << format_line(current_line, lines[current_line])
 
@@ -114,11 +114,11 @@ class Chef
         end
 
         def parse_source
-          resource.source_line[/^(([\w]:)?[^:]+):([\d]+)/, 1]
+          resource.source_line[/^((\w:)?[^:]+):(\d+)/, 1]
         end
 
         def parse_line(source)
-          resource.source_line[/^#{Regexp.escape(source)}:([\d]+)/, 1].to_i
+          resource.source_line[/^#{Regexp.escape(source)}:(\d+)/, 1].to_i
         end
 
       end

--- a/lib/chef/knife/core/cookbook_scm_repo.rb
+++ b/lib/chef/knife/core/cookbook_scm_repo.rb
@@ -22,7 +22,7 @@ class Chef
   class Knife
     class CookbookSCMRepo
 
-      DIRTY_REPO = /^[\s]+M/.freeze
+      DIRTY_REPO = /^\s+M/.freeze
 
       include Chef::Mixin::ShellOut
 

--- a/lib/chef/knife/core/gem_glob_loader.rb
+++ b/lib/chef/knife/core/gem_glob_loader.rb
@@ -22,7 +22,7 @@ class Chef
   class Knife
     class SubcommandLoader
       class GemGlobLoader < Chef::Knife::SubcommandLoader
-        MATCHES_CHEF_GEM ||= %r{/chef-[\d]+\.[\d]+\.[\d]+}.freeze
+        MATCHES_CHEF_GEM ||= %r{/che-[\d+.[\d+.[\d+}.freeze
         MATCHES_THIS_CHEF_GEM ||= %r{/chef-#{Chef::VERSION}(-\w+)?(-\w+)?/}.freeze
 
         def subcommand_files

--- a/lib/chef/mixin/unformatter.rb
+++ b/lib/chef/mixin/unformatter.rb
@@ -21,7 +21,7 @@ class Chef
     module Unformatter
 
       def write(message)
-        data = message.match(/(\[.+?\] )?([\w]+):(.*)$/)
+        data = message.match(/(\[.+?\] )?(\w+):(.*)$/)
         send(data[2].downcase.chomp.to_sym, data[3].strip)
       rescue NoMethodError
         send(:info, message)

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -427,7 +427,7 @@ class Chef
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true
-          elsif RbConfig::CONFIG["bindir"].sub(/^[\w]:/, "") == "/opscode/chef/embedded/bin"
+          elsif RbConfig::CONFIG["bindir"].sub(/^\w:/, "") == "/opscode/chef/embedded/bin"
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # windows, with the drive letter removed
             true

--- a/lib/chef/provider/package/yum/rpm_utils.rb
+++ b/lib/chef/provider/package/yum/rpm_utils.rb
@@ -46,7 +46,7 @@ class Chef
               lead = 0
               tail = evr.size
 
-              if /^([\d]+):/.match(evr) # rubocop:disable Performance/RedundantMatch
+              if /^(\d+):/.match(evr) # rubocop:disable Performance/RedundantMatch
                 epoch = $1.to_i
                 lead = $1.length + 1
               elsif evr[0].ord == ":".ord

--- a/lib/chef/run_lock.rb
+++ b/lib/chef/run_lock.rb
@@ -173,7 +173,7 @@ class Chef
     # Mutex name is case-sensitive contrary to other things in
     # windows. "\" is the only invalid character.
     def acquire_win32_mutex
-      @mutex = Chef::ReservedNames::Win32::Mutex.new("Global\\#{runlock_file.gsub(/[\\]/, "/").downcase}")
+      @mutex = Chef::ReservedNames::Win32::Mutex.new("Global\\#{runlock_file.gsub(/\\/, "/").downcase}")
       mutex.test
     end
 

--- a/spec/functional/resource/apt_package_spec.rb
+++ b/spec/functional/resource/apt_package_spec.rb
@@ -326,7 +326,7 @@ describe Chef::Resource::AptPackage, metadata do
         pkg_check = shell_out!("dpkg -l chef-integration-test", returns: [0, 1])
 
         if pkg_check.exitstatus == 0
-          expect(pkg_check.stdout).to match(/un[\s]+chef-integration-test/)
+          expect(pkg_check.stdout).to match(/un\s+chef-integration-test/)
         end
       end
 
@@ -359,7 +359,7 @@ describe Chef::Resource::AptPackage, metadata do
       it "upgrades the package for action :upgrade" do
         package_resource.run_action(:upgrade)
         dpkg_l = shell_out!("dpkg -l chef-integration-test", returns: [0])
-        expect(dpkg_l.stdout).to match(/chef\-integration\-test[\s]+1\.1\-1/)
+        expect(dpkg_l.stdout).to match(/chef\-integration\-test\s+1\.1\-1/)
         expect(package_resource).to be_updated_by_last_action
       end
 
@@ -373,7 +373,7 @@ describe Chef::Resource::AptPackage, metadata do
         it "upgrades the package for action :install" do
           package_resource.run_action(:install)
           dpkg_l = shell_out!("dpkg -l chef-integration-test", returns: [0])
-          expect(dpkg_l.stdout).to match(/chef\-integration\-test[\s]+1\.1\-1/)
+          expect(dpkg_l.stdout).to match(/chef\-integration\-test\s+1\.1\-1/)
           expect(package_resource).to be_updated_by_last_action
         end
       end

--- a/spec/unit/knife/configure_spec.rb
+++ b/spec/unit/knife/configure_spec.rb
@@ -157,9 +157,9 @@ describe Chef::Knife::Configure do
     expect(::File).to receive(:open).with("/home/you/.chef/credentials", "w").and_yield config_file
     @knife.config[:repository] = "/home/you/chef-repo"
     @knife.run
-    expect(config_file.string).to match(/^client_name[\s]+=[\s]+'#{Etc.getlogin}'$/)
-    expect(config_file.string).to match(%r{^client_key[\s]+=[\s]+'/home/you/.chef/#{Etc.getlogin}.pem'$})
-    expect(config_file.string).to match(/^chef_server_url\s+=[\s]+'#{default_server_url}'$/)
+    expect(config_file.string).to match(/^client_name\s+=\s+'#{Etc.getlogin}'$/)
+    expect(config_file.string).to match(%r{^client_ky[\s=[\s+'/home/you/.chef/#{Etc.getlogin}.pem'$})
+    expect(config_file.string).to match(/^chef_server_url\s+=\s+'#{default_server_url}'$/)
   end
 
   it "creates a new client when given the --initial option" do

--- a/spec/unit/resource/breakpoint_spec.rb
+++ b/spec/unit/resource/breakpoint_spec.rb
@@ -58,7 +58,7 @@ describe Chef::Resource::Breakpoint do
 
   it "names itself after the line number of the file where it's created" do
     resource = Chef::Resource::Breakpoint.new
-    expect(resource.name).to match(/breakpoint_spec\.rb\:[\d]{2}\:in \`new\'$/)
+    expect(resource.name).to match(/breakpoint_spec\.rb\:\d{2}\:in \`new\'$/)
   end
 
 end

--- a/spec/unit/shell_spec.rb
+++ b/spec/unit/shell_spec.rb
@@ -150,8 +150,8 @@ describe Shell do
     end
 
     it "creates a help banner with the command descriptions" do
-      expect(@chef_object.help_banner).to match(/^\|\ Command[\s]+\|\ Description[\s]*$/)
-      expect(@chef_object.help_banner).to match(/^\|\ rspec_method[\s]+\|\ rspecin\'[\s]*$/)
+      expect(@chef_object.help_banner).to match(/^\|\ Command\s+\|\ Description\s*$/)
+      expect(@chef_object.help_banner).to match(/^\|\ rspec_method\s+\|\ rspecin\'\s*$/)
     end
   end
 


### PR DESCRIPTION
New RuboCop here. There's no need for character classes when all we have is a single character.

Signed-off-by: Tim Smith <tsmith@chef.io>