### PR TITLE
Fix the ruby-3 omnibus builds/tests

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: f903311ba8ae9ff8f1e7bd7a9c21421fd39f7c7e
+  revision: 1769ef260837e73a3a865f1fa3e02ef2e0aa394c
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.433.0)
+    aws-partitions (1.434.0)
     aws-sdk-core (3.113.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -41,15 +41,15 @@ GEM
     aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.91.0)
+    aws-sdk-s3 (1.92.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.3)
       aws-eventstream (~> 1, >= 1.0.2)
-    bcrypt_pbkdf (1.1.0.rc2)
-    bcrypt_pbkdf (1.1.0.rc2-x64-mingw32)
-    bcrypt_pbkdf (1.1.0.rc2-x86-mingw32)
+    bcrypt_pbkdf (1.1.0)
+    bcrypt_pbkdf (1.1.0-x64-mingw32)
+    bcrypt_pbkdf (1.1.0-x86-mingw32)
     berkshelf (7.2.0)
       chef (>= 15.7.32)
       chef-config
@@ -64,12 +64,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.10.17)
+    chef (16.11.7)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc2)
+      bcrypt_pbkdf (~> 1.1)
       bundler (>= 1.10)
-      chef-config (= 16.10.17)
-      chef-utils (= 16.10.17)
+      chef-config (= 16.11.7)
+      chef-utils (= 16.11.7)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -101,12 +101,12 @@ GEM
       tty-screen (~> 0.6)
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
-    chef (16.10.17-universal-mingw32)
+    chef (16.11.7-universal-mingw32)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc2)
+      bcrypt_pbkdf (~> 1.1)
       bundler (>= 1.10)
-      chef-config (= 16.10.17)
-      chef-utils (= 16.10.17)
+      chef-config (= 16.11.7)
+      chef-utils (= 16.11.7)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -140,7 +140,7 @@ GEM
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
       win32-api (~> 1.5.3)
-      win32-certstore (~> 0.5)
+      win32-certstore (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
       win32-mmap (~> 0.4.1)
@@ -150,9 +150,9 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (16.10.17)
+    chef-config (16.11.7)
       addressable
-      chef-utils (= 16.10.17)
+      chef-utils (= 16.11.7)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -160,7 +160,7 @@ GEM
     chef-telemetry (1.0.29)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (16.10.17)
+    chef-utils (16.11.7)
     chef-vault (4.1.0)
     chef-zero (15.0.4)
       ffi-yajl (~> 2.2)
@@ -202,7 +202,7 @@ GEM
     highline (2.0.3)
     httpclient (2.8.3)
     iniparse (1.5.0)
-    inspec-core (4.26.13)
+    inspec-core (4.28.0)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0)
       faraday (>= 0.9.0, < 1.4)
@@ -238,7 +238,7 @@ GEM
       tomlrb (>= 1.2, < 3.0)
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
-    license_scout (1.2.9)
+    license_scout (1.2.10)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)
@@ -252,11 +252,11 @@ GEM
       mixlib-log
     mixlib-archive (1.1.7-universal-mingw32)
       mixlib-log
-    mixlib-authentication (3.0.7)
+    mixlib-authentication (3.0.10)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-install (3.12.7)
+    mixlib-install (3.12.11)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -286,7 +286,7 @@ GEM
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (16.10.6)
+    ohai (16.10.7)
       chef-config (>= 12.8, < 17)
       chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
@@ -346,9 +346,9 @@ GEM
       molinillo (~> 0.6)
       semverse (>= 1.1, < 4.0)
     sslshake (1.3.1)
-    strings (0.2.0)
+    strings (0.2.1)
       strings-ansi (~> 0.2)
-      unicode-display_width (~> 1.5)
+      unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
     structured_warnings (0.4.0)
@@ -400,12 +400,12 @@ GEM
       pastel (~> 0.8)
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
     unicode_utils (1.4.0)
     uuidtools (2.2.0)
     webrick (1.7.0)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.6.1)
+    win32-certstore (0.5.3)
       ffi
       mixlib-shellout
     win32-event (0.6.3)

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -82,7 +82,6 @@ build do
     # find the embedded ruby gems dir and clean it up for globbing
     target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
     files = %w{
-      *.gemspec
       Gemfile
       Rakefile
       tasks

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -103,7 +103,7 @@ describe Chef::Provider::Package::Rubygems::CurrentGemEnvironment do
     expect(Gem.sources).to eq(normal_sources)
   end
 
-  context "new default rubygems behavior" do
+  context "new default rubygems behavior", ruby: ">= 3.0" do
     before do
       Chef::Config[:rubygems_cache_enabled] = false
 


### PR DESCRIPTION
This switches omnibus to using the post-bundle-install hook

One fix here to avoid some tests that no longer work on ruby < 3.0 (rubygems changed so the stubs need to change, our code isn't any different)
