### PR TITLE
Remove support for Ubuntu 16.04

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -55,8 +55,7 @@ builder-to-testers-map:
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
   windows-2012r2-i386:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -390,22 +390,6 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen: Ubuntu 16.04"
-  commands:
-    - scripts/bk_tests/bk_linux_exec.sh
-    - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-1604
-  artifact_paths:
-    - $PWD/.kitchen/logs/kitchen.log
-  env:
-      UBUNTU: "16.04"
-      KITCHEN_YAML: kitchen.yml
-  expeditor:
-    executor:
-      linux:
-        privileged: true
-        single-use: true
-
 - label: "Kitchen: Ubuntu 18.04"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -114,13 +114,6 @@ platforms:
     intermediate_instructions:
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: ubuntu-16.04
-  driver:
-    image: dokken/ubuntu-16.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-
 - name: ubuntu-18.04
   driver:
     image: dokken/ubuntu-18.04

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -38,7 +38,7 @@ platforms:
     run_list: apt::default
   - name: freebsd-11
     run_list: freebsd::portsnap
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
     run_list: apt::default
 
   # macOS


### PR DESCRIPTION
By the time we ship Chef 17 Ubuntu 16.04 will be EOL.

Signed-off-by: Tim Smith <tsmith@chef.io>