### PR TITLE
Use .compact instead of .select/.reject to remove nils

### DIFF
--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -451,7 +451,7 @@ class Chef
       attr_reader :wrapped_errors
 
       def initialize(*errors)
-        errors = errors.select { |e| !e.nil? }
+        errors = errors.compact
         output = "Found #{errors.size} errors, they are stored in the backtrace"
         @wrapped_errors = errors
         super output

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -79,7 +79,7 @@ class Chef
           name_versions_to_install = desired_name_versions.select { |n, v| lowercase_names(names).include?(n) }
 
           name_nil_versions = name_versions_to_install.select { |n, v| v.nil? }
-          name_has_versions = name_versions_to_install.reject { |n, v| v.nil? }
+          name_has_versions = name_versions_to_install.compact
 
           # choco does not support installing multiple packages with version pins
           name_has_versions.each do |name, version|
@@ -101,7 +101,7 @@ class Chef
           name_versions_to_install = desired_name_versions.select { |n, v| lowercase_names(names).include?(n) }
 
           name_nil_versions = name_versions_to_install.select { |n, v| v.nil? }
-          name_has_versions = name_versions_to_install.reject { |n, v| v.nil? }
+          name_has_versions = name_versions_to_install.compact
 
           # choco does not support installing multiple packages with version pins
           name_has_versions.each do |name, version|


### PR DESCRIPTION
This is 3-5x faster from the benchmarks I've run locally. There's a cop
coming in the next release of RuboCop to enforce this going forward.

Signed-off-by: Tim Smith <tsmith@chef.io>