### PR TITLE
Move idempotency logs to debug

### DIFF
--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -101,7 +101,7 @@ class Chef
 
         if @cron_exists
           unless cron_different?
-            logger.trace("Skipping existing cron entry '#{new_resource.name}'")
+            logger.debug("#{new_resource}: Skipping existing cron entry")
             return
           end
           read_crontab.each_line do |line|

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -152,7 +152,7 @@ class Chef
         unless ::File.exist?(new_resource.path)
           action_create
         else
-          logger.trace("#{new_resource} exists at #{new_resource.path} taking no action.")
+          logger.debug("#{new_resource} exists at #{new_resource.path} taking no action.")
         end
       end
 

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -94,7 +94,7 @@ class Chef
           enable_submodules
           add_remotes
         else
-          logger.trace "#{new_resource} checkout destination #{cwd} already exists or is a non-empty directory"
+          logger.debug "#{new_resource} checkout destination #{cwd} already exists or is a non-empty directory"
         end
       end
 

--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -67,7 +67,7 @@ class Chef
                 members_to_be_added << member unless current_resource.members.include?(member)
               end
               members_to_be_added.each do |member|
-                logger.trace("#{new_resource} appending member #{member} to group #{new_resource.group_name}")
+                logger.debug("#{new_resource} appending member #{member} to group #{new_resource.group_name}")
                 add_member(member)
               end
             end
@@ -79,13 +79,13 @@ class Chef
               end
 
               members_to_be_removed.each do |member|
-                logger.trace("#{new_resource} removing member #{member} from group #{new_resource.group_name}")
+                logger.debug("#{new_resource} removing member #{member} from group #{new_resource.group_name}")
                 remove_member(member)
               end
             end
           else
             members_description = new_resource.members.empty? ? "none" : new_resource.members.join(", ")
-            logger.trace("#{new_resource} setting group members to: #{members_description}")
+            logger.debug("#{new_resource} setting group members to: #{members_description}")
             set_members(new_resource.members)
           end
         end

--- a/lib/chef/provider/group/groupmod.rb
+++ b/lib/chef/provider/group/groupmod.rb
@@ -66,13 +66,13 @@ class Chef
               end
             end
 
-            logger.trace("#{new_resource} not changing group members, the group has no members to add") if members_to_be_added.empty?
+            logger.debug("#{new_resource} not changing group members, the group has no members to add") if members_to_be_added.empty?
 
             add_group_members(members_to_be_added)
           else
             # We are resetting the members of a group so use the same trick
             reset_group_membership
-            logger.trace("#{new_resource} setting group members to: none") if new_resource.members.empty?
+            logger.debug("#{new_resource} setting group members to: none") if new_resource.members.empty?
             add_group_members(new_resource.members)
           end
         end
@@ -84,7 +84,7 @@ class Chef
 
         # Adds a list of usernames to the group using `user mod`
         def add_group_members(members)
-          logger.trace("#{new_resource} adding members #{members.join(", ")}") unless members.empty?
+          logger.debug("#{new_resource} adding members #{members.join(", ")}") unless members.empty?
           members.each do |user|
             shell_out!("user", "mod", "-G", new_resource.group_name, user)
           end

--- a/lib/chef/provider/group/pw.rb
+++ b/lib/chef/provider/group/pw.rb
@@ -44,7 +44,7 @@ class Chef
             # new or existing group. Because pw groupadd does not support the -m
             # and -d options used by manage_group, we treat group creation as a
             # special case and use -M.
-            logger.trace("#{new_resource} setting group members: #{new_resource.members.join(",")}")
+            logger.debug("#{new_resource} setting group members: #{new_resource.members.join(",")}")
             command += [ "-M", new_resource.members.join(",") ]
           end
 
@@ -119,12 +119,12 @@ class Chef
           end
 
           unless members_to_be_added.empty?
-            logger.trace("#{new_resource} adding group members: #{members_to_be_added.join(",")}")
+            logger.debug("#{new_resource} adding group members: #{members_to_be_added.join(",")}")
             opts << [ "-m", members_to_be_added.join(",") ]
           end
 
           unless members_to_be_removed.empty?
-            logger.trace("#{new_resource} removing group members: #{members_to_be_removed.join(",")}")
+            logger.debug("#{new_resource} removing group members: #{members_to_be_removed.join(",")}")
             opts << [ "-d", members_to_be_removed.join(",") ]
           end
 

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -205,7 +205,7 @@ class Chef
             logger.info("#{new_resource} deleted")
           end
         else
-          logger.trace("#{new_resource} does not exist - nothing to do")
+          logger.debug("#{new_resource} does not exist - nothing to do")
         end
         delete_config
       end
@@ -220,7 +220,7 @@ class Chef
             logger.info("#{new_resource} disabled")
           end
         else
-          logger.trace("#{new_resource} does not exist - nothing to do")
+          logger.debug("#{new_resource} does not exist - nothing to do")
         end
       end
 

