### PR TITLE
Add support for lazy attributes

### DIFF
--- a/chef-utils/lib/chef-utils/mash.rb
+++ b/chef-utils/lib/chef-utils/mash.rb
@@ -94,12 +94,21 @@ module ChefUtils
       end
     end
 
+    unless method_defined?(:regular_reader)
+      alias_method :regular_reader, :[]
+    end
+
     unless method_defined?(:regular_writer)
       alias_method :regular_writer, :[]=
     end
 
     unless method_defined?(:regular_update)
       alias_method :regular_update, :update
+    end
+
+    # @param key<Object> The key to get.
+    def [](key)
+      regular_reader(key)
     end
 
     # @param key<Object> The key to set.
@@ -110,6 +119,12 @@ module ChefUtils
     # @see Mash#convert_value
     def []=(key, value)
       regular_writer(convert_key(key), convert_value(value))
+    end
+
+    # internal API for use by Chef's deep merge cache
+    # @api private
+    def internal_get(key)
+      regular_reader(key)
     end
 
     # internal API for use by Chef's deep merge cache

--- a/lib/chef/delayed_evaluator.rb
+++ b/lib/chef/delayed_evaluator.rb
@@ -17,5 +17,9 @@
 
 class Chef
   class DelayedEvaluator < Proc
+    def dup
+      # super returns a "Proc" (which seems buggy) so re-wrap it
+      self.class.new(&super) # rubocop:disable Layout/SpaceAroundKeyword
+    end
   end
 end

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -596,7 +596,7 @@ class Chef
           merge_with.each do |key, merge_with_value|
             value =
               if merge_onto.key?(key)
-                deep_merge!(safe_dup(merge_onto[key]), merge_with_value)
+                deep_merge!(safe_dup(merge_onto.internal_get(key)), merge_with_value)
               else
                 merge_with_value
               end
@@ -632,7 +632,7 @@ class Chef
           merge_with.each do |key, merge_with_value|
             value =
               if merge_onto.key?(key)
-                hash_only_merge!(safe_dup(merge_onto[key]), merge_with_value)
+                hash_only_merge!(safe_dup(merge_onto.internal_get(key)), merge_with_value)
               else
                 merge_with_value
               end

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -19,6 +19,7 @@ require_relative "common_api"
 require_relative "mixin/state_tracking"
 require_relative "mixin/immutablize_array"
 require_relative "mixin/immutablize_hash"
+require_relative "../delayed_evaluator"
 
 class Chef
   class Node
@@ -111,7 +112,7 @@ class Chef
 
       def [](*args)
         value = super
-        value = value.call while value.is_a?(Proc)
+        value = value.call while value.is_a?(::Chef::DelayedEvaluator)
         value
       end
 
@@ -195,7 +196,7 @@ class Chef
 
       def [](*args)
         value = super
-        value = value.call while value.is_a?(Proc)
+        value = value.call while value.is_a?(::Chef::DelayedEvaluator)
         value
       end
 

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -109,7 +109,7 @@ class Chef
         key
       end
 
-      def [](index)
+      def [](*args)
         value = super
         value = value.call while value.is_a?(Proc)
         value
@@ -193,7 +193,7 @@ class Chef
         e
       end
 
-      def [](key)
+      def [](*args)
         value = super
         value = value.call while value.is_a?(Proc)
         value

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -109,6 +109,12 @@ class Chef
         key
       end
 
+      def [](index)
+        value = super
+        value = value.call while value.is_a?(Proc)
+        value
+      end
+
       prepend Chef::Node::Mixin::StateTracking
       prepend Chef::Node::Mixin::ImmutablizeArray
     end
@@ -185,6 +191,12 @@ class Chef
         e.dup
       rescue TypeError
         e
+      end
+
+      def [](key)
+        value = super
+        value = value.call while value.is_a?(Proc)
+        value
       end
 
       prepend Chef::Node::Mixin::StateTracking

--- a/lib/chef/node/mixin/deep_merge_cache.rb
+++ b/lib/chef/node/mixin/deep_merge_cache.rb
@@ -46,13 +46,15 @@ class Chef
         alias :reset :reset_cache
 
         def [](key)
-          if deep_merge_cache.key?(key.to_s)
-            # return the cache of the deep merged values by top-level key
-            deep_merge_cache[key.to_s]
-          else
-            # save all the work of computing node[key]
-            deep_merge_cache[key.to_s] = merged_attributes(key)
-          end
+          ret = if deep_merge_cache.key?(key.to_s)
+                  # return the cache of the deep merged values by top-level key
+                  deep_merge_cache[key.to_s]
+                else
+                  # save all the work of computing node[key]
+                  deep_merge_cache[key.to_s] = merged_attributes(key)
+                end
+          ret = ret.call while ret.is_a?(Proc)
+          ret
         end
 
       end

