### PR TITLE
Dup default property values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This section serves to track things we should later document here for 17.0
 
 - Dropped support for Ruby 2.6
 - Lazy attribute loading: https://github.com/chef/chef/pull/10861
+- Duping property defaults: https://github.com/chef/chef/pull/11095
 - Compliance Phase in GA: https://github.com/chef/chef/pull/10547
 - gem resource: assume rubygems 1.8+ now: https://github.com/chef/chef/pull/10379
 - remove support for RHEL 6 i386 / Ubuntu 16.04 / macOS 10.13

--- a/lib/chef/resource/template.rb
+++ b/lib/chef/resource/template.rb
@@ -61,7 +61,7 @@ class Chef
 
       property :variables, Hash,
         description: "The variables property of the template resource can be used to reference a partial template file by using a Hash.",
-        default: lazy { {} }
+        default: {}
 
       property :cookbook, String,
         description: "The cookbook in which a file is located (if it is not located in the current cookbook). The default value is the current cookbook.",

--- a/spec/unit/mixin/params_validate_spec.rb
+++ b/spec/unit/mixin/params_validate_spec.rb
@@ -359,10 +359,11 @@ describe Chef::Mixin::ParamsValidate do
     expect(@vo.set_or_return(:test, nil, {}).object_id).to eq(value.object_id)
   end
 
-  it "should set and return a default value when the argument is nil, then return the same value" do
+  it "should set and return a default value when the argument is nil, then return a dup of the value" do
     value = "meow"
-    expect(@vo.set_or_return(:test, nil, { default: value }).object_id).to eq(value.object_id)
-    expect(@vo.set_or_return(:test, nil, {}).object_id).to eq(value.object_id)
+    expect(@vo.set_or_return(:test, nil, { default: value }).object_id).not_to eq(value.object_id)
+    expect(@vo.set_or_return(:test, nil, {}).object_id).not_to eq(value.object_id)
+    expect(@vo.set_or_return(:test, nil, {})).to eql(value)
   end
 
   it "should raise an ArgumentError when argument is nil and required is true" do

--- a/spec/unit/provider/group_spec.rb
+++ b/spec/unit/provider/group_spec.rb
@@ -101,19 +101,19 @@ describe Chef::Provider::User do
     end
 
     it "should return false if append is true and the group member(s) already exists" do
-      @current_resource.members += [ "extra_user" ]
+      @current_resource.members << "extra_user"
       @new_resource.append(true)
       expect(@provider.compare_group).to be_falsey
     end
 
     it "should return true if append is true and the group member(s) do not already exist" do
-      @new_resource.members += [ "extra_user" ]
+      @new_resource.members << "extra_user"
       @new_resource.append(true)
       expect(@provider.compare_group).to be_truthy
     end
 
     it "should return false if append is true and excluded_members include a non existing member" do
-      @new_resource.excluded_members += [ "extra_user" ]
+      @new_resource.excluded_members << "extra_user"
       @new_resource.append(true)
       expect(@provider.compare_group).to be_falsey
     end


### PR DESCRIPTION
This largely makes frozen default value errors go away.  Each
copy of a resource will get a dup of the default.  Defaults are
still frozen so we have defense-in-depth against them being
mutated.  This eliminates the need to `default: lazy{ {} }`
things like Hashes or Arrays.
