### PR TITLE
Disable compliance phase by default

### DIFF
--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -89,9 +89,9 @@ class Chef
       # named `chef_node`.
       "chef_node_attribute_enabled" => false,
 
-      # Should the built-in compliance phase run.  True and false force the behavior.  Nil does magic based on if you have
+      # Should the built-in compliance phase run. True and false force the behavior. Nil does magic based on if you have
       # profiles defined but do not have the audit cookbook enabled.
-      "compliance_phase" => nil
+      "compliance_phase" => false
     )
   end
 end


### PR DESCRIPTION
Require an explicit opt-in for this feature due to named run lists and
override run lists breaking the detection

Signed-off-by: Tim Smith <tsmith@chef.io>