### PR TITLE
Update gem pins to better match changes in chef 16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
   gem "inspec-core", "~> 4.18"
-  gem "inspec-core-bin", "~> 4.18" # need to provide the binaries for inspec
+  gem "inspec-core-bin", "~> 4.24" # need to provide the binaries for inspec
   gem "chef-vault"
   gem "ed25519" # ed25519 ssh key support done here as it's a native gem we can't put in train
   gem "bcrypt_pbkdf", ">= 1.1.0.rc1" # ed25519 ssh key support done here as it's a native gem we can't put in train

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ PATH
       chef-config (= 15.15.2)
       chef-utils (= 15.15.2)
       chef-zero (>= 14.0.11)
-      diff-lcs (~> 1.2, >= 1.2.4)
+      diff-lcs (>= 1.2.4, < 1.4.0)
       ed25519 (~> 1.2)
       erubis (~> 2.7)
       ffi (~> 1.9, >= 1.9.25)
@@ -34,7 +34,7 @@ PATH
       ffi-yajl (~> 2.2)
       highline (>= 1.6.9, < 2)
       iniparse (~> 1.4)
-      license-acceptance (~> 1.0, >= 1.0.5)
+      license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
@@ -50,7 +50,7 @@ PATH
       train-core (~> 3.2, >= 3.2.28)
       train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
-      uuidtools (~> 2.1.5)
+      uuidtools (>= 2.1.5, < 3.0)
     chef (15.15.2-universal-mingw32)
       addressable
       bcrypt_pbkdf (~> 1.0)
@@ -58,7 +58,7 @@ PATH
       chef-config (= 15.15.2)
       chef-utils (= 15.15.2)
       chef-zero (>= 14.0.11)
-      diff-lcs (~> 1.2, >= 1.2.4)
+      diff-lcs (>= 1.2.4, < 1.4.0)
       ed25519 (~> 1.2)
       erubis (~> 2.7)
       ffi (~> 1.9, >= 1.9.25)
@@ -67,7 +67,7 @@ PATH
       highline (>= 1.6.9, < 2)
       iniparse (~> 1.4)
       iso8601 (>= 0.12.1, < 0.14)
-      license-acceptance (~> 1.0, >= 1.0.5)
+      license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
@@ -83,15 +83,15 @@ PATH
       train-core (~> 3.2, >= 3.2.28)
       train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
-      uuidtools (~> 2.1.5)
+      uuidtools (>= 2.1.5, < 3.0)
       win32-api (~> 1.5.3)
-      win32-certstore (~> 0.3)
+      win32-certstore (~> 0.5.0)
       win32-dir (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
       win32-mmap (~> 0.4.1)
       win32-mutex (~> 0.4.2)
-      win32-process (~> 0.8.2)
+      win32-process (~> 0.9)
       win32-service (>= 2.1.5, < 3.0)
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
@@ -153,8 +153,8 @@ GEM
     concurrent-ruby (1.1.8)
     crack (0.4.5)
       rexml
-    debug_inspector (1.0.0)
-    diff-lcs (1.4.4)
+    debug_inspector (1.1.0)
+    diff-lcs (1.3)
     ed25519 (1.2.4)
     erubi (1.10.0)
     erubis (2.7.0)
@@ -215,11 +215,11 @@ GEM
     iso8601 (0.13.0)
     json (2.5.1)
     libyajl2 (1.2.0)
-    license-acceptance (1.0.19)
+    license-acceptance (2.1.13)
       pastel (~> 0.7)
-      tomlrb (~> 1.2)
-      tty-box (~> 0.3)
-      tty-prompt (~> 0.18)
+      tomlrb (>= 1.2, < 3.0)
+      tty-box (~> 0.6)
+      tty-prompt (~> 0.20)
     little-plugger (1.1.4)
     logging (2.3.0)
       little-plugger (~> 1.1)
@@ -234,12 +234,12 @@ GEM
     mixlib-config (3.0.9)
       tomlrb
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.0)
+    mixlib-shellout (3.2.5)
       chef-utils
