### PR TITLE
Fix broken code in compliance runner's send_report.

### DIFF
--- a/lib/chef/compliance/reporter/chef_server_automate.rb
+++ b/lib/chef/compliance/reporter/chef_server_automate.rb
@@ -7,6 +7,8 @@ class Chef
       # Used to send inspec reports to Chef Automate server via Chef Server
       #
       class ChefServerAutomate < Chef::Compliance::Reporter::Automate
+        attr_reader :url
+
         def initialize(opts)
           @entity_uuid           = opts[:entity_uuid]
           @run_id                = opts[:run_id]

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -201,14 +201,20 @@ class Chef
         }
       end
 
-      def send_report(reporter, report)
-        logger.info "Reporting to #{reporter}"
+      def send_report(reporter_type, report)
+        logger.info "Reporting to #{reporter_type}"
 
+        reporter = reporter(reporter_type)
+
+        reporter.send_report(report) if reporter
+      end
+
+      def reporter(reporter_type)
         insecure = node["audit"]["insecure"]
         run_time_limit = node["audit"]["run_time_limit"]
         control_results_limit = node["audit"]["control_results_limit"]
 
-        case reporter
+        case reporter_type
         when "chef-automate"
           opts = {
             entity_uuid: node["chef_guid"],
@@ -218,7 +224,7 @@ class Chef
             run_time_limit: run_time_limit,
             control_results_limit: control_results_limit,
           }
-          Chef::Compliance::Reporter::Automate.new(opts).send_report(report)
+          Chef::Compliance::Reporter::Automate.new(opts)
         when "chef-server-automate"
           url = chef_server_automate_url
           if url
@@ -231,18 +237,20 @@ class Chef
               run_time_limit: run_time_limit,
               control_results_limit: control_results_limit,
             }
-            Chef::Compliance::Reporter::ChefServerAutomate.new(opts).send_report(report)
+            Chef::Compliance::Reporter::ChefServerAutomate.new(opts)
           else
-            logger.warn "Unable to determine #{ChefUtils::Dist::Server::PRODUCT} url required by #{Inspec::Dist::PRODUCT_NAME} report collector '#{reporter}'. Skipping..."
+            logger.warn "Unable to determine #{ChefUtils::Dist::Server::PRODUCT} url required by #{Inspec::Dist::PRODUCT_NAME} report collector 'chef-server-automate'. Skipping..."
+            nil
           end
         when "json-file"
           path = node["audit"]["json_file"]["location"]
           logger.info "Writing compliance report to #{path}"
-          Chef::Compliance::Reporter::JsonFile.new(file: path).send_report(report)
+          Chef::Compliance::Reporter::JsonFile.new(file: path)
         when "audit-enforcer"
-          Chef::Compliance::Reporter::ComplianceEnforcer.new.send_report(report)
+          Chef::Compliance::Reporter::ComplianceEnforcer.new
         else
-          logger.warn "#{reporter} is not a supported #{Inspec::Dist::PRODUCT_NAME} report collector"
+          logger.warn "'#{reporter_type}' is not a supported #{Inspec::Dist::PRODUCT_NAME} report collector"
+          nil
         end
       end
 

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -239,7 +239,7 @@ class Chef
         when "audit-enforcer"
           Chef::Compliance::Reporter::ComplianceEnforcer.new
         else
-          logger.warn "'#{reporter_type}' is not a supported #{Inspec::Dist::PRODUCT_NAME} report collector"
+          logger.warn "'#{reporter_type}' is not a supported reporter for Compliance Phase."
           nil
         end
       end

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -210,30 +210,26 @@ class Chef
       end
 
       def reporter(reporter_type)
