### PR TITLE
Avoid calculating self.etc_chef_dir multiple times on startup

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -84,8 +84,10 @@ module ChefConfig
     # @return [String] the platform-specific path
     #
     def self.etc_chef_dir(windows: ChefUtils.windows?)
-      path = windows ? c_chef_dir : PathHelper.join("/etc", ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
-      PathHelper.cleanpath(path, windows: windows)
+      @etc_chef_dir ||= begin
+        path = windows ? c_chef_dir : PathHelper.join("/etc", ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
+        PathHelper.cleanpath(path, windows: windows)
+      end
     end
 
     # On *nix, /var/chef, on Windows C:\chef

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -84,7 +84,8 @@ module ChefConfig
     # @return [String] the platform-specific path
     #
     def self.etc_chef_dir(windows: ChefUtils.windows?)
-      @etc_chef_dir ||= begin
+      @etc_chef_dir ||= {}
+      @etc_chef_dir[windows] ||= begin
         path = windows ? c_chef_dir : PathHelper.join("/etc", ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
         PathHelper.cleanpath(path, windows: windows)
       end


### PR DESCRIPTION
Running chef-apply we calculated this value 5 times. We also have several other resources that use this method which would again have to be calculated. Each of those calculations run the PathHelper.join which involves a whole series of terrible string manipulations. Just calculate this once and be done with it.

Signed-off-by: Tim Smith <tsmith@chef.io>