### PR TITLE
Handle sysv compat mode when checking enabled status for systemd service

### DIFF
--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -202,6 +202,11 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
   end
 
   def is_enabled?
+    # if the service is in sysv compat mode, shellout to determine if enabled
+    if systemd_service_status["UnitFileState"] == "bad"
+      options, args = get_systemctl_options_args
+      return shell_out(systemctl_path, args, "is-enabled", new_resource.service_name, "--quiet", **options).exitstatus == 0
+    end
     # See https://github.com/systemd/systemd/blob/master/src/systemctl/systemctl-is-enabled.c
     # Note: enabled-runtime is excluded because this is volatile, and the state of enabled-runtime
     # specifically means that the service is not enabled

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -412,6 +412,28 @@ describe Chef::Provider::Service::Systemd do
           with_systemctl_show(systemctl_path, enabled_runtime_and_active)
           expect(provider.is_enabled?).to be false
         end
+
+        it "should shellout to 'is-enabled' and return false if unit file is bad and sysv compat isn't enabled" do
+          bad_and_inactive = <<-STDOUT
+            ActiveState=inactive
+            UnitFileState=bad
+          STDOUT
+          with_systemctl_show(systemctl_path, bad_and_inactive)
+          systemctl_isenabled = [systemctl_path, "--system", "is-enabled", service_name, "--quiet"]
+          expect(provider).to receive(:shell_out).with(*systemctl_isenabled).and_return(shell_out_failure)
+          expect(provider.is_enabled?).to be false
+        end
+
+        it "should shellout to 'is-enabled' and return true if unit file is bad and sysv compat is enabled" do
+          bad_and_inactive = <<-STDOUT
+            ActiveState=inactive
+            UnitFileState=bad
+          STDOUT
+          with_systemctl_show(systemctl_path, bad_and_inactive)
+          systemctl_isenabled = [systemctl_path, "--system", "is-enabled", service_name, "--quiet"]
+          expect(provider).to receive(:shell_out).with(*systemctl_isenabled).and_return(shell_out_success)
+          expect(provider.is_enabled?).to be true
+        end
       end
 
       describe "is_masked?" do


### PR DESCRIPTION
Signed-off-by: Joshua Miller <joshmiller@fb.com>

When deciding on enabled status of a systemd service, if the version of systemd is sufficiently old, and the service is not a native systemd service but instead relies on the systemd-sysv-generator, shellout to `is-enabled` to determine whether the service is enabled.  

## Description
Idempotency for action :enable on systemd service was broken (due to https://github.com/chef/chef/pull/10776), such that every chef run triggered enablement despite the service already being enabled.

## Related Issue
NA

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
