### PR TITLE
Update spellcheck task for new version of cspell.

### DIFF
--- a/tasks/spellcheck.rb
+++ b/tasks/spellcheck.rb
@@ -17,12 +17,7 @@
 
 namespace :spellcheck do
   task run: :prereqs do
-    sh 'cspell "**/*"'
-  end
-
-  desc "List the unique unrecognized words in the project."
-  task unknown_words: :prereqs do
-    sh 'cspell "**/*" --wordsOnly --no-summary | sort | uniq'
+    sh 'cspell lint --no-progress "**/*"'
   end
 
   task prereqs: %i{cspell_check config_check fetch_common}


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

After cspell's recent update, it's default output got much more verbose because it prints the path of every file it is checking. This makes it hard to see what the errors are when you get a spellcheck violation.

The other task didn't work anymore and it was only useful to me when I was initially implementing the spellcheck task, so I removed it rather than trying to get it working again.

An example of the newer verbose output is here: https://buildkite.com/chef-oss/chef-chef-master-verify/builds/7390#fef4f0ea-c7ef-413b-a370-844c7dfd4693