### PR TITLE
Update the Docker file to use the RHEL 7 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 ARG CHANNEL=stable
 ARG VERSION=16.7.61
 
-RUN wget "http://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/6/chef-${VERSION}-1.el6.x86_64.rpm" -O /tmp/chef-client.rpm && \
+RUN wget "http://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/7/chef-${VERSION}-1.el7.x86_64.rpm" -O /tmp/chef-client.rpm && \
     rpm2cpio /tmp/chef-client.rpm | cpio -idmv && \
     rm -rf /tmp/chef-client.rpm
 


### PR DESCRIPTION
These are the same package, but in a while we're getting rid of RHEL 6 and this will break.

@ramereth inspired this

Signed-off-by: Tim Smith <tsmith@chef.io>