### PR TITLE
Add an expeditor script specific to bundler updated gems

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -226,8 +226,8 @@ subscriptions:
   # NOTE: The branch of Ohai here needs to be updated when setting up a stable branch of chef/chef
   - workload: chef/ohai:master_completed:pull_request_merged:chef/ohai:master:*
     actions:
-      - bash:.expeditor/update_dep.sh
+      - bash:.expeditor/update_bundler_dep.sh
   # NOTE: When the stable branch of chef/chef is being cut you probably want to remove this subscription
   - workload: chef/chefstyle:master_completed:pull_request_merged:chef/chefstyle:master:*
     actions:
-      - bash:.expeditor/update_dep.sh
+      - bash:.expeditor/update_bundler_dep.sh

--- a/.expeditor/update_bundler_dep.sh
+++ b/.expeditor/update_bundler_dep.sh
@@ -11,7 +11,7 @@
 
 set -evx
 
-branch="expeditor/$EXPEDITOR_REPO_$EXPEDITOR_LATEST_COMMIT"
+branch="expeditor/${EXPEDITOR_REPO}_${EXPEDITOR_LATEST_COMMIT}"
 git checkout -b "$branch"
 
 bundle lock --update
@@ -20,7 +20,7 @@ git add .
 
 # give a friendly message for the commit and make sure it's noted for any future audit of our codebase that no
 # DCO sign-off is needed for this sort of PR since it contains no intellectual property
-git commit --message "Bump $DEPNAME to $EXPEDITOR_LATEST_COMMIT" --message "This pull request was triggered automatically via Expeditor when $DEPNAME $EXPEDITOR_LATEST_COMMIT was merged." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+git commit --message "Bump $EXPEDITOR_REPO to $EXPEDITOR_LATEST_COMMIT" --message "This pull request was triggered automatically via Expeditor when $DEPNAME $EXPEDITOR_LATEST_COMMIT was merged." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
 
 open_pull_request "$EXPEDITOR_BRANCH"
 

--- a/.expeditor/update_bundler_dep.sh
+++ b/.expeditor/update_bundler_dep.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+############################################################################
+# What is this script?
+#
+# Chef uses a workflow tool called Expeditor to manage version bumps, changelogs
+# and releases. When a dependency of chef is released, expeditor is triggered
+# against this repository to run this script. It bumps our gem lock files and opens
+# a PR. That way humans can do hard work and bots can open gem bump PRs.
+############################################################################
+
+set -evx
+
+branch="expeditor/$EXPEDITOR_REPO_$EXPEDITOR_LATEST_COMMIT"
+git checkout -b "$branch"
+
+bundle lock --update
+
+git add .
+
+# give a friendly message for the commit and make sure it's noted for any future audit of our codebase that no
+# DCO sign-off is needed for this sort of PR since it contains no intellectual property
+git commit --message "Bump $DEPNAME to $EXPEDITOR_LATEST_COMMIT" --message "This pull request was triggered automatically via Expeditor when $DEPNAME $EXPEDITOR_LATEST_COMMIT was merged." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+
+open_pull_request "$EXPEDITOR_BRANCH"
+
+# Get back to master and cleanup the leftovers - any changed files left over at the end of this script will get committed to master.
+git checkout -
+git branch -D "$branch"


### PR DESCRIPTION
The more I hacked on the previous script the more I realized they're not
doing the same thing. This script is not concerned with things that
happened via rubygems promotes. It's just running bundle update when a
new commit is available in the repo.

Signed-off-by: Tim Smith <tsmith@chef.io>

