### PR TITLE
Add a compliance_mode node attribute

### DIFF
--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -1,5 +1,5 @@
 # Author:: Stephan Renatus <srenatus@chef.io>
-# Copyright:: (c) 2016-2019, Chef Software Inc. <legal@chef.io>
+# Copyright:: Copyright (c) Chef Software Inc. <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,7 +87,10 @@ class Chef
 
       # If enabled, a hash representation of the Chef Infra node object will be sent to Chef InSpec in an input
       # named `chef_node`.
-      "chef_node_attribute_enabled" => false
+      "chef_node_attribute_enabled" => false,
+
+      # Should the built-in compliance phase run.
+      "compliance_phase" => true
     )
   end
 end

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -24,7 +24,7 @@ class Chef
         logger.debug("#{self.class}##{__method__}: #{Inspec::Dist::PRODUCT_NAME} profiles? #{inspec_profiles.any?}")
         logger.debug("#{self.class}##{__method__}: audit cookbook? #{audit_cookbook_present}")
 
-        inspec_profiles.any? && !audit_cookbook_present
+        inspec_profiles.any? && !audit_cookbook_present && node["audit"]["compliance_phase"]
       end
 
       def node=(node)

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -19,6 +19,13 @@ describe Chef::Compliance::Runner do
       expect(runner).to be_enabled
     end
 
+    it "is false if the node attributes have audit profiles and the audit cookbook is not present, and the compliance mode attribute is unset" do
+      node.normal["audit"]["profiles"]["ssh"] = { 'compliance': "base/ssh" }
+      node.normal["audit"]["compliance_mode"] = false
+
+      expect(runner).to be_enabled
+    end
+
     it "is false if the node attributes have audit profiles and the audit cookbook is present" do
       stub_const("::Reporter::ChefAutomate", true)
       node.normal["audit"]["profiles"]["ssh"] = { 'compliance': "base/ssh" }


### PR DESCRIPTION
Setting node["audit"]["compliance_mode"] to be false should force the
compliance mode to not run.

This is for sites which run override run lists which have the audit
cookbook in them, but the rest of their cookbooks define profiles so
that in normal running they still have those profiles defined but
they're manually running the cookbook.

That is likely a pretty bad pattern since the cookbook_synchronizer will
be thrashing on at least the audit cookbook being downloaded and then
removed, but it seems people have settled on this as their solution
which breaks the assumptions we had for the compliance_mode.

To sort this out those sites should set node["audit"]["compliance_mode"]
to be false on their runs which aren't supposed to run audits.  Instead
of an override run list with the audit cookbook in it, they can just run
an override run_list which sets this node attribute to true (in any
fashion: roles, policyfiles, wrapper cookbook style, recipe mode, etc.)

This also is obviously an opt-out switch, although sites preferring to
use the audit cookbook should understand that cookbook development will
be abandoned after it is deprecated and there will be no more bugfixes
or support for that.
