### PR TITLE
Create a PR any time Ohai is bumped

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -208,3 +208,7 @@ subscriptions:
   - workload: ruby_gem_published:fauxhai-ng-*
     actions:
       - bash:.expeditor/update_dep.sh
+  # NOTE: The branch of Ohai here needs to be updated when setting up a stable branch of chef/chef
+  - workload: chef/ohai:master_completed:pull_request_merged:chef/ohai:master:*
+    actions:
+      - bash:.expeditor/update_dep.sh


### PR DESCRIPTION
Avoid the need to manually create PRs when a PR is merged to Ohai

Signed-off-by: Tim Smith <tsmith@chef.io>