### PR TITLE
Remove an Upstart check for Ubuntu 8.04-9.04

### DIFF
--- a/lib/chef/provider/service/upstart.rb
+++ b/lib/chef/provider/service/upstart.rb
@@ -65,15 +65,8 @@ class Chef
             end
           end
 
-          platform, version = Chef::Platform.find_platform_and_version(run_context.node)
-          if platform == "ubuntu" && (8.04..9.04).cover?(version.to_f)
-            @upstart_job_dir = "/etc/event.d"
-            @upstart_conf_suffix = ""
-          else
-            @upstart_job_dir = "/etc/init"
-            @upstart_conf_suffix = ".conf"
-          end
-
+          @upstart_job_dir = "/etc/init"
+          @upstart_conf_suffix = ".conf"
           @command_success = true # new_resource.status_command= false, means upstart used
           @config_file_found = true
           @upstart_command_success = true

--- a/spec/unit/provider/service/upstart_service_spec.rb
+++ b/spec/unit/provider/service/upstart_service_spec.rb
@@ -27,41 +27,12 @@ describe Chef::Provider::Service::Upstart do
     @node = Chef::Node.new
     @node.name("upstarter")
     @node.automatic_attrs[:platform] = "ubuntu"
-    @node.automatic_attrs[:platform_version] = "9.10"
 
     @events = Chef::EventDispatch::Dispatcher.new
     @run_context = Chef::RunContext.new(@node, {}, @events)
 
     @new_resource = Chef::Resource::Service.new("rsyslog")
     @provider = Chef::Provider::Service::Upstart.new(@new_resource, @run_context)
-  end
-
-  describe "when first created" do
-    before do
-      @platform = nil
-    end
-
-    it "should return /etc/event.d as the upstart job directory when running on Ubuntu 9.04" do
-      @node.automatic_attrs[:platform_version] = "9.04"
-      # Chef::Platform.stub(:find_platform_and_version).and_return([ "ubuntu", "9.04" ])
-      @provider = Chef::Provider::Service::Upstart.new(@new_resource, @run_context)
-      expect(@provider.instance_variable_get(:@upstart_job_dir)).to eq("/etc/event.d")
-      expect(@provider.instance_variable_get(:@upstart_conf_suffix)).to eq("")
-    end
-
-    it "should return /etc/init as the upstart job directory when running on Ubuntu 9.10" do
-      @node.automatic_attrs[:platform_version] = "9.10"
-      @provider = Chef::Provider::Service::Upstart.new(@new_resource, @run_context)
-      expect(@provider.instance_variable_get(:@upstart_job_dir)).to eq("/etc/init")
-      expect(@provider.instance_variable_get(:@upstart_conf_suffix)).to eq(".conf")
-    end
-
-    it "should return /etc/init as the upstart job directory by default" do
-      @node.automatic_attrs[:platform_version] = "9000"
-      @provider = Chef::Provider::Service::Upstart.new(@new_resource, @run_context)
-      expect(@provider.instance_variable_get(:@upstart_job_dir)).to eq("/etc/init")
-      expect(@provider.instance_variable_get(:@upstart_conf_suffix)).to eq(".conf")
-    end
   end
 
   describe "load_current_resource" do


### PR DESCRIPTION
No need to do this anymore

Signed-off-by: Tim Smith <tsmith@chef.io>