### PR TITLE
Namespace ResourceInspector to avoid conflicts with Inspec's

### DIFF
--- a/chef-bin/bin/chef-resource-inspector
+++ b/chef-bin/bin/chef-resource-inspector
@@ -23,4 +23,4 @@ $:.unshift(File.expand_path(File.join(__dir__, "..", "lib")))
 
 require "chef/resource_inspector"
 
-ResourceInspector.start
+Chef::ResourceInspector.start

--- a/lib/chef/resource_inspector.rb
+++ b/lib/chef/resource_inspector.rb
@@ -23,94 +23,96 @@ require_relative "node"
 require_relative "resources"
 require_relative "json_compat"
 
-module ResourceInspector
-  def self.get_default(default)
-    if default.is_a?(Chef::DelayedEvaluator)
-      # ideally we'd get the block we pass to `lazy`, but the best we can do
-      # is to get the source location, which then results in reparsing the source
-      # code for the resource ourselves and just no
-      "lazy default"
-    else
-      default.is_a?(Symbol) ? default.inspect : default # inspect properly returns symbols
+class Chef
+  module ResourceInspector
+    def self.get_default(default)
+      if default.is_a?(Chef::DelayedEvaluator)
+        # ideally we'd get the block we pass to `lazy`, but the best we can do
+        # is to get the source location, which then results in reparsing the source
+        # code for the resource ourselves and just no
+        "lazy default"
+      else
+        default.is_a?(Symbol) ? default.inspect : default # inspect properly returns symbols
+      end
     end
-  end
 
-  def self.extract_resource(resource, complete = false)
-    data = {}
-    data[:description] = resource.description
-    # data[:deprecated] = resource.deprecated || false
-    data[:default_action] = resource.default_action
-    data[:actions] = resource.allowed_actions
-    data[:examples] = resource.examples
-    data[:introduced] = resource.introduced
-    data[:preview] = resource.preview_resource
+    def self.extract_resource(resource, complete = false)
+      data = {}
+      data[:description] = resource.description
+      # data[:deprecated] = resource.deprecated || false
+      data[:default_action] = resource.default_action
+      data[:actions] = resource.allowed_actions
+      data[:examples] = resource.examples
+      data[:introduced] = resource.introduced
+      data[:preview] = resource.preview_resource
 
-    properties = unless complete
-                   resource.properties.reject { |_, k| k.options[:declared_in] == Chef::Resource || k.options[:skip_docs] }
-                 else
-                   resource.properties.reject { |_, k| k.options[:skip_docs] }
-                 end
+      properties = unless complete
+                     resource.properties.reject { |_, k| k.options[:declared_in] == Chef::Resource || k.options[:skip_docs] }
+                   else
+                     resource.properties.reject { |_, k| k.options[:skip_docs] }
+                   end
 
-    data[:properties] = properties.each_with_object([]) do |(n, k), acc|
-      opts = k.options
-      acc << { name: n, description: opts[:description],
-               introduced: opts[:introduced], is: opts[:is],
-               deprecated: opts[:deprecated] || false,
-               required: opts[:required] || false,
-               default: opts[:default_description] || get_default(opts[:default]),
-               name_property: opts[:name_property] || false,
-               equal_to: sort_equal_to(opts[:equal_to]) }
+      data[:properties] = properties.each_with_object([]) do |(n, k), acc|
+        opts = k.options
+        acc << { name: n, description: opts[:description],
+                 introduced: opts[:introduced], is: opts[:is],
+                 deprecated: opts[:deprecated] || false,
+                 required: opts[:required] || false,
+                 default: opts[:default_description] || get_default(opts[:default]),
+                 name_property: opts[:name_property] || false,
+                 equal_to: sort_equal_to(opts[:equal_to]) }
+      end
+      data
     end
-    data
-  end
 
-  def self.sort_equal_to(equal_to)
-    Array(equal_to).sort.map(&:inspect)
-  rescue ArgumentError
-    Array(equal_to).map(&:inspect)
-  end
-
-  def self.extract_cookbook(path, complete)
-    path = File.expand_path(path)
-    dir, name = File.split(path)
-    Chef::Cookbook::FileVendor.fetch_from_disk(path)
-    loader = Chef::CookbookLoader.new(dir)
-    cookbook = loader.load_cookbook(name)
-    resources = cookbook.files_for(:resources)
-
-    resources.each_with_object({}) do |r, res|
-      pth = r["full_path"]
-      cur = Chef::Resource::LWRPBase.build_from_file(name, pth, Chef::RunContext.new(Chef::Node.new, nil, nil))
-      res[cur.resource_name] = extract_resource(cur, complete)
+    def self.sort_equal_to(equal_to)
+      Array(equal_to).sort.map(&:inspect)
+    rescue ArgumentError
+      Array(equal_to).map(&:inspect)
     end
-  end
 
