### PR TITLE
Add audit cookbook's chef_node_attribute_enabled to Compliance Phase.

### DIFF
--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -83,7 +83,11 @@ class Chef
 
       # The array of results per control will be truncated at this limit to avoid large reports that cannot be
       # processed by Chef Automate. A summary of removed results will be sent with each impacted control.
-      "control_results_limit" => 50
+      "control_results_limit" => 50,
+
+      # If enabled, a hash representation of the Chef Infra node object will be sent to Chef InSpec in an input
+      # named `chef_node`.
+      "chef_node_attribute_enabled" => false
     )
   end
 end

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -61,7 +61,6 @@ class Chef
 
       DEPRECATED_CONFIG_VALUES = %w{
         attributes_save
-        chef_node_attribute_enabled
         fail_if_not_present
         inspec_gem_source
         inspec_version
@@ -93,9 +92,15 @@ class Chef
       end
 
       def inspec_opts
+        inputs = node["audit"]["attributes"].to_h
+        if node["audit"]["chef_node_attribute_enabled"]
+          inputs["chef_node"] = node.to_h
+          inputs["chef_node"]["chef_environment"] = node.chef_environment
+        end
+
         {
           backend_cache: node["audit"]["inspec_backend_cache"],
-          inputs: node["audit"]["attributes"],
+          inputs: inputs,
           logger: logger,
           output: node["audit"]["quiet"] ? ::File::NULL : STDOUT,
           report: true,

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -137,4 +137,32 @@ describe Chef::Compliance::Runner do
       expect { runner.reporter("tacos") }.to raise_error(/'tacos' is not a supported reporter for Compliance Phase/)
     end
   end
+
+  describe "#inspec_opts" do
+    it "does not include chef_node in inputs by default" do
+      node.normal["audit"]["attributes"] = {
+        "tacos" => "lunch",
+        "nachos" => "dinner",
+      }
+
+      inputs = runner.inspec_opts[:inputs]
+
+      expect(inputs["tacos"]).to eq("lunch")
+      expect(inputs.key?("chef_node")).to eq(false)
+    end
+
+    it "includes chef_node in inputs with chef_node_attribute_enabled set" do
+      node.normal["audit"]["chef_node_attribute_enabled"] = true
+      node.normal["audit"]["attributes"] = {
+        "tacos" => "lunch",
+        "nachos" => "dinner",
+      }
+
+      inputs = runner.inspec_opts[:inputs]
+
+      expect(inputs["tacos"]).to eq("lunch")
+      expect(inputs["chef_node"]["audit"]["reporter"]).to eq("json-file")
+      expect(inputs["chef_node"]["chef_environment"]).to eq("_default")
+    end
+  end
 end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

I removed this early on because it was complicating some things, but it's mentioned in the audit cookbook README that has turned into chef/chef-web-docs#2781, so it either needs to get added for backwards compatibility or deprecated and removed from the docs.