### PR TITLE
Cleanup bootstrap's trusted_certs_dir tests.

### DIFF
--- a/spec/data/trusted_certs_empty/README.md
+++ b/spec/data/trusted_certs_empty/README.md
@@ -1,1 +1,0 @@
-A directory with no certs. Used for testing directories with no certs during bootstrap.


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

In #10751, I initially tried adding a binary-encoded SSL cert to `spec/data/trusted_certs` and that caused failures in these tests. I was going to try adding a friendlier error message for that case but the changes got pretty invasive since the exception raised happened far away from where the certs are read. This cleanup of the tests seemed worth salvaging from the code that I otherwise threw away.