### PR TITLE
Mount resources not idempotent with label fixes

### DIFF
--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -121,9 +121,12 @@ class Chef
       # It's entirely plausible that a site might prefer UUIDs or labels, so
       # we need to be able to update fstab to conform with their wishes
       # without necessarily needing to remount the device.
-      # See #6851 for more.
+      # See #6851 for more. 
+      # We have to compare current resource device with device_fstab value 
+      # because entry in /etc/fstab will be as per device_type.
+      # For Ex: 'LABEL=/tmp/ /mnt ext3 defaults,nofail 0 2', where 'device_type' is :label.
       def device_unchanged?
-        @current_resource.device == @new_resource.device
+        @current_resource.device == device_fstab
       end
 
       #
@@ -167,6 +170,18 @@ class Chef
           end
 
           sleep 0.1
+        end
+      end
+
+      # Retruns the new_resource device as per device_type
+      def device_fstab
+        case @new_resource.device_type
+        when :device
+          @new_resource.device
+        when :label
+          "LABEL=#{@new_resource.device}"
+        when :uuid
+          "UUID=#{@new_resource.device}"
         end
       end
     end

--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -121,10 +121,10 @@ class Chef
       # It's entirely plausible that a site might prefer UUIDs or labels, so
       # we need to be able to update fstab to conform with their wishes
       # without necessarily needing to remount the device.
-      # See #6851 for more. 
-      # We have to compare current resource device with device_fstab value 
+      # See #6851 for more.
+      # We have to compare current resource device with device_fstab value
       # because entry in /etc/fstab will be as per device_type.
-      # For Ex: 'LABEL=/tmp/ /mnt ext3 defaults,nofail 0 2', where 'device_type' is :label.
+      # For Ex: 'LABEL=/tmp/ /mnt ext3 defaults 0 2', where 'device_type' is :label.
       def device_unchanged?
         @current_resource.device == device_fstab
       end
@@ -173,7 +173,7 @@ class Chef
         end
       end
 
-      # Retruns the new_resource device as per device_type
+      # Returns the new_resource device as per device_type
       def device_fstab
         case @new_resource.device_type
         when :device

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -212,17 +212,6 @@ class Chef
 
         private
 
-        def device_fstab
-          case @new_resource.device_type
-          when :device
-            @new_resource.device
-          when :label
-            "LABEL=#{@new_resource.device}"
-          when :uuid
-            "UUID=#{@new_resource.device}"
-          end
-        end
-
         def device_real
           if @real_device.nil?
             if @new_resource.device_type == :device

--- a/spec/unit/provider/mount_spec.rb
+++ b/spec/unit/provider/mount_spec.rb
@@ -151,6 +151,24 @@ describe Chef::Provider::Mount do
       provider.run_action(:enable)
       expect(new_resource).not_to be_updated_by_last_action
     end
+
+    it "should enable the mount if device changed" do
+      allow(current_resource).to receive(:enabled).and_return(true)
+      expect(provider).to receive(:mount_options_unchanged?).and_return(true)
+      expect(provider).to receive(:device_unchanged?).and_return(false)
+      expect(provider).to receive(:enable_fs).and_return(true)
+      provider.run_action(:enable)
+      expect(new_resource).to be_updated_by_last_action
+    end
+
+    it "should not enable the mount if device not changed" do
+      allow(current_resource).to receive(:enabled).and_return(true)
+      expect(provider).to receive(:mount_options_unchanged?).and_return(true)
+      expect(provider).to receive(:device_unchanged?).and_return(true)
+      expect(provider).not_to receive(:enable_fs)
+      provider.run_action(:enable)
+      expect(new_resource).not_to be_updated_by_last_action
+    end
   end
 
   describe "when the target state is to disable the mount" do
@@ -187,5 +205,17 @@ describe Chef::Provider::Mount do
 
   it "should delegates the disable implementation to subclasses" do
     expect { provider.disable_fs }.to raise_error(Chef::Exceptions::UnsupportedAction)
+  end
+
+  describe "#device_unchanged?" do
+    it "should be true when device_type not changed" do
+      expect(provider.device_unchanged?).to be_truthy
+    end
+
+    it "should be false when device_type changed" do
+      new_resource.device_type :label
+      current_resource.device_type :device
+      expect(provider.device_unchanged?).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

### Fixed mount resource not idempotent with `device_type` property issue

## Description
- Moved `device_fstab` method from `provider/mount/mount.rb` to `provider/mount.rb`
- Compare current resource device with new resource `device_fstab` value.
- Added specs for `device_unchanged?` method changes.

## Related Issue
#8260 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
