### PR TITLE
Stop updating bundler in CI

### DIFF
--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -2,6 +2,9 @@
 
 echo "--- Container Config..."
 
+source /etc/os-release
+echo $PRETTY_NAME
+
 echo "ruby version:"
 ruby -v
 echo "bundler version:"

--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -11,11 +11,8 @@ if [ -f /etc/debian_version ]; then
   touch /etc/network/interfaces
 fi
 
-# make sure we have the omnibus_overrides specified version of rubygems / bundler
-echo "--- Install proper bundler"
-gem uninstall bundler -a -x || true
-gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
-bundle --version
+
+# remove default bundler config if there is one
 rm -f .bundle/config
 
 echo "+++ Run tests"

--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -1,6 +1,13 @@
 # This script gets a container ready to run our various tests in BuildKite
 
-echo "--- preparing..."
+echo "--- Container Config..."
+
+echo "ruby version:"
+ruby -v
+echo "bundler version:"
+bundler -v
+
+echo "--- Preparing Container..."
 
 export FORCE_FFI_YAJL="ext"
 export CHEF_LICENSE="accept-no-persist"

--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -8,7 +8,7 @@ echo $PRETTY_NAME
 echo "ruby version:"
 ruby -v
 echo "bundler version:"
-bundler -v
+bundle -v
 
 echo "--- Preparing Container..."
 

--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -11,7 +11,6 @@ if [ -f /etc/debian_version ]; then
   touch /etc/network/interfaces
 fi
 
-
 # remove default bundler config if there is one
 rm -f .bundle/config
 

--- a/.expeditor/scripts/bk_linux_exec.sh
+++ b/.expeditor/scripts/bk_linux_exec.sh
@@ -32,9 +32,9 @@ echo "--- Config information"
 echo "!!!! RUBY VERSION !!!!"
 ruby --version
 echo "!!!! BUNDLER LOCATION !!!!"
-which bundler
+which bundle
 echo "!!!! BUNDLER VERSION !!!!"
-bundler -v
+bundle -v
 echo "!!!! DOCKER VERSION !!!!"
 docker version
 echo "!!!! DOCKER STATUS !!!!"

--- a/.expeditor/scripts/bk_linux_exec.sh
+++ b/.expeditor/scripts/bk_linux_exec.sh
@@ -31,8 +31,10 @@ echo "--- Config information"
 
 echo "!!!! RUBY VERSION !!!!"
 ruby --version
-echo "!!!! BUNDLE LOCATION !!!!"
-which bundle
+echo "!!!! BUNDLER LOCATION !!!!"
+which bundler
+echo "!!!! BUNDLER VERSION !!!!"
+bundler -v
 echo "!!!! DOCKER VERSION !!!!"
 docker version
 echo "!!!! DOCKER STATUS !!!!"

--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -8,6 +8,9 @@ Remove-Item -Path C:\ProgramData\chocolatey\bin\choco.exe -ErrorAction SilentlyC
 $ErrorActionPreference = 'Stop'
 
 Write-Output "--- Enable Ruby 2.7"
