### PR TITLE
Drop off a sample client.rb config on *nix

### DIFF
--- a/omnibus/package-scripts/chef/postinst
+++ b/omnibus/package-scripts/chef/postinst
@@ -97,13 +97,15 @@ ln -sf $INSTALLER_DIR/bin/chef-client $PREFIX/bin || error_exit "Cannot link che
 # the sample client.rb is only written out of no chef config dir exists yet
 if ! [ -d $CONFIG_DIR ]; then
    mkdir -p $CONFIG_DIR
-   echo -e "# The client.rb file specifies how Chef Infra Client is configured on a node" > "$CONFIG_DIR/client.rb"
-   echo -e "# See https://docs.chef.io/config_rb_client/ for detailed configuration options" >> "$CONFIG_DIR/client.rb"
-   echo -e "#" >> "$CONFIG_DIR/client.rb"
-   echo -e "# Minimal example configuration:"  >> "$CONFIG_DIR/client.rb"
-   echo -e "# node_name  \"THIS_NODE_NAME\""  >> "$CONFIG_DIR/client.rb"
-   echo -e "# chef_server_url  \"https://CHEF.MYCOMPANY.COM/organizations/MY_CHEF_ORG\""  >> "$CONFIG_DIR/client.rb"
-   echo -e "# chef_license  \"accept\""  >> "$CONFIG_DIR/client.rb"
+   cat >"$CONFIG_DIR/client.rb" <<EOF
+# The client.rb file specifies how Chef Infra Client is configured on a node
+# See https://docs.chef.io/config_rb_client/ for detailed configuration options
+#
+# Minimal example configuration:
+# node_name  "THIS_NODE_NAME"
+# chef_server_url  "https://CHEF.MYCOMPANY.COM/organizations/MY_CHEF_ORG"
+# chef_license  "accept"
+EOF
 fi
 
 mkdir -p "$CONFIG_DIR/client.d"

--- a/omnibus/package-scripts/chef/postinst
+++ b/omnibus/package-scripts/chef/postinst
@@ -94,10 +94,22 @@ ln -sf $INSTALLER_DIR/bin/ohai $PREFIX/bin || error_exit "Cannot link ohai to $P
 ln -sf $INSTALLER_DIR/bin/chef-client $PREFIX/bin || error_exit "Cannot link chef-client to $PREFIX/bin"
 
 # make the base structure for chef to run
-mkdir -p /etc/chef/client.d/
-mkdir -p /etc/chef/accepted_licenses
-mkdir -p /etc/chef/trusted_certs
-mkdir -p /etc/chef/ohai/plugins
+# the sample client.rb is only written out of no chef config dir exists yet
+if ! [ -d $CONFIG_DIR ]; then
+   mkdir -p $CONFIG_DIR
+   echo -e "# The client.rb file specifies how Chef Infra Client is configured on a node" > "$CONFIG_DIR/client.rb"
+   echo -e "# See https://docs.chef.io/config_rb_client/ for detailed configuration options" >> "$CONFIG_DIR/client.rb"
+   echo -e "#" >> "$CONFIG_DIR/client.rb"
+   echo -e "# Minimal example configuration:"  >> "$CONFIG_DIR/client.rb"
+   echo -e "# node_name  \"THIS_NODE_NAME\""  >> "$CONFIG_DIR/client.rb"
+   echo -e "# chef_server_url  \"https://CHEF.MYCOMPANY.COM/organizations/MY_CHEF_ORG\""  >> "$CONFIG_DIR/client.rb"
+   echo -e "# chef_license  \"accept\""  >> "$CONFIG_DIR/client.rb"
+fi
+
+mkdir -p "$CONFIG_DIR/client.d"
+mkdir -p "$CONFIG_DIR/accepted_licenses"
+mkdir -p "$CONFIG_DIR/trusted_certs"
+mkdir -p "$CONFIG_DIR/ohai/plugins"
 
 echo "Thank you for installing Chef Infra Client! For help getting started visit https://learn.chef.io"
 


### PR DESCRIPTION
This change builds on my earlier PR (#11158) that created the /etc/chef/* directories necessary to get started. With this change, we now give them a sample /etc/chef/client.rb that they can edit to get started. Also, point them to the docs that tell them what all the config options are.

/etc/chef/client.rb:
```
# The client.rb file specifies how Chef Infra Client is configured on a node
# See https://docs.chef.io/config_rb_client/ for detailed configuration options
#
# Minimal example configuration:
# node_name  "THIS_NODE_NAME"
# chef_server_url  "https://CHEF.MYCOMPANY.COM/organizations/MY_CHEF_ORG"
# chef_license  "accept"
```

Signed-off-by: Tim Smith <tsmith@chef.io>