### PR TITLE
Remove Ruby 2.6 tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -15,6 +15,16 @@ steps:
   # Tests Ruby 2.7
 #########################################################################
 
+- label: "Chefstyle :ruby: 2.7"
+  commands:
+    - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - bundle exec rake style
+  expeditor:
+    executor:
+      docker:
+        image: rubydistros/ubuntu-18.04:2.7
+
 - label: "Integration Ubuntu 18.04 :ruby: 2.7"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
@@ -237,59 +247,6 @@ steps:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
         shell: ["powershell", "-Command"]
-
-#########################################################################
-# Tests Ruby 2.6
-#########################################################################
-
-- label: "Chefstyle :ruby: 2.6"
-  commands:
-    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
-    - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
-    - bundle exec rake style
-  expeditor:
-    executor:
-      docker:
-        image: rubydistros/ubuntu-18.04:2.6
-
-- label: "Integration :ruby: 2.6"
-  commands:
-    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
-    - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
-    - bundle exec rake spec:integration
-  expeditor:
-    executor:
-      docker:
-        image: rubydistros/ubuntu-18.04:2.6
-        privileged: true
-
-- label: "Functional :ruby: 2.6"
-  commands:
-    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
-    - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - apt-get update -y
-    - apt-get install -y cron locales net-tools # needed for functional tests to pass
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
-    - bundle exec rake spec:functional
-  expeditor:
-    executor:
-      docker:
-        image: rubydistros/ubuntu-18.04:2.6
-        privileged: true
-
-- label: "Unit :ruby: 2.6"
-  commands:
-    - gem install bundler -v 2.1.4 # match Ruby 2.7 bundler
-    - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
-    - bundle exec rake spec:unit
-    - bundle exec rake component_specs
-  expeditor:
-    executor:
-      docker:
-        image: rubydistros/ubuntu-18.04:2.6
 
 #########################################################################
   # EXTERNAL GEM TESTING


### PR DESCRIPTION
Ohai requires Ruby 2.7+ now

Signed-off-by: Tim Smith <tsmith@chef.io>