### PR TITLE
Manually install necessary Ruby for verify pipeline

### DIFF
--- a/.expeditor/scripts/bk_linux_exec.sh
+++ b/.expeditor/scripts/bk_linux_exec.sh
@@ -11,21 +11,28 @@ sudo systemctl start docker
 echo "--- Installing package deps"
 sudo yum install -y gcc gcc-c++ openssl-devel readline-devel zlib-devel
 
-# Install omnibus-toolchain for git bundler and gem
-echo "--- Installing omnibus toolchain"
-curl -fsSL https://chef.io/chef/install.sh | sudo bash -s -- -P omnibus-toolchain
+# Install ASDF
+echo "--- Installing asdf"
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf
+cd ~/.asdf; git checkout "$(git describe --abbrev=0 --tags)"; cd -
+. $HOME/.asdf/asdf.sh
+
+# Install Ruby
+ruby_version=$(sed -n '/"ruby"/{s/.*version: "//;s/"//;p;}' omnibus_overrides.rb)
+asdf plugin add ruby
+asdf install ruby $ruby_version
+asdf global ruby $ruby_version
 
 # Set Environment Variables
 export BUNDLE_GEMFILE=$PWD/kitchen-tests/Gemfile
 export FORCE_FFI_YAJL=ext
 export CHEF_LICENSE="accept-silent"
-export PATH=$PATH:/opt/omnibus-toolchain/embedded/bin
 
 # Update Gems
 echo "--- Installing Gems"
 echo 'gem: --no-document' >> ~/.gemrc
 sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-/opt/omnibus-toolchain/bin/bundle install --jobs=3 --retry=3 --path=../vendor/bundle
+bundle install --jobs=3 --retry=3 --path=../vendor/bundle
 
 echo "--- Config information"
 

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -368,7 +368,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-amazonlinux-2
+    - bundle exec kitchen test end-to-end-amazonlinux-2
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -383,7 +383,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-1804
+    - bundle exec kitchen test end-to-end-ubuntu-1804
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -398,7 +398,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-2004
+    - bundle exec kitchen test end-to-end-ubuntu-2004
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -413,7 +413,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-2104
+    - bundle exec kitchen test end-to-end-ubuntu-2104
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -428,7 +428,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-9
+    - bundle exec kitchen test end-to-end-debian-9
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -443,7 +443,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-10
+    - bundle exec kitchen test end-to-end-debian-10
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -458,7 +458,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-11
+    - bundle exec kitchen test end-to-end-debian-11
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -473,7 +473,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-6
+    - bundle exec kitchen test end-to-end-centos-6
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -488,7 +488,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-7
+    - bundle exec kitchen test end-to-end-centos-7
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -503,7 +503,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-8
+    - bundle exec kitchen test end-to-end-centos-8
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -518,7 +518,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-oraclelinux-7
+    - bundle exec kitchen test end-to-end-oraclelinux-7
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -533,7 +533,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-oraclelinux-8
+    - bundle exec kitchen test end-to-end-oraclelinux-8
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -548,7 +548,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-fedora-latest
+    - bundle exec kitchen test end-to-end-fedora-latest
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -563,7 +563,7 @@ steps:
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-opensuse-leap-15
+    - bundle exec kitchen test end-to-end-opensuse-leap-15
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description

This PR replaces the use of Ruby from `omnibus-toolchain` in the verify pipeline's kitchen tests with a version of Ruby defined in `omnibus_overrides.rb`.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
