### PR TITLE
Fix audit cookbook detection in Compliance Phase

### DIFF
--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -16,7 +16,7 @@ class Chef
       def_delegators :node, :logger
 
       def enabled?
-        audit_cookbook_present = recipes.include?("audit::default")
+        audit_cookbook_present = recipes.include?("audit::default") || recipes.include?("audit")
 
         logger.info("#{self.class}##{__method__}: #{Inspec::Dist::PRODUCT_NAME} profiles? #{inspec_profiles.any?}")
         logger.info("#{self.class}##{__method__}: audit cookbook? #{audit_cookbook_present}")


### PR DESCRIPTION
We have some simple logic right now to skip the Compliance Phase if the
audit::default recipe is on the node. This doesn't work if the user
adding the audit cookbook directly instead of the full path to the
default recipe. Confirmed via Test Kitchen testing on the audit
cookbook against 16.9

Signed-off-by: Tim Smith <tsmith@chef.io>