### PR TITLE
Remove ohai from omnibus_overrides

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -21,11 +21,3 @@ override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
 override "zlib", version: "1.2.11"
-
-# We build both chef and ohai omnibus-software definitions which creates the
-# chef-client and ohai binstubs. Out of the box the ohai definition uses whatever
-# is in master, which won't match what's in the Gemfile.lock and used by the chef
-# definition. This pin will ensure that ohai and chef-client commands use the
-# same (released) version of ohai.
-gemfile_lock = File.join(File.expand_path(__dir__), "Gemfile.lock")
-override "ohai", version: "#{::File.readlines(gemfile_lock).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; "v" + $1}" # rubocop: disable Layout/SpaceInsideStringInterpolation


### PR DESCRIPTION
The omnibus-software defn no longer exists.
