### PR TITLE
Allow remote_file consider certificates stored under /etc/chef/trusted_certs

### DIFF
--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -70,6 +70,12 @@ class Chef
           end
 
           http_client.ca_file = config[:ssl_ca_file]
+        elsif ENV["SSL_CERT_FILE"]
+          unless ::File.exist?(ENV["SSL_CERT_FILE"])
+            raise Chef::Exceptions::ConfigurationError, "The configured ssl_ca_file #{ENV["SSL_CERT_FILE"]} does not exist"
+          end
+
+          http_client.ca_file = ENV["SSL_CERT_FILE"]
         end
       end
 

--- a/spec/unit/http/ssl_policies_spec.rb
+++ b/spec/unit/http/ssl_policies_spec.rb
@@ -26,6 +26,7 @@ describe "HTTP SSL Policy" do
     Chef::Config[:ssl_client_key]  = nil
     Chef::Config[:ssl_ca_path]     = nil
     Chef::Config[:ssl_ca_file]     = nil
+    ENV["SSL_CERT_FILE"]           = nil
   end
 
   let(:unconfigured_http_client) { Net::HTTP.new("example.com", 443) }
@@ -70,6 +71,16 @@ describe "HTTP SSL Policy" do
       it "should set the CA file if that is set in the configuration" do
         Chef::Config[:ssl_ca_file] = CHEF_SPEC_DATA + "/ssl/5e707473.0"
         expect(http_client.ca_file).to eq(CHEF_SPEC_DATA + "/ssl/5e707473.0")
+      end
+
+      it "should set the custom CA file if SSL_CERT_FILE environment variable is set" do
+        ENV["SSL_CERT_FILE"] = CHEF_SPEC_DATA + "/trusted_certs/intermediate.pem"
+        expect(http_client.ca_file).to eq(CHEF_SPEC_DATA + "/trusted_certs/intermediate.pem")
+      end
+
+      it "raises a ConfigurationError if SSL_CERT_FILE environment variable is set to a file that does not exist" do
+        ENV["SSL_CERT_FILE"] = "/dev/null/nothing_here"
+        expect { http_client }.to raise_error(Chef::Exceptions::ConfigurationError)
       end
     end
 


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
- Use the `SSL_CERT_FILE` environment variable to specify the location for the SSL certificate authority (CA)
- Added test cases
- Ensured chefstyle on the code changes made

## Related Issue
Fixes: #5944 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
