### PR TITLE
Fix homebrew_update

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
@@ -73,6 +73,16 @@ launchd "io.chef.testing.fake" do
   action "enable"
 end
 
+homebrew_update "update" do
+  action :update
+end
+
+homebrew_package "vim"
+
+homebrew_package "vim" do
+  action :purge
+end
+
 include_recipe "::_dmg_package"
 include_recipe "::_macos_userdefaults"
 include_recipe "::_ohai_hint"

--- a/lib/chef/resource/homebrew_update.rb
+++ b/lib/chef/resource/homebrew_update.rb
@@ -19,11 +19,14 @@
 #
 
 require_relative "../resource"
+require_relative "../mixin/homebrew_user"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 
 class Chef
   class Resource
     class HomebrewUpdate < Chef::Resource
+      include Chef::Mixin::HomebrewUser
+
       unified_mode true
 
       provides(:homebrew_update) { true }
@@ -79,7 +82,7 @@ class Chef
           execute "brew update" do
             command %w{brew update}
             default_env true
-            user Homebrew.owner
+            user find_homebrew_uid
             notifies :touch, "file[#{BREW_STAMP}]", :immediately
           end
         end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

@johnmccrae noticed that the `homebrew_update` resource would fail with an undefined constant error. This PR adds some basic homebrew usage to the kitchen tests and fixes the bad reference.