### PR TITLE
Chef 16: backport the post-bundle-install support

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -94,14 +94,10 @@ do_build() {
   ( cd "$CACHE_PATH" || exit_with "unable to enter hab-cache directory" 1
     build_line "Installing gem dependencies ..."
     bundle install --jobs=3 --retry=3
+    build_line "Installing gems from git repos properly ..."
+    ruby ./post-bundle-install.rb
     build_line "Installing this project's gems ..."
     bundle exec rake install
-    for gem in $GEM_HOME/bundler/gems/*; do
-      ( cd $gem
-        build_line "Installing gems from git repos properly ..."
-        rake install
-      )
-    done
   )
 }
 

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -21,8 +21,18 @@ lifecycle:
     - remote: /opt/chef/bin/chef-client -v
     - remote: /opt/chef/bin/ohai -v
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+    - remote: scl enable devtoolset-8 '/opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %> --tarball --github chef/ohai'
+      includes:
+        - centos-6
+    - remote: scl enable devtoolset-8 '/opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['BUILDKITE_COMMIT']  || %x(git rev-parse HEAD).chomp %> --tarball --github chef/chef'
+      includes:
+        - centos-6
     - remote: /opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %> --tarball --github chef/ohai
+      excludes:
+        - centos-6
     - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['BUILDKITE_COMMIT']  || %x(git rev-parse HEAD).chomp %> --tarball --github chef/chef
+      excludes:
+        - centos-6
     - remote: echo "Installed Chef / Ohai release:"
     - remote: /opt/chef/bin/chef-client -v
     - remote: /opt/chef/bin/ohai -v
@@ -72,7 +82,6 @@ platforms:
       - RUN wget -O /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo
       - RUN printf "[centos-sclo-rh]\nname=CentOS-6 - SCLo rh\nbaseurl=http://vault.centos.org/centos/6/sclo/x86_64/rh\ngpgcheck=1\nenabled=1\ngpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo" > /etc/yum.repos.d/CentOS-SCLo-rh.repo
       - RUN yum install -y devtoolset-7
-      - RUN scl enable devtoolset-7 bash
 
 - name: centos-7
   driver:

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: f903311ba8ae9ff8f1e7bd7a9c21421fd39f7c7e
+  revision: 1769ef260837e73a3a865f1fa3e02ef2e0aa394c
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -41,15 +41,15 @@ GEM
     aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.91.0)
+    aws-sdk-s3 (1.92.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.3)
       aws-eventstream (~> 1, >= 1.0.2)
-    bcrypt_pbkdf (1.1.0.rc2)
-    bcrypt_pbkdf (1.1.0.rc2-x64-mingw32)
-    bcrypt_pbkdf (1.1.0.rc2-x86-mingw32)
+    bcrypt_pbkdf (1.1.0)
+    bcrypt_pbkdf (1.1.0-x64-mingw32)
+    bcrypt_pbkdf (1.1.0-x86-mingw32)
     berkshelf (7.2.0)
       chef (>= 15.7.32)
       chef-config
@@ -64,12 +64,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.10.17)
+    chef (16.11.7)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc2)
+      bcrypt_pbkdf (~> 1.1)
       bundler (>= 1.10)
-      chef-config (= 16.10.17)
-      chef-utils (= 16.10.17)
+      chef-config (= 16.11.7)
+      chef-utils (= 16.11.7)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -101,12 +101,12 @@ GEM
       tty-screen (~> 0.6)
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
-    chef (16.10.17-universal-mingw32)
+    chef (16.11.7-universal-mingw32)
       addressable
-      bcrypt_pbkdf (= 1.1.0.rc2)
+      bcrypt_pbkdf (~> 1.1)
       bundler (>= 1.10)
-      chef-config (= 16.10.17)
-      chef-utils (= 16.10.17)
+      chef-config (= 16.11.7)
+      chef-utils (= 16.11.7)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -140,7 +140,7 @@ GEM
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
       win32-api (~> 1.5.3)
-      win32-certstore (~> 0.5)
+      win32-certstore (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
       win32-mmap (~> 0.4.1)
@@ -150,9 +150,9 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (16.10.17)
+    chef-config (16.11.7)
       addressable
-      chef-utils (= 16.10.17)
+      chef-utils (= 16.11.7)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -160,7 +160,7 @@ GEM
     chef-telemetry (1.0.29)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (16.10.17)
+    chef-utils (16.11.7)
     chef-vault (4.1.0)
     chef-zero (15.0.4)
       ffi-yajl (~> 2.2)
@@ -405,7 +405,7 @@ GEM
     uuidtools (2.2.0)
     webrick (1.7.0)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.6.1)
+    win32-certstore (0.5.3)
       ffi
       mixlib-shellout
     win32-event (0.6.3)

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -82,7 +82,6 @@ build do
     # find the embedded ruby gems dir and clean it up for globbing
     target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
     files = %w{
-      *.gemspec
       Gemfile
       Rakefile
       tasks

--- a/post-bundle-install.rb
+++ b/post-bundle-install.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+gem_home = Gem.paths.home
+
+puts "fixing bundle installed gems in #{gem_home}"
+
+# Install gems from git repos.  This makes the assumption that there is a <gem_name>.gemspec and
+# you can simply gem build + gem install the resulting gem, so nothing fancy.  This does not use
+# rake install since we need --conservative --minimal-deps in order to not install duplicate gems.
+#
+Dir["#{gem_home}/bundler/gems/*"].each do |gempath|
+  matches = File.basename(gempath).match(/(.*)-[A-Fa-f0-9]{12}/)
+  next unless matches
+
+  gem_name = matches[1]
+  next unless gem_name
+
+  puts "re-installing #{gem_name}..."
+
+  # we can't use "commmand" or "bundle" or "gem" DSL methods here since those are lazy and we need to run commands immediately
+  # (this is like a shell_out inside of a ruby_block in core chef, you don't use an execute resource inside of a ruby_block or
+  # things get really weird and unexpected)
+  Dir.chdir(gempath) do
+    system("gem build #{gem_name}.gemspec") or raise "gem build failed"
+    system("gem install #{gem_name}*.gem --conservative --minimal-deps --no-document") or raise "gem install failed"
+  end
+end

--- a/post-bundle-install.rb
+++ b/post-bundle-install.rb
@@ -15,6 +15,8 @@ Dir["#{gem_home}/bundler/gems/*"].each do |gempath|
   gem_name = matches[1]
   next unless gem_name
 
+  next if gem_name == "chef"
+
   puts "re-installing #{gem_name}..."
 
   # we can't use "commmand" or "bundle" or "gem" DSL methods here since those are lazy and we need to run commands immediately

--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -32,7 +32,7 @@ Dir.mktmpdir("chef-external-test") do |dir|
   Dir.chdir(dir) do
     shell_out!("git checkout #{git_thing}", live_stream: STDOUT)
     Bundler.with_unbundled_env do
-      shell_out!("bundle install --jobs=3 --retry=3", live_stream: STDOUT, env: env)
+      shell_out!("bundle install --jobs=3 --retry=3", live_stream: STDOUT, env: env, timeout: 3600)
       shell_out!("bundle exec #{ARGV.join(" ")}", live_stream: STDOUT, env: env)
     end
   end


### PR DESCRIPTION
This is necessary to build against current omnibus-software and should hopefully be more reliable and is more flexible in terms of being able
to pull git gems into the appbundle.