### PR TITLE
Remove Test Kitchen tests for Amazon Linux 201X

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -364,21 +364,6 @@ steps:
   # START TEST KITCHEN ONLY
 #########################################################################
 
-- label: "Kitchen: Amazon Linux 201X"
-  commands:
-    - .expeditor/scripts/bk_linux_exec.sh
-    - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-amazonlinux
-  artifact_paths:
-    - $PWD/.kitchen/logs/kitchen.log
-  env:
-      KITCHEN_YAML: kitchen.yml
-  expeditor:
-    executor:
-      linux:
-        privileged: true
-        single-use: true
-
 - label: "Kitchen: Amazon Linux 2"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -20,7 +20,6 @@ lifecycle:
     - remote: echo "Chef container's Chef / Ohai release:"
     - remote: /opt/chef/bin/chef-client -v
     - remote: /opt/chef/bin/ohai -v
-    - remote: /opt/chef/embedded/bin/bundle -v
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
     - remote: /opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %> --tarball --github chef/ohai
     - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['BUILDKITE_COMMIT']  || %x(git rev-parse HEAD).chomp %> --tarball --github chef/chef
@@ -33,13 +32,6 @@ verifier:
   format: progress
 
 platforms:
-- name: amazonlinux
-  driver:
-    image: dokken/amazonlinux
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
-
 - name: amazonlinux-2
   driver:
     image: dokken/amazonlinux-2


### PR DESCRIPTION
The version of ld on Amazon Linux 201x cannot handle the ffi gem so these tests are going to fail forever now. This is a RHEL 6 based distro that is EOL as of the end of 2020.

https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life/

Signed-off-by: Tim Smith <tsmith@chef.io>