### PR TITLE
[Backport to chef-16] DNF package: fix abrt errors

### DIFF
--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -168,6 +168,10 @@ try:
         setup_exit_handler()
         line = inpipe.readline()
 
+        # only way to detect EOF in python
+        if line == "":
+            break
+
         try:
             command = json.loads(line)
         except ValueError:

--- a/lib/chef/provider/package/yum/yum_helper.py
+++ b/lib/chef/provider/package/yum/yum_helper.py
@@ -196,6 +196,10 @@ try:
         setup_exit_handler()
         line = inpipe.readline()
 
+        # only way to detect EOF in python
+        if line == "":
+            break
+
         try:
             command = json.loads(line)
         except ValueError, e:


### PR DESCRIPTION
For people with ABRT logging every exit of chef-client would have ABRT
errors due to readline returning '' for EOF and then the JSON parsing
throwing.

This causes it to exit gracefully.

AFAIK there was actually no impact to this bug and chef was behaving
entirely correctly in terms of doing its job, but the python helper was
shutting down uncleanly.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>

Fixes: https://github.com/chef/customer-bugs/issues/322