### PR TITLE
Update mixlib-shellout to 3.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,10 +251,11 @@ GEM
     mixlib-config (3.0.9)
       tomlrb
     mixlib-log (3.0.9)
-    mixlib-shellout (3.1.7)
+    mixlib-shellout (3.2.2)
       chef-utils
-    mixlib-shellout (3.1.7-universal-mingw32)
+    mixlib-shellout (3.2.2-universal-mingw32)
       chef-utils
+      ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
     multi_json (1.15.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -226,12 +226,12 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.0)
+    mixlib-shellout (3.2.2)
       chef-utils
-    mixlib-shellout (3.2.0-universal-mingw32)
+    mixlib-shellout (3.2.2-universal-mingw32)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
-      win32-process (~> 0.8.2)
+      win32-process (~> 0.9)
       wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
     molinillo (0.7.0)


### PR DESCRIPTION
This loads the user env when specifying alternative windows users.

Signed-off-by: Tim Smith <tsmith@chef.io>