### PR TITLE
user: Log what changed when updating a user

### DIFF
--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -159,7 +159,7 @@ class Chef
 
         converge_by(["manage group #{new_resource.group_name}"] + change_desc) do
           manage_group
-          logger.info("#{new_resource} managed")
+          logger.info("#{new_resource} managed: #{change_desc.join(", ")}")
         end
       end
 
@@ -168,7 +168,7 @@ class Chef
 
         converge_by(["modify group #{new_resource.group_name}"] + change_desc) do
           manage_group
-          logger.info("#{new_resource} modified")
+          logger.info("#{new_resource} modified: #{change_desc.join(", ")}")
         end
       end
 

--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -221,7 +221,17 @@ class Chef
         end
 
         def compare_user
-          %i{comment shell uid gid salt password admin secure_token hidden}.any? { |m| diverged?(m) }
+          @change_desc = []
+          %i{comment shell uid gid salt password admin secure_token hidden}.each do |attr|
+            if diverged?(m)
+              desc = "Update #{attr}"
+              unless %i{password gid secure_token hidden}.include?(attr)
+                desc << " from #{current_resource.send(attr)} to #{new_resource.send(attr)}"
+              end
+              @change_desc << desc
+            end
+          end
+          !@change_desc.empty?
         end
 
         def manage_user
@@ -290,9 +300,7 @@ class Chef
           end
 
           if diverged?(:hidden)
-            converge_by("alter hidden") do
-              set_hidden
-            end
+            converge_by("alter hidden") { set_hidden }
           end
 
           reload_user_plist

--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -61,13 +61,20 @@ class Chef
         # <true>:: If a change is required
         # <false>:: If the users are identical
         def compare_user
+          @change_desc = []
           unless @net_user.validate_credentials(new_resource.password)
-            logger.trace("#{new_resource} password has changed")
-            return true
+            @change_desc << "update password"
           end
+
           %i{uid comment home shell full_name}.any? do |user_attrib|
-            !new_resource.send(user_attrib).nil? && new_resource.send(user_attrib) != current_resource.send(user_attrib)
+            new_val = new_resource.send(user_attrib)
+            cur_val = current_resource.send(user_attrib)
+            if !new_val.nil? && new_val != cur_val
+              @change_desc << "change #{user_attrib} from #{cur_val} to #{new_val}"
+            end
           end
+
+          !@change_desc.empty?
         end
 
         def create_user

--- a/spec/unit/provider/user_spec.rb
+++ b/spec/unit/provider/user_spec.rb
@@ -259,6 +259,7 @@ describe Chef::Provider::User do
     it "should call manage_user if the user exists and has mismatched properties" do
       @provider.user_exists = true
       allow(@provider).to receive(:compare_user).and_return(true)
+      allow(@provider).to receive(:change_desc).and_return([ ])
       expect(@provider).to receive(:manage_user).and_return(true)
       @provider.action_create
     end
@@ -266,6 +267,7 @@ describe Chef::Provider::User do
     it "should set the new_resources updated flag when it creates the user if we call manage_user" do
       @provider.user_exists = true
       allow(@provider).to receive(:compare_user).and_return(true)
+      allow(@provider).to receive(:change_desc).and_return([ ])
       allow(@provider).to receive(:manage_user).and_return(true)
       @provider.action_create
       @provider.set_updated_status
@@ -315,14 +317,16 @@ describe Chef::Provider::User do
       # @provider.stub(:manage_user).and_return(true)
     end
 
-    it "should run manage_user if the user exists and has mismatched properties" do
+    it "should call manage_user if the user exists and has mismatched properties" do
       expect(@provider).to receive(:compare_user).and_return(true)
+      allow(@provider).to receive(:change_desc).and_return([ ])
       expect(@provider).to receive(:manage_user).and_return(true)
       @provider.action_manage
     end
 
     it "should set the new resources updated flag to true if manage_user is called" do
       allow(@provider).to receive(:compare_user).and_return(true)
+      allow(@provider).to receive(:change_desc).and_return([ ])
       allow(@provider).to receive(:manage_user).and_return(true)
       @provider.action_manage
       @provider.set_updated_status
@@ -360,12 +364,14 @@ describe Chef::Provider::User do
 
     it "should run manage_user if the user exists and has mismatched properties" do
       expect(@provider).to receive(:compare_user).and_return(true)
+      allow(@provider).to receive(:change_desc).and_return([ ])
       expect(@provider).to receive(:manage_user).and_return(true)
       @provider.action_modify
     end
 
     it "should set the new resources updated flag to true if manage_user is called" do
       allow(@provider).to receive(:compare_user).and_return(true)
+      allow(@provider).to receive(:change_desc).and_return([ ])
       allow(@provider).to receive(:manage_user).and_return(true)
       @provider.action_modify
       @provider.set_updated_status


### PR DESCRIPTION
Fixes #10645

Linux:
```
[2020-11-18T12:09:31-08:00] INFO: Processing linux_user[bin] action create (/var/chef/cache/cookbooks/fb_users/resources/default.rb line 118)
[2020-11-18T12:09:32-08:00] INFO: linux_user[bin] altered, change shell from /usr/sbin/phil to /usr/sbin/nologin
```

Windows:
```
[2020-11-18T12:18:02-08:00] INFO: windows_user[john] altered, update password
```

Note this does not fix an ongoing but where no matter waht you set the
password to it always thinks it needs to be updated, likely a bug
somewhere in Chef::Util::Windows::NetUser, and vaguely related to #10455
