### PR TITLE
Coerce uid to integer in Windows user resource.

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -106,3 +106,11 @@ include_recipe "::_ohai_hint"
 hostname "new-hostname" do
   windows_reboot false
 end
+
+user "phil" do
+  uid "8019"
+end
+
+user "phil" do
+  action :remove
+end

--- a/spec/unit/resource/user/windows_user_spec.rb
+++ b/spec/unit/resource/user/windows_user_spec.rb
@@ -15,26 +15,22 @@
 # limitations under the License.
 #
 
-require_relative "../user"
+require "spec_helper"
 
-class Chef
-  class Resource
-    class User
-      class WindowsUser < Chef::Resource::User
-        unified_mode true
+describe Chef::Resource::User::WindowsUser, "#uid" do
+  let(:resource) { Chef::Resource::User::WindowsUser.new("notarealuser") }
 
-        provides :windows_user
-        provides :user, os: "windows"
+  it "allows a string" do
+    resource.uid "100"
+    expect(resource.uid).to eql(100)
+  end
 
-        property :full_name, String,
-          description: "The full name of the user.",
-          introduced: "14.6"
+  it "allows an integer" do
+    resource.uid 100
+    expect(resource.uid).to eql(100)
+  end
 
-        # Override the property from the parent class to coerce to integer.
-        property :uid, [ String, Integer, NilClass ], # nil for backwards compat
-          description: "The numeric user identifier.",
-          coerce: proc { |n| n && Integer(n) rescue n }
-      end
-    end
+  it "does not allow a hash" do
+    expect { resource.uid({ woot: "i found it" }) }.to raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Fixes #10454. Followup to #10797.

I ended up including the `rescue` call because it made the error message much nicer.

without `rescue`:

```
     TypeError:
       can't convert Hash into Integer
```

with `rescue`:

```
     Chef::Exceptions::ValidationFailed:
       Property uid must be one of: String, Integer, NilClass!  You passed {:woot=>"i found it"}.
```

After this PR, the uid of the user doesn't actually change (probably related to #10657), but this fixes the crash.

Backports https://github.com/chef/chef/pull/10803