### PR TITLE
hostname: Avoid erroring out when hostname is not set on mac

### DIFF
--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -131,18 +131,18 @@ class Chef
             # darwin
             declare_resource(:execute, "set HostName via scutil") do
               command "/usr/sbin/scutil --set HostName #{new_resource.hostname}"
-              not_if { shell_out!("/usr/sbin/scutil --get HostName").stdout.chomp == new_resource.hostname }
+              not_if { shell_out("/usr/sbin/scutil --get HostName").stdout.chomp == new_resource.hostname }
               notifies :reload, "ohai[reload hostname]"
             end
             declare_resource(:execute, "set ComputerName via scutil") do
               command "/usr/sbin/scutil --set ComputerName  #{new_resource.hostname}"
-              not_if { shell_out!("/usr/sbin/scutil --get ComputerName").stdout.chomp == new_resource.hostname }
+              not_if { shell_out("/usr/sbin/scutil --get ComputerName").stdout.chomp == new_resource.hostname }
               notifies :reload, "ohai[reload hostname]"
             end
             shortname = new_resource.hostname[/[^\.]*/]
             declare_resource(:execute, "set LocalHostName via scutil") do
               command "/usr/sbin/scutil --set LocalHostName #{shortname}"
-              not_if { shell_out!("/usr/sbin/scutil --get LocalHostName").stdout.chomp == shortname }
+              not_if { shell_out("/usr/sbin/scutil --get LocalHostName").stdout.chomp == shortname }
               notifies :reload, "ohai[reload hostname]"
             end
           when linux?


### PR DESCRIPTION
Addresses this failure mode:

```
    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    execute[set HostName via scutil] (/opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.5.64/lib/chef/resource/hostname.rb line 132) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
    ---- Begin output of /usr/sbin/scutil --get HostName ----
    STDOUT: 
    STDERR: HostName: not set
    ---- End output of /usr/sbin/scutil --get HostName ----
    Ran /usr/sbin/scutil --get HostName returned 1
lib/chef/resource/hostname.rb:134
              not_if { shell_out!("/usr/sbin/scutil --get HostName").stdout.chomp == new_resource.hostname }
```