### PR TITLE
Fix windows_user password idempotency

### DIFF
--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -62,7 +62,7 @@ class Chef
         # <false>:: If the users are identical
         def compare_user
           @change_desc = []
-          unless @net_user.validate_credentials(new_resource.password)
+          if new_resource.password && !@net_user.validate_credentials(new_resource.password)
             @change_desc << "update password"
           end
 


### PR DESCRIPTION
If we're not trying to set a password - which given #10455 is probably
the case - we will always think it's wrong and try to set it. This fixes
that.

Note it does *not* fix #10657 - do not close that one!