### PR TITLE
Remove the evals in the omnibus gemfile for Dependabot

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -22,9 +22,3 @@ group :development do
   gem "kitchen-vagrant", ">= 1.3.1"
   gem "winrm-fs", "~> 1.0"
 end
-
-instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
-
-# If you want to load debugging tools into the bundle exec sandbox,
-# add these additional dependencies into Gemfile.local
-eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")


### PR DESCRIPTION
We can let dependabot manage the bumps to this file if we remove these. It's worth having to hand edit the file with extra test gems. It's going to save a ton of time.

Signed-off-by: Tim Smith <tsmith@chef.io>