-    mixlib-shellout (3.2.0-universal-mingw32)
+    mixlib-shellout (3.2.5-universal-mingw32)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
-      win32-process (~> 0.8.2)
+      win32-process (~> 0.9)
       wmi-lite (~> 1.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
@@ -330,7 +330,7 @@ GEM
     systemu (2.6.5)
     thor (1.1.0)
     tomlrb (1.3.0)
-    train-core (3.5.4)
+    train-core (3.5.5)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)
@@ -361,13 +361,13 @@ GEM
       tty-screen (~> 0.8)
     unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
-    uuidtools (2.1.5)
+    uuidtools (2.2.0)
     webmock (3.12.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.6.1)
+    win32-certstore (0.5.3)
       ffi
       mixlib-shellout
     win32-dir (0.5.1)
@@ -382,7 +382,7 @@ GEM
       ffi
     win32-mutex (0.4.3)
       win32-ipc (>= 0.6.0)
-    win32-process (0.8.3)
+    win32-process (0.9.0)
       ffi (>= 1.0.0)
     win32-service (2.2.0)
       ffi
@@ -431,7 +431,7 @@ DEPENDENCIES
   ed25519
   fauxhai-ng
   inspec-core (~> 4.18)
-  inspec-core-bin (~> 4.18)
+  inspec-core-bin (~> 4.24)
   ohai!
   pry
   pry-byebug
@@ -449,4 +449,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,4 +449,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -10,12 +10,12 @@ gemspec.add_dependency "win32-event", "~> 0.6.1"
 gemspec.add_dependency "win32-eventlog", "0.6.3"
 gemspec.add_dependency "win32-mmap", "~> 0.4.1"
 gemspec.add_dependency "win32-mutex", "~> 0.4.2"
-gemspec.add_dependency "win32-process", "~> 0.8.2"
+gemspec.add_dependency "win32-process", "~> 0.9"
 gemspec.add_dependency "win32-service", ">= 2.1.5", "< 3.0"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
 gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
 gemspec.add_dependency "iso8601", ">= 0.12.1", "< 0.14" # validate 0.14 when it comes out
-gemspec.add_dependency "win32-certstore", "~> 0.3"
+gemspec.add_dependency "win32-certstore", "~> 0.5.0" # 0.5+ required for specifying user vs. system store
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")
 

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "train-core", "~> 3.2", ">= 3.2.28" # 3.2.28 fixes sudo prompts. See https://github.com/chef/chef/pull/9635
   s.add_dependency "train-winrm", ">= 0.2.5"
 
-  s.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.5"
+  s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"
   s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency "highline", ">= 1.6.9", "< 2"
   s.add_dependency "tty-screen", "~> 0.6" # knife list
   s.add_dependency "erubis", "~> 2.7"
-  s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
+  s.add_dependency "diff-lcs", ">= 1.2.4", "< 1.4.0" # 1.4 breaks output
   s.add_dependency "ffi-libarchive", "~> 1.0", ">= 1.0.3"
   s.add_dependency "chef-zero", ">= 14.0.11"
 
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
   s.add_dependency "iniparse", "~> 1.4"
   s.add_dependency "addressable"
   s.add_dependency "syslog-logger", "~> 1.6"
-  s.add_dependency "uuidtools", "~> 2.1.5"
+  s.add_dependency "uuidtools", ">= 2.1.5", "< 3.0"
 
   s.add_dependency "proxifier", "~> 1.0"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 5286aa675239cf2ed36c7412625fbfb375575fdd
+  revision: f6aa2edd80c4b896738f843d9e613212c8510481
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.92.0)
+    aws-sdk-s3 (1.93.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -353,7 +353,7 @@ GEM
     strings-ansi (0.2.0)
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
-    test-kitchen (2.11.1)
+    test-kitchen (2.11.2)
       bcrypt_pbkdf (~> 1.0)
       chef-utils (>= 16.4.35)
       ed25519 (~> 1.2)
@@ -371,7 +371,7 @@ GEM
     toml-rb (2.0.1)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.3.0)
-    train-core (3.5.4)
+    train-core (3.5.5)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)


### PR DESCRIPTION
Add version ceilings, allow for the new mixlib-shellout, pin win32-certstore.

Signed-off-by: Tim Smith <tsmith@chef.io>