### PR TITLE
Use URI::DEFAULT_PARSER.make_regexp instead of URI.regexp

### DIFF
--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -366,7 +366,7 @@ class Chef::Application::Base < Chef::Application
     Chef::Log.trace("Download recipes tarball from #{url} to #{path}")
     if File.exist?(url)
       FileUtils.cp(url, path)
-    elsif URI.regexp.match?(url)
+    elsif URI::DEFAULT_PARSER.make_regexp.match?(url)
       File.open(path, "wb") do |f|
         open(url) do |r|
           f.write(r.read)

--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -285,7 +285,7 @@ class Chef
           # Train.unpack_target_from_uri only works for complete URIs in
           # form of proto://[user[:pass]@]host[:port]/
           # So we'll add the protocol prefix if it's not supplied.
-          uri_to_check = if URI.regexp.match(uri)
+          uri_to_check = if URI::DEFAULT_PARSER.make_regexp.match(uri)
                            uri
                          else
                            "#{default_protocol}://#{uri}"


### PR DESCRIPTION
RuboCop claims that URI.regexp is the obsolete way of doing this. Both produce the same regex.

Signed-off-by: Tim Smith <tsmith@chef.io>