### PR TITLE
mount: Fix for network mounts which use the root level as the device

### DIFF
--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -203,7 +203,7 @@ class Chef
             end
           end
           # Removed "/" from the end of str, because it was causing idempotency issue.
-          @real_device == "/" ? @real_device : @real_device.chomp("/")
+          (@real_device == "/" || @real_device.match?(":/$")) ? @real_device : @real_device.chomp("/")
         end
 
         def device_logstring

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -66,6 +66,7 @@ describe Chef::Provider::Mount::Mount do
 
     describe "when dealing with network mounts" do
       { "nfs" => "nfsserver:/vol/path",
+        "cephfs" => "cephserver:6789:/",
         "cifs" => "//cifsserver/share" }.each do |type, fs_spec|
           it "should detect network fs_spec (#{type})" do
             @new_resource.device fs_spec


### PR DESCRIPTION
PR #10614 introduce a bug which can impact network mounts which try to mount from the root level (i.e. server:/). Specifically, we run into this on cephfs where this is pretty common. This adds some logic to detect if this is a network mount at the root level and doesn't strip the '/'.

This resolves #10764.

Signed-off-by: Lance Albertson <lance@osuosl.org>

Backport https://github.com/chef/chef/pull/11031