### PR TITLE
Remove the tempfile closing during fetch

### DIFF
--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -73,7 +73,6 @@ class Chef
           end
           if tempfile
             update_cache_control_data(tempfile, http.last_response)
-            tempfile.close
           else
             # cache_control shows the file is unchanged, so we got back nil from the streaming_request above, and it is
             # now our responsibility to unlink the tempfile we created


### PR DESCRIPTION
Signed-off-by: thechosenone124 <thechosenone124@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Fetch refers to chef::http.streaming_request which on line 182. This function sets the tempfile to 

stream_to_tempfile(url, http_response, tempfile, &progress_block)

On line 546 stream_to_tempfile closes the file. This means that the fetch function attempts to close the file a second time, causing an IOError

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
