### PR TITLE
Update the alternatives and chef_client_launchd descriptions

### DIFF
--- a/lib/chef/resource/alternatives.rb
+++ b/lib/chef/resource/alternatives.rb
@@ -26,7 +26,7 @@ class Chef
 
       provides(:alternatives) { true }
 
-      description "The alternatives resource allows for configuration of command alternatives in Linux using the alternatives or update-alternatives packages."
+      description "Use the **alternatives** resource allows to configure command alternatives in Linux using the alternatives or update-alternatives packages."
       introduced "16.0"
       examples <<~DOC
       **Install an alternative**:

--- a/lib/chef/resource/alternatives.rb
+++ b/lib/chef/resource/alternatives.rb
@@ -26,7 +26,7 @@ class Chef
 
       provides(:alternatives) { true }
 
-      description "Use the **alternatives** resource allows to configure command alternatives in Linux using the alternatives or update-alternatives packages."
+      description "Use the **alternatives** resource to configure command alternatives in Linux using the alternatives or update-alternatives packages."
       introduced "16.0"
       examples <<~DOC
       **Install an alternative**:

--- a/lib/chef/resource/chef_client_launchd.rb
+++ b/lib/chef/resource/chef_client_launchd.rb
@@ -23,7 +23,7 @@ class Chef
 
       provides :chef_client_launchd
 
-      description "Use the **chef_client_launchd** resource to configure the #{ChefUtils::Dist::Infra::PRODUCT} to run on a schedule."
+      description "Use the **chef_client_launchd** resource to configure the #{ChefUtils::Dist::Infra::PRODUCT} to run on a schedule on macOS systems."
       introduced "16.5"
       examples <<~DOC
         **Set the #{ChefUtils::Dist::Infra::PRODUCT} to run on a schedule**:


### PR DESCRIPTION
Match our current format and make it more clear that launchd == macos

Signed-off-by: Tim Smith <tsmith@chef.io>