### PR TITLE
Manually install necessary Ruby for verify pipeline

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -367,8 +367,9 @@ steps:
 - label: "Kitchen: Amazon Linux 2"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-amazonlinux-2
+    - bundle exec kitchen test end-to-end-amazonlinux-2
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -382,8 +383,9 @@ steps:
 - label: "Kitchen: Ubuntu 16.04"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-1604
+    - bundle exec kitchen test end-to-end-ubuntu-1604
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -398,8 +400,9 @@ steps:
 - label: "Kitchen: Ubuntu 18.04"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-1804
+    - bundle exec kitchen test end-to-end-ubuntu-1804
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -413,8 +416,9 @@ steps:
 - label: "Kitchen: Ubuntu 20.04"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-2004
+    - bundle exec kitchen test end-to-end-ubuntu-2004
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -428,8 +432,9 @@ steps:
 - label: "Kitchen: Ubuntu 21.04"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-2104
+    - bundle exec kitchen test end-to-end-ubuntu-2104
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -443,8 +448,9 @@ steps:
 - label: "Kitchen: Debian 9"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-9
+    - bundle exec kitchen test end-to-end-debian-9
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -458,8 +464,9 @@ steps:
 - label: "Kitchen: Debian 10"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-10
+    - bundle exec kitchen test end-to-end-debian-10
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -473,8 +480,9 @@ steps:
 - label: "Kitchen: Debian 11"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-11
+    - bundle exec kitchen test end-to-end-debian-11
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -488,8 +496,9 @@ steps:
 - label: "Kitchen: CentOS 6"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-6
+    - bundle exec kitchen test end-to-end-centos-6
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -503,8 +512,9 @@ steps:
 - label: "Kitchen: CentOS 7"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-7
+    - bundle exec kitchen test end-to-end-centos-7
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -518,8 +528,9 @@ steps:
 - label: "Kitchen: CentOS 8"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-8
+    - bundle exec kitchen test end-to-end-centos-8
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -533,8 +544,9 @@ steps:
 - label: "Kitchen: Oracle Linux 7"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-oraclelinux-7
+    - bundle exec kitchen test end-to-end-oraclelinux-7
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -548,8 +560,9 @@ steps:
 - label: "Kitchen: Oracle Linux 8"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-oraclelinux-8
+    - bundle exec kitchen test end-to-end-oraclelinux-8
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -563,8 +576,9 @@ steps:
 - label: "Kitchen: Fedora latest"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-fedora-latest
+    - bundle exec kitchen test end-to-end-fedora-latest
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -578,8 +592,9 @@ steps:
 - label: "Kitchen: openSUSE Leap: 15"
   commands:
     - .expeditor/scripts/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-opensuse-leap-15
+    - bundle exec kitchen test end-to-end-opensuse-leap-15
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:


### PR DESCRIPTION
## Description
This PR replaces the use of Ruby from `omnibus-toolchain` in the verify pipeline's kitchen tests with a version of Ruby defined in `omnibus_overrides.rb`.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