--- a/lib/chef/provider/link.rb
+++ b/lib/chef/provider/link.rb
@@ -106,7 +106,7 @@ class Chef
           if new_resource.link_type == :symbolic
             converge_by("create symlink at #{new_resource.target_file} to #{new_resource.to}") do
               file_class.symlink(canonicalize(new_resource.to), new_resource.target_file)
-              logger.trace("#{new_resource} created #{new_resource.link_type} link from #{new_resource.target_file} -> #{new_resource.to}")
+              logger.debug("#{new_resource} created #{new_resource.link_type} link from #{new_resource.target_file} -> #{new_resource.to}")
               logger.info("#{new_resource} created")
               # file_class.symlink will create the link with default access controls.
               # This means that the access controls of the file could be different
@@ -118,7 +118,7 @@ class Chef
           elsif new_resource.link_type == :hard
             converge_by("create hard link at #{new_resource.target_file} to #{new_resource.to}") do
               file_class.link(new_resource.to, new_resource.target_file)
-              logger.trace("#{new_resource} created #{new_resource.link_type} link from #{new_resource.target_file} -> #{new_resource.to}")
+              logger.debug("#{new_resource} created #{new_resource.link_type} link from #{new_resource.target_file} -> #{new_resource.to}")
               logger.info("#{new_resource} created")
             end
           end

--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -42,7 +42,7 @@ class Chef
             logger.info("#{new_resource} mounted")
           end
         else
-          logger.trace("#{new_resource} is already mounted")
+          logger.debug("#{new_resource} is already mounted")
         end
       end
 
@@ -53,7 +53,7 @@ class Chef
             logger.info("#{new_resource} unmounted")
           end
         else
-          logger.trace("#{new_resource} is already unmounted")
+          logger.debug("#{new_resource} is already unmounted")
         end
       end
 
@@ -76,7 +76,7 @@ class Chef
             end
           end
         else
-          logger.trace("#{new_resource} not mounted, nothing to remount")
+          logger.debug("#{new_resource} not mounted, nothing to remount")
         end
       end
 
@@ -87,7 +87,7 @@ class Chef
             logger.info("#{new_resource} enabled")
           end
         else
-          logger.trace("#{new_resource} already enabled")
+          logger.debug("#{new_resource} already enabled")
         end
       end
 
@@ -98,7 +98,7 @@ class Chef
             logger.info("#{new_resource} disabled")
           end
         else
-          logger.trace("#{new_resource} already disabled")
+          logger.debug("#{new_resource} already disabled")
         end
       end
 

--- a/lib/chef/provider/mount/aix.rb
+++ b/lib/chef/provider/mount/aix.rb
@@ -140,7 +140,7 @@ class Chef
             shell_out!(command)
             logger.trace("#{@new_resource} is mounted at #{@new_resource.mount_point}")
           else
-            logger.trace("#{@new_resource} is already mounted at #{@new_resource.mount_point}")
+            logger.debug("#{@new_resource} is already mounted at #{@new_resource.mount_point}")
           end
         end
 
@@ -154,7 +154,7 @@ class Chef
 
         def enable_fs
           if @current_resource.enabled && mount_options_unchanged?
-            logger.trace("#{@new_resource} is already enabled - nothing to do")
+            logger.debug("#{@new_resource} is already enabled - nothing to do")
             return nil
           end
 
@@ -211,7 +211,7 @@ class Chef
               contents.each { |line| fstab.puts line }
             end
           else
-            logger.trace("#{@new_resource} is not enabled - nothing to do")
+            logger.debug("#{@new_resource} is not enabled - nothing to do")
           end
         end
 

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -120,7 +120,7 @@ class Chef
             shell_out!(*command)
             logger.trace("#{@new_resource} is mounted at #{@new_resource.mount_point}")
           else
-            logger.trace("#{@new_resource} is already mounted at #{@new_resource.mount_point}")
+            logger.debug("#{@new_resource} is already mounted at #{@new_resource.mount_point}")
           end
         end
 
@@ -129,7 +129,7 @@ class Chef
             shell_out!("umount", @new_resource.mount_point)
             logger.trace("#{@new_resource} is no longer mounted at #{@new_resource.mount_point}")
           else
-            logger.trace("#{@new_resource} is not mounted at #{@new_resource.mount_point}")
+            logger.debug("#{@new_resource} is not mounted at #{@new_resource.mount_point}")
           end
         end
 
@@ -147,7 +147,7 @@ class Chef
             sleep 1
             mount_fs
           else
-            logger.trace("#{@new_resource} is not mounted at #{@new_resource.mount_point} - nothing to do")
+            logger.debug("#{@new_resource} is not mounted at #{@new_resource.mount_point} - nothing to do")
           end
         end
 
@@ -158,7 +158,7 @@ class Chef
 
         def enable_fs
           if @current_resource.enabled && mount_options_unchanged? && device_unchanged?
-            logger.trace("#{@new_resource} is already enabled - nothing to do")
+            logger.debug("#{@new_resource} is already enabled - nothing to do")
             return nil
           end
 
