### PR TITLE
Raise error and retry with PTY on sudo password prompt

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -27,6 +27,7 @@ class Chef
         require "net/ssh" unless defined?(Net::SSH)
         require "net/ssh/multi"
         require "readline"
+        require "tty-prompt"
         require_relative "../exceptions"
         require_relative "../search/query"
         require_relative "../util/path_helper"
@@ -385,6 +386,7 @@ class Chef
               end
 
               ch.on_extended_data do |_, _type, data|
+                raise ArgumentError if data.eql?("sudo: no tty present and no askpass program specified\n")
                 stderr += data
               end
 

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -386,6 +386,7 @@ class Chef
 
               ch.on_extended_data do |_, _type, data|
                 raise ArgumentError if data.eql?("sudo: no tty present and no askpass program specified\n")
+
                 stderr += data
               end
 

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -27,7 +27,6 @@ class Chef
         require "net/ssh" unless defined?(Net::SSH)
         require "net/ssh/multi"
         require "readline"
-        require "tty-prompt"
         require_relative "../exceptions"
         require_relative "../search/query"
         require_relative "../util/path_helper"


### PR DESCRIPTION
Signed-off-by: Robert Vežnaver <rveznaver@users.noreply.github.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The `knife ssh` command will silently fail if it starts with `sudo` and will not prompt for a password. The proposed change shall error out of `open_session` on `sudo` complaining about not having a TTY and will retry the command with a PTY.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
This fixes a regression introduced in #9482 by requesting a PTY only when `open_session` errors out. In addition, it also requires `tty-prompt` as once a PTY is allocated the prompt fails with #10705.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).