### PR TITLE
Fixed cron_d resource ignoring sensitive property in Chef 17

### DIFF
--- a/lib/chef/resource/cron/cron_d.rb
+++ b/lib/chef/resource/cron/cron_d.rb
@@ -160,6 +160,7 @@ class Chef
             source ::File.expand_path("../support/cron.d.erb", __dir__)
             local true
             mode new_resource.mode
+            sensitive new_resource.sensitive
             variables(
               name: sanitized_name,
               predefined_value: new_resource.predefined_value,


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Fixes `cron_d` resource not being aware of the `sensitive` property, potentially leaking sensitive data into Chef Client's stdout.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The `create_template` function of the `CronD` class ignored the `sensitive` property.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#10766 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
