### PR TITLE
Avoid a splat operator where we don't need one

### DIFF
--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -29,17 +29,7 @@ class Chef
       extend Forwardable
       provides :launchd, os: "darwin"
 
-      def_delegators :new_resource, *%i{
-        backup
-        cookbook
-        group
-        label
-        mode
-        owner
-        source
-        session_type
-        type
-      }
+      def_delegators :new_resource, :backup, :cookbook, :group, :label, :mode, :owner, :source, :session_type, :type
 
       def load_current_resource
         current_resource = Chef::Resource::Launchd.new(new_resource.name)


### PR DESCRIPTION
Just pass in the symbols

Signed-off-by: Tim Smith <tsmith@chef.io>