### PR TITLE
ifconfig is not compatible with Fedora 33 or later

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_ifconfig.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_ifconfig.rb
@@ -1,3 +1,5 @@
+return if fedora? && node["platform_version"] >= "33" # ifconfig does not support the new network manager keyfile format
+
 execute "create virtual interface for testing" do
   command "ifconfig eth0:0 123.123.22.22"
 end

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -26,7 +26,7 @@ class Chef
 
       provides :ifconfig
 
-      description "Use the **ifconfig** resource to manage interfaces on Unix and Linux systems. Note: This resource requires the ifconfig binary to be present on the system and may require additional packages to be installed first. On Ubuntu 18.04 or later you will need to install the `ifupdown` package, which disables the built in Netplan functionality. This resource will not work with Fedora release 33 or later."
+      description "Use the **ifconfig** resource to manage interfaces on Unix and Linux systems. Note: This resource requires the ifconfig binary to be present on the system and may require additional packages to be installed first. On Ubuntu 18.04 or later you will need to install the `ifupdown` package, which disables the built in Netplan functionality. Warning: This resource will not work with Fedora release 33 or later."
       examples <<~DOC
       **Configure a network interface with a static IP**
 

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -26,7 +26,7 @@ class Chef
 
       provides :ifconfig
 
-      description "Use the **ifconfig** resource to manage interfaces on Unix and Linux systems. Note: This resource requires the ifconfig binary to be present on the system and may require additional packages to be installed first. On Ubuntu 18.04 or later you will need to install the `ifupdown` package, which disables the built in Netplan functionality."
+      description "Use the **ifconfig** resource to manage interfaces on Unix and Linux systems. Note: This resource requires the ifconfig binary to be present on the system and may require additional packages to be installed first. On Ubuntu 18.04 or later you will need to install the `ifupdown` package, which disables the built in Netplan functionality. This resource will not work with Fedora release 33 or later."
       examples <<~DOC
       **Configure a network interface with a static IP**
 


### PR DESCRIPTION
This resource only works with the legacy redhat /etc/networks configuration format. That format was slapped onto NetworkManager when RHEL moved off legacy init scripts. Fedora 33 switches to the keyfile format so this resource no longer works on those systems. Stop testing it there and add a note to the resource description so we get that up on the docs site.

Signed-off-by: Tim Smith <tsmith@chef.io>