### PR TITLE
Add backup functionality to windows_task

### DIFF
--- a/lib/chef/util/backup.rb
+++ b/lib/chef/util/backup.rb
@@ -64,7 +64,7 @@ class Chef
       end
 
       def backup_path
-        @backup_path ||= ::File.join(prefix, backup_filename)
+        @backup_path ||= PathHelper.cleanpath(::File.join(prefix, backup_filename))
       end
 
       def do_backup
@@ -83,7 +83,7 @@ class Chef
         fn = Regexp.escape(::File.basename(path))
         Dir.entries(::File.dirname(backup_path)).select do |f|
           !!(f =~ /\A#{fn}.chef-[0-9.]*\B/)
-        end.map { |f| ::File.join(::File.dirname(backup_path), f) }
+        end.map { |f| PathHelper.cleanpath(::File.join(::File.dirname(backup_path), f)) }
       end
 
       def sorted_backup_files

--- a/lib/chef/util/backup.rb
+++ b/lib/chef/util/backup.rb
@@ -64,7 +64,7 @@ class Chef
       end
 
       def backup_path
-        @backup_path ||= PathHelper.cleanpath(::File.join(prefix, backup_filename))
+        @backup_path ||= ::File.join(prefix, backup_filename)
       end
 
       def do_backup
@@ -83,7 +83,7 @@ class Chef
         fn = Regexp.escape(::File.basename(path))
         Dir.entries(::File.dirname(backup_path)).select do |f|
           !!(f =~ /\A#{fn}.chef-[0-9.]*\B/)
-        end.map { |f| PathHelper.cleanpath(::File.join(::File.dirname(backup_path), f)) }
+        end.map { |f| ::File.join(::File.dirname(backup_path), f) }
       end
 
       def sorted_backup_files


### PR DESCRIPTION
Adds backup property to windows_task, allowing the XML of the task to be saved for rollback purposes.

## Description
Allows rollbacks and history for windows tasks modified or deleted by chef

## Related Issue
https://github.com/chef/chef/issues/10883

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
