### PR TITLE
Remove a useless test.

### DIFF
--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -21,13 +21,6 @@ describe Chef::Mixin::OpenSSLHelper do
     Class.new { include Chef::Mixin::OpenSSLHelper }.new
   end
 
-  describe ".included" do
-    it "requires openssl" do
-      instance
-      expect(defined?(OpenSSL)).to_not be(false)
-    end
-  end
-
   # Path helpers
   describe "#get_key_filename" do
     context "When the input is not a string" do


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

The module this is testing does not have an `included` method, and it autoloads OpenSSL at the top of the file so this will always be defined by referencing it: https://github.com/chef/chef/blob/master/lib/chef/mixin/openssl_helper.rb#L17