### PR TITLE
Remove pending test for use_inline_resources

### DIFF
--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -189,12 +189,4 @@ describe Chef::Provider do
 
     end
   end
-
-  context "when using use_inline_resources" do
-    it "should log a deprecation warning" do
-      pending Chef::VERSION.start_with?("14.1")
-      expect(Chef).to receive(:deprecated).with(:use_inline_resources, kind_of(String))
-      Class.new(described_class) { use_inline_resources }
-    end
-  end
 end


### PR DESCRIPTION
The original intent was to remove the use_inline_resources method from
the codebase. We have a Cookstyle rule cleaning that up, but there's
really no value to customers in removing the empty method. It doesn't
bloat the app or cause us any additional maint effort. We can just
remove them via cookstyle as we find them and carry on with our life
within chef-client. Removing the method just makes upgrades harder for
customers.

Signed-off-by: Tim Smith <tsmith@chef.io>