### PR TITLE
Fix users_manage usage in kitchen-tests

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -44,8 +44,11 @@ resolver_config "/etc/resolv.conf" do
   search [ "chef.io" ]
 end
 
+users_from_databag = search("users", "*:*")
+
 users_manage "sysadmin" do
   group_id 2300
+  users users_from_databag
   action [:create]
 end
 

--- a/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
@@ -28,15 +28,19 @@ resolver_config "/etc/resolv.conf" do
   search [ "chef.io" ]
 end
 
+users_from_databag = search("users", "*:*")
+
 users_manage "remove sysadmin" do
   group_name "sysadmin"
   group_id 2300
+  users users_from_databag
   action [:remove]
 end
 
 users_manage "create sysadmin" do
   group_name "sysadmin"
   group_id 2300
+  users users_from_databag
   action [:create]
 end
 

--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -66,22 +66,23 @@ windows_audit_policy "Update Some Advanced Audit Policies to No Auditing" do
   failure false
 end
 
-users_from_databag = search("users", "*:*")
-
-users_manage "remove sysadmin" do
-  group_name "sysadmin"
-  group_id 2300
-  users users_from_databag
-  action [:remove]
-end
-
-# FIXME: create is not idempotent. it fails with a windows error if this already exists.
-users_manage "create sysadmin" do
-  group_name "sysadmin"
-  group_id 2300
-  users users_from_databag
-  action [:create]
-end
+# FIXME: upstream users cookbooks is currently broken on windows
+# users_from_databag = search("users", "*:*")
+#
+# users_manage "remove sysadmin" do
+#   group_name "sysadmin"
+#   group_id 2300
+#   users users_from_databag
+#   action [:remove]
+# end
+#
+# # FIXME: create is not idempotent. it fails with a windows error if this already exists.
+# users_manage "create sysadmin" do
+#   group_name "sysadmin"
+#   group_id 2300
+#   users users_from_databag
+#   action [:create]
+# end
 
 include_recipe "::_chef_client_config"
 include_recipe "::_chef_client_trusted_certificate"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -66,9 +66,12 @@ windows_audit_policy "Update Some Advanced Audit Policies to No Auditing" do
   failure false
 end
 
+users_from_databag = search("users", "*:*")
+
 users_manage "remove sysadmin" do
   group_name "sysadmin"
   group_id 2300
+  users users_from_databag
   action [:remove]
 end
 
@@ -76,6 +79,7 @@ end
 users_manage "create sysadmin" do
   group_name "sysadmin"
   group_id 2300
+  users users_from_databag
   action [:create]
 end
 

--- a/kitchen-tests/data_bags/users/adam.json
+++ b/kitchen-tests/data_bags/users/adam.json
@@ -5,5 +5,5 @@
     "shell": "/bin/zsh",
     "groups": [ "sysadmin" ],
     "comment":  "Adam Jacob",
-    "password": "*"
+    "password": "$6$QQk10qmDjMv.o$wHIjLH9JOxUmaJTsxYFttFhP1jZZtTk/ovhpasmQJS5mfimeFs8HMRWGWM8uBB5dhEmP6svqhRdJE5k1oWRPF1"
 }


### PR DESCRIPTION
The use of data bags in the users cookbook was removed in 6.0.0 [1]. This applies the recommended workaround and allow the integration tests to pass.

[1] https://github.com/sous-chefs/users/blob/master/CHANGELOG.md#600---2021-03-12

Signed-off-by: Lance Albertson <lance@osuosl.org>
