### PR TITLE
Add alibaba? helper and pull in Ohai with alibaba support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: ba09f9b476b37c9c07e8d572c8fdba73450fbd06
+  revision: f26c3ce26c63eb06d714073f920b1f75c4feef25
   branch: master
   specs:
-    ohai (17.0.18)
+    ohai (17.0.19)
       chef-config (>= 12.8, < 18)
       chef-utils (>= 16.0, < 18)
       ffi (~> 1.9)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ This section serves to track things we should later document here for 17.0
 - Remove ability to run client as a service on Windows - https://github.com/chef/chef/pull/10928
 - apt_package allow_downgrades now functions as expected, but also raises on invalid versions - https://github.com/chef/chef/pull/10993
 - reboot_pending? now works on all debian platform_family distros not just Ubuntu specifically - https://github.com/chef/chef/pull/10989
+- Alibaba Cloud support with node['alibaba'] showing metadata, `alibaba?` helper and node['cloud'] returning data now - https://github.com/chef/chef/pull/11004
 
 ## What's New in 16.10
 

--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -120,6 +120,7 @@ Architecture Helpers allow you to determine the processor architecture of your n
 ### Cloud Helpers
 
 * `cloud?` - if the node is running in any cloud, including internal ones
+* `alibaba?` - if the node is running in alibaba cloud
 * `ec2?` - if the node is running in ec2
 * `gce?` - if the node is running in gce
 * `rackspace?` - if the node is running in rackspace

--- a/chef-utils/lib/chef-utils/dsl/cloud.rb
+++ b/chef-utils/lib/chef-utils/dsl/cloud.rb
@@ -35,6 +35,17 @@ module ChefUtils
         !node["cloud"].nil?
       end
 
+      # Determine if the current node is running in Alibaba Cloud
+      #
+      # @param [Chef::Node] node the node to check
+      # @since 17.0
+      #
+      # @return [Boolean]
+      #
+      def alibaba?(node = __getnode)
+        node.key?("alibaba")
+      end
+
       # Determine if the current node is running in AWS EC2.
       #
       # @param [Chef::Node] node the node to check

--- a/chef-utils/spec/unit/dsl/cloud_spec.rb
+++ b/chef-utils/spec/unit/dsl/cloud_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe ChefUtils::DSL::Cloud do
     end
   end
 
+  context "on alibaba" do
+    cloud_reports_true_for(:cloud?, :alibaba?, node: { "alibaba" => {}, "cloud" => {} })
+  end
+
   context "on ec2" do
     cloud_reports_true_for(:cloud?, :ec2?, node: { "ec2" => {}, "cloud" => {} })
   end

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.424.0)
+    aws-partitions (1.426.0)
     aws-sdk-core (3.112.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -188,7 +188,7 @@ GEM
     ffi (1.14.2)
     ffi (1.14.2-x64-mingw32)
     ffi (1.14.2-x86-mingw32)
-    ffi-libarchive (1.0.4)
+    ffi-libarchive (1.0.17)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
@@ -249,9 +249,9 @@ GEM
       multi_json (~> 1.14)
     method_source (1.0.0)
     minitar (0.9)
-    mixlib-archive (1.0.7)
+    mixlib-archive (1.1.4)
       mixlib-log
-    mixlib-archive (1.0.7-universal-mingw32)
+    mixlib-archive (1.1.4-universal-mingw32)
       mixlib-log
     mixlib-authentication (3.0.7)
     mixlib-cli (2.1.8)
@@ -312,7 +312,7 @@ GEM
       zhexdump (>= 0.0.2)
     plist (3.6.0)
     proxifier (1.0.3)
-    pry (0.13.1)
+    pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)


### PR DESCRIPTION
This is a fully supported cloud now

```
[root@1234 mixin]# ohai alibaba
{
  "meta_data": {
    "dns_conf_": "nameservers",
    "eipv4": "47.89.242.123",
    "hibernation_": "configured",
    "hostname": "1234",
    "image_id": "aliyun_2_1903_x64_20G_alibase_20210120.vhd",
    "instance_id": "i-rj996x25ht5omuhhzod7",
    "instance_": {
      "instance_type": "ecs.t6-c2m1.large",
      "last_host_landing_time": "2021-02-07 19:10:04",
      "max_netbw_egress": 81920,
      "max_netbw_ingress": 81920,
      "virtualization_solution": "ECS Virt",
      "virtualization_solution_version": 2.0
    },
    "mac": "00:16:3e:00:d9:01",
    "network_type": "vpc",
    "network_": "interfaces/",
    "ntp_conf_": "ntp-servers",
    "owner_account_id": 1234,
    "private_ipv4": "172.25.58.242",
    "region_id": "us-west-1",
    "serial_number": "ac344378-4d5d-4b9e-851b-1234",
    "source_address": "http://us1.mirrors.cloud.aliyuncs.com",
    "sub_private_ipv4_list": "172.25.58.243",
    "vpc_cidr_block": "172.16.0.0/12",
    "vpc_id": "vpc-1234",
    "vswitch_cidr_block": "172.25.48.0/20",
    "vswitch_id": "vsw-rj9eiw6yqh6zll23h0tlt",
    "zone_id": "us-west-1b"
  },
  "user_data": null,
  "dynamic": "instance-identity",
  "global_config": null,
  "maintenance": "active-system-events"
}
```

Signed-off-by: Tim Smith <tsmith@chef.io>