### PR TITLE
only run file verifiers when the contents changed

### DIFF
--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -338,7 +338,7 @@ class Chef
           raise Chef::Exceptions::ChecksumMismatch.new(short_cksum(new_resource.checksum), short_cksum(tempfile_checksum))
         end
 
-        if tempfile
+        if tempfile && contents_changed?
           new_resource.verify.each do |v|
             unless v.verify(tempfile.path)
               backupfile = "#{Chef::Config[:file_cache_path]}/failed_validations/#{::File.basename(tempfile.path)}"

--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -479,12 +479,14 @@ shared_examples_for Chef::Provider::File do
         it "calls #verify on each verification with tempfile path" do
           provider.new_resource.verify windows? ? "REM" : "true"
           provider.new_resource.verify windows? ? "REM" : "true"
+          allow(provider).to receive(:contents_changed?).and_return(true)
           provider.send(:do_validate_content)
         end
 
         it "raises an exception if any verification fails" do
           allow(File).to receive(:directory?).with("C:\\Windows\\system32/cmd.exe").and_return(false)
           allow(provider).to receive(:tempfile).and_return(tempfile)
+          allow(provider).to receive(:contents_changed?).and_return(true)
           provider.new_resource.verify windows? ? "cmd.exe c exit 1" : "false"
           provider.new_resource.verify.each do |v|
             allow(v).to receive(:verify).and_return(false)
@@ -492,9 +494,21 @@ shared_examples_for Chef::Provider::File do
           expect { provider.send(:do_validate_content) }.to raise_error(Chef::Exceptions::ValidationFailed)
         end
 
+        it "does not run verifications when the contents did not change" do
+          allow(File).to receive(:directory?).with("C:\\Windows\\system32/cmd.exe").and_return(false)
+          allow(provider).to receive(:tempfile).and_return(tempfile)
+          allow(provider).to receive(:contents_changed?).and_return(false)
+          provider.new_resource.verify windows? ? "cmd.exe c exit 1" : "false"
+          provider.new_resource.verify.each do |v|
+            expect(v).not_to receive(:verify)
+          end
+          provider.send(:do_validate_content)
+        end
+
         it "does not show verification for sensitive resources" do
           allow(File).to receive(:directory?).with("C:\\Windows\\system32/cmd.exe").and_return(false)
           allow(provider).to receive(:tempfile).and_return(tempfile)
+          allow(provider).to receive(:contents_changed?).and_return(true)
           provider.new_resource.sensitive true
           provider.new_resource.verify windows? ? "cmd.exe c exit 1" : "false"
           provider.new_resource.verify.each do |v|


### PR DESCRIPTION
Signed-off-by: Joshua Miller <joshmiller@fb.com>

Only run file verifiers when the file contents have actually changed

## Description
Only run file verifiers when the file contents have actually changed.  This prevents unnecessary verifier overhead, as well as verifier failures unrelated to chef changes.

## Related Issue
#11170

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
