### PR TITLE
Pin win32-certstore to 0.5.x until we resolve failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ PATH
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
       win32-api (~> 1.5.3)
-      win32-certstore (~> 0.5)
+      win32-certstore (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
       win32-mmap (~> 0.4.1)
@@ -375,7 +375,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.6.1)
+    win32-certstore (0.5.3)
       ffi
       mixlib-shellout
     win32-event (0.6.3)

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -14,7 +14,7 @@ gemspec.add_dependency "win32-service", ">= 2.1.5", "< 3.0"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
 gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
 gemspec.add_dependency "iso8601", ">= 0.12.1", "< 0.14" # validate 0.14 when it comes out
-gemspec.add_dependency "win32-certstore", "~> 0.5" # 0.5+ required for specifying user vs. system store
+gemspec.add_dependency "win32-certstore", "~> 0.5.0" # 0.5+ required for specifying user vs. system store
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -405,7 +405,7 @@ GEM
     uuidtools (2.2.0)
     webrick (1.7.0)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.5.3)
+    win32-certstore (0.6.1)
       ffi
       mixlib-shellout
     win32-event (0.6.3)


### PR DESCRIPTION
0.6.0 is causing build failures

Signed-off-by: Tim Smith <tsmith@chef.io>