### PR TITLE
Fix automate compliance fetcher for profiles with at signs

### DIFF
--- a/lib/chef/compliance/fetcher/automate.rb
+++ b/lib/chef/compliance/fetcher/automate.rb
@@ -32,12 +32,12 @@ class Chef
             profile_fetch_url = target[:url]
           else
             # verifies that the target e.g base/ssh exists
-            base_path = "/compliance/profiles/#{uri.host}#{uri.path}"
-
+            profile = sanitize_profile_name(uri)
+            owner, id = profile.split("/")
             profile_path = if target.respond_to?(:key?) && target.key?(:version)
-                             "#{base_path}/version/#{target[:version]}/tar"
+                             "/compliance/profiles/#{owner}/#{id}/version/#{target[:version]}/tar"
                            else
-                             "#{base_path}/tar"
+                             "/compliance/profiles/#{owner}/#{id}/tar"
                            end
 
             url = URI(Chef::Config[:data_collector][:server_url])
@@ -58,6 +58,17 @@ class Chef
           new(profile_fetch_url, config)
         rescue URI::Error => _e
           nil
+        end
+
+        # returns a parsed url for `admin/profile` or `compliance://admin/profile`
+        # TODO: remove in future, copied from inspec to support older versions of inspec
+        def self.sanitize_profile_name(profile)
+          uri = if URI(profile).scheme == "compliance"
+                  URI(profile)
+                else
+                  URI("compliance://#{profile}")
+                end
+          uri.to_s.sub(%r{^compliance:\/\/}, "")
         end
 
         def to_s

--- a/spec/unit/compliance/fetcher/automate_spec.rb
+++ b/spec/unit/compliance/fetcher/automate_spec.rb
@@ -21,6 +21,14 @@ describe Chef::Compliance::Fetcher::Automate do
         expect(res.target).to eq(expected)
       end
 
+      it "should resolve a compliance URL with a @ in the namespace" do
+        res = Chef::Compliance::Fetcher::Automate.resolve("compliance://name@space/profile_name")
+
+        expect(res).to be_kind_of(Chef::Compliance::Fetcher::Automate)
+        expected = "https://automate.test/compliance/profiles/name@space/profile_name/tar"
+        expect(res.target).to eq(expected)
+      end
+
       it "raises an exception with no data collector token" do
         Chef::Config[:data_collector].delete(:token)
 


### PR DESCRIPTION
This is largely copypasta directly out of the audit cookbook.

I've preserved the original backcompat in the cookbook because
it seems more important for this code to be correct than to try
to mess around deprecating code that isn't hurting anything.

closes #10862