### PR TITLE
Add login option to execute resource

### DIFF
--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -27,7 +27,7 @@ class Chef
 
       provides :execute, target_mode: true
 
-      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates, :elevated, :default_env, :timeout, :input
+      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates, :elevated, :default_env, :timeout, :input, :login
 
       def load_current_resource
         current_resource = Chef::Resource::Execute.new(new_resource.name)
@@ -92,6 +92,7 @@ class Chef
         opts[:cwd]         = cwd if cwd
         opts[:umask]       = umask if umask
         opts[:input]       = input if input
+        opts[:login]       = login if login
         opts[:default_env] = default_env
         opts[:log_level]   = :info
         opts[:log_tag]     = new_resource.to_s

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -572,6 +572,10 @@ class Chef
         introduced: "16.2",
         description: "An optional property to set the input sent to the command as STDIN."
 
+      property :login, [ TrueClass, FalseClass ], default: false,
+        introduced: "17.0",
+        description: "Use a login shell to run the commands instead of inheriting the existing execution environment."
+
       alias :env :environment
 
       def self.set_guard_inherited_attributes(*inherited_attributes)
@@ -666,7 +670,8 @@ class Chef
         :group,
         :password,
         :user,
-        :umask
+        :umask,
+        :login
       )
 
     end

--- a/spec/support/shared/unit/script_resource.rb
+++ b/spec/support/shared/unit/script_resource.rb
@@ -47,9 +47,9 @@ shared_examples_for "a script resource" do
   end
 
   describe "when executing guards" do
-    it "inherits exactly the :cwd, :domain, :environment, :group, :password, :path, :user, and :umask attributes from a parent resource class" do
+    it "inherits exactly the :cwd, :domain, :environment, :group, :password, :path, :user, :umask, and :login attributes from a parent resource class" do
       inherited_difference = Chef::Resource::Script.guard_inherited_attributes -
-        %i{cwd domain environment group password path user umask}
+        %i{cwd domain environment group password path user umask login}
 
       expect(inherited_difference).to eq([])
     end

--- a/spec/unit/resource/powershell_script_spec.rb
+++ b/spec/unit/resource/powershell_script_spec.rb
@@ -47,9 +47,9 @@ describe Chef::Resource::PowershellScript do
     expect(resource.convert_boolean_return).to eq(false)
   end
 
-  it "inherits exactly the :cwd, :domain, :environment, :group, :password, :path, :user, :umask, :architecture, :elevated, :interpreter properties from a parent resource class" do
+  it "inherits exactly the :cwd, :domain, :environment, :group, :password, :path, :user, :umask, :architecture, :elevated, :interpreter, :login properties from a parent resource class" do
     inherited_difference = Chef::Resource::PowershellScript.guard_inherited_attributes -
-      %i{cwd domain environment group password path user umask architecture elevated interpreter}
+      %i{cwd domain environment group password path user umask architecture elevated interpreter login}
 
     expect(inherited_difference).to eq([])
   end


### PR DESCRIPTION
This implements https://github.com/chef/mixlib-shellout/pull/78 in the
execute resource.  Default stays the same.

Using `login true` useful things happen like the environment being
set correctly including USER and HOME.