@@ -272,7 +272,7 @@ class Chef
               contents.reverse_each { |line| fstab.puts line }
             end
           else
-            logger.trace("#{@new_resource} is not enabled - nothing to do")
+            logger.debug("#{@new_resource} is not enabled - nothing to do")
           end
         end
 

--- a/lib/chef/provider/mount/windows.rb
+++ b/lib/chef/provider/mount/windows.rb
@@ -67,7 +67,7 @@ class Chef
                        password: @new_resource.password)
             logger.trace("#{@new_resource} is mounted at #{@new_resource.mount_point}")
           else
-            logger.trace("#{@new_resource} is already mounted at #{@new_resource.mount_point}")
+            logger.debug("#{@new_resource} is already mounted at #{@new_resource.mount_point}")
           end
         end
 

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -109,7 +109,7 @@ class Chef
 
       action :install do
         unless target_version_array.any?
-          logger.trace("#{new_resource} is already installed - nothing to do")
+          logger.debug("#{new_resource} is already installed - nothing to do")
           return
         end
 
@@ -138,7 +138,7 @@ class Chef
 
       action :upgrade do
         unless target_version_array.any?
-          logger.trace("#{new_resource} no versions to upgrade - nothing to do")
+          logger.debug("#{new_resource} no versions to upgrade - nothing to do")
           return
         end
 
@@ -177,7 +177,7 @@ class Chef
             logger.info("#{new_resource} removed")
           end
         else
-          logger.trace("#{new_resource} package does not exist - nothing to do")
+          logger.debug("#{new_resource} package does not exist - nothing to do")
         end
       end
 
@@ -229,7 +229,7 @@ class Chef
             end
           end
         else
-          logger.trace("#{new_resource} is already locked")
+          logger.debug("#{new_resource} is already locked")
         end
       end
 
@@ -248,7 +248,7 @@ class Chef
             end
           end
         else
-          logger.trace("#{new_resource} is already unlocked")
+          logger.debug("#{new_resource} is already unlocked")
         end
       end
 

--- a/lib/chef/provider/package/deb.rb
+++ b/lib/chef/provider/package/deb.rb
@@ -28,12 +28,12 @@ class Chef
 
             action :reconfig do
               if current_resource.version.nil?
-                logger.trace("#{new_resource} is NOT installed - nothing to do")
+                logger.debug("#{new_resource} is NOT installed - nothing to do")
                 return
               end
 
               unless new_resource.response_file
-                logger.trace("#{new_resource} no response_file provided - nothing to do")
+                logger.debug("#{new_resource} no response_file provided - nothing to do")
                 return
               end
 
@@ -46,7 +46,7 @@ class Chef
                   logger.info("#{new_resource} reconfigured")
                 end
               else
-                logger.trace("#{new_resource} preseeding has not changed - nothing to do")
+                logger.debug("#{new_resource} preseeding has not changed - nothing to do")
               end
             end
 

--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -131,7 +131,7 @@ class Chef
       action :add do
         # check to see if load_current_resource found the route
         if is_running
-          logger.trace("#{new_resource} route already active - nothing to do")
+          logger.debug("#{new_resource} route already active - nothing to do")
         else
           command = generate_command(:add)
           converge_by("run #{command.join(" ")} to add route") do
@@ -152,7 +152,7 @@ class Chef
             logger.info("#{new_resource} removed")
           end
         else
-          logger.trace("#{new_resource} route does not exist - nothing to do")
+          logger.debug("#{new_resource} route does not exist - nothing to do")
         end
 
         # for now we always write the file (ugly but its what it is)

--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -82,7 +82,7 @@ class Chef
 
       action :enable do
         if current_resource.enabled
-          logger.trace("#{new_resource} already enabled - nothing to do")
+          logger.debug("#{new_resource} already enabled - nothing to do")
         else
           converge_by("enable service #{new_resource}") do
             enable_service
@@ -100,7 +100,7 @@ class Chef
             logger.info("#{new_resource} disabled")
           end
         else
-          logger.trace("#{new_resource} already disabled - nothing to do")
+          logger.debug("#{new_resource} already disabled - nothing to do")
         end
         load_new_resource_state
         new_resource.enabled(false)
@@ -108,7 +108,7 @@ class Chef
 
       action :mask do
         if current_resource.masked
-          logger.trace("#{new_resource} already masked - nothing to do")
+          logger.debug("#{new_resource} already masked - nothing to do")
         else
           converge_by("mask service #{new_resource}") do
             mask_service
@@ -126,7 +126,7 @@ class Chef
             logger.info("#{new_resource} unmasked")
           end
         else
-          logger.trace("#{new_resource} already unmasked - nothing to do")
+          logger.debug("#{new_resource} already unmasked - nothing to do")
         end
         load_new_resource_state
         new_resource.masked(false)
@@ -139,7 +139,7 @@ class Chef
             logger.info("#{new_resource} started")
           end
         else
