### PR TITLE
Stop producing Habitat kernel2 packages

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,6 +1,5 @@
 [chef-infra-client]
 build_targets = [
   "x86_64-linux",
-  "x86_64-linux-kernel2",
   "x86_64-windows"
 ]

--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -21,18 +21,6 @@ steps:
         privileged: true
         single-use: true
 
-- label: ":linux: Validate Linux (kernel2)"
-  commands:
-    - sudo ./.expeditor/scripts/install-hab.sh x86_64-linux-kernel2
-    - 'echo "--- :hammer_and_wrench: Installing $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2"'
-    - sudo hab pkg install $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2
-    - sudo ./habitat/tests/test.sh $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2
-  expeditor:
-    executor:
-      linux:
-        privileged: true
-        single-use: true
-
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
     - powershell -File ./.expeditor/scripts/ensure-minimum-viable-hab.ps1

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -591,17 +591,6 @@ steps:
         privileged: true
         single-use: true
 
-- label: ":habicat: Linux plan (kernel2)"
-  commands:
-    - sudo ./.expeditor/scripts/install-hab.sh 'x86_64-linux-kernel2'
-    - sudo ./.expeditor/scripts/verify-plan.sh
-  timeout_in_minutes: 60
-  expeditor:
-    executor:
-      linux:
-        privileged: true
-        single-use: true
-
 - label: ":habicat: Windows plan"
   commands:
     - ./.expeditor/scripts/verify-plan.ps1


### PR DESCRIPTION
RHEL 6 is EOL. Stop shipping these packages

Signed-off-by: Tim Smith <tsmith@chef.io>