-        insecure = node["audit"]["insecure"]
-        run_time_limit = node["audit"]["run_time_limit"]
-        control_results_limit = node["audit"]["control_results_limit"]
-
         case reporter_type
         when "chef-automate"
           opts = {
+            control_results_limit: node["audit"]["control_results_limit"],
             entity_uuid: node["chef_guid"],
-            run_id: run_id,
+            insecure: node["audit"]["insecure"],
             node_info: node_info,
-            insecure: insecure,
-            run_time_limit: run_time_limit,
-            control_results_limit: control_results_limit,
+            run_id: run_id,
+            run_time_limit: node["audit"]["run_time_limit"],
           }
           Chef::Compliance::Reporter::Automate.new(opts)
         when "chef-server-automate"
           opts = {
+            control_results_limit: node["audit"]["control_results_limit"],
             entity_uuid: node["chef_guid"],
-            run_id: run_id,
+            insecure: node["audit"]["insecure"],
             node_info: node_info,
-            insecure: insecure,
+            run_id: run_id,
+            run_time_limit: node["audit"]["run_time_limit"],
             url: chef_server_automate_url,
-            run_time_limit: run_time_limit,
-            control_results_limit: control_results_limit,
           }
           Chef::Compliance::Reporter::ChefServerAutomate.new(opts)
         when "json-file"

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -226,22 +226,16 @@ class Chef
           }
           Chef::Compliance::Reporter::Automate.new(opts)
         when "chef-server-automate"
-          url = chef_server_automate_url
-          if url
-            opts = {
-              entity_uuid: node["chef_guid"],
-              run_id: run_id,
-              node_info: node_info,
-              insecure: insecure,
-              url: url,
-              run_time_limit: run_time_limit,
-              control_results_limit: control_results_limit,
-            }
-            Chef::Compliance::Reporter::ChefServerAutomate.new(opts)
-          else
-            logger.warn "Unable to determine #{ChefUtils::Dist::Server::PRODUCT} url required by #{Inspec::Dist::PRODUCT_NAME} report collector 'chef-server-automate'. Skipping..."
-            nil
-          end
+          opts = {
+            entity_uuid: node["chef_guid"],
+            run_id: run_id,
+            node_info: node_info,
+            insecure: insecure,
+            url: chef_server_automate_url,
+            run_time_limit: run_time_limit,
+            control_results_limit: control_results_limit,
+          }
+          Chef::Compliance::Reporter::ChefServerAutomate.new(opts)
         when "json-file"
           path = node["audit"]["json_file"]["location"]
           logger.info "Writing compliance report to #{path}"

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -239,8 +239,7 @@ class Chef
         when "audit-enforcer"
           Chef::Compliance::Reporter::ComplianceEnforcer.new
         else
-          logger.warn "'#{reporter_type}' is not a supported reporter for Compliance Phase."
-          nil
+          raise "'#{reporter_type}' is not a supported reporter for Compliance Phase."
         end
       end
 

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -131,11 +131,6 @@ describe Chef::Compliance::Runner do
         expect(reporter).to be_kind_of(Chef::Compliance::Reporter::ChefServerAutomate)
         expect(reporter.url).to eq(URI("https://chef_config_url.example.com/organizations/my_org/data-collector"))
       end
-
-      xit "returns nil with no 'server' attribute or chef_server_url configured" do
-        Chef::Config[:chef_server_url] = nil
-        expect(runner.reporter("chef-server-automate")).to be_nil
-      end
     end
 
     it "returns nil for unexpected reporter value" do

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -134,7 +134,7 @@ describe Chef::Compliance::Runner do
     end
 
     it "returns nil for unexpected reporter value" do
-      expect(logger).to receive(:warn).with("'tacos' is not a supported Chef InSpec report collector")
+      expect(logger).to receive(:warn).with("'tacos' is not a supported reporter for Chef Infra Client's Compliance Phase")
 
       expect(runner.reporter("tacos")).to be_nil
     end

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -133,10 +133,8 @@ describe Chef::Compliance::Runner do
       end
     end
 
-    it "returns nil for unexpected reporter value" do
-      expect(logger).to receive(:warn).with("'tacos' is not a supported reporter for Chef Infra Client's Compliance Phase")
-
-      expect(runner.reporter("tacos")).to be_nil
+    it "fails with unexpected reporter value" do
+      expect { runner.reporter("tacos") }.to raise_error(/'tacos' is not a supported reporter for Compliance Phase/)
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

* Fixes #10729. Added code equivalent to what was missing and added some basic unit tests to make sure the code can execute.
* Refactored the reporter creation from the report sending to make the tests less mock-and-stub heavy.
* In the spirit of not failing silently with bad configuration, changed the behavior when an unrecognized reporter type is specified to raise an exception rather than just logging an error and continuing.
* Removed a check for an impossible case. There was code handling the case where `Chef::Config[:chef_server_url]` was nil, but that has a default value and has a guard against setting it to a non-URL value.