### PR TITLE
Remove legacy Policyfiles compatibility mode for Server < 12.1

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -612,26 +612,6 @@ module ChefConfig
 
     default :named_run_list, nil
 
-    # Policyfiles can be used in a native mode (default) or compatibility mode.
-    # Native mode requires Chef Server 12.1 (it can be enabled via feature flag
-    # on some prior versions). In native mode, policies and associated
-    # cookbooks are accessed via feature-specific APIs. In compat mode,
-    # policies are stored as data bags and cookbooks are stored at the
-    # cookbooks/ endpoint. Compatibility mode can be dangerous on existing Chef
-    # Servers; it's recommended to upgrade your Chef Server rather than use
-    # compatibility mode. Compatibility mode remains available so you can use
-    # policyfiles with servers that don't yet support the native endpoints.
-    default :policy_document_native_api, true
-
-    # When policyfiles are used in compatibility mode, `policy_name` and
-    # `policy_group` are instead specified using a combined configuration
-    # setting, `deployment_group`. For example, if policy_name should be
-    # "webserver" and policy_group should be "staging", then `deployment_group`
-    # should be set to "webserver-staging", which is the name of the data bag
-    # item that the policy will be stored as. NOTE: this setting only has an
-    # effect if `policy_document_native_api` is set to `false`.
-    default :deployment_group, nil
-
     # Set these to enable SSL authentication / mutual-authentication
     # with the server
 

--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -153,8 +153,7 @@ class Chef
       def select_implementation(node)
         if policyfile_set_in_config? ||
             policyfile_attribs_in_node_json? ||
-            node_has_policyfile_attrs?(node) ||
-            policyfile_compat_mode_config?
+            node_has_policyfile_attrs?(node)
           @implementation = Policyfile.new(node_name, ohai_data, json_attribs, override_runlist, events)
         else
           @implementation = ExpandNodeObject.new(node_name, ohai_data, json_attribs, override_runlist, events)
@@ -178,11 +177,6 @@ class Chef
       def policyfile_set_in_config?
         config[:policy_name] || config[:policy_group]
       end
-
-      def policyfile_compat_mode_config?
-        config[:deployment_group] && !config[:policy_document_native_api]
-      end
-
     end
   end
 end

--- a/spec/unit/policy_builder/dynamic_spec.rb
+++ b/spec/unit/policy_builder/dynamic_spec.rb
@@ -144,19 +144,6 @@ describe Chef::PolicyBuilder::Dynamic do
 
         end
 
-        context "and deployment_group and policy_document_native_api are set on Chef::Config" do
-
-          before do
-            Chef::Config[:deployment_group] = "example-policy-staging"
-            Chef::Config[:policy_document_native_api] = false
-          end
-
-          it "uses the Policyfile implementation" do
-            expect(implementation).to be_a(Chef::PolicyBuilder::Policyfile)
-          end
-
-        end
-
         context "and policyfile attributes are present in json_attribs" do
 
           let(:json_attribs) { { "policy_name" => "example-policy", "policy_group" => "testing" } }


### PR DESCRIPTION
Require Chef Infra Server 12.1+ to use Policyfiles. As Lamont put it this was prototype support code that was most likely unused and is useless to continue to cart around.

Signed-off-by: Tim Smith <tsmith@chef.io>