### PR TITLE
Remove EOL RHEL 6 32bit builds

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -15,8 +15,6 @@ builder-to-testers-map:
     - debian-10-x86_64
   debian-10-aarch64:
     - debian-10-aarch64
-  el-6-i686:
-    - el-6-i686
   el-6-x86_64:
     - el-6-x86_64
   el-7-aarch64:


### PR DESCRIPTION
RHEL 6 went EOL Nov 30th 2020

Signed-off-by: Tim Smith <tsmith@chef.io>