### PR TITLE
chef_client_config: Resolve invalid configuration in client.rb

### DIFF
--- a/kitchen-tests/test/integration/end-to-end/_chef_client_config.rb
+++ b/kitchen-tests/test/integration/end-to-end/_chef_client_config.rb
@@ -5,7 +5,7 @@ client_rb = if os.windows?
             end
 
 describe file(client_rb) do
-  its("content") { should match(%r{chef_server_url = "https://localhost"}) }
-  its("content") { should match(/chef_license = "accept"/) }
+  its("content") { should match(%r{chef_server_url "https://localhost"}) }
+  its("content") { should match(/chef_license "accept"/) }
   its("content") { should match(/require 'aws-sdk'/) }
 end

--- a/lib/chef/resource/support/client.erb
+++ b/lib/chef/resource/support/client.erb
@@ -20,12 +20,12 @@
       @policy_group
       @policy_name
       @ssl_verify_mode).each do |prop| -%>
-<% next if instance_variable_get(prop).nil? || instance_variable_get(prop).empty? -%>
+<% next if instance_variable_get(prop).nil? || instance_variable_get(prop).empty? || prop == '@log_location' -%>
 <%=prop.delete_prefix("@") %> <%= instance_variable_get(prop).inspect %>
 <% end -%>
 <%# log_location is special due to STDOUT/STDERR from String -> IO Object -%>
 <% unless @log_location.nil? %>
-  <% if @log_location.is_a? String && %w(STDOUT STDERR).include?(@log_location) -%>
+  <% if (@log_location.is_a? String) && (%w(STDOUT STDERR).include?(@log_location)) -%>
 log_location <%= @log_location %>
   <% else -%>
 log_location <%= @log_location.inspect %>

--- a/lib/chef/resource/support/client.erb
+++ b/lib/chef/resource/support/client.erb
@@ -10,7 +10,6 @@
       @https_proxy
       @ftp_proxy
       @log_level
-      @log_location
       @minimal_ohai
       @named_run_list
       @no_proxy
@@ -20,12 +19,12 @@
       @policy_group
       @policy_name
       @ssl_verify_mode).each do |prop| -%>
-<% next if instance_variable_get(prop).nil? || instance_variable_get(prop).empty? || prop == '@log_location' -%>
+<% next if instance_variable_get(prop).nil? || instance_variable_get(prop).empty? -%>
 <%=prop.delete_prefix("@") %> <%= instance_variable_get(prop).inspect %>
 <% end -%>
 <%# log_location is special due to STDOUT/STDERR from String -> IO Object -%>
 <% unless @log_location.nil? %>
-  <% if (@log_location.is_a? String) && (%w(STDOUT STDERR).include?(@log_location)) -%>
+  <% if @log_location.is_a?(String) && %w(STDOUT STDERR).include?(@log_location) -%>
 log_location <%= @log_location %>
   <% else -%>
 log_location <%= @log_location.inspect %>

--- a/lib/chef/resource/support/client.erb
+++ b/lib/chef/resource/support/client.erb
@@ -21,14 +21,14 @@
       @policy_name
       @ssl_verify_mode).each do |prop| -%>
 <% next if instance_variable_get(prop).nil? || instance_variable_get(prop).empty? -%>
-<%=prop.delete_prefix("@") %> = <%= instance_variable_get(prop).inspect %>
+<%=prop.delete_prefix("@") %> <%= instance_variable_get(prop).inspect %>
 <% end -%>
 <%# log_location is special due to STDOUT/STDERR from String -> IO Object -%>
 <% unless @log_location.nil? %>
   <% if @log_location.is_a? String && %w(STDOUT STDERR).include?(@log_location) -%>
-log_location = <%= @log_location %>
+log_location <%= @log_location %>
   <% else -%>
-log_location = <%= @log_location.inspect %>
+log_location <%= @log_location.inspect %>
   <% end -%>
 <% end -%>
 <%# The code below is not DRY on purpose to improve readability -%>


### PR DESCRIPTION
## Description

Address two issues in the chef_client_config resource. It removes unneeded `=` signs and fixes logic for log_location

## Related Issue
#10606 
#10607 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
