### PR TITLE
Update our bcrypt_pbkdf dep to allow the final 1.1.0 release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: c250cca41d3a7fb6eb62eb57a3ada12d4b71458c
+  revision: 2397af29ecc3c3e849d817a8519d32866aab89ff
   branch: master
   specs:
-    ohai (17.0.23)
+    ohai (17.0.24)
       chef-config (>= 12.8, < 18)
       chef-utils (>= 16.0, < 18)
       ffi (~> 1.9)
@@ -30,7 +30,7 @@ PATH
   specs:
     chef (17.0.132)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc2)
+      bcrypt_pbkdf (~> 1.1)
       chef-config (= 17.0.132)
       chef-utils (= 17.0.132)
       chef-vault
@@ -66,7 +66,7 @@ PATH
       uuidtools (>= 2.1.5, < 3.0)
     chef (17.0.132-universal-mingw32)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc2)
+      bcrypt_pbkdf (~> 1.1)
       chef-config (= 17.0.132)
       chef-utils (= 17.0.132)
       chef-vault
@@ -143,9 +143,9 @@ GEM
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.2)
-    bcrypt_pbkdf (1.1.0.rc2)
-    bcrypt_pbkdf (1.1.0.rc2-x64-mingw32)
-    bcrypt_pbkdf (1.1.0.rc2-x86-mingw32)
+    bcrypt_pbkdf (1.1.0)
+    bcrypt_pbkdf (1.1.0-x64-mingw32)
+    bcrypt_pbkdf (1.1.0-x86-mingw32)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 4.0"
   s.add_dependency "ed25519", "~> 1.2" # ed25519 ssh key support
-  s.add_dependency "bcrypt_pbkdf", "= 1.1.0.rc2" # ed25519 ssh key support
+  s.add_dependency "bcrypt_pbkdf", "~> 1.1" # ed25519 ssh key support
   s.add_dependency "highline", ">= 1.6.9", "< 3"
   s.add_dependency "tty-prompt", "~> 0.21" # knife ui.ask prompt
   s.add_dependency "tty-screen", "~> 0.6" # knife list

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: a1e9c90875f9a6267bdbf9742881178245411c52
+  revision: a7ed951108689cad13b1ad29293bfe1a0b9e5271
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.429.0)
+    aws-partitions (1.430.0)
     aws-sdk-core (3.112.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -353,7 +353,7 @@ GEM
     strings-ansi (0.2.0)
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
-    test-kitchen (2.11.0)
+    test-kitchen (2.11.1)
       bcrypt_pbkdf (~> 1.0)
       chef-utils (>= 16.4.35)
       ed25519 (~> 1.2)


### PR DESCRIPTION
This should be the same thing except they did a non-RC release.

Signed-off-by: Tim Smith <tsmith@chef.io>