-          logger.trace("#{new_resource} already running - nothing to do")
+          logger.debug("#{new_resource} already running - nothing to do")
         end
         load_new_resource_state
         new_resource.running(true)
@@ -152,7 +152,7 @@ class Chef
             logger.info("#{new_resource} stopped")
           end
         else
-          logger.trace("#{new_resource} already stopped - nothing to do")
+          logger.debug("#{new_resource} already stopped - nothing to do")
         end
         load_new_resource_state
         new_resource.running(false)

--- a/lib/chef/provider/service/aixinit.rb
+++ b/lib/chef/provider/service/aixinit.rb
@@ -45,7 +45,7 @@ class Chef
             priority_ok = @current_resource.priority == @new_resource.priority
           end
           if @current_resource.enabled && priority_ok
-            logger.trace("#{@new_resource} already enabled - nothing to do")
+            logger.debug("#{@new_resource} already enabled - nothing to do")
           else
             converge_by("enable service #{@new_resource}") do
               enable_service

--- a/lib/chef/provider/service/debian.rb
+++ b/lib/chef/provider/service/debian.rb
@@ -138,7 +138,7 @@ class Chef
             priority_ok = @current_resource.priority == new_resource.priority
           end
           if current_resource.enabled && priority_ok
-            logger.trace("#{new_resource} already enabled - nothing to do")
+            logger.debug("#{new_resource} already enabled - nothing to do")
           else
             converge_by("enable service #{new_resource}") do
               enable_service

--- a/lib/chef/provider/service/freebsd.rb
+++ b/lib/chef/provider/service/freebsd.rb
@@ -171,7 +171,7 @@ class Chef
           end
 
           if current_resource.enabled.nil?
-            logger.trace("#{new_resource.name} enable/disable state unknown")
+            logger.debug("#{new_resource.name} enable/disable state unknown")
             current_resource.enabled false
           end
         end

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -105,7 +105,7 @@ class Chef
 
         def start_service
           if @current_resource.running
-            logger.trace("#{@new_resource} already running, not starting")
+            logger.debug("#{@new_resource} already running, not starting")
           else
             if @new_resource.start_command
               super
@@ -117,7 +117,7 @@ class Chef
 
         def stop_service
           unless @current_resource.running
-            logger.trace("#{@new_resource} not running, not stopping")
+            logger.debug("#{@new_resource} not running, not stopping")
           else
             if @new_resource.stop_command
               super
@@ -153,7 +153,7 @@ class Chef
         #
         def enable_service
           if @current_resource.enabled
-            logger.trace("#{@new_resource} already enabled, not enabling")
+            logger.debug("#{@new_resource} already enabled, not enabling")
           else
             load_service
           end
@@ -161,7 +161,7 @@ class Chef
 
         def disable_service
           unless @current_resource.enabled
-            logger.trace("#{@new_resource} not enabled, not disabling")
+            logger.debug("#{@new_resource} not enabled, not disabling")
           else
             unload_service
           end

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -122,7 +122,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def start_service
     if current_resource.running
-      logger.trace("#{new_resource} already running, not starting")
+      logger.debug("#{new_resource} already running, not starting")
     else
       if new_resource.start_command
         super
@@ -135,7 +135,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def stop_service
     unless current_resource.running
-      logger.trace("#{new_resource} not running, not stopping")
+      logger.debug("#{new_resource} not running, not stopping")
     else
       if new_resource.stop_command
         super
@@ -170,7 +170,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def enable_service
     if current_resource.masked || current_resource.indirect
-      logger.trace("#{new_resource} cannot be enabled: it is masked or indirect")
+      logger.debug("#{new_resource} cannot be enabled: it is masked or indirect")
       return
     end
     options, args = get_systemctl_options_args
@@ -179,7 +179,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def disable_service
     if current_resource.masked || current_resource.indirect
-      logger.trace("#{new_resource} cannot be disabled: it is masked or indirect")
+      logger.debug("#{new_resource} cannot be disabled: it is masked or indirect")
       return
     end
     options, args = get_systemctl_options_args

--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -85,7 +85,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
 
       state = current_state
       if state == RUNNING
-        logger.trace "#{@new_resource} already started - nothing to do"
+        logger.debug "#{@new_resource} already started - nothing to do"
       elsif state == START_PENDING
         logger.trace "#{@new_resource} already sent start signal - waiting for start"
         wait_for_state(RUNNING)
@@ -114,7 +114,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
         raise Chef::Exceptions::Service, "Service #{@new_resource} can't be started from state [#{state}]"
       end
     else
-      logger.trace "#{@new_resource} does not exist - nothing to do"
+      logger.debug "#{@new_resource} does not exist - nothing to do"
     end
   end
 
@@ -133,7 +133,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
         end
         @new_resource.updated_by_last_action(true)
       elsif state == STOPPED
-        logger.trace "#{@new_resource} already stopped - nothing to do"
+        logger.debug "#{@new_resource} already stopped - nothing to do"
       elsif state == STOP_PENDING
         logger.trace "#{@new_resource} already sent stop signal - waiting for stop"
         wait_for_state(STOPPED)
