### PR TITLE
Add Test Kitchen testing on Ubuntu 20.10

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -436,6 +436,21 @@ steps:
         privileged: true
         single-use: true
 
+- label: "Kitchen: Ubuntu 20.10"
+  commands:
+    - scripts/bk_tests/bk_linux_exec.sh
+    - cd kitchen-tests
+    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-2010
+  artifact_paths:
+    - $PWD/.kitchen/logs/kitchen.log
+  env:
+      KITCHEN_YAML: kitchen.yml
+  expeditor:
+    executor:
+      linux:
+        privileged: true
+        single-use: true
+
 - label: "Kitchen: Debian 9"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -136,6 +136,14 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
 
+- name: ubuntu-20.10
+  driver:
+    image: dokken/ubuntu-20.10
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
+
 - name: opensuse-leap-15
   driver:
     image: dokken/opensuse-leap-15


### PR DESCRIPTION
We can bump this up to the latest non-LTS release every 6 months to
determine if there's any resource updates we need to make in advance of
the LTS release.

Signed-off-by: Tim Smith <tsmith@chef.io>