### PR TITLE
Rename macOS target from 11 to 11.0 to avoid logic issue in Omnitruck

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -40,7 +40,7 @@ builder-to-testers-map:
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
-    - mac_os_x-11-x86_64
+    - mac_os_x-11.0-x86_64
   sles-12-s390x:
     - sles-12-s390x
     - sles-15-s390x


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>
