### PR TITLE
Remove rspec_junit_formatter and rspec version pins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,9 +54,7 @@ end
 
 group(:development, :test) do
   gem "rake"
-  gem "rspec-core", "~> 3.5"
-  gem "rspec-mocks", "~> 3.5"
-  gem "rspec-expectations", "~> 3.5"
+  gem "rspec"
   gem "rspec_junit_formatter", "~> 0.2.0"
   gem "webmock"
   gem "fauxhai-ng" # for chef-utils gem

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ end
 group(:development, :test) do
   gem "rake"
   gem "rspec"
-  gem "rspec_junit_formatter", "~> 0.2.0"
   gem "webmock"
   gem "fauxhai-ng" # for chef-utils gem
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,9 +313,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.4)
-    rspec_junit_formatter (0.2.3)
-      builder (< 4)
-      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.93.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
@@ -452,7 +449,6 @@ DEPENDENCIES
   rake
   rb-readline
   rspec
-  rspec_junit_formatter (~> 0.2.0)
   ruby-prof (< 1.3.0)
   ruby-shadow
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,9 +451,7 @@ DEPENDENCIES
   pry-stack_explorer
   rake
   rb-readline
-  rspec-core (~> 3.5)
-  rspec-expectations (~> 3.5)
-  rspec-mocks (~> 3.5)
+  rspec
   rspec_junit_formatter (~> 0.2.0)
   ruby-prof (< 1.3.0)
   ruby-shadow

--- a/chef-config/Gemfile
+++ b/chef-config/Gemfile
@@ -6,5 +6,5 @@ gemspec
 
 group(:development, :test) do
   gem "rake"
-  gem "rspec", "~> 3.2"
+  gem "rspec"
 end

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -114,13 +114,13 @@ $env:Path = $p
 # desktop heap exhaustion seems likely (https://docs.microsoft.com/en-us/archive/blogs/ntdebugging/desktop-heap-overview)
 $exit = 0
 
-bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile -- ./spec/unit
+bundle exec rspec -f progress --profile -- ./spec/unit
 If ($lastexitcode -ne 0) { $exit = 1 }
 
-bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile -- ./spec/functional
+bundle exec rspec -f progress --profile -- ./spec/functional
 If ($lastexitcode -ne 0) { $exit = 1 }
 
-bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile -- ./spec/integration
+bundle exec rspec -f progress --profile -- ./spec/integration
 If ($lastexitcode -ne 0) { $exit = 1 }
 
 Exit $exit

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -151,4 +151,4 @@ export CHEF_LICENSE=accept-no-persist
 
 cd "$chef_gem"
 sudo -E bundle install --jobs=3 --retry=3
-sudo -E bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml --profile -f progress
+sudo -E bundle exec rspec --profile -f progress


### PR DESCRIPTION
This was added a long time ago (https://github.com/chef/chef/commit/87612bf41873efd9c783be7732415c23a171f58d) and exists to write test output in junit format to a file named "test.xml" that does not appear to be consumed by anything.

I figure if this breaks something we'll find out pretty quickly.