### PR TITLE
Pin our InSpec version and use Chefstyle from rubygems for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,8 @@ gem "chef-telemetry", ">=1.0.8" # 1.0.8 removes the http dep
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec-core", "~> 4.18"
-  gem "inspec-core-bin", "~> 4.18" # need to provide the binaries for inspec
+  gem "inspec-core", "~> 4.23"
+  gem "inspec-core-bin", "~> 4.23" # need to provide the binaries for inspec
   gem "chef-vault"
 end
 
@@ -58,7 +58,9 @@ end
 
 group(:chefstyle) do
   # for testing new chefstyle rules
-  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  # disabled until we resolve the conflict in regexp_parser deps between rubocop and inspec
+  # gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  gem "chefstyle", "= 1.5.2"
 end
 
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,9 @@
 GIT
-  remote: https://github.com/chef/chefstyle.git
-  revision: 2176e18262ccdaee221be8323dd2b06e04463d2b
-  branch: master
-  specs:
-    chefstyle (1.5.5)
-      rubocop (= 1.4.2)
-
-GIT
   remote: https://github.com/chef/ohai.git
-  revision: 8d1ae429422439c4123e7973fe087a7d53514f15
+  revision: 876839a6324a635f15db4118366c938bdd3d675b
   branch: master
   specs:
-    ohai (16.7.37)
+    ohai (16.8.0)
       chef-config (>= 12.8, < 17)
       chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
@@ -164,6 +156,8 @@ GEM
     cheffish (16.0.12)
       chef-zero (>= 14.0)
       net-ssh
+    chefstyle (1.5.2)
+      rubocop (= 1.3.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crack (0.4.4)
@@ -176,7 +170,7 @@ GEM
     erubis (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    fauxhai-ng (8.5.0)
+    fauxhai-ng (8.6.0)
       net-ssh
     ffi (1.13.1)
     ffi (1.13.1-x64-mingw32)
@@ -311,7 +305,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.0)
-    rubocop (1.4.2)
+    rubocop (1.3.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -320,7 +314,7 @@ GEM
       rubocop-ast (>= 1.1.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.2.0)
+    rubocop-ast (1.3.0)
       parser (>= 2.7.1.5)
     ruby-prof (1.2.0)
     ruby-progressbar (1.10.1)
@@ -432,10 +426,10 @@ DEPENDENCIES
   chef-utils!
   chef-vault
   cheffish (>= 14)
-  chefstyle!
+  chefstyle (= 1.5.2)
   fauxhai-ng
-  inspec-core (~> 4.18)
-  inspec-core-bin (~> 4.18)
+  inspec-core (~> 4.23)
+  inspec-core-bin (~> 4.23)
   ohai!
   pry
   pry-byebug

--- a/lib/chef/encrypted_data_bag_item/assertions.rb
+++ b/lib/chef/encrypted_data_bag_item/assertions.rb
@@ -30,7 +30,7 @@ class Chef::EncryptedDataBagItem
       unless format_version.is_a?(Integer) && format_version >= Chef::Config[:data_bag_decrypt_minimum_version]
         raise UnacceptableEncryptedDataBagItemFormat,
           "The encrypted data bag item has format version `#{format_version}', " +
-            "but the config setting 'data_bag_decrypt_minimum_version' requires version `#{Chef::Config[:data_bag_decrypt_minimum_version]}'"
+          "but the config setting 'data_bag_decrypt_minimum_version' requires version `#{Chef::Config[:data_bag_decrypt_minimum_version]}'"
       end
     end
 

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -68,9 +68,9 @@ class Chef
           a.assertion { !(new_resource.revision =~ %r{^origin/}) }
           a.failure_message Chef::Exceptions::InvalidRemoteGitReference,
             "Deploying remote branches is not supported. " +
-              "Specify the remote branch as a local branch for " +
-              "the git repository you're deploying from " +
-              "(ie: '#{new_resource.revision.gsub("origin/", "")}' rather than '#{new_resource.revision}')."
+            "Specify the remote branch as a local branch for " +
+            "the git repository you're deploying from " +
+            "(ie: '#{new_resource.revision.gsub("origin/", "")}' rather than '#{new_resource.revision}')."
         end
 
         requirements.assert(:all_actions) do |a|
@@ -80,8 +80,8 @@ class Chef
           a.assertion { !target_revision.nil? }
           a.failure_message Chef::Exceptions::UnresolvableGitReference,
             "Unable to parse SHA reference for '#{new_resource.revision}' in repository '#{new_resource.repository}'. " +
-              "Verify your (case-sensitive) repository URL and revision.\n" +
-              "`git ls-remote '#{new_resource.repository}' '#{rev_search_pattern}'` output: #{@resolved_reference}"
+            "Verify your (case-sensitive) repository URL and revision.\n" +
+            "`git ls-remote '#{new_resource.repository}' '#{rev_search_pattern}'` output: #{@resolved_reference}"
         end
       end
 

--- a/lib/chef/resource/template.rb
+++ b/lib/chef/resource/template.rb
@@ -169,8 +169,8 @@ class Chef
         elsif module_name.nil?
           raise Exceptions::ValidationFailed,
             "#helpers requires either a module name or inline module code as a block.\n" +
-              "e.g.: helpers do; helper_code; end;\n" +
-              "OR: helpers(MyHelpersModule)"
+            "e.g.: helpers do; helper_code; end;\n" +
+            "OR: helpers(MyHelpersModule)"
         else
           raise Exceptions::ValidationFailed,
             "Argument to #helpers must be a module. You gave #{module_name.inspect} (#{module_name.class})"

--- a/lib/chef/resource_collection/resource_set.rb
+++ b/lib/chef/resource_collection/resource_set.rb
@@ -131,7 +131,7 @@ class Chef
           else
             raise Chef::Exceptions::InvalidResourceSpecification,
               "The object `#{query_object.inspect}' is not valid for resource collection lookup. " +
-                "Use a String like `resource_type[resource_name]' or a Chef::Resource object"
+              "Use a String like `resource_type[resource_name]' or a Chef::Resource object"
         end
       end
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: dada23e7f4237e9353aff0362f2dde964ee5abe0
+  revision: 01f76620796c00bea448f0355bb177647b3a64a2
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.399.0)
+    aws-partitions (1.401.0)
     aws-sdk-core (3.109.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.39.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.85.0)
+    aws-sdk-s3 (1.86.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -64,12 +64,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.6.14)
+    chef (16.7.61)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.6.14)
-      chef-utils (= 16.6.14)
+      chef-config (= 16.7.61)
+      chef-utils (= 16.7.61)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -100,12 +100,12 @@ GEM
       tty-screen (~> 0.6)
       tty-table (~> 0.11)
       uuidtools (~> 2.1.5)
