### PR TITLE
Fix escaping in doc string.

### DIFF
--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -69,7 +69,7 @@ class Chef
         description: "The password to access the source if it is a pfx file."
 
       property :private_key_acl, Array,
-        description: "An array of 'domain\account' entries to be granted read-only access to the certificate's private key. Not idempotent."
+        description: "An array of 'domain\\account' entries to be granted read-only access to the certificate's private key. Not idempotent."
 
       property :store_name, String,
         description: "The certificate store to manipulate.",


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

This is not getting rendered correctly.

![Screen Shot 2020-12-29 at 12 14 18 PM](https://user-images.githubusercontent.com/22962/103311511-6cf53800-49cf-11eb-9d94-b81cf9a3a819.png)
