### PR TITLE
mount: changes to fix solaris test failure

### DIFF
--- a/spec/unit/provider/mount_spec.rb
+++ b/spec/unit/provider/mount_spec.rb
@@ -207,7 +207,8 @@ describe Chef::Provider::Mount do
     expect { provider.disable_fs }.to raise_error(Chef::Exceptions::UnsupportedAction)
   end
 
-  describe "#device_unchanged?" do
+  # Not supported on solaris because it can't cope with a LABEL device type.
+  describe "#device_unchanged?", :not_supported_on_solaris do
     it "should be true when device_type not changed" do
       expect(provider.device_unchanged?).to be_truthy
     end


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
- Added `not_supported_on_solaris` because it can't cope with `LABEL` and `UUID` device type.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/10615
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
