### PR TITLE
Update FFI to 1.15 for M1 Macs + libarchive to 3.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-# pin until issues with Windows builds in 1.14.2 are resolved
-gem "ffi", "=1.13.1"
+# 1.15+ is required for M1 mac builds
+gem "ffi", ">=1.15"
 
 # Note we do not use the gemspec DSL which restricts to the
 # gemspec for the current platform and filters out other platforms

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,9 +178,9 @@ GEM
       faraday (~> 1.0)
     fauxhai-ng (8.7.0)
       net-ssh
-    ffi (1.13.1)
-    ffi (1.13.1-x64-mingw32)
-    ffi (1.13.1-x86-mingw32)
+    ffi (1.15.0)
+    ffi (1.15.0-x64-mingw32)
+    ffi (1.15.0-x86-mingw32)
     ffi-libarchive (1.0.17)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -429,7 +429,7 @@ DEPENDENCIES
   cheffish (>= 14)
   chefstyle (= 1.5.9)
   fauxhai-ng
-  ffi (= 1.13.1)
+  ffi (>= 1.15)
   inspec-core-bin (~> 4.24)
   ohai!
   pry

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.433.0)
+    aws-partitions (1.434.0)
     aws-sdk-core (3.113.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -202,7 +202,7 @@ GEM
     highline (2.0.3)
     httpclient (2.8.3)
     iniparse (1.5.0)
-    inspec-core (4.26.13)
+    inspec-core (4.28.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0)
       faraday (>= 0.9.0, < 1.4)
@@ -238,7 +238,7 @@ GEM
       tomlrb (>= 1.2, < 3.0)
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
-    license_scout (1.2.9)
+    license_scout (1.2.10)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)
@@ -256,7 +256,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-install (3.12.7)
+    mixlib-install (3.12.11)
       mixlib-shellout
       mixlib-versioning
       thor

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,7 +3,7 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override "libarchive", version: "3.5.0"
+override "libarchive", version: "3.5.1"
 override "libffi", version: "3.3"
 override "libiconv", version: "1.16"
 override "liblzma", version: "5.2.5"


### PR DESCRIPTION
Minor fixes in libarchive for the archive_file resource, but we need to
bump FFI for the new Macs

Signed-off-by: Tim Smith <tsmith@chef.io>