### PR TITLE
Revert "Update name of macos builder in Buildkite"

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -38,7 +38,7 @@ builder-to-testers-map:
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
-    - mac_os_x-11-x86_64
+    - mac_os_x-11.0-x86_64
   sles-12-s390x:
     - sles-12-s390x
     - sles-15-s390x


### PR DESCRIPTION
This reverts commit dbd0234e87c7e324f8349f6ed3a04187e681bcf3.

There is some errors with upstream logic that prevent us from doing this right now.
