### PR TITLE
Don't uses regexes in splits when we don't need to

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -330,7 +330,7 @@ class Chef
         long: "--bootstrap-vault-item VAULT_ITEM",
         description: 'A single vault and item to update as "vault:item".',
         proc: Proc.new { |i, accumulator|
-          (vault, item) = i.split(/:/)
+          (vault, item) = i.split(":")
           accumulator ||= {}
           accumulator[vault] ||= []
           accumulator[vault].push(item)

--- a/lib/chef/knife/config_show.rb
+++ b/lib/chef/knife/config_show.rb
@@ -79,7 +79,7 @@ class Chef
               end
             else
               # It's a dotted path string.
-              filter_parts = filter.split(/\./)
+              filter_parts = filter.split(".")
               extract = lambda do |memo, filter_part|
                 memo.is_a?(Hash) ? memo[filter_part.to_sym] : nil
               end

--- a/lib/chef/provider/package/freebsd/pkgng.rb
+++ b/lib/chef/provider/package/freebsd/pkgng.rb
@@ -62,7 +62,7 @@ class Chef
             end
 
             pkg_query = shell_out!("pkg", "rquery", options, "%v", new_resource.package_name, env: nil)
-            pkg_query.exitstatus == 0 ? pkg_query.stdout.strip.split(/\n/).last : nil
+            pkg_query.exitstatus == 0 ? pkg_query.stdout.strip.split('\n').last : nil
           end
 
           def repo_regex

--- a/spec/unit/provider/mount/solaris_spec.rb
+++ b/spec/unit/provider/mount/solaris_spec.rb
@@ -544,7 +544,7 @@ describe Chef::Provider::Mount::Solaris, :unix_only do
 
       it "should mount the filesystem with options if options were passed" do
         options = "logging,noatime,largefiles,nosuid,rw,quota"
-        new_resource.options(options.split(/,/))
+        new_resource.options(options.split(","))
         expect(provider).to receive(:shell_out_compacted!).with("mount", "-F", fstype, "-o", options, device, mountpoint)
         provider.mount_fs
       end


### PR DESCRIPTION
We can do this with strings alone

Signed-off-by: Tim Smith <tsmith@chef.io>