### PR TITLE
Compliance phase: change the audit cb checker to use the recipes list on the node.

### DIFF
--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -11,12 +11,12 @@ class Chef
     class Runner < EventDispatch::Base
       extend Forwardable
 
-      attr_accessor :run_id, :recipes
+      attr_accessor :run_id
       attr_reader :node
       def_delegators :node, :logger
 
       def enabled?
-        audit_cookbook_present = recipes.include?("audit::default")
+        audit_cookbook_present = node["recipes"].include?("audit::default")
 
         logger.info("#{self.class}##{__method__}: #{Inspec::Dist::PRODUCT_NAME} profiles? #{inspec_profiles.any?}")
         logger.info("#{self.class}##{__method__}: audit cookbook? #{audit_cookbook_present}")
@@ -35,10 +35,6 @@ class Chef
 
       def run_started(run_status)
         self.run_id = run_status.run_id
-      end
-
-      def run_list_expanded(run_list_expansion)
-        self.recipes = run_list_expansion.recipes
       end
 
       def run_completed(_node, _run_status)

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -8,41 +8,40 @@ describe Chef::Compliance::Runner do
     described_class.new.tap do |r|
       r.node = node
       r.run_id = "my_run_id"
-      r.recipes = []
     end
   end
 
   describe "#enabled?" do
     it "is true if the node attributes have audit profiles and the audit cookbook is not present" do
       node.normal["audit"]["profiles"]["ssh"] = { 'compliance': "base/ssh" }
-      runner.recipes = %w{ fancy_cookbook::fanciness tacobell::nachos }
+      node.automatic["recipes"] = %w{ fancy_cookbook::fanciness tacobell::nachos }
 
       expect(runner).to be_enabled
     end
 
     it "is false if the node attributes have audit profiles and the audit cookbook is present" do
       node.normal["audit"]["profiles"]["ssh"] = { 'compliance': "base/ssh" }
-      runner.recipes = %w{ audit::default fancy_cookbook::fanciness tacobell::nachos }
+      node.automatic["recipes"] = %w{ audit::default fancy_cookbook::fanciness tacobell::nachos }
 
       expect(runner).not_to be_enabled
     end
 
     it "is false if the node attributes do not have audit profiles and the audit cookbook is not present" do
       node.normal["audit"]["profiles"] = {}
-      runner.recipes = %w{ fancy_cookbook::fanciness tacobell::nachos }
+      node.automatic["recipes"] = %w{ fancy_cookbook::fanciness tacobell::nachos }
 
       expect(runner).not_to be_enabled
     end
 
     it "is false if the node attributes do not have audit profiles and the audit cookbook is present" do
       node.normal["audit"]["profiles"] = {}
-      runner.recipes = %w{ audit::default fancy_cookbook::fanciness tacobell::nachos }
+      node.automatic["recipes"] = %w{ audit::default fancy_cookbook::fanciness tacobell::nachos }
 
       expect(runner).not_to be_enabled
     end
 
     it "is false if the node attributes do not have audit attributes and the audit cookbook is not present" do
-      runner.recipes = %w{ fancy_cookbook::fanciness tacobell::nachos }
+      node.automatic["recipes"] = %w{ fancy_cookbook::fanciness tacobell::nachos }
       expect(runner).not_to be_enabled
     end
   end


### PR DESCRIPTION
The expanded_run_list doesn't capture any recipes which are not in the
run_list but are dynamically `include_recipe`'d.  This change uses the
recipes list, which by the end of the run should be complete and
accurate.