### PR TITLE
Removed unused rubygems from the omnibus overrides file

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,7 +3,6 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "3.1.4" # pin to what ships in the ruby version
 override "libarchive", version: "3.5.0"
 override "libffi", version: "3.3"
 override "libiconv", version: "1.16"


### PR DESCRIPTION
We no longer update this and the only software def in omnibus-software that deps on it is bundler, which nothing else deps on at this point.

Signed-off-by: Tim Smith <tsmith@chef.io>