### PR TITLE
Remove macOS 10.13 from the build matrix

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -35,8 +35,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
-  mac_os_x-10.13-x86_64:
-    - mac_os_x-10.13-x86_64
+  mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11.0-x86_64


### PR DESCRIPTION
We support N-2 macOS releases so 10.13 can be dropped now that Big Sur
is out.

Signed-off-by: Tim Smith <tsmith@chef.io>