### PR TITLE
Extend the PR verification timeout to 45 minutes

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -7,7 +7,7 @@ expeditor:
       retry:
         automatic:
           limit: 1
-      timeout_in_minutes: 30
+      timeout_in_minutes: 45
 
 steps:
 


### PR DESCRIPTION
Windows can take a while to run now.

Signed-off-by: Tim Smith <tsmith@chef.io>