### PR TITLE
Update resolver cookbook usage in test-kitchen tests

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/attributes/default.rb
+++ b/kitchen-tests/cookbooks/end_to_end/attributes/default.rb
@@ -67,13 +67,6 @@ default["chef_client"]["config"]["verbose_logging"] = false
 default["chef_client"]["chef_license"] = "accept-no-persist"
 
 #
-# resolver cookbook overrides
-#
-
-default["resolver"]["nameservers"] = [ "8.8.8.8", "8.8.4.4" ]
-default["resolver"]["search"] = "chef.io"
-
-#
 # nscd cookbook overrides
 #
 

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -39,7 +39,10 @@ include_recipe "::_packages"
 
 include_recipe "ntp"
 
-include_recipe "resolver"
+resolver_config "/etc/resolv.conf" do
+  nameservers [ "8.8.8.8", "8.8.4.4" ]
+  search [ "chef.io" ]
+end
 
 users_manage "sysadmin" do
   group_id 2300

--- a/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
@@ -23,7 +23,10 @@ timezone "America/Los_Angeles"
 
 include_recipe "ntp"
 
-include_recipe "resolver"
+resolver_config "/etc/resolv.conf" do
+  nameservers [ "8.8.8.8", "8.8.4.4" ]
+  search [ "chef.io" ]
+end
 
 users_manage "remove sysadmin" do
   group_name "sysadmin"


### PR DESCRIPTION
Recently, the Sous Chefs released a new resource driven resolver cookbook and removed the default recipe, thus breaking tests. This should fix the tests related to this.

Signed-off-by: Lance Albertson <lance@osuosl.org>
