### PR TITLE
Compliance Phase: even better audit cookbook detection

### DIFF
--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -16,7 +16,9 @@ class Chef
       def_delegators :node, :logger
 
       def enabled?
-        audit_cookbook_present = node["recipes"].include?("audit::default")
+        # Did we parse the libraries file from the audit cookbook?  This class dates back to when Chef Automate was
+        # renamed from Chef Visibility in 2017, so should capture all modern versions of the audit cookbook.
+        audit_cookbook_present = defined?(::Reporter::ChefAutomate)
 
         logger.info("#{self.class}##{__method__}: #{Inspec::Dist::PRODUCT_NAME} profiles? #{inspec_profiles.any?}")
         logger.info("#{self.class}##{__method__}: audit cookbook? #{audit_cookbook_present}")

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -12,29 +12,28 @@ describe Chef::Compliance::Runner do
   end
 
   describe "#enabled?" do
+
     it "is true if the node attributes have audit profiles and the audit cookbook is not present" do
       node.normal["audit"]["profiles"]["ssh"] = { 'compliance': "base/ssh" }
-      node.automatic["recipes"] = %w{ fancy_cookbook::fanciness tacobell::nachos }
 
       expect(runner).to be_enabled
     end
 
     it "is false if the node attributes have audit profiles and the audit cookbook is present" do
+      stub_const("::Reporter::ChefAutomate", true)
       node.normal["audit"]["profiles"]["ssh"] = { 'compliance': "base/ssh" }
-      node.automatic["recipes"] = %w{ audit::default fancy_cookbook::fanciness tacobell::nachos }
 
       expect(runner).not_to be_enabled
     end
 
     it "is false if the node attributes do not have audit profiles and the audit cookbook is not present" do
       node.normal["audit"]["profiles"] = {}
-      node.automatic["recipes"] = %w{ fancy_cookbook::fanciness tacobell::nachos }
 
       expect(runner).not_to be_enabled
     end
 
     it "is false if the node attributes do not have audit profiles and the audit cookbook is present" do
-      node.normal["audit"]["profiles"] = {}
+      stub_const("::Reporter::ChefAutomate", true)
       node.automatic["recipes"] = %w{ audit::default fancy_cookbook::fanciness tacobell::nachos }
 
       expect(runner).not_to be_enabled


### PR DESCRIPTION
This detects if the audit cookbook's library files have been parsed,
which is mildly brittle but this constant has been stable back to 2017.

This catches the case where a site:

1. Has the audit cookbook as a cookbook dependency so it is in the run_list.
2. The wrapper cookbook is loading the attributes.
3. But the audit cookbook is not run every time and is controlled by
   "include_recipe" with a conditional wrapper.

It may also catch cases where the site uses a named_run_list in a
PolicyFile since the cookbook set is the same no matter what named_run_list
you are running (pretty sure that's a feature of how PolicyFiles work).

What it can't do is catch old-style override run_lists with the audit
cookbook normally not in the cookbook set at all.  That is quite
literally impossible to detect.