-  # If we're given no resources, dump all of Chef's built ins
-  # otherwise, if we have a path then extract all the resources from the cookbook
-  # or else do a list of built in resources
-  #
-  # @param arguments [Array, String] One of more paths to a cookbook or a resource file to inspect
-  # @param complete [TrueClass, FalseClass] Whether to show properties defined in the base Resource class
-  # @return [String] JSON formatting of all resources
-  def self.inspect(arguments = [], complete: false)
-    output = if arguments.empty?
-               ObjectSpace.each_object(Class).select { |k| k < Chef::Resource }.each_with_object({}) { |klass, acc| acc[klass.resource_name] = extract_resource(klass) }
-             else
-               Array(arguments).each_with_object({}) do |arg, acc|
-                 if File.directory?(arg)
-                   extract_cookbook(arg, complete).each { |k, v| acc[k] = v }
-                 else
-                   r = Chef::ResourceResolver.resolve(arg.to_sym)
-                   acc[r.resource_name] = extract_resource(r, complete)
+    def self.extract_cookbook(path, complete)
+      path = File.expand_path(path)
+      dir, name = File.split(path)
+      Chef::Cookbook::FileVendor.fetch_from_disk(path)
+      loader = Chef::CookbookLoader.new(dir)
+      cookbook = loader.load_cookbook(name)
+      resources = cookbook.files_for(:resources)
+
+      resources.each_with_object({}) do |r, res|
+        pth = r["full_path"]
+        cur = Chef::Resource::LWRPBase.build_from_file(name, pth, Chef::RunContext.new(Chef::Node.new, nil, nil))
+        res[cur.resource_name] = extract_resource(cur, complete)
+      end
+    end
+
+    # If we're given no resources, dump all of Chef's built ins
+    # otherwise, if we have a path then extract all the resources from the cookbook
+    # or else do a list of built in resources
+    #
+    # @param arguments [Array, String] One of more paths to a cookbook or a resource file to inspect
+    # @param complete [TrueClass, FalseClass] Whether to show properties defined in the base Resource class
+    # @return [String] JSON formatting of all resources
+    def self.inspect(arguments = [], complete: false)
+      output = if arguments.empty?
+                 ObjectSpace.each_object(Class).select { |k| k < Chef::Resource }.each_with_object({}) { |klass, acc| acc[klass.resource_name] = extract_resource(klass) }
+               else
+                 Array(arguments).each_with_object({}) do |arg, acc|
+                   if File.directory?(arg)
+                     extract_cookbook(arg, complete).each { |k, v| acc[k] = v }
+                   else
+                     r = Chef::ResourceResolver.resolve(arg.to_sym)
+                     acc[r.resource_name] = extract_resource(r, complete)
+                   end
                  end
                end
-             end
 
-    Chef::JSONCompat.to_json_pretty(output)
+      Chef::JSONCompat.to_json_pretty(output)
+    end
+
+    def self.start
+      puts inspect(ARGV, complete: true)
+    end
+
   end
-
-  def self.start
-    puts inspect(ARGV, complete: true)
-  end
-
 end

--- a/spec/unit/resource_inspector_spec.rb
+++ b/spec/unit/resource_inspector_spec.rb
@@ -33,9 +33,9 @@ class DummyResource < Chef::Resource
   end
 end
 
-describe ResourceInspector do
+describe Chef::ResourceInspector do
   describe "inspecting a resource" do
-    subject { ResourceInspector.extract_resource(DummyResource, false) }
+    subject { Chef::ResourceInspector.extract_resource(DummyResource, false) }
 
     it "returns a hash with required data" do
       expect(subject[:description]).to eq "A dummy resource"
@@ -50,7 +50,7 @@ describe ResourceInspector do
     end
 
     context "including built in properties" do
-      subject { ResourceInspector.extract_resource(DummyResource, true) }
+      subject { Chef::ResourceInspector.extract_resource(DummyResource, true) }
       it "returns many properties" do
         expect(subject[:properties].count).to be > 1
         expect(subject[:properties].map { |n| n[:name] }).to include(:name, :first, :sensitive)

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -294,7 +294,7 @@ namespace :docs_site do
     end
 
     FileUtils.mkdir_p "docs_site"
-    resources = Chef::JSONCompat.parse(ResourceInspector.inspect)
+    resources = Chef::JSONCompat.parse(Chef::ResourceInspector.inspect)
 
     resources.each do |resource, data|
       # skip some resources we don't directly document


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

On #10547 I was seeing errors like this on CI:

```
An error occurred while loading ./spec/unit/resource_inspector_spec.rb.
Failure/Error: module ResourceInspector
 
TypeError:
  ResourceInspector is not a module
# ./lib/chef/resource_inspector.rb:26:in `<top (required)>'
# ./spec/unit/resource_inspector_spec.rb:18:in `require'
# ./spec/unit/resource_inspector_spec.rb:18:in `<top (required)>'
Run options:
  include {:focus=>true}
  exclude {:provider=>#<Proc:./spec/spec_helper.rb:213>, :arch=>#<Proc:./spec/spec_helper.rb:207>, :pwsh_installed=>true, :choco_installed=>true, :ruby=>"2.6.6", :chef=>"16.7.20", :not_intel_64bit=>true, :rhel_gte_8=>true, :rhel8=>true, :rhel7=>true, :rhel6=>true, :rhel=>true, :not_wpar=>true, :broken=>true, :openssl_lt_101=>true, :requires_unprivileged_user=>true, :selinux_only=>true, :opensuse=>true, :suse_only=>true, :aix_only=>true, :system_windows_service_gem_only=>true, :solaris_only=>true, :windows_service_requires_assign_token=>true, :windows_domain_joined_only=>true, :windows_powershell_dsc_only=>true, :ruby32_only=>true, :windows_gte_10=>true, :windows32_only=>true, :windows64_only=>true, :win2012r2_only=>true, :macos_gte_1014=>true, :macos_1013=>true, :macos_only=>true, :windows_only=>true, :skip_buildkite=>true, :volatile_from_verify=>false, :volatile=>true, :external=>true}
 
All examples were filtered out; ignoring {:focus=>true}
 
Top 0 slowest examples (0 seconds, 0.0% of total time):
 
Finished in 0.00006 seconds (files took 4.27 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
 
🚨 Error: The command exited with status 1
```

It turns out inspec also defines a ResourceInspector:
https://github.com/inspec/inspec/blob/9f2b621f9bbcecb029c5e64290cc2704e029caf0/lib/inspec/rspec_extensions.rb#L118