### PR TITLE
Fix download errors during knife bootstrap on windows due to lack of TLS 1.2 support

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -255,6 +255,8 @@ class Chef
                [String] $localPath
             )
 
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
             $ProxyUrl = $env:http_proxy;
             $webClient = new-object System.Net.WebClient;
 

--- a/lib/chef/resource/windows_service.rb
+++ b/lib/chef/resource/windows_service.rb
@@ -147,7 +147,6 @@ class Chef
       ```
       DOC
 
-
       allowed_actions :configure_startup, :create, :delete, :configure
 
       property :timeout, Integer,


### PR DESCRIPTION



<!--- Provide a short summary of your changes in the Title above -->

## Description
Adding tls1.2 support for powershell.

Knife bootstrap on TLS 1.2 enabled servers can fail to bootstrap when downloading using powershell with the error: Could not create SSL/TLS secure channel.

## Related Issue
https://github.com/chef/chef/issues/8713

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
