### PR TITLE
Switch macOS kitchen test homebrew package.

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
@@ -77,9 +77,9 @@ homebrew_update "update" do
   action :update
 end
 
-homebrew_package "vim"
+homebrew_package "nethack"
 
-homebrew_package "vim" do
+homebrew_package "nethack" do
   action :purge
 end
 


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

The macOS kitchen end-to-end tests are failing because of an apparent conflict in one of vim's dependencies. `nethack` has no dependencies, is unlikely to be pre-installed in a CI image, and is likely to be maintained for a long time.

Example failure:
https://dev.azure.com/chef-software/chef/_build/results?buildId=3497&view=logs&j=b911c377-bd81-5cf7-b87f-ce01442373ee&t=43d8696b-e497-570b-b2fc-abebc77456ed