### PR TITLE
Remove the provides :package for solaris_package

### DIFF
--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -26,7 +26,6 @@ class Chef
 
         include Chef::Mixin::GetSourceFromPackage
 
-        provides :package, platform: "solaris2", platform_version: "< 5.11"
         provides :solaris_package
 
         # def initialize(*args)

--- a/lib/chef/resource/solaris_package.rb
+++ b/lib/chef/resource/solaris_package.rb
@@ -25,7 +25,6 @@ class Chef
       unified_mode true
 
       provides :solaris_package
-      provides :package, os: "solaris2", platform_family: "solaris2", platform_version: "<= 5.10"
 
       description "Use the **solaris_package** resource to manage packages on the Solaris platform."
 


### PR DESCRIPTION
This only worked on Solaris 5.10, which we don't support anymore. Just
nuke the line entirely

Signed-off-by: Tim Smith <tsmith@chef.io>