### PR TITLE
Update bcrypt_pbkdf to support Ruby 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
   specs:
     chef (16.9.7)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc1)
+      bcrypt_pbkdf (= 1.1.0.rc2)
       bundler (>= 1.10)
       chef-config (= 16.9.7)
       chef-utils (= 16.9.7)
@@ -67,7 +67,7 @@ PATH
       uuidtools (~> 2.1.5)
     chef (16.9.7-universal-mingw32)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc1)
+      bcrypt_pbkdf (= 1.1.0.rc2)
       bundler (>= 1.10)
       chef-config (= 16.9.7)
       chef-utils (= 16.9.7)
@@ -145,9 +145,9 @@ GEM
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.1)
-    bcrypt_pbkdf (1.1.0.rc1)
-    bcrypt_pbkdf (1.1.0.rc1-x64-mingw32)
-    bcrypt_pbkdf (1.1.0.rc1-x86-mingw32)
+    bcrypt_pbkdf (1.1.0.rc2)
+    bcrypt_pbkdf (1.1.0.rc2-x64-mingw32)
+    bcrypt_pbkdf (1.1.0.rc2-x86-mingw32)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 4.0"
   s.add_dependency "ed25519", "~> 1.2" # ed25519 ssh key support
-  s.add_dependency "bcrypt_pbkdf", "= 1.1.0.rc1" # ed25519 ssh key support
+  s.add_dependency "bcrypt_pbkdf", "= 1.1.0.rc2" # ed25519 ssh key support
   s.add_dependency "highline", ">= 1.6.9", "< 3"
   s.add_dependency "tty-prompt", "~> 0.21" # knife ui.ask prompt
   s.add_dependency "tty-screen", "~> 0.6" # knife list

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -47,9 +47,9 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    bcrypt_pbkdf (1.1.0.rc1)
-    bcrypt_pbkdf (1.1.0.rc1-x64-mingw32)
-    bcrypt_pbkdf (1.1.0.rc1-x86-mingw32)
+    bcrypt_pbkdf (1.1.0.rc2)
+    bcrypt_pbkdf (1.1.0.rc2-x64-mingw32)
+    bcrypt_pbkdf (1.1.0.rc2-x86-mingw32)
     berkshelf (7.1.0)
       chef (>= 15.7.32)
       chef-config
@@ -66,7 +66,7 @@ GEM
     builder (3.2.4)
     chef (16.7.61)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc1)
+      bcrypt_pbkdf (= 1.1.0.rc2)
       bundler (>= 1.10)
       chef-config (= 16.7.61)
       chef-utils (= 16.7.61)
@@ -102,7 +102,7 @@ GEM
       uuidtools (~> 2.1.5)
     chef (16.7.61-universal-mingw32)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc1)
+      bcrypt_pbkdf (= 1.1.0.rc2)
       bundler (>= 1.10)
       chef-config (= 16.7.61)
       chef-utils (= 16.7.61)


### PR DESCRIPTION
RC2 now includes support for Ruby 3

Backports https://github.com/chef/chef/pull/10804

Signed-off-by: Tim Smith <tsmith@chef.io>