### PR TITLE
Fix misspelling in spec/functional/resource/aixinit_service_spec.rb.

### DIFF
--- a/spec/functional/resource/aixinit_service_spec.rb
+++ b/spec/functional/resource/aixinit_service_spec.rb
@@ -34,7 +34,7 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
     expect(File.exist?("#{Dir.tmpdir}/#{file_name}")).to be_falsey
   end
 
-  def valide_symlinks(expected_output, run_level = nil, status = nil, priority = nil)
+  def valid_symlinks(expected_output, run_level = nil, status = nil, priority = nil)
     directory = []
     if priority.is_a? Hash
       priority.each do |level, o|
@@ -129,7 +129,7 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
     context "when the service doesn't set a priority" do
       it "creates symlink with status S" do
         new_resource.run_action(:enable)
-        valide_symlinks(["/etc/rc.d/rc2.d/Schefinittest"], 2, "S")
+        valid_symlinks(["/etc/rc.d/rc2.d/Schefinittest"], 2, "S")
       end
     end
 
@@ -140,7 +140,7 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
 
       it "creates a symlink with status S and a priority" do
         new_resource.run_action(:enable)
-        valide_symlinks(["/etc/rc.d/rc2.d/S75chefinittest"], 2, "S", 75)
+        valid_symlinks(["/etc/rc.d/rc2.d/S75chefinittest"], 2, "S", 75)
       end
     end
 
@@ -152,7 +152,7 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
 
       it "create symlink with status start (S) or stop (K) and a priority " do
         new_resource.run_action(:enable)
-        valide_symlinks(["/etc/rc.d/rc2.d/S20chefinittest", "/etc/rc.d/rc3.d/K10chefinittest"], 2, "S", new_resource.priority)
+        valid_symlinks(["/etc/rc.d/rc2.d/S20chefinittest", "/etc/rc.d/rc3.d/K10chefinittest"], 2, "S", new_resource.priority)
       end
     end
   end
@@ -170,7 +170,7 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
 
       it "creates symlink with status K" do
         new_resource.run_action(:disable)
-        valide_symlinks(["/etc/rc.d/rc2.d/Kchefinittest"], 2, "K")
+        valid_symlinks(["/etc/rc.d/rc2.d/Kchefinittest"], 2, "K")
       end
     end
 
@@ -186,7 +186,7 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
 
       it "creates a symlink with status K and a priority" do
         new_resource.run_action(:disable)
-        valide_symlinks(["/etc/rc.d/rc2.d/K25chefinittest"], 2, "K", 25)
+        valid_symlinks(["/etc/rc.d/rc2.d/K25chefinittest"], 2, "K", 25)
       end
     end
 
@@ -203,7 +203,7 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
 
       it "create symlink with status stop (K) and a priority " do
         new_resource.run_action(:disable)
-        valide_symlinks(["/etc/rc.d/rc2.d/K80chefinittest"], 2, "K", 80)
+        valid_symlinks(["/etc/rc.d/rc2.d/K80chefinittest"], 2, "K", 80)
       end
     end
   end


### PR DESCRIPTION
Fix misspelling in `spec/functional/resource/aixinit_service_spec.rb`.

Obvious fix.

## Description
Changed `valide_symlinks` to `valid_symlinks` in `spec/functional/resource/aixinit_service_spec.rb`.
## Related Issue
n/a, typo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
 - n/a, this is within a test, which furthermore is for AIX, a platform I do not have access to. However, it's a simple typo fix so it shouldn't break anything.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
 - NA, obvious fix