@@ -141,7 +141,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
         raise Chef::Exceptions::Service, "Service #{@new_resource} can't be stopped from state [#{state}]"
       end
     else
-      logger.trace "#{@new_resource} does not exist - nothing to do"
+      logger.debug "#{@new_resource} does not exist - nothing to do"
     end
   end
 
@@ -156,7 +156,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
       end
       @new_resource.updated_by_last_action(true)
     else
-      logger.trace "#{@new_resource} does not exist - nothing to do"
+      logger.debug "#{@new_resource} does not exist - nothing to do"
     end
   end
 
@@ -164,7 +164,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
     if Win32::Service.exists?(@new_resource.service_name)
       set_startup_type(:automatic)
     else
-      logger.trace "#{@new_resource} does not exist - nothing to do"
+      logger.debug "#{@new_resource} does not exist - nothing to do"
     end
   end
 
@@ -172,13 +172,13 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
     if Win32::Service.exists?(@new_resource.service_name)
       set_startup_type(:disabled)
     else
-      logger.trace "#{@new_resource} does not exist - nothing to do"
+      logger.debug "#{@new_resource} does not exist - nothing to do"
     end
   end
 
   action :create do
     if Win32::Service.exists?(new_resource.service_name)
-      logger.trace "#{new_resource} already exists - nothing to do"
+      logger.debug "#{new_resource} already exists - nothing to do"
       return
     end
 
@@ -191,7 +191,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
 
   action :delete do
     unless Win32::Service.exists?(new_resource.service_name)
-      logger.trace "#{new_resource} does not exist - nothing to do"
+      logger.debug "#{new_resource} does not exist - nothing to do"
       return
     end
 
@@ -222,7 +222,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
         logger.info("#{@new_resource} enabled")
       end
     else
-      logger.trace("#{@new_resource} already enabled - nothing to do")
+      logger.debug("#{@new_resource} already enabled - nothing to do")
     end
     load_new_resource_state
     @new_resource.enabled(true)
@@ -235,7 +235,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
         logger.info("#{@new_resource} disabled")
       end
     else
-      logger.trace("#{@new_resource} already disabled - nothing to do")
+      logger.debug("#{@new_resource} already disabled - nothing to do")
     end
     load_new_resource_state
     @new_resource.enabled(false)
@@ -248,7 +248,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
         set_startup_type(startup_type)
       end
     else
-      logger.trace("#{@new_resource} startup_type already #{startup_type} - nothing to do")
+      logger.debug("#{@new_resource} startup_type already #{startup_type} - nothing to do")
     end
 
     converge_delayed_start

--- a/lib/chef/provider/subversion.rb
+++ b/lib/chef/provider/subversion.rb
@@ -61,7 +61,7 @@ class Chef
             shell_out!(checkout_command, run_options)
           end
         else
-          logger.trace "#{new_resource} checkout destination #{new_resource.destination} already exists or is a non-empty directory - nothing to do"
+          logger.debug "#{new_resource} checkout destination #{new_resource.destination} already exists or is a non-empty directory - nothing to do"
         end
       end
 
@@ -69,7 +69,7 @@ class Chef
         if target_dir_non_existent_or_empty?
           action_force_export
         else
-          logger.trace "#{new_resource} export destination #{new_resource.destination} already exists or is a non-empty directory - nothing to do"
+          logger.debug "#{new_resource} export destination #{new_resource.destination} already exists or is a non-empty directory - nothing to do"
         end
       end
 

--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -107,10 +107,10 @@ class Chef
 
       action :enable do
         if current_resource.static
-          logger.trace("#{new_resource.unit_name} is a static unit, enabling is a NOP.")
+          logger.debug("#{new_resource.unit_name} is a static unit, enabling is a NOP.")
         end
         if current_resource.indirect
-          logger.trace("#{new_resource.unit_name} is an indirect unit, enabling is a NOP.")
+          logger.debug("#{new_resource.unit_name} is an indirect unit, enabling is a NOP.")
         end
 
         unless current_resource.enabled || current_resource.static || current_resource.indirect
@@ -123,11 +123,11 @@ class Chef
 
       action :disable do
         if current_resource.static
-          logger.trace("#{new_resource.unit_name} is a static unit, disabling is a NOP.")
+          logger.debug("#{new_resource.unit_name} is a static unit, disabling is a NOP.")
         end
 
         if current_resource.indirect
-          logger.trace("#{new_resource.unit_name} is an indirect unit, enabling is a NOP.")
+          logger.debug("#{new_resource.unit_name} is an indirect unit, enabling is a NOP.")
         end
 
         if current_resource.enabled && !current_resource.static && !current_resource.indirect
@@ -195,7 +195,7 @@ class Chef
             logger.info("#{new_resource} reloaded")
           end
         else
-          logger.trace("#{new_resource.unit_name} is not active, skipping reload.")
+          logger.debug("#{new_resource.unit_name} is not active, skipping reload.")
         end
       end
 

