### PR TITLE
[Backport to chef-15] DNF package: fix abrt errors

### DIFF
--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -101,6 +101,11 @@ while 1:
     if ppid == 1:
         sys.exit(0)
     line = sys.stdin.readline()
+
+    # only way to detect EOF in python
+    if line == "":
+        break
+
     command = json.loads(line)
     if command['action'] == "whatinstalled":
         query(command)

--- a/lib/chef/provider/package/yum/yum_helper.py
+++ b/lib/chef/provider/package/yum/yum_helper.py
@@ -196,6 +196,10 @@ try:
         setup_exit_handler()
         line = inpipe.readline()
 
+        # only way to detect EOF in python
+        if line == "":
+            break
+
         try:
             command = json.loads(line)
         except ValueError, e:


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

For people with ABRT logging every exit of chef-client would have ABRT
errors due to readline returning '' for EOF and then the JSON parsing
throwing.

This causes it to exit gracefully.

AFAIK there was actually no impact to this bug and chef was behaving
entirely correctly in terms of doing its job, but the python helper was
shutting down uncleanly.
PR merged on master : https://github.com/chef/chef/pull/10991
Fixes : https://github.com/chef/chef/issues/10108

NOTE : Originated in chef-15 per https://github.com/chef/chef/issues/10108