### PR TITLE
Use the full path to the which helper to avoid conflicts with chef-sugar

### DIFF
--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -43,7 +43,7 @@ class Chef
 
         # amazon will eventually use DNF
         provides :package, platform: "amazon" do
-          which("dnf")
+          Chef::Mixin::Which.which("dnf")
         end
 
         provides :dnf_package

--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -42,7 +42,7 @@ class Chef
           def dnf_command
             # platform-python is used for system tools on RHEL 8 and is installed under /usr/libexec
             @dnf_command ||= begin
-              cmd = which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
+              cmd = Chef::Mixin::Which.which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
                 shell_out("#{f} -c 'import dnf'").exitstatus == 0
               end
               raise Chef::Exceptions::Package, "cannot find dnf libraries, you may need to use yum_package" unless cmd

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -437,7 +437,7 @@ class Chef
         end
 
         def find_gem_by_path
-          which("gem", extra_path: RbConfig::CONFIG["bindir"])
+          Chef::Mixin::Which.which("gem", extra_path: RbConfig::CONFIG["bindir"])
         end
 
         def gem_dependency

--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -41,7 +41,7 @@ class Chef
 
           def yum_command
             @yum_command ||= begin
-              cmd = which("platform-python", "python", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
+              cmd = Chef::Mixin::Which.which("platform-python", "python", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
                 shell_out("#{f} -c 'import yum'").exitstatus == 0
               end
               raise Chef::Exceptions::Package, "cannot find yum libraries, you may need to use dnf_package" unless cmd

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -198,7 +198,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def systemctl_path
     if @systemctl_path.nil?
-      @systemctl_path = which("systemctl")
+      @systemctl_path = Chef::Mixin::Which.which("systemctl")
     end
     @systemctl_path
   end

--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -259,7 +259,7 @@ class Chef
       end
 
       def systemctl_path
-        @systemctl_path ||= which("systemctl")
+        @systemctl_path ||= Chef::Mixin::Which.which("systemctl")
       end
 
       def systemctl_args

--- a/lib/chef/resource/chef_client_cron.rb
+++ b/lib/chef/resource/chef_client_cron.rb
@@ -196,7 +196,7 @@ class Chef
         def client_command
           cmd = ""
           cmd << "/bin/sleep #{splay_sleep_time(new_resource.splay)}; "
-          cmd << "#{which("nice")} -n #{new_resource.nice} " if new_resource.nice
+          cmd << "#{Chef::Mixin::Which.which("nice")} -n #{new_resource.nice} " if new_resource.nice
           cmd << "#{new_resource.chef_binary_path} "
           cmd << "#{new_resource.daemon_options.join(" ")} " unless new_resource.daemon_options.empty?
           cmd << "-c #{::File.join(new_resource.config_directory, "client.rb")} "

--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -37,7 +37,7 @@ class Chef
 
       # amazon will eventually use DNF
       provides :package, platform: "amazon" do
-        which("dnf")
+        Chef::Mixin::Which.which("dnf")
       end
 
       description "Use the **dnf_package** resource to install, upgrade, and remove packages with DNF for Fedora and RHEL 8+. The dnf_package resource is able to resolve provides data for packages much like DNF can do when it is run from the command line. This allows a variety of options for installing packages, like minimum versions, virtual provides and library names."

--- a/lib/chef/resource/file/verification/systemd_unit.rb
+++ b/lib/chef/resource/file/verification/systemd_unit.rb
@@ -59,7 +59,7 @@ class Chef
           end
 
           def systemd_analyze_path
-            @systemd_analyze_path ||= which("systemd-analyze")
+            @systemd_analyze_path ||= Chef::Mixin::Which.Chef::Mixin::Which.which("systemd-analyze")
           end
         end
       end

--- a/lib/chef/util/selinux.rb
+++ b/lib/chef/util/selinux.rb
@@ -61,12 +61,12 @@ class Chef
       private
 
       def restorecon_path
-        @@restorecon_path = which("restorecon") if @@restorecon_path.nil?
+        @@restorecon_path = Chef::Mixin::Which.which("restorecon") if @@restorecon_path.nil?
         @@restorecon_path
       end
 
       def selinuxenabled_path
-        @@selinuxenabled_path = which("selinuxenabled") if @@selinuxenabled_path.nil?
+        @@selinuxenabled_path = Chef::Mixin::Which.which("selinuxenabled") if @@selinuxenabled_path.nil?
         @@selinuxenabled_path
       end
 

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -382,7 +382,7 @@ shared_examples_for "a configured file resource" do
   include Chef::Mixin::ShellOut
 
   def selinux_security_context_restored?(path)
-    @restorecon_path = which("restorecon") if @restorecon_path.nil?
+    @restorecon_path = Chef::Mixin::Which.which("restorecon") if @restorecon_path.nil?
     restorecon_test_command = "#{@restorecon_path} -n -v #{path}"
     cmdresult = shell_out!(restorecon_test_command)
     # restorecon will print the required changes to stdout if any is


### PR DESCRIPTION
When uses are migrating from legacy chef-client releases with chef-sugar to Chef Infra Client 16+ they need to continue using chef-sugar in their runlists for some time period. We want to make sure that we don't break in those upgrade scenarios. Using the complete path to our which helper makes sure that we get that helper instead of the one from chef-sugar which injects itself into the recipe dsl.

Signed-off-by: Tim Smith <tsmith@chef.io>