### PR TITLE
Resolve failures in testing due to an old rspec_junit_formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group(:development, :test) do
   gem "rspec-core", "~> 3.5"
   gem "rspec-mocks", "~> 3.5"
   gem "rspec-expectations", "~> 3.5"
-  gem "rspec_junit_formatter", "~> 0.2.0"
+  gem "rspec_junit_formatter", "~> 0.4.0"
   gem "webmock"
   gem "fauxhai-ng" # for chef-utils gem
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,8 +297,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rspec_junit_formatter (0.2.3)
-      builder (< 4)
+    rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.89.1)
       parallel (~> 1.10)
@@ -440,7 +439,7 @@ DEPENDENCIES
   rspec-core (~> 3.5)
   rspec-expectations (~> 3.5)
   rspec-mocks (~> 3.5)
-  rspec_junit_formatter (~> 0.2.0)
+  rspec_junit_formatter (~> 0.4.0)
   ruby-prof (< 1.3.0)
   ruby-shadow
   webmock

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.434.0)
+    aws-partitions (1.435.0)
     aws-sdk-core (3.113.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
This should fix our spec failures in buildkite

Signed-off-by: Tim Smith <tsmith@chef.io>