### PR TITLE
Fix DNF version comparison bug

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -446,8 +446,8 @@ class Chef
                   # requested new_resource.version constraints
                   logger.trace("#{new_resource} has no existing installed version. Installing install #{candidate_version}")
                   target_version_array.push(candidate_version)
-                elsif version_equals?(current_version, new_version)
-                  # this is a short-circuit to avoid needing to (expensively) query the candidate_version which must come later
+                elsif !use_magic_version? && version_equals?(current_version, new_version)
+                  # this is a short-circuit (mostly for the rubygems provider) to avoid needing to expensively query the candidate_version which must come later
                   logger.trace("#{new_resource} #{package_name} #{new_version} is already installed")
                   target_version_array.push(nil)
                 elsif candidate_version.nil?

--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -64,7 +64,7 @@ def version_tuple(versionstr):
         tmp = versionstr[colon_index + 1:dash_index]
         if tmp != '':
             v = tmp
-        arch_index = versionstr.find('.', dash_index)
+        arch_index = versionstr.rfind('.', dash_index)
         if arch_index > 0:
             r = versionstr[dash_index + 1:arch_index]
         else:

--- a/spec/unit/provider/package/dnf/python_helper_spec.rb
+++ b/spec/unit/provider/package/dnf/python_helper_spec.rb
@@ -19,11 +19,17 @@ require "spec_helper"
 
 # NOTE: most of the tests of this functionality are baked into the func tests for the dnf package provider
 
-describe Chef::Provider::Package::Dnf::PythonHelper do
+# run this test only for following platforms.
+exclude_test = !(%w{rhel fedora amazon}.include?(ohai[:platform_family]) && File.exist?("/usr/bin/dnf"))
+describe Chef::Provider::Package::Dnf::PythonHelper, :requires_root, external: exclude_test do
   let(:helper) { Chef::Provider::Package::Dnf::PythonHelper.instance }
 
   it "propagates stacktraces on stderr from the forked subprocess", :rhel do
     allow(helper).to receive(:dnf_command).and_return("ruby -e 'raise \"your hands in the air\"'")
     expect { helper.package_query(:whatprovides, "tcpdump") }.to raise_error(/your hands in the air/)
+  end
+
+  it "compares EVRAs with dots in the release correctly" do
+    expect(helper.compare_versions("0:1.8.29-6.el8.x86_64", "0:1.8.29-6.el8_3.1.x86_64")).to eql(-1)
   end
 end


### PR DESCRIPTION
Also suppresses a version comparison that normally fails when it is
called on the dnf provider which was ignorable.
