### PR TITLE
Fix ohai resource spec

### DIFF
--- a/spec/functional/resource/ohai_spec.rb
+++ b/spec/functional/resource/ohai_spec.rb
@@ -19,10 +19,6 @@
 require "spec_helper"
 
 describe Chef::Resource::Ohai do
-  let(:ohai) do
-    OHAI_SYSTEM
-  end
-
   let(:node) { Chef::Node.new }
 
   let(:run_context) do
@@ -34,13 +30,9 @@ describe Chef::Resource::Ohai do
 
   shared_examples_for "reloaded :uptime" do
     it "should reload :uptime" do
-      initial_uptime = ohai[:uptime]
-
-      # Sleep for a second so the uptime gets updated.
-      sleep 1
-
+      expect(node[:uptime_seconds]).to be nil
       ohai_resource.run_action(:reload)
-      expect(node[:uptime]).not_to eq(initial_uptime)
+      expect(Integer(node[:uptime_seconds])).to be_an(Integer)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,7 +87,7 @@ Dir["spec/support/**/*.rb"]
   .each { |f| require f }
 
 OHAI_SYSTEM = Ohai::System.new
-OHAI_SYSTEM.all_plugins(["platform", "hostname", "languages/powershell"])
+OHAI_SYSTEM.all_plugins(["platform", "hostname", "languages/powershell", "uptime"])
 
 test_node = Chef::Node.new
 test_node.automatic["os"] = (OHAI_SYSTEM["os"] || "unknown_os").dup.freeze


### PR DESCRIPTION
1. this speeds it up by avoiding the sleep and the old ohai data
2. this fixes it because it was totally broken and the old uptime value was nil anyway

