### PR TITLE
knife bootstrap: Windows Trusted cert path slashes fix

### DIFF
--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -140,7 +140,7 @@ class Chef
           end
 
           unless trusted_certs_script.empty?
-            client_rb << %Q{trusted_certs_dir "#{ChefConfig::Config.etc_chef_dir(windows: true)}/trusted_certs"\n}
+            client_rb << %Q{trusted_certs_dir "#{ChefConfig::PathHelper.escapepath(ChefConfig::Config.etc_chef_dir(windows: true))}\\\\trusted_certs"\n}
           end
 
           if chef_config[:fips]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Bootstrapping on Windows generates a weirdly slashed trusted_certs path resulting in the following error when trying to use `Chef::Config[:trusted_certs_dir]` in a resource:

```
 directory("C:ef/trusted_certs") do
    action [:create]
     default_guard_interpreter :default
    declared_type :directory
    cookbook_name "Base"
    recipe_name "certificates"
    recursive true
    owner nil
    group nil
    mode nil
   path "C:\bef/trusted_certs"
end
```
the bootstrap sets the path too `echo.trusted_certs_dir "C:\chef/trusted_certs"`

compared to the other paths using the escape helper the difference is clear
```
echo.file_cache_path   "C:\\chef\\cache"
echo.file_backup_path  "C:\\chef\\backup"
echo.trusted_certs_dir "C:\chef/trusted_certs"
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
