### PR TITLE
Don't make upstart service to service on any debian platform families

### DIFF
--- a/lib/chef/provider/service/upstart.rb
+++ b/lib/chef/provider/service/upstart.rb
@@ -28,10 +28,6 @@ class Chef
         # to maintain a local state of service across restart's internal calls
         attr_accessor :upstart_service_running
 
-        provides :service, platform_family: "debian", override: true do
-          upstart?
-        end
-
         UPSTART_STATE_FORMAT = %r{\S+ \(?(start|stop)?\)? ?[/ ](\w+)}.freeze
 
         # Returns true if the configs for the service name has upstart variable


### PR DESCRIPTION
None of these include upstart at this point

Signed-off-by: Tim Smith <tsmith@chef.io>