--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -172,7 +172,7 @@ class Chef
             logger.info("#{new_resource} locked")
           end
         else
-          logger.trace("#{new_resource} already locked - nothing to do")
+          logger.debug("#{new_resource} already locked - nothing to do")
         end
       end
 
@@ -183,7 +183,7 @@ class Chef
             logger.info("#{new_resource} unlocked")
           end
         else
-          logger.trace("#{new_resource} already unlocked - nothing to do")
+          logger.debug("#{new_resource} already unlocked - nothing to do")
         end
       end
 

--- a/lib/chef/provider/user/pw.rb
+++ b/lib/chef/provider/user/pw.rb
@@ -97,7 +97,7 @@ class Chef
             command = "pw usermod #{new_resource.username} -H 0"
             shell_out!(command, input: new_resource.password.to_s)
           else
-            logger.trace("#{new_resource} no change needed to password")
+            logger.debug("#{new_resource} no change needed to password")
           end
         end
       end

--- a/lib/chef/provider/zypper_repository.rb
+++ b/lib/chef/provider/zypper_repository.rb
@@ -33,7 +33,7 @@ class Chef
         if new_resource.gpgautoimportkeys
           install_gpg_key(new_resource.gpgkey)
         else
-          logger.trace("'gpgautoimportkeys' property is set to false. Skipping key import.")
+          logger.debug("'gpgautoimportkeys' property is set to false. Skipping key import.")
         end
 
         declare_resource(:template, "/etc/zypp/repos.d/#{escaped_repo_name}.repo") do
@@ -162,7 +162,7 @@ class Chef
       # @param [String] uri the uri of the local or remote gpg key
       def install_gpg_key(uri)
         unless uri
-          logger.trace("'gpgkey' property not provided or set to nil. Skipping key import.")
+          logger.debug("'gpgkey' property not provided or set to nil. Skipping key import.")
           return
         end
 

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -477,7 +477,7 @@ class Chef
             end
           end
         else
-          logger.trace("/etc/apt/sources.list.d/#{new_resource.repo_name}.list does not exist. Nothing to do")
+          logger.debug("/etc/apt/sources.list.d/#{new_resource.repo_name}.list does not exist. Nothing to do")
         end
       end
 

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -138,7 +138,7 @@ class Chef
             logger.info("#{new_resource} created raid device (#{new_resource.raid_device})")
           end
         else
-          logger.trace("#{new_resource} raid device already exists, skipping create (#{new_resource.raid_device})")
+          logger.debug("#{new_resource} raid device already exists, skipping create (#{new_resource.raid_device})")
         end
       end
 
@@ -151,7 +151,7 @@ class Chef
             logger.info("#{new_resource} assembled raid device (#{new_resource.raid_device})")
           end
         else
-          logger.trace("#{new_resource} raid device already exists, skipping assemble (#{new_resource.raid_device})")
+          logger.debug("#{new_resource} raid device already exists, skipping assemble (#{new_resource.raid_device})")
         end
       end
 
@@ -164,7 +164,7 @@ class Chef
             logger.info("#{new_resource} stopped raid device (#{new_resource.raid_device})")
           end
         else
-          logger.trace("#{new_resource} raid device doesn't exist (#{new_resource.raid_device}) - not stopping")
+          logger.debug("#{new_resource} raid device doesn't exist (#{new_resource.raid_device}) - not stopping")
         end
       end
 

--- a/lib/chef/resource/windows_font.rb
+++ b/lib/chef/resource/windows_font.rb
@@ -47,7 +47,7 @@ class Chef
 
       action :install, description: "Install a font to the system fonts directory" do
         if font_exists?
-          logger.trace("Not installing font: #{new_resource.font_name} as font already installed.")
+          logger.debug("Not installing font: #{new_resource.font_name} as font already installed.")
         else
           retrieve_cookbook_font
           install_font

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -1009,7 +1009,7 @@ class Chef
             end
           end
         else
-          logger.warn "#{new_resource} task does not exist - nothing to do"
+          logger.debug "#{new_resource} task does not exist - nothing to do"
         end
       end
 
@@ -1022,7 +1022,7 @@ class Chef
             ts.delete(current_resource.task_name)
           end
         else
-          logger.warn "#{new_resource} task does not exist - nothing to do"
+          logger.debug "#{new_resource} task does not exist - nothing to do"
         end
       end
 
@@ -1030,14 +1030,14 @@ class Chef
         if current_resource.exists
           logger.trace "#{new_resource} task exists"
           if current_resource.task.status != "running"
-            logger.trace "#{new_resource} is not running - nothing to do"
+            logger.debug "#{new_resource} is not running - nothing to do"
           else
             converge_by("#{new_resource} task ended") do
               current_resource.task.stop
             end
           end
         else
-          logger.warn "#{new_resource} task does not exist - nothing to do"
+          logger.debug "#{new_resource} task does not exist - nothing to do"
         end
       end
 
@@ -1050,7 +1050,7 @@ class Chef
               run_schtasks "CHANGE", "ENABLE" => ""
             end
           else
