### PR TITLE
Fix failing tests on Solaris / Enable Solaris builds again

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -50,10 +50,10 @@ builder-to-testers-map:
     - sles-15-x86_64
   sles-15-aarch64:
     - sles-15-aarch64
-#  solaris2-5.11-i386:
-#    - solaris2-5.11-i386
-#  solaris2-5.11-sparc:
-#    - solaris2-5.11-sparc
+  solaris2-5.11-i386:
+    - solaris2-5.11-i386
+  solaris2-5.11-sparc:
+    - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -142,8 +142,6 @@ module ChefConfig
     def working_directory
       if ChefUtils.windows?
         env["CD"]
-      elsif ChefUtils.solaris2?
-        Dir.pwd
       else
         env["PWD"]
       end || Dir.pwd

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -142,6 +142,8 @@ module ChefConfig
     def working_directory
       if ChefUtils.windows?
         env["CD"]
+      elsif ChefUtils.solaris2?
+        Dir.pwd
       else
         env["PWD"]
       end || Dir.pwd

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -97,7 +97,8 @@ describe "chef-client" do
       before { file ".chef/knife.rb", "xxx.xxx" }
 
       it "should load .chef/knife.rb when -z is specified" do
-        result = shell_out("#{chef_client} -z -o 'x::default'", cwd: path_to(""))
+        # On Solaris shell_out will invoke /bin/sh which doesn't understand how to correctly update ENV['PWD']
+        result = shell_out("#{chef_client} -z -o 'x::default'", cwd: path_to(""), env: {})
         # FATAL: Configuration error NoMethodError: undefined method `xxx' for nil:NilClass
         expect(result.stdout).to include("xxx")
       end

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -98,7 +98,7 @@ describe "chef-client" do
 
       it "should load .chef/knife.rb when -z is specified" do
         # On Solaris shell_out will invoke /bin/sh which doesn't understand how to correctly update ENV['PWD']
-        result = shell_out("#{chef_client} -z -o 'x::default'", cwd: path_to(""), env: {})
+        result = shell_out("#{chef_client} -z -o 'x::default'", cwd: path_to(""), env: { "PWD" => nil })
         # FATAL: Configuration error NoMethodError: undefined method `xxx' for nil:NilClass
         expect(result.stdout).to include("xxx")
       end


### PR DESCRIPTION
fixes #10616 

On Solaris, setting `Mixlib::ShellOut`'s `:cwd` does not update the `pwd` environment variable. Based on some follow up research I could not find evidence that the `pwd` environment variable is guaranteed to reflect the `pwd` command. It feels like there might be a cleaner approach here - like just using `Dir.pwd` across the board. I'd think that should work everywhere. However there may be a reason (and perhaps a good one, or not) why we prefer the environment variable.

Signed-off-by: mwrock <matt@mattwrock.com>