-    chef (16.6.14-universal-mingw32)
+    chef (16.7.61-universal-mingw32)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.6.14)
-      chef-utils (= 16.6.14)
+      chef-config (= 16.7.61)
+      chef-utils (= 16.7.61)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -143,19 +143,19 @@ GEM
       win32-eventlog (= 0.6.3)
       win32-mmap (~> 0.4.1)
       win32-mutex (~> 0.4.2)
-      win32-process (~> 0.8.2)
+      win32-process (~> 0.9)
       win32-service (>= 2.1.5, < 3.0)
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (16.6.14)
+    chef-config (16.7.61)
       addressable
-      chef-utils (= 16.6.14)
+      chef-utils (= 16.7.61)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
-    chef-utils (16.6.14)
+    chef-utils (16.7.61)
     chef-vault (4.1.0)
     chef-zero (15.0.3)
       ffi-yajl (~> 2.2)
@@ -359,7 +359,7 @@ GEM
       ffi
     win32-mutex (0.4.3)
       win32-ipc (>= 0.6.0)
-    win32-process (0.8.3)
+    win32-process (0.9.0)
       ffi (>= 1.0.0)
     win32-service (2.2.0)
       ffi

--- a/spec/unit/knife/core/node_editor_spec.rb
+++ b/spec/unit/knife/core/node_editor_spec.rb
@@ -74,7 +74,7 @@ describe Chef::Knife::NodeEditor do
 
         expect(ui).to have_received(:warn)
           .with "Changing the name of a node results in a new node being " +
-            "created, test_node will not be modified or removed."
+          "created, test_node will not be modified or removed."
 
         expect(ui).to have_received(:confirm)
           .with("Proceed with creation of new node")


### PR DESCRIPTION
We have an inspec / rubocop conflict that's getting worked out right now, but for now we need to make sure a bundle update doesn't downgrade inspec.

Signed-off-by: Tim Smith <tsmith@chef.io>