--- a/lib/chef/node/mixin/deep_merge_cache.rb
+++ b/lib/chef/node/mixin/deep_merge_cache.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+require_relative "../../delayed_evaluator"
+
 class Chef
   class Node
     module Mixin
@@ -53,7 +55,7 @@ class Chef
                   # save all the work of computing node[key]
                   deep_merge_cache[key.to_s] = merged_attributes(key)
                 end
-          ret = ret.call while ret.is_a?(Proc)
+          ret = ret.call while ret.is_a?(::Chef::DelayedEvaluator)
           ret
         end
 


### PR DESCRIPTION
Implements #10345

This is very much not the poise-derived solution.

This allows the user to store procs/lazy-evaluators into the attribute tree.  Those are saved into the merged view of the node object.  On access, the proc is evaluated before the value is given back to the user.

This allows the user to lazy derived attributes:

```ruby
default['user'] = "Avasarala"
default['homedir'] = lazy { "/home/#{node['user']}" }
```

Since the proc is saved in the deep merge cache rather than the evaluated value, the result is truly lazy:

```ruby
default['user'] = "Avasarala"
default['homedir'] = lazy { "/home/#{node['user']}" }

# prints "/home/Avasarala"
puts node['homedir']

override['user'] = "Amos"

# prints "/home/Amos"
puts node['homedir']
```

The user can arbitrarily mess with the dependent variable in recipe code and the lazied attribute should change accordingly.

The access through the precedence level is still the proc (this is pretty much a feature not a bug and trying to change this behavior would cache the lazy evaluation on first access):

```ruby
default['user'] = "Holden"
default['homedir'] = lazy { "/home/#{node['user']}" }

# prints something about being a proc defined on some source line
puts default['homedir'] 
# prints "/home/Holden"
puts default['homedir'].call 
```

It also supports recursive laziness

```ruby
default["program"] = "ganymede"
default["program_var"] = lazy { "/var/#{node["program"}" }
default["program_cache"] = lazy { "#{node["program_var"]}/cache" }

default["program"] = "phoebe"

# prints "/var/phoebe/cache"
puts node["program_cache"] 
```

This will not work with poise-derived, users will get poise-derived behavior (which I suspect has been broken for several major releases of chef-client now)

Note that since it returns a real value on access, that means it does not lazy the value all the way to converge time in the recipe context, it will still be necessary to lazy the access in recipe code as well.  There is technically a breaking change issue here, because users may have figured out that they can already pass a lazy proc into an attribute and pass it to a property which will lazy the evaluation (and lazy it all the way to converge time).  This change enhances the former behavior -- any user that was trying to work around the derived attribute issue will have found that it fails when passed into e.g. template variables without littering their templates with ".call" modifiers and such, which this PR fixes.  However it necessarily breaks lazy procs in attributes from being lazied all the way to converge time, which uses may have abused as a feature, or may have just accidentally become dependent upon.  This is actually better behavior since having the contents of the attribute control the evaluation at converge time is going to surprise people who overwrite the attribute and lose the behavior as well.  There is no good way to deprecate this behavior since it requires very, very spooky action at a distance (the evaluation of the proc by the property does not have any information about the proc being declared immediately in the recipe code or distantly from the attributes file, and a lazy proc in the attributes file might not require the behavior of lazying to compile time so some very distant coordination would be required to accurately emit a deprecation -- and doing this with cookstyle would be impossible).  At the same time the amount of cookbooks using this trick that will break should be very, very low.

It looks like there's only two groups of cookbooks on the supermarket that have discovered this trick:

```
alfresco-appserver/attributes/default.rb
alfresco-appserver/attributes/tomcat.rb
alfresco-db/attributes/mysql_local.rb
alfresco-transformations/attributes/default.rb
kafka/attributes/default.rb
kkafka/attributes/default.rb
```

Those seem to be using `lazy {}` in order to do derived attributes so presumably would still work okay, but no other cookbooks should be affected.

BONUS FIX:

The deep merge code was calling ImmutableMash#[] while merging arrays which was incurring additional expense and complexity in invoking all the decorated state_tracking stuff and other calls in the inheritance heirarchy on those.  Similarly to how we use the Mash#internal_set API in that routine to set values without going through convert_value this introduces a change to use the new Mash#internal_get API which directly gets the value from the underlying Hash without any magic associated with it.  This should provide at least a little bit of perf boost to the deep merge caching routines, and it eliminates an infinite loop that I created here.

DOUBLE-SUPER-BONUS FIX:

The Chef::DelayedEvaluator class seems to exercise a ruby bug where dup returns a Proc rather than the subclass, so fix that.