-            logger.trace "#{new_resource} already enabled - nothing to do"
+            logger.debug "#{new_resource} already enabled - nothing to do"
           end
         else
           logger.fatal "#{new_resource} task does not exist - nothing to do"

--- a/spec/unit/provider/cron_spec.rb
+++ b/spec/unit/provider/cron_spec.rb
@@ -719,7 +719,7 @@ describe Chef::Provider::Cron do
 
         it "should log nothing changed" do
           expect(logger).to receive(:trace).with("Found cron '#{@new_resource.name}'")
-          expect(logger).to receive(:trace).with("Skipping existing cron entry '#{@new_resource.name}'")
+          expect(logger).to receive(:debug).with("#{@new_resource}: Skipping existing cron entry")
           @provider.run_action(:create)
         end
       end

--- a/spec/unit/provider/group/gpasswd_spec.rb
+++ b/spec/unit/provider/group/gpasswd_spec.rb
@@ -68,7 +68,7 @@ describe Chef::Provider::Group::Gpasswd, "modify_group_members" do
       end
 
       it "logs a message and sets group's members to 'none'" do
-        expect(logger).to receive(:trace).with("group[wheel] setting group members to: none")
+        expect(logger).to receive(:debug).with("group[wheel] setting group members to: none")
         expect(@provider).to receive(:shell_out_compacted!).with("gpasswd", "-M", "", "wheel")
         @provider.modify_group_members
       end
@@ -88,7 +88,7 @@ describe Chef::Provider::Group::Gpasswd, "modify_group_members" do
 
     describe "when the resource specifies group members" do
       it "should log an appropriate debug message" do
-        expect(logger).to receive(:trace).with("group[wheel] setting group members to: lobster, rage, fist")
+        expect(logger).to receive(:debug).with("group[wheel] setting group members to: lobster, rage, fist")
         allow(@provider).to receive(:shell_out_compacted!)
         @provider.modify_group_members
       end

--- a/spec/unit/provider/group/groupmod_spec.rb
+++ b/spec/unit/provider/group/groupmod_spec.rb
@@ -64,7 +64,7 @@ describe Chef::Provider::Group::Groupmod do
         end
 
         it "logs a message and sets group's members to 'none', then removes existing group members" do
-          expect(logger).to receive(:trace).with("group[wheel] setting group members to: none")
+          expect(logger).to receive(:debug).with("group[wheel] setting group members to: none")
           expect(@provider).to receive(:shell_out_compacted!).with("group", "mod", "-n", "wheel_bak", "wheel")
           expect(@provider).to receive(:shell_out_compacted!).with("group", "add", "-g", "123", "-o", "wheel")
           expect(@provider).to receive(:shell_out_compacted!).with("group", "del", "wheel_bak")
@@ -79,7 +79,7 @@ describe Chef::Provider::Group::Groupmod do
         end
 
         it "logs a message and does not modify group membership" do
-          expect(logger).to receive(:trace).with("group[wheel] not changing group members, the group has no members to add")
+          expect(logger).to receive(:debug).with("group[wheel] not changing group members, the group has no members to add")
           expect(@provider).not_to receive(:shell_out_compacted!)
           @provider.manage_group
         end

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -96,7 +96,7 @@ describe Chef::Provider::Group::Pw do
       end
 
       it "should log an appropriate message" do
-        expect(logger).to receive(:trace).with("group[wheel] removing group members: all,your,base")
+        expect(logger).to receive(:debug).with("group[wheel] removing group members: all,your,base")
         @provider.set_members_options
       end
 
@@ -112,7 +112,7 @@ describe Chef::Provider::Group::Pw do
       end
 
       it "should log an appropriate debug message" do
-        expect(logger).to receive(:trace).with("group[wheel] adding group members: all,your,base")
+        expect(logger).to receive(:debug).with("group[wheel] adding group members: all,your,base")
         @provider.set_members_options
       end
 

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -579,7 +579,7 @@ describe Chef::Provider::Package::Apt do
         ).and_return(instance_double(
           Mixlib::ShellOut, stdout: "irssi"
         ))
-        expect(logger).to receive(:trace).with("#{@provider.new_resource} is already locked")
+        expect(logger).to receive(:debug).with("#{@provider.new_resource} is already locked")
 
         @provider.action_lock
       end
@@ -600,7 +600,7 @@ describe Chef::Provider::Package::Apt do
         ).and_return(instance_double(
           Mixlib::ShellOut, stdout: ""
         ))
-        expect(logger).to receive(:trace).with("#{@provider.new_resource} is already unlocked")
+        expect(logger).to receive(:debug).with("#{@provider.new_resource} is already unlocked")
 
         @provider.action_unlock
       end

--- a/spec/unit/provider/package/deb_spec.rb
+++ b/spec/unit/provider/package/deb_spec.rb
@@ -66,7 +66,7 @@ describe Chef::Provider::Package::Deb do
       it "does not reconfigure the package if the package is not installed" do
         allow(provider).to receive(:get_current_versions).and_return(nil)
         allow(provider.load_current_resource).to receive(:version).and_return(nil)
