### PR TITLE
adapt to FreeBSD pkgng sysexit changes

### DIFF
--- a/lib/chef/provider/package/freebsd/pkgng.rb
+++ b/lib/chef/provider/package/freebsd/pkgng.rb
@@ -42,7 +42,9 @@ class Chef
           end
 
           def current_installed_version
-            pkg_info = shell_out!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
+            # pkgng up to version 1.15.99.7 returns 70 for pkg not found,
+            # later versions return 1
+            pkg_info = shell_out!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 1, 70])
             pkg_info.stdout[/^Version +: (.+)$/, 1]
           end
 

--- a/spec/unit/provider/package/freebsd/pkgng_spec.rb
+++ b/spec/unit/provider/package/freebsd/pkgng_spec.rb
@@ -66,7 +66,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     end
 
     it "should query pkg database" do
-      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "zsh", env: nil, returns: [0, 70], timeout: 900).and_return(@pkg_info)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "zsh", env: nil, returns: [0, 1, 70], timeout: 900).and_return(@pkg_info)
       expect(@provider.current_installed_version).to eq("3.1.7")
     end
   end


### PR DESCRIPTION
## Description

The exit code for pkgng changed with https://github.com/freebsd/pkg/commit/f446c790707993656934e0c378b64ae28cb96575 from `70` to `1` making the provider fail on any non-converged node because `pkg info <pkg>` raises an error now. E.g.

```
    ================================================================================
    Error executing action `install` on resource 'freebsd_package[tmux]'
    ================================================================================

    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0, 70], but received '1'
    ---- Begin output of ["pkg", "info", "tmux"] ----
    STDOUT:
    STDERR: pkg: No package(s) matching tmux
    ---- End output of ["pkg", "info", "tmux"] ----
    Ran ["pkg", "info", "tmux"] returned 1
```

I'm a bit wary of how this could be masking legitimate errors of the `pkg info` command.  So I'd definitely love some input on whether there should be additional checking going on to make sure it's not an exit code that should `raise`. That's why I also marked "Breaking Change" below.

This breaks on any FreeBSD node with pkgng version `1.15.99.7` or newer. The current version being `1.16.1`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


Backports https://github.com/chef/chef/pull/10813