### PR TITLE
Unpin rspec to bring in 3.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ end
 
 group(:development, :test) do
   gem "rake"
-  gem "rspec", "=3.9.0" # remove pin once https://github.com/chef/chef/issues/10817 is resolved
+  gem "rspec"
   gem "webmock"
   gem "fauxhai-ng" # for chef-utils gem
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 4843bb3d6bbf8ad73a23bac7b3feba8cf9597b5c
+  revision: d175d5189c8dc7bfed4689927fa4c6312fec80c1
   branch: master
   specs:
-    ohai (17.0.12)
+    ohai (17.0.13)
       chef-config (>= 12.8, < 18)
       chef-utils (>= 16.0, < 18)
       ffi (~> 1.9)
@@ -294,22 +294,22 @@ GEM
     rb-readline (0.5.5)
     regexp_parser (2.0.3)
     rexml (3.2.4)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.3)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
+      rspec-support (~> 3.10.0)
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.9.1)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.4)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
     rubocop (1.9.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -441,7 +441,7 @@ DEPENDENCIES
   pry-stack_explorer
   rake
   rb-readline
-  rspec (= 3.9.0)
+  rspec
   ruby-prof (< 1.3.0)
   ruby-shadow
   webmock


### PR DESCRIPTION
With the new rspec-mocks we may be able to use rspec 3.10 again

Signed-off-by: Tim Smith <tsmith@chef.io>