### PR TITLE
Resolve NameError running mac_user resource

### DIFF
--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -223,7 +223,7 @@ class Chef
         def compare_user
           @change_desc = []
           %i{comment shell uid gid salt password admin secure_token hidden}.each do |attr|
-            if diverged?(m)
+            if diverged?(attr)
               desc = "Update #{attr}"
               unless %i{password gid secure_token hidden}.include?(attr)
                 desc << " from #{current_resource.send(attr)} to #{new_resource.send(attr)}"


### PR DESCRIPTION
The m variable is never defined. This should be attr. The variable was m before, but https://github.com/chef/chef/pull/10656 refactored to attr.

Signed-off-by: Tim Smith <tsmith@chef.io>