### PR TITLE
Change how zypper_package calculates the candidate_version

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -443,6 +443,9 @@ class Chef
                   elsif current_version && !allow_downgrade && version_compare(current_version, new_version) == 1
                     logger.warn("#{new_resource} #{package_name} has installed version #{current_version}, which is newer than available version #{new_version}. Skipping...)")
                     target_version_array.push(nil)
+                  elsif version_equals?(current_version, candidate_version)
+                    logger.trace("#{new_resource} #{package_name} #{candidate_version} is already installed")
+                    target_version_array.push(nil)
                   else
                     logger.trace("#{new_resource} #{package_name} #{current_version} needs updating to #{new_version}")
                     target_version_array.push(new_version)

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -102,6 +102,7 @@ class Chef
             if md = line.match(/^(\S*)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(.*)$/)
               (status, name, type, version, arch, repo) = [ md[1], md[2], md[3], md[4], md[5], md[6] ]
               next if version == "Version" # header
+
               return version
             end
           end
@@ -121,7 +122,7 @@ class Chef
         end
 
         def zip(names, versions)
-          ret = names.zip(versions).map do |n, v|
+          names.zip(versions).map do |n, v|
             (v.nil? || v.empty?) ? n : "#{n}=#{v}"
           end.compact
         end

--- a/spec/functional/resource/zypper_package_spec.rb
+++ b/spec/functional/resource/zypper_package_spec.rb
@@ -96,6 +96,15 @@ describe Chef::Resource::ZypperPackage, :requires_root, :suse_only do
       expect(zypper_package.updated_by_last_action?).to be false
       expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
     end
+
+    it "multipackage" do
+      preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+      zypper_package.package_name(["chef_rpm", "chef_rpm"])
+      zypper_package.version(["1.2", "1.10"])
+      zypper_package.run_action(:install)
+      expect(zypper_package.updated_by_last_action?).to be true
+      expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+    end
   end
 
   context "with versions" do

--- a/spec/functional/resource/zypper_package_spec.rb
+++ b/spec/functional/resource/zypper_package_spec.rb
@@ -97,9 +97,11 @@ describe Chef::Resource::ZypperPackage, :requires_root, :suse_only do
       expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
     end
 
-    it "multipackage" do
+    it "multipackage installs which result in nils from the superclass" do
+      # this looks weird, it tests an internal condition of the allow_nils behavior where the arrays passed to install_package will have
+      # nil values, and ensures that doesn't wind up creating weirdness in the resulting shell_out that causes it to fail
       preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-      zypper_package.package_name(["chef_rpm", "chef_rpm"])
+      zypper_package.package_name(%w{chef_rpm chef_rpm})
       zypper_package.version(["1.2", "1.10"])
       zypper_package.run_action(:install)
       expect(zypper_package.updated_by_last_action?).to be true

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -96,31 +96,6 @@ describe Chef::Provider::Package::Zypper do
       provider.load_current_resource
     end
 
-    it "should set the candidate version if zypper info has one (zypper version < 1.13.0)" do
-      status = double(stdout: "Version: 1.0\nInstalled: No\nStatus: out-of-date (version 0.9 installed)", exitstatus: 0)
-
-      allow(provider).to receive(:shell_out_compacted!).and_return(status)
-      provider.load_current_resource
-      expect(provider.candidate_version).to eql(["1.0"])
-    end
-
-    it "should set the candidate version if zypper info has one (zypper version >= 1.13.0)" do
-      status = double(stdout: "Version        : 1.0                             \nInstalled      : No                              \nStatus         : out-of-date (version 0.9 installed)", exitstatus: 0)
-
-      allow(provider).to receive(:shell_out_compacted!).and_return(status)
-      provider.load_current_resource
-      expect(provider.candidate_version).to eql(["1.0"])
-    end
-
-    it "should have differing current and candidate versions if zypper detects an upgrade" do
-      status = double(stdout: "Version        : 1.0                             \nInstalled      : Yes                              \nStatus         : out-of-date (version 0.9 installed)", exitstatus: 0)
-
-      allow(provider).to receive(:shell_out_compacted!).and_return(status)
-      provider.load_current_resource
-      expect(provider.get_current_versions).to eq(["0.9"])
-      expect(provider.get_candidate_versions).to eq(["1.0"])
-    end
-
     it "should return the current resouce" do
       expect(provider.load_current_resource).to eql(current_resource)
     end

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -517,8 +517,8 @@ describe "Chef::Provider::Package - Multi" do
     end
 
     it "installs the specified version when some are out of date" do
-      current_resource.version(["1.0", "6.2"])
-      new_resource.version(["1.0", "6.3"])
+      current_resource.version(["1.0", "6.1"])
+      new_resource.version(["1.0", "6.2"])
       provider.run_action(:install)
       expect(new_resource).to be_updated
     end


### PR DESCRIPTION
Previously the candidate_version in zypper_package was only ever the latest version, even if the new_resource.version was attempting to pin to a prior version or do a downgrade.  This changes how the candidate_version is calculated in order to fix that.  This allows the additional idempotency check in here which is a requirement for fixing dnf_package and which broke the old version of zypper_package.  There's also an old unit test that was always slightly broken and having the wrong candidate_version for the requested new_resource.version which needed fixing.  Some conversion to the overall style of the yum+dnf package providers was done so that it will be easier to extend the functionality of the zypper package provider in the future to handle whatever aliases/virtual packages and other features it might grow in the future.
