### PR TITLE
Extend the reboot_pending? helper to all debian-ish platforms

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,7 +61,7 @@ Note: In the upcoming release of Chef Workstation, you'll be able to skip the `b
 
 #### Knife Bootstrapping Without Sudo
 
-The `knife boostrap` command now supports elevating privileges on systems without `sudo` by using the `su` command instead. Use the new `--su-user` and `--su-password` flags to specify credentials for `su`.
+The `knife bootstrap` command now supports elevating privileges on systems without `sudo` by using the `su` command instead. Use the new `--su-user` and `--su-password` flags to specify credentials for `su`.
 
 ### Resource Updates
 

--- a/lib/chef/dsl/reboot_pending.rb
+++ b/lib/chef/dsl/reboot_pending.rb
@@ -45,8 +45,7 @@ class Chef
 
             # Vista + Server 2008 and newer may have reboots pending from CBS
             registry_key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending')
-        elsif platform?("ubuntu")
-          # This should work for Debian as well if update-notifier-common happens to be installed. We need an API for that.
+        elsif platform_family?("debian")
           File.exist?("/var/run/reboot-required")
         else
           false

--- a/lib/chef/resource/user_ulimit.rb
+++ b/lib/chef/resource/user_ulimit.rb
@@ -106,7 +106,7 @@ class Chef
         end
       end
 
-      action :delete, description: "Delete an existing ulimit configuration file"  do
+      action :delete, description: "Delete an existing ulimit configuration file" do
         file "/etc/security/limits.d/#{new_resource.filename}" do
           action :delete
         end

--- a/spec/unit/dsl/reboot_pending_spec.rb
+++ b/spec/unit/dsl/reboot_pending_spec.rb
@@ -51,9 +51,9 @@ describe Chef::DSL::RebootPending do
         end
       end
 
-      context "platform is ubuntu" do
+      context "platform_family is debian" do
         before do
-          allow(recipe).to receive(:platform?).with("ubuntu").and_return(true)
+          allow(recipe).to receive(:platform_family?).with("debian").and_return(true)
         end
 
         it "should return true if /var/run/reboot-required exists" do


### PR DESCRIPTION
This works on Debian as well and we want to check it on all
Ubuntu-derivatives.

Signed-off-by: Tim Smith <tsmith@chef.io>