### PR TITLE
Remove support for nexentacore and opensolaris which are both a decade EOL

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -43,7 +43,7 @@ Super Families:
 
 * `fedora_based?` - anything of fedora lineage (fedora, redhat, centos, amazon, pidora, etc)
 * `rpm_based?`- all `fedora_based` systems plus `suse` and any future linux distros based on RPM (excluding AIX)
-* `solaris_based?`- all solaris-derived systems (opensolaris, nexentacore, omnios, smartos, etc)
+* `solaris_based?`- all solaris-derived systems (opensolaris, omnios, smartos, etc)
 * `bsd_based?`- all bsd-derived systems (freebsd, netbsd, openbsd, dragonflybsd).
 
 ### Platform Helpers
@@ -64,7 +64,6 @@ The Platform helpers provide an alternative to comparing values from `node['plat
 * `linuxmint_platform?`
 * `macos_platform?`
 * `netbsd_platform?`
-* `nexentacore_platform?`
 * `omnios_platform?`
 * `openbsd_platform?`
 * `openindiana_platform?`
@@ -86,7 +85,6 @@ For compatibility with old chef-sugar code the following aliases work for backwa
 * `centos?`
 * `clearos?`
 * `linuxmint?`
-* `nexentacore?`
 * `omnios?`
 * `openindiana?`
 * `opensolaris?`

--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -43,7 +43,7 @@ Super Families:
 
 * `fedora_based?` - anything of fedora lineage (fedora, redhat, centos, amazon, pidora, etc)
 * `rpm_based?`- all `fedora_based` systems plus `suse` and any future linux distros based on RPM (excluding AIX)
-* `solaris_based?`- all solaris-derived systems (opensolaris, omnios, smartos, etc)
+* `solaris_based?`- all solaris-derived systems (omnios, smartos, openindiana, etc)
 * `bsd_based?`- all bsd-derived systems (freebsd, netbsd, openbsd, dragonflybsd).
 
 ### Platform Helpers
@@ -67,7 +67,6 @@ The Platform helpers provide an alternative to comparing values from `node['plat
 * `omnios_platform?`
 * `openbsd_platform?`
 * `openindiana_platform?`
-* `opensolaris_platform?`
 * `opensuse_platform?`
 * `oracle_platform?`
 * `raspbian_platform?`
@@ -87,7 +86,6 @@ For compatibility with old chef-sugar code the following aliases work for backwa
 * `linuxmint?`
 * `omnios?`
 * `openindiana?`
-* `opensolaris?`
 * `opensuse?`
 * `oracle?`
 * `raspbian?`

--- a/chef-utils/lib/chef-utils/dsl/platform.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform.rb
@@ -235,19 +235,6 @@ module ChefUtils
       # chef-sugar backcompat method
       alias_method :openindiana?, :openindiana_platform?
 
-      # Determine if the current node is Nexenta Core Platform aka Nexenta OS.
-      #
-      # @param [Chef::Node] node the node to check
-      # @since 15.5
-      #
-      # @return [Boolean]
-      #
-      def nexentacore_platform?(node = __getnode)
-        node["platform"] == "nexentacore"
-      end
-      # chef-sugar backcompat method
-      alias_method :nexentacore?, :nexentacore_platform?
-
       # Determine if the current node is AIX.
       #
       # @param [Chef::Node] node the node to check

--- a/chef-utils/lib/chef-utils/dsl/platform_family.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform_family.rb
@@ -320,7 +320,7 @@ module ChefUtils
       # @return [Boolean]
       #
       def solaris_based?(node = __getnode)
-        %w{solaris2 smartos omnios openindiana opensolaris nexentacore}.include?(node["platform"])
+        %w{solaris2 smartos omnios openindiana opensolaris}.include?(node["platform"])
       end
 
       # All of the BSD-lineage.

--- a/chef-utils/lib/chef-utils/dsl/platform_family.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform_family.rb
@@ -320,7 +320,7 @@ module ChefUtils
       # @return [Boolean]
       #
       def solaris_based?(node = __getnode)
-        %w{solaris2 smartos omnios openindiana opensolaris}.include?(node["platform"])
+        %w{solaris2 smartos omnios openindiana}.include?(node["platform"])
       end
 
       # All of the BSD-lineage.

--- a/cspell.json
+++ b/cspell.json
@@ -1064,8 +1064,6 @@
     "newguard",
     "newpkg",
     "newval",
-    "Nexenta",
-    "nexentacore",
     "nillable",
     "Nimisha",
     "nlist",

--- a/lib/chef/provider/package/ips.rb
+++ b/lib/chef/provider/package/ips.rb
@@ -26,7 +26,7 @@ class Chef
     class Package
       class Ips < Chef::Provider::Package
 
-        provides :package, platform: %w{openindiana opensolaris omnios solaris2}
+        provides :package, platform: %w{openindiana omnios solaris2}
         provides :ips_package
 
         attr_accessor :virtual

--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -26,7 +26,6 @@ class Chef
 
         include Chef::Mixin::GetSourceFromPackage
 
-        provides :package, platform: "nexentacore"
         provides :package, platform: "solaris2", platform_version: "< 5.11"
         provides :solaris_package
 

--- a/lib/chef/provider/user/solaris.rb
+++ b/lib/chef/provider/user/solaris.rb
@@ -25,7 +25,7 @@ class Chef
     class User
       class Solaris < Chef::Provider::User
         provides :solaris_user
-        provides :user, os: %w{openindiana opensolaris illumos omnios solaris2 smartos}
+        provides :user, os: %w{openindiana illumos omnios solaris2 smartos}
 
         PASSWORD_FILE = "/etc/shadow".freeze
 

--- a/lib/chef/resource/solaris_package.rb
+++ b/lib/chef/resource/solaris_package.rb
@@ -25,7 +25,6 @@ class Chef
       unified_mode true
 
       provides :solaris_package
-      provides :package, os: "solaris2", platform_family: "nexentacore"
       provides :package, os: "solaris2", platform_family: "solaris2", platform_version: "<= 5.10"
 
       description "Use the **solaris_package** resource to manage packages on the Solaris platform."

--- a/lib/chef/resource/windows_service.rb
+++ b/lib/chef/resource/windows_service.rb
@@ -147,7 +147,6 @@ class Chef
       ```
       DOC
 
-
       allowed_actions :configure_startup, :create, :delete, :configure
 
       property :timeout, Integer,

--- a/spec/functional/resource/cron_spec.rb
+++ b/spec/functional/resource/cron_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::Cron, :requires_root, :unix_only do
   # Platform specific validation routines.
   def cron_should_exists(cron_name, command)
     case ohai[:platform]
-    when "aix", "opensolaris", "solaris2", "omnios"
+    when "aix", "solaris2", "omnios"
       expect(shell_out("crontab -l #{new_resource.user} | grep \"#{cron_name}\"").exitstatus).to eq(0)
       expect(shell_out("crontab -l #{new_resource.user} | grep \"#{cron_name}\"").stdout.lines.to_a.size).to eq(1)
       expect(shell_out("crontab -l #{new_resource.user} | grep \"#{command}\"").exitstatus).to eq(0)
@@ -41,7 +41,7 @@ describe Chef::Resource::Cron, :requires_root, :unix_only do
 
   def cron_should_not_exists(cron_name)
     case ohai[:platform]
-    when "aix", "opensolaris", "solaris2", "omnios"
+    when "aix", "solaris2", "omnios"
       expect(shell_out("crontab -l #{new_resource.user} | grep \"#{cron_name}\"").exitstatus).to eq(1)
       expect(shell_out("crontab -l #{new_resource.user} | grep \"#{new_resource.command}\"").stdout.lines.to_a.size).to eq(0)
     else
@@ -113,7 +113,7 @@ describe Chef::Resource::Cron, :requires_root, :unix_only do
     end
   end
 
-  exclude_solaris = %w{solaris opensolaris solaris2 omnios}.include?(ohai[:platform])
+  exclude_solaris = %w{solaris solaris2 omnios}.include?(ohai[:platform])
   describe "create action with various attributes", external: exclude_solaris do
     def create_and_validate_with_property(resource, attribute, value)
       if ohai[:platform] == "aix"

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -424,7 +424,7 @@ describe Chef::ProviderResolver do
         it_behaves_like "a debian platform using the insserv provider"
       end
 
-      on_platform %w{solaris2 openindiana opensolaris nexentacore omnios smartos}, os: "solaris2", platform_version: "5.11" do
+      on_platform %w{solaris2 openindiana opensolaris omnios smartos}, os: "solaris2", platform_version: "5.11" do
         it "returns a Solaris provider" do
           stub_service_providers
           stub_service_configs
@@ -811,10 +811,6 @@ describe Chef::ProviderResolver do
           },
 
           "solaris2" => {
-            "nexentacore" => {
-              "3.1.4" => {
-              },
-            },
             "omnios" => {
               "3.1.4" => {
                 user: [ Chef::Resource::User::SolarisUser, Chef::Provider::User::Solaris ],

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -424,7 +424,7 @@ describe Chef::ProviderResolver do
         it_behaves_like "a debian platform using the insserv provider"
       end
 
-      on_platform %w{solaris2 openindiana opensolaris omnios smartos}, os: "solaris2", platform_version: "5.11" do
+      on_platform %w{solaris2 openindiana omnios smartos}, os: "solaris2", platform_version: "5.11" do
         it "returns a Solaris provider" do
           stub_service_providers
           stub_service_configs
@@ -817,10 +817,6 @@ describe Chef::ProviderResolver do
               },
             },
             "openindiana" => {
-              "3.1.4" => {
-              },
-            },
-            "opensolaris" => {
               "3.1.4" => {
               },
             },

--- a/spec/unit/resource/solaris_package_spec.rb
+++ b/spec/unit/resource/solaris_package_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Resource::SolarisPackage, "initialize" do
     name: :solaris_package,
     action: :install,
     os: "solaris2",
-    platform_family: solaris2
+    platform_family: "solaris2"
   )
 
   let(:resource) { Chef::Resource::SolarisPackage.new("foo") }

--- a/spec/unit/resource/solaris_package_spec.rb
+++ b/spec/unit/resource/solaris_package_spec.rb
@@ -21,16 +21,14 @@ require "support/shared/unit/resource/static_provider_resolution"
 
 describe Chef::Resource::SolarisPackage, "initialize" do
 
-  %w{solaris2 nexentacore}.each do |platform_family|
-    static_provider_resolution(
-      resource: Chef::Resource::SolarisPackage,
-      provider: Chef::Provider::Package::Solaris,
-      name: :solaris_package,
-      action: :install,
-      os: "solaris2",
-      platform_family: platform_family
-    )
-  end
+  static_provider_resolution(
+    resource: Chef::Resource::SolarisPackage,
+    provider: Chef::Provider::Package::Solaris,
+    name: :solaris_package,
+    action: :install,
+    os: "solaris2",
+    platform_family: solaris2
+  )
 
   let(:resource) { Chef::Resource::SolarisPackage.new("foo") }
 


### PR DESCRIPTION
### Nexenta

https://en.wikipedia.org/wiki/Nexenta_OS

"In late 2011, the Nexenta OS brand was terminated and replaced with Illumian, which is derived from community development for illumos and OpenIndiana, but was distinguished by its use of Debian packaging. Illumian version 1.0 was released in February 2012. Following the initial release of Illumian in 2012, the Illumian project was discontinued.[3]"

and

"Final release	3.1.3.5 (October 31, 2012; 7 years ago)"

### OpenSolaris

https://en.wikipedia.org/wiki/OpenSolaris

"OpenSolaris is a discontinued open source computer operating system based on Solaris and created by Sun Microsystems."

and

Latest release	2009.06 / June 1, 2009; 11 years ago

These are beyond dead and we never supported either of them officially. Just nuke it along with the helpers. There's no way anyone used these.

Signed-off-by: Tim Smith <tsmith@chef.io>