### PR TITLE
Manually install necessary Ruby for verify pipeline

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -328,8 +328,9 @@ steps:
 - label: "Kitchen: Amazon Linux 201X"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-amazonlinux
+    - bundle exec kitchen test end-to-end-amazonlinux
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -343,8 +344,9 @@ steps:
 - label: "Kitchen: Amazon Linux 2"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-amazonlinux-2
+    - bundle exec kitchen test end-to-end-amazonlinux-2
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -358,8 +360,9 @@ steps:
 - label: "Kitchen: Ubuntu 16.04"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-1604
+    - bundle exec kitchen test end-to-end-ubuntu-1604
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -374,8 +377,9 @@ steps:
 - label: "Kitchen: Ubuntu 18.04"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-1804
+    - bundle exec kitchen test end-to-end-ubuntu-1804
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -389,8 +393,9 @@ steps:
 - label: "Kitchen: Ubuntu 20.04"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-ubuntu-2004
+    - bundle exec kitchen test end-to-end-ubuntu-2004
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -404,8 +409,9 @@ steps:
 - label: "Kitchen: Debian 8"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-8
+    - bundle exec kitchen test end-to-end-debian-8
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -419,8 +425,9 @@ steps:
 - label: "Kitchen: Debian 9"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-9
+    - bundle exec kitchen test end-to-end-debian-9
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -434,8 +441,9 @@ steps:
 - label: "Kitchen: Debian 10"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-debian-10
+    - bundle exec kitchen test end-to-end-debian-10
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -449,8 +457,9 @@ steps:
 - label: "Kitchen: CentOS 6"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-6
+    - bundle exec kitchen test end-to-end-centos-6
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -464,8 +473,9 @@ steps:
 - label: "Kitchen: CentOS 7"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-7
+    - bundle exec kitchen test end-to-end-centos-7
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -479,8 +489,9 @@ steps:
 - label: "Kitchen: CentOS 8"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-centos-8
+    - bundle exec kitchen test end-to-end-centos-8
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -494,8 +505,9 @@ steps:
 - label: "Kitchen: Oracle Linux 7"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-oraclelinux-7
+    - bundle exec kitchen test end-to-end-oraclelinux-7
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -509,8 +521,9 @@ steps:
 - label: "Kitchen: Fedora latest"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-fedora-latest
+    - bundle exec kitchen test end-to-end-fedora-latest
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -524,8 +537,9 @@ steps:
 - label: "Kitchen: openSUSE Leap: 15"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
+    - . /var/lib/buildkite-agent/.asdf/asdf.sh
     - cd kitchen-tests
-    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-opensuse-leap-15
+    - bundle exec kitchen test end-to-end-opensuse-leap-15
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:

--- a/scripts/bk_tests/bk_linux_exec.sh
+++ b/scripts/bk_tests/bk_linux_exec.sh
@@ -11,28 +11,38 @@ sudo systemctl start docker
 echo "--- Installing package deps"
 sudo yum install -y gcc gcc-c++ openssl-devel readline-devel zlib-devel
 
-# Install omnibus-toolchain for git bundler and gem
-echo "--- Installing omnibus toolchain"
-curl -fsSL https://chef.io/chef/install.sh | sudo bash -s -- -P omnibus-toolchain
+# Install ASDF
+echo "--- Installing asdf to ${HOME}/.asdf"
+git clone https://github.com/asdf-vm/asdf.git "${HOME}/.asdf"
+cd "${HOME}/.asdf"; git checkout "$(git describe --abbrev=0 --tags)"; cd -
+. "${HOME}/.asdf/asdf.sh"
+
+# Install Ruby
+ruby_version=$(sed -n '/"ruby"/{s/.*version: "//;s/"//;p;}' omnibus_overrides.rb)
+echo "--- Installing Ruby $ruby_version"
+asdf plugin add ruby
+asdf install ruby $ruby_version
+asdf global ruby $ruby_version
 
 # Set Environment Variables
 export BUNDLE_GEMFILE=$PWD/kitchen-tests/Gemfile
 export FORCE_FFI_YAJL=ext
 export CHEF_LICENSE="accept-silent"
-export PATH=$PATH:/opt/omnibus-toolchain/embedded/bin
 
 # Update Gems
 echo "--- Installing Gems"
 echo 'gem: --no-document' >> ~/.gemrc
 sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-/opt/omnibus-toolchain/bin/bundle install --jobs=3 --retry=3 --path=../vendor/bundle
+bundle install --jobs=3 --retry=3 --path=../vendor/bundle
 
 echo "--- Config information"
 
 echo "!!!! RUBY VERSION !!!!"
 ruby --version
-echo "!!!! BUNDLE LOCATION !!!!"
+echo "!!!! BUNDLER LOCATION !!!!"
 which bundle
+echo "!!!! BUNDLER VERSION !!!!"
+bundle -v
 echo "!!!! DOCKER VERSION !!!!"
 docker version
 echo "!!!! DOCKER STATUS !!!!"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR replaces the use of Ruby from `omnibus-toolchain` in the verify pipeline's kitchen tests with a version of Ruby defined in `omnibus_overrides.rb`.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
