### PR TITLE
Replace Ubuntu 20.10 testing with 21.04

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -409,11 +409,11 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen: Ubuntu 20.10"
+- label: "Kitchen: Ubuntu 21.04"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-2010
+    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-2104
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -123,9 +123,9 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
 
-- name: ubuntu-20.10
+- name: ubuntu-21.04
   driver:
-    image: dokken/ubuntu-20.10
+    image: dokken/ubuntu-21.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update


### PR DESCRIPTION
These containers are alpha/beta quality, but we should start testing on
this since it'll be out when Chef Infra 17 is released.

Signed-off-by: Tim Smith <tsmith@chef.io>