### PR TITLE
Add missing require for TTY::Prompt.

### DIFF
--- a/lib/chef/knife/core/ui.rb
+++ b/lib/chef/knife/core/ui.rb
@@ -64,7 +64,10 @@ class Chef
       # Creates a new object of class TTY::Prompt
       # with interrupt as exit so that it can be terminated with status code.
       def prompt
-        @prompt ||= TTY::Prompt.new(interrupt: :exit)
+        @prompt ||= begin
+          require "tty-prompt"
+          TTY::Prompt.new(interrupt: :exit)
+        end
       end
 
       # pastel.decorate is a lightweight replacement for highline.color


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Fix for #10705.

Before:
```
Petes-MacBook-Pro:chef pete$ bundle exec knife ssh "foobar" -P
WARNING: No knife configuration file found. See https://docs.chef.io/config_rb/ for details.
ERROR: knife encountered an unexpected error
This may be a bug in the 'ssh' knife command or plugin
Please collect the output of this command with the `-VVV` option before filing a bug report.
Exception: NameError: uninitialized constant Chef::Knife::UI::TTY
```

After:
```
Petes-MacBook-Pro:chef pete$ bundle exec knife ssh "foobar" -P
WARNING: No knife configuration file found. See https://docs.chef.io/config_rb/ for details.
Enter your password:  
```