### PR TITLE
Add a new `reposdir` property in the `yum_repository` resource

### DIFF
--- a/lib/chef/provider/yum_repository.rb
+++ b/lib/chef/provider/yum_repository.rb
@@ -33,7 +33,7 @@ class Chef
       def load_current_resource; end
 
       action :create do
-        declare_resource(:template, "/etc/yum.repos.d/#{new_resource.repositoryid}.repo") do
+        declare_resource(:template, ::File.join(new_resource.reposdir, "#{new_resource.repositoryid}.repo")) do
           if template_available?(new_resource.source)
             source new_resource.source
           else
@@ -81,7 +81,7 @@ class Chef
           only_if "yum repolist all | grep -P '^#{new_resource.repositoryid}([ \t]|$)'"
         end
 
-        declare_resource(:file, "/etc/yum.repos.d/#{new_resource.repositoryid}.repo") do
+        declare_resource(:file, ::File.join(new_resource.reposdir, "#{new_resource.repositoryid}.repo")) do
           action :delete
           notifies :create, "ruby_block[package-cache-reload-#{new_resource.repositoryid}]", :immediately
         end

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -50,6 +50,11 @@ class Chef
 
       # http://linux.die.net/man/5/yum.conf as well as
       # http://dnf.readthedocs.io/en/latest/conf_ref.html
+      property :reposdir, String,
+        description: "The directory where the Yum repository files should be stored",
+        default: "/etc/yum.repos.d/",
+        introduced: "16.9"
+
       property :baseurl, [String, Array],
         description: "URL to the directory where the Yum repository's `repodata` directory lives. Can be an `http://`, `https://` or a `ftp://` URLs. You can specify multiple URLs in one `baseurl` statement."
 


### PR DESCRIPTION
This lets you optionally add/remove repo configs from a non-standard dir.

Resolves https://github.com/chef/chef/issues/9618

Signed-off-by: Tim Smith <tsmith@chef.io>