### PR TITLE
Don't run rspec with documentation formatter.

### DIFF
--- a/habitat/tests/spec.ps1
+++ b/habitat/tests/spec.ps1
@@ -18,7 +18,7 @@ try {
     SETX GEM_PATH $($gemPath.Split("=")[1]) /m
 
     hab pkg binlink --force $PackageIdentifier
-    /hab/bin/rspec --format documentation --tag ~executables --tag ~choco_installed spec/functional
+    /hab/bin/rspec --tag ~executables --tag ~choco_installed spec/functional
     if (-not $?) { throw "functional testing failed"}
 } finally {
     Pop-Location

--- a/habitat/tests/test.sh
+++ b/habitat/tests/test.sh
@@ -34,4 +34,4 @@ for executable in 'chef-client' 'ohai' 'chef-shell' 'chef-apply' 'knife' 'chef-s
 done
 
 echo "--- :mag_right: Testing ${pkg_ident} functionality"
-hab pkg exec "${pkg_ident}" rspec -f documentation --tag ~executables spec/functional || error 'failures during rspec tests'
+hab pkg exec "${pkg_ident}" rspec --tag ~executables spec/functional || error 'failures during rspec tests'


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

This output can be useful occasionally, but more often its just annoying to have to scroll past 10k lines of output to see what the failures are.

Example: https://buildkite.com/chef-oss/chef-chef-master-verify/builds/6766#0278bdf8-27a6-4e40-9e12-d35438b1fdfc