### PR TITLE
Fix idempotency issues with network mounts

### DIFF
--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -175,7 +175,7 @@ class Chef
 
       # Returns the new_resource device as per device_type
       def device_fstab
-        # Removed "/" from the end of str, because it was causing idempotency issue.
+        # Removed "/" from the end of str unless it's a network mount, because it was causing idempotency issue.
         device =
           if @new_resource.device == "/" || @new_resource.device.match?(":/$")
             @new_resource.device

--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -176,7 +176,12 @@ class Chef
       # Returns the new_resource device as per device_type
       def device_fstab
         # Removed "/" from the end of str, because it was causing idempotency issue.
-        device = @new_resource.device == "/" ? @new_resource.device : @new_resource.device.chomp("/")
+        device =
+          if @new_resource.device == "/" || @new_resource.device.match?(":/$")
+            @new_resource.device
+          else
+            @new_resource.device.chomp("/")
+          end
         case @new_resource.device_type
         when :device
           device


### PR DESCRIPTION
Resolves #11255

This is basically a continuation of #11031 where I fixed it in one place but then created a regression with idempotency as noted in #11255. This ensures that the /etc/fstab file actually gets the output we expect with network mounts using a root device.

Signed-off-by: Lance Albertson <lance@osuosl.org>
