### PR TITLE
only run systemd unit tests on linux

### DIFF
--- a/spec/unit/provider/systemd_unit_spec.rb
+++ b/spec/unit/provider/systemd_unit_spec.rb
@@ -18,7 +18,7 @@
 
 require "spec_helper"
 
-describe Chef::Provider::SystemdUnit do
+describe Chef::Provider::SystemdUnit, :linux_only do
 
   let(:node) { Chef::Node.new }
   let(:events) { Chef::EventDispatch::Dispatcher.new }


### PR DESCRIPTION
fixes #10695 

These is no reason to run systemd unit tests on windows. On our omnibus pipeline, these consumed several minutes. What is baffling is why they are super fast locally and in our verify pipeline. They are also fast in a manually spun up omnibus image. After profiling, the bottleneck is in the shell out to systemd. It makes sense that would be where the bottleneck is but I'm still confused why the slow down is isolated to the omnibus pipeline.

In the end it does make sense to just remove them from windows.

Signed-off-by: mwrock <matt@mattwrock.com>
