### PR TITLE
Extend the pure ruby Ohai timeout to 4 seconds

### DIFF
--- a/spec/integration/ohai/ohai_spec.rb
+++ b/spec/integration/ohai/ohai_spec.rb
@@ -51,11 +51,11 @@ describe "ohai" do
     # test succeeds and the other one fails, then it can be some kind of shelling-out
     # issue or poor performance due to I/O on starting up ruby to run ohai, etc.
     #
-    it "the hostname plugin must return in under 2 seconds when called from pure ruby" do
+    it "the hostname plugin must return in under 4 seconds when called from pure ruby" do
       delta = Benchmark.realtime do
         Ohai::System.new.all_plugins(["hostname"])
       end
-      expect(delta).to be < 2
+      expect(delta).to be < 4
     end
   end
 end


### PR DESCRIPTION
This times out from time to time when the system is configured
correctly. It just makes the test cycles take an hour longer.

Signed-off-by: Tim Smith <tsmith@chef.io>