### PR TITLE
Add a spellcheck exception for RELEASE_NOTES.md

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1432,6 +1432,7 @@
     "runrun",
     "runtimes",
     "Runtimes",
+    "rveznaver",
     "RXACT",
     "rxhash",
     "rxvlan",


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Spellcheck is failing on CI:

```
wget -q https://raw.githubusercontent.com/chef/chef_dictionary/master/chef.txt -O chef_dictionary.txt
cspell "**/*"
/workdir/RELEASE_NOTES.md:7:89 - Unknown word (rveznaver)
CSpell: Files checked: 1091, Issues found: 1 in 1 files
rake aborted!
Command failed with status (1): [cspell "**/*"...]
/workdir/tasks/spellcheck.rb:20:in `block (2 levels) in <top (required)>'
Tasks: TOP => spellcheck => spellcheck:run
(See full trace by running task with --trace)
```