+ruby -v
+if (-not $?) { throw "Can't run Ruby. Is it installed?" }
+
 Write-Output "Add Uru to Environment PATH"
 $env:PATH = "C:\Program Files (x86)\Uru;" + $env:PATH
 [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
@@ -18,21 +21,7 @@ uru 271
 if (-not $?) { throw "Can't Activate Ruby. Did Uru Registration Succeed?" }
 
 Write-Output "--- configure winrm"
-
 winrm quickconfig -q
-
-Write-Output "--- update bundler"
-
-ruby -v
-if (-not $?) { throw "Can't run Ruby. Is it installed?" }
-
-$env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
-$env:BUNDLER_VERSION=($env:BUNDLER_VERSION -replace '"', "")
-Write-Output $env:BUNDLER_VERSION
-
-gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
-if (-not $?) { throw "Unable to update Bundler" }
-bundle --version
 
 Write-Output "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package

--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -8,8 +8,6 @@ Remove-Item -Path C:\ProgramData\chocolatey\bin\choco.exe -ErrorAction SilentlyC
 $ErrorActionPreference = 'Stop'
 
 Write-Output "--- Enable Ruby 2.7"
-ruby -v
-if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
 Write-Output "Add Uru to Environment PATH"
 $env:PATH = "C:\Program Files (x86)\Uru;" + $env:PATH
@@ -19,6 +17,8 @@ Write-Output "Register Installed Ruby Version 2.7 With Uru"
 Start-Process "C:\Program Files (x86)\Uru\uru_rt.exe" -ArgumentList 'admin add C:\ruby27\bin' -Wait
 uru 271
 if (-not $?) { throw "Can't Activate Ruby. Did Uru Registration Succeed?" }
+ruby -v
+if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
 Write-Output "--- configure winrm"
 winrm quickconfig -q

--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -24,7 +24,8 @@ Write-Output "--- configure winrm"
 winrm quickconfig -q
 
 Write-Output "--- bundle install"
-bundle install --jobs=3 --retry=3 --without omnibus_package
+bundle config set --local without 'omnibus_package'
+bundle install --jobs=3 --retry=3
 if (-not $?) { throw "Unable to install gem dependencies" }
 
 Write-Output "+++ bundle exec rake spec:functional"

--- a/.expeditor/scripts/bk_win_prep.ps1
+++ b/.expeditor/scripts/bk_win_prep.ps1
@@ -2,9 +2,11 @@ echo "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
+echo "ruby version:"
 ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
+echo "bundler version: "
 bundle --version
 if (-not $?) { throw "Can't run Bundler. Is it installed?" }
 

--- a/.expeditor/scripts/bk_win_prep.ps1
+++ b/.expeditor/scripts/bk_win_prep.ps1
@@ -11,5 +11,5 @@ bundle --version
 if (-not $?) { throw "Can't run Bundler. Is it installed?" }
 
 echo "--- bundle install"
-bundle install --jobs=3 --retry=3 --without omnibus_package
+bundle install --jobs=3 --retry=3  --path=vendor/bundle --without omnibus_package
 if (-not $?) { throw "Unable to install gem dependencies" }

--- a/.expeditor/scripts/bk_win_prep.ps1
+++ b/.expeditor/scripts/bk_win_prep.ps1
@@ -2,17 +2,9 @@ echo "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
-echo "--- update bundler"
-
 ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
-$env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
-$env:BUNDLER_VERSION=($env:BUNDLER_VERSION -replace '"', "")
-echo $env:BUNDLER_VERSION
-
-gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
-if (-not $?) { throw "Unable to update Bundler" }
 bundle --version
 
 echo "--- bundle install"

--- a/.expeditor/scripts/bk_win_prep.ps1
+++ b/.expeditor/scripts/bk_win_prep.ps1
@@ -6,6 +6,7 @@ ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
 bundle --version
+if (-not $?) { throw "Can't run Bundler. Is it installed?" }
 
 echo "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -245,6 +245,7 @@ steps:
 - label: "Chefstyle :ruby: 2.6"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake style
   expeditor:
@@ -255,6 +256,7 @@ steps:
 - label: "Integration :ruby: 2.6"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:integration
   expeditor:
@@ -268,6 +270,7 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales net-tools # needed for functional tests to pass
+    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:functional
   expeditor:
@@ -279,6 +282,7 @@ steps:
 - label: "Unit :ruby: 2.6"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
@@ -322,7 +326,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: rubydistros/ubuntu-18.04:2.6
+        image: rubydistros/ubuntu-18.04:2.7
 
 - label: "chefspec gem :ruby: 2.7"
   commands:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -244,8 +244,8 @@ steps:
 
 - label: "Chefstyle :ruby: 2.6"
   commands:
-    - /workdir/.expeditor/scripts/bk_container_prep.sh
     - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
+    - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
     - bundle exec rake style
   expeditor:
@@ -255,8 +255,8 @@ steps:
 
 - label: "Integration :ruby: 2.6"
   commands:
-    - /workdir/.expeditor/scripts/bk_container_prep.sh
     - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
+    - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:integration
   expeditor:
@@ -267,10 +267,10 @@ steps:
 
 - label: "Functional :ruby: 2.6"
   commands:
+    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales net-tools # needed for functional tests to pass
-    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:functional
   expeditor:
@@ -281,8 +281,8 @@ steps:
 
 - label: "Unit :ruby: 2.6"
   commands:
-    - /workdir/.expeditor/scripts/bk_container_prep.sh
     - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
+    - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:unit
     - bundle exec rake component_specs

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,7 +4,6 @@
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
 override :rubygems, version: "3.1.4" # pin to what ships in the ruby version
-override :bundler, version: "2.1.4" # pin to what ships in the ruby version
 override "libarchive", version: "3.5.0"
 override "libffi", version: "3.3"
 override "libiconv", version: "1.16"


### PR DESCRIPTION
We don't update it in our builds anymore. We just use the version that's built into Ruby. This omnibus override was only used for CI and we had to match the versions, which was a real pain and pretty pointless.

Signed-off-by: Tim Smith <tsmith@chef.io>