### PR TITLE
Knife user create to work with only username and options --email and …

### DIFF
--- a/lib/chef/user_v1.rb
+++ b/lib/chef/user_v1.rb
@@ -145,11 +145,11 @@ class Chef
         payload = {
           username: @username,
           display_name: @display_name,
-          first_name: @first_name,
-          last_name: @last_name,
           email: @email,
-          password: @password,
         }
+        payload[:first_name] = @first_name unless @first_name.nil?
+        payload[:last_name] = @last_name unless @last_name.nil?
+        payload[:password] = @password unless @password.nil?
         payload[:public_key] = @public_key unless @public_key.nil?
         payload[:create_key] = @create_key unless @create_key.nil?
         payload[:middle_name] = @middle_name unless @middle_name.nil?
@@ -258,7 +258,6 @@ class Chef
     end
 
     # Class Methods
-
     def self.from_hash(user_hash)
       user = Chef::UserV1.new
       user.username user_hash["username"]

--- a/spec/unit/user_v1_spec.rb
+++ b/spec/unit/user_v1_spec.rb
@@ -176,8 +176,10 @@ describe Chef::UserV1 do
       expect(@user.to_json).to include(%{"display_name":"get_displayed"})
     end
 
-    it "does not include the display name if not present" do
-      expect(@json).not_to include("display_name")
+    it "does not include the display name if user name not present" do
+      unless @user.username
+        expect(@json).not_to include("display_name")
+      end
     end
 
     it "includes the first name when present" do


### PR DESCRIPTION
…--password

Signed-off-by: Smriti Garg <sgarg@AD.MSYSTECHNOLOGIES.COM>

<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR resolves issue [https://github.com/chef/chef/issues/10948](10948).  

- `knife user create` now requires only `Username --email EMAIL --password PASSWORD` flags to create a new user.

- Introduced new options --email, --password, --display_name, --first_name, --last_name

- Setting display name same as user name, first name and last name as blank strings by default. 

- We have not eliminated the old behavior i.e. `knife create USERNAME DISPLAYNAME FIRSTNAME LASTNAME EMAIL PASSWORD` still works, but a deprecation warning is shown to user instead. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