-        expect(logger).to receive(:trace).with("apt_package[emacs] is NOT installed - nothing to do")
+        expect(logger).to receive(:debug).with("apt_package[emacs] is NOT installed - nothing to do")
         expect(provider).not_to receive(:reconfig_package)
         provider.run_action(:reconfig)
         expect(new_resource).not_to be_updated_by_last_action
@@ -75,7 +75,7 @@ describe Chef::Provider::Package::Deb do
       it "does not reconfigure the package if no response_file is given" do
         allow(provider).to receive(:get_current_versions).and_return("1.0")
         allow(new_resource).to receive(:response_file).and_return(nil)
-        expect(logger).to receive(:trace).with("apt_package[emacs] no response_file provided - nothing to do")
+        expect(logger).to receive(:debug).with("apt_package[emacs] no response_file provided - nothing to do")
         expect(provider).not_to receive(:reconfig_package)
         provider.run_action(:reconfig)
         expect(new_resource).not_to be_updated_by_last_action
@@ -86,7 +86,7 @@ describe Chef::Provider::Package::Deb do
         allow(new_resource).to receive(:response_file).and_return(true)
         expect(provider).to receive(:get_preseed_file).and_return(false)
         allow(provider).to receive(:preseed_package).and_return(false)
-        expect(logger).to receive(:trace).with("apt_package[emacs] preseeding has not changed - nothing to do")
+        expect(logger).to receive(:debug).with("apt_package[emacs] preseeding has not changed - nothing to do")
         expect(provider).not_to receive(:reconfig_package)
         provider.run_action(:reconfig)
         expect(new_resource).not_to be_updated_by_last_action

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -259,7 +259,7 @@ describe Chef::Provider::Service::Macosx do
 
             it "shows warning message if service is already running" do
               allow(current_resource).to receive(:running).and_return(true)
-              expect(logger).to receive(:trace).with("macosx_service[#{service_name}] already running, not starting")
+              expect(logger).to receive(:debug).with("macosx_service[#{service_name}] already running, not starting")
 
               provider.start_service
             end
@@ -291,7 +291,7 @@ describe Chef::Provider::Service::Macosx do
 
             it "shows warning message if service is not running" do
               allow(current_resource).to receive(:running).and_return(false)
-              expect(logger).to receive(:trace).with("macosx_service[#{service_name}] not running, not stopping")
+              expect(logger).to receive(:debug).with("macosx_service[#{service_name}] not running, not stopping")
 
               provider.stop_service
             end

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -254,7 +254,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       end
 
       it "logs debug message" do
-        expect(logger).to receive(:trace).with("windows_service[#{chef_service_name}] already exists - nothing to do")
+        expect(logger).to receive(:debug).with("windows_service[#{chef_service_name}] already exists - nothing to do")
         provider.action_create
       end
 
@@ -334,7 +334,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       end
 
       it "logs debug message" do
-        expect(logger).to receive(:trace).with("windows_service[#{chef_service_name}] does not exist - nothing to do")
+        expect(logger).to receive(:debug).with("windows_service[#{chef_service_name}] does not exist - nothing to do")
         provider.action_delete
       end
 

--- a/spec/unit/provider/zypper_repository_spec.rb
+++ b/spec/unit/provider/zypper_repository_spec.rb
@@ -96,7 +96,7 @@ describe Chef::Provider::ZypperRepository do
     it "skips key import if gpgautoimportkeys is false" do
       new_resource.gpgautoimportkeys(false)
       expect(provider).to receive(:declare_resource)
-      expect(logger).to receive(:trace)
+      expect(logger).to receive(:debug)
       provider.run_action(:create)
     end
   end
@@ -169,7 +169,7 @@ describe Chef::Provider::ZypperRepository do
 
   describe "#install_gpg_key" do
     it "skips installing the key if a nil value for key is passed" do
-      expect(logger).to receive(:trace)
+      expect(logger).to receive(:debug)
       provider.install_gpg_key(nil)
     end
   end


### PR DESCRIPTION
This was discussed in the last Chef Triage meeting.

In the great move to trace logging, which is great, idempotency check
logs moved to trace, which defeats the purpose. The goal is to keep
"internal chef" logging in trace so that when users are trying to figure
out why their cookbook isn't acting as expected they can look at debug
without having to see all the other cruft. But "here's why I didn't
install the package you said to install" is table-steaks "I'm trying to
debug my cookbook."

This moves those logs back to debug. There were a variety of cases where
logging was pretty nonstandard in other ways, but to keep this PR
scoped, I didn't change those.

I did fix a few related logging issues:
* A few warns that should have been debug in windows_task
* A few places where there was basically no logging whatsoever, I put a
  few of the "I did X" logs to 'debug' (from trace). It coudl be argued
  some of those should be 'info', but that's a bigger change that I
  didn't want to put into this PR