### PR TITLE
Coerce uid and gid to integer to prevent failures in Windows.

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -126,3 +126,11 @@ include_recipe "::_ohai_hint"
 hostname "new-hostname" do
   windows_reboot false
 end
+
+user "phil" do
+  uid "8019"
+end
+
+user "phil" do
+  action :remove
+end

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -67,10 +67,12 @@ class Chef
         default: false
 
       property :uid, [ String, Integer, NilClass ], # nil for backwards compat
-        description: "The numeric user identifier."
+        description: "The numeric user identifier.",
+        coerce: proc { |n| n && Integer(n) }
 
       property :gid, [ String, Integer, NilClass ], # nil for backwards compat
-        description: "The numeric group identifier."
+        description: "The numeric group identifier.",
+        coerce: proc { |n| n && Integer(n) }
 
       alias_method :group, :gid
     end

--- a/spec/unit/resource/user_spec.rb
+++ b/spec/unit/resource/user_spec.rb
@@ -85,7 +85,7 @@ end
 
     it "allows a string" do
       resource.send(attrib, "100")
-      expect(resource.send(attrib)).to eql("100")
+      expect(resource.send(attrib)).to eql(100)
     end
 
     it "allows an integer" do
@@ -94,7 +94,7 @@ end
     end
 
     it "does not allow a hash" do
-      expect { resource.send(attrib, { woot: "i found it" }) }.to raise_error(ArgumentError)
+      expect { resource.send(attrib, { woot: "i found it" }) }.to raise_error(TypeError)
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Fixes #10454.

There doesn't appear to be a valid usecase for a uid or gid that is not an integer string, ie `uid "pete"`. 

Running the test script in the linked issue after this PR:

```
PS C:\vagrant\chef> ruby -Ilib chef-bin\bin\chef-apply .\test_user_uid.rb
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * windows_user[dude] action create
    - alter user dude
    - change uid from 1001 to 8019
```