### PR TITLE
Use full path for launchctl calls

### DIFF
--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -169,12 +169,12 @@ class Chef
 
         def load_service
           session = @session_type ? "-S #{@session_type} " : ""
-          cmd = "launchctl load -w " + session + @plist
+          cmd = "/bin/launchctl load -w " + session + @plist
           shell_out_as_user(cmd)
         end
 
         def unload_service
-          cmd = "launchctl unload -w " + @plist
+          cmd = "/bin/launchctl unload -w " + @plist
           shell_out_as_user(cmd)
         end
 
@@ -190,7 +190,7 @@ class Chef
         def set_service_status
           return if @plist.nil? || @service_label.to_s.empty?
 
-          cmd = "launchctl list #{@service_label}"
+          cmd = "/bin/launchctl list #{@service_label}"
           res = shell_out_as_user(cmd)
 
           if res.exitstatus == 0

--- a/lib/chef/resource/chef_client_launchd.rb
+++ b/lib/chef/resource/chef_client_launchd.rb
@@ -134,7 +134,7 @@ class Chef
           standard_error_path ::File.join(new_resource.log_directory, new_resource.log_file_name)
           program_arguments ["/bin/bash",
                              "-c",
-                             "echo; echo #{ChefUtils::Dist::Infra::PRODUCT} launchd daemon config has been updated. Manually unloading and reloading the daemon; echo Now unloading the daemon; launchctl unload /Library/LaunchDaemons/com.#{ChefUtils::Dist::Infra::SHORT}.#{ChefUtils::Dist::Infra::CLIENT}.plist; sleep 2; echo Now loading the daemon; launchctl load /Library/LaunchDaemons/com.#{ChefUtils::Dist::Infra::SHORT}.#{ChefUtils::Dist::Infra::CLIENT}.plist"]
+                             "echo; echo #{ChefUtils::Dist::Infra::PRODUCT} launchd daemon config has been updated. Manually unloading and reloading the daemon; echo Now unloading the daemon; /bin/launchctl unload /Library/LaunchDaemons/com.#{ChefUtils::Dist::Infra::SHORT}.#{ChefUtils::Dist::Infra::CLIENT}.plist; sleep 2; echo Now loading the daemon; /bin/launchctl load /Library/LaunchDaemons/com.#{ChefUtils::Dist::Infra::SHORT}.#{ChefUtils::Dist::Infra::CLIENT}.plist"]
           action :enable # enable creates the plist & triggers service restarts on change
         end
 

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -78,7 +78,7 @@ describe Chef::Provider::Service::Macosx do
           @getpwuid = double("Etc::Passwd", { name: "mikedodge04" })
           allow(Etc).to receive(:getpwuid).and_return(@getpwuid)
           allow(node).to receive(:[]).with("platform_version").and_return("10.11.1")
-          cmd = "launchctl list #{service_label}"
+          cmd = "/bin/launchctl list #{service_label}"
           allow(provider).to receive(:shell_out)
             .with(/(#{su_cmd} '#{cmd}'|#{cmd})/, default_env: false)
             .and_return(double("Status",
@@ -265,7 +265,7 @@ describe Chef::Provider::Service::Macosx do
             end
 
             it "starts service via launchctl if service found" do
-              cmd = "launchctl load -w " + session + plist
+              cmd = "/bin/launchctl load -w " + session + plist
               expect(provider).to receive(:shell_out)
                 .with(/(#{su_cmd} .#{cmd}.|#{cmd})/, default_env: false)
                 .and_return(0)
@@ -297,7 +297,7 @@ describe Chef::Provider::Service::Macosx do
             end
 
             it "stops the service via launchctl if service found" do
-              cmd = "launchctl unload -w " + plist
+              cmd = "/bin/launchctl unload -w " + plist
               expect(provider).to receive(:shell_out)
                 .with(/(#{su_cmd} .#{cmd}.|#{cmd})/, default_env: false)
                 .and_return(0)


### PR DESCRIPTION
Signed-off-by: Jeff Johnson <jeff@jeffs-tech.com>

## Description
This change uses the full path for the launchctl binary in OSX. By default, /bin is not always in Chef's path so the resource fails out of the box (a workaround is to add /bin to Chefctl::Config.path)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
