### PR TITLE
Update libiconv to 1.16

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -7,7 +7,7 @@ override :rubygems, version: "3.1.4" # pin to what ships in the ruby version
 override :bundler, version: "2.1.4" # pin to what ships in the ruby version
 override "libarchive", version: "3.5.0"
 override "libffi", version: "3.3"
-override "libiconv", version: "1.15"
+override "libiconv", version: "1.16"
 override "liblzma", version: "5.2.5"
 override "libtool", version: "2.4.2"
 override "libxml2", version: "2.9.10"


### PR DESCRIPTION
use the latest library

https://fossies.org/diffs/libiconv/1.15_vs_1.16/ChangeLog-diff.html

Signed-off-by: Tim Smith <tsmith@chef.io>