### PR TITLE
[Example] Refactor yum_helper.py for quicker transactions

### DIFF
--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -8,49 +8,6 @@ import signal
 import os
 import json
 
-base = None
-
-def get_sack():
-    global base
-    if base is None:
-        base = dnf.Base()
-        conf = base.conf
-        conf.read()
-        conf.installroot = '/'
-        conf.assumeyes = True
-        subst = conf.substitutions
-        subst.update_from_etc(conf.installroot)
-        try:
-            base.init_plugins()
-            base.pre_configure_plugins()
-        except AttributeError:
-            pass
-        base.read_all_repos()
-        repos = base.repos
-
-        if 'repos' in command:
-            for repo_pattern in command['repos']:
-                if 'enable' in repo_pattern:
-                    for repo in repos.get_matching(repo_pattern['enable']):
-                        repo.enable()
-                if 'disable' in repo_pattern:
-                    for repo in repos.get_matching(repo_pattern['disable']):
-                        repo.disable()
-
-        try:
-            base.configure_plugins()
-        except AttributeError:
-            pass
-        base.fill_sack(load_system_repo='auto')
-    return base.sack
-
-# FIXME: leaks memory and does not work
-def flushcache():
-    try:
-        os.remove('/var/cache/dnf/@System.solv')
-    except OSError:
-        pass
-    get_sack().load_system_repo(build_cache=True)
 
 def version_tuple(versionstr):
     e = '0'
@@ -75,116 +32,187 @@ def version_tuple(versionstr):
             v = tmp
     return (e, v, r)
 
-def versioncompare(versions):
-    sack = get_sack()
-    if (versions[0] is None) or (versions[1] is None):
-      outpipe.write('0\n')
-      outpipe.flush()
-    else:
-      evr_comparison = dnf.rpm.rpm.labelCompare(version_tuple(versions[0]), version_tuple(versions[1]))
-      outpipe.write('{}\n'.format(evr_comparison))
-      outpipe.flush()
 
-def query(command):
-    sack = get_sack()
+class AutoCloseDNFBase(object):
+    base = None
 
-    subj = dnf.subject.Subject(command['provides'])
-    q = subj.get_best_query(sack, with_provides=True)
+    def __enter__(self):
+        self.base = dnf.Base()
 
-    if command['action'] == "whatinstalled":
-        q = q.installed()
+    def __exit__(self, *args, **kwargs):
+        if self.base is not None:
+            self.base.close()
 
-    if command['action'] == "whatavailable":
-        q = q.available()
 
-    if 'epoch' in command:
-        # We assume that any glob is "*" so just omit the filter since the dnf libraries have no
-        # epoch__glob filter.  That means "?" wildcards in epochs will fail.  The workaround is to
-        # not use the version filter here but to put the version with all the globs in the package name.
-        if not dnf.util.is_glob_pattern(command['epoch']):
-            q = q.filterm(epoch=int(command['epoch']))
-    if 'version' in command:
-        if dnf.util.is_glob_pattern(command['version']):
-            q = q.filterm(version__glob=command['version'])
+class DNFWrapper(object):
+    base = None
+    inpipe = None
+    outpipe = None
+    command = None
+    _repos_loaded = False
+
+    def __init__(self, base):
+
+        if len(sys.argv) < 3:
+            self.inpipe = sys.stdin
+            self.outpipe = sys.stdout
         else:
-            q = q.filterm(version=command['version'])
-    if 'release' in command:
-        if dnf.util.is_glob_pattern(command['release']):
-            q = q.filterm(release__glob=command['release'])
-        else:
-            q = q.filterm(release=command['release'])
+            self.inpipe = os.fdopen(int(sys.argv[1]), "r")
+            self.outpipe = os.fdopen(int(sys.argv[2]), "w")
 
-    if 'arch' in command:
-        if dnf.util.is_glob_pattern(command['arch']):
-            q = q.filterm(arch__glob=command['arch'])
-        else:
-            q = q.filterm(arch=command['arch'])
+        self.base = base
 
-    # only apply the default arch query filter if it returns something
-    archq = q.filter(arch=[ 'noarch', hawkey.detect_arch() ])
-    if len(archq.run()) > 0:
-        q = archq
+        signal.signal(signal.SIGINT, self.exit_handler)
+        signal.signal(signal.SIGHUP, self.exit_handler)
+        signal.signal(signal.SIGPIPE, self.exit_handler)
+        signal.signal(signal.SIGQUIT, self.exit_handler)
 
-    pkgs = q.latest(1).run()
+        self.command = {}
 
-    if not pkgs:
-        outpipe.write('{} nil nil\n'.format(command['provides'].split().pop(0)))
-        outpipe.flush()
-    else:
-        # make sure we picked the package with the highest version
-        pkgs.sort
-        pkg = pkgs.pop()
-        outpipe.write('{} {}:{}-{} {}\n'.format(pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch))
-        outpipe.flush()
+    @property
+    def sack(self):
+        """
+        allows for one time delayed loading of bases configuration
+        the delayed loaded is needed in the case of `repos` comming in
+        as a command
+        """
+        if not self._repos_loaded:
+            conf = self.base.conf
+            conf.read()
+            conf.installroot = '/'
+            conf.assumeyes = True
+            subst = conf.substitutions
+            subst.update_from_etc(conf.installroot)
+            try:
+                base.init_plugins()
+                base.pre_configure_plugins()
+            except AttributeError:
+                pass
+            self.base.read_all_repos()
+            repos = self.base.repos
 
-# the design of this helper is that it should try to be 'brittle' and fail hard and exit in order
-# to keep process tables clean.  additional error handling should probably be added to the retry loop
-# on the ruby side.
-def exit_handler(signal, frame):
-    if base is not None:
-        base.close()
-    sys.exit(0)
+            if 'repos' in self.command:
+                for repo_pattern in self.command['repos']:
+                    if 'enable' in repo_pattern:
+                        for repo in repos.get_matching(repo_pattern['enable']):
+                            repo.enable()
+                    if 'disable' in repo_pattern:
+                        for repo in repos.get_matching(repo_pattern['disable']):
+                            repo.disable()
 
-def setup_exit_handler():
-    signal.signal(signal.SIGINT, exit_handler)
-    signal.signal(signal.SIGHUP, exit_handler)
-    signal.signal(signal.SIGPIPE, exit_handler)
-    signal.signal(signal.SIGQUIT, exit_handler)
+            try:
+                self.base.configure_plugins()
+            except AttributeError:
+                pass
+            self.base.fill_sack(load_system_repo='auto')
+        return self.base.sack
 
-if len(sys.argv) < 3:
-  inpipe = sys.stdin
-  outpipe = sys.stdout
-else:
-  inpipe = os.fdopen(int(sys.argv[1]), "r")
-  outpipe = os.fdopen(int(sys.argv[2]), "w")
-
-try:
-    while 1:
-        # stop the process if the parent proc goes away
-        ppid = os.getppid()
-        if ppid == 1:
-            raise RuntimeError("orphaned")
-
-        setup_exit_handler()
-        line = inpipe.readline()
-
-        # only way to detect EOF in python
-        if line == "":
-            break
-
-        try:
-            command = json.loads(line)
-        except ValueError:
-            raise RuntimeError("bad json parse")
+    def query(self, command):
+        sack = self.sack
+        subj = dnf.subject.Subject(command['provides'])
+        q = subj.get_best_query(sack, with_provides=True)
 
         if command['action'] == "whatinstalled":
-            query(command)
-        elif command['action'] == "whatavailable":
-            query(command)
-        elif command['action'] == "versioncompare":
-            versioncompare(command['versions'])
+            q = q.installed()
+
+        if command['action'] == "whatavailable":
+            q = q.available()
+
+        if 'epoch' in command:
+            # We assume that any glob is "*" so just omit the filter since the dnf libraries have no
+            # epoch__glob filter.  That means "?" wildcards in epochs will fail.  The workaround is to
+            # not use the version filter here but to put the version with all the globs in the package name.
+            if not dnf.util.is_glob_pattern(command['epoch']):
+                q = q.filterm(epoch=int(command['epoch']))
+        if 'version' in command:
+            if dnf.util.is_glob_pattern(command['version']):
+                q = q.filterm(version__glob=command['version'])
+            else:
+                q = q.filterm(version=command['version'])
+        if 'release' in command:
+            if dnf.util.is_glob_pattern(command['release']):
+                q = q.filterm(release__glob=command['release'])
+            else:
+                q = q.filterm(release=command['release'])
+
+        if 'arch' in command:
+            if dnf.util.is_glob_pattern(command['arch']):
+                q = q.filterm(arch__glob=command['arch'])
+            else:
+                q = q.filterm(arch=command['arch'])
+
+        # only apply the default arch query filter if it returns something
+        archq = q.filter(arch=['noarch', hawkey.detect_arch()])
+        if len(archq.run()) > 0:
+            q = archq
+
+        pkgs = q.latest(1).run()
+
+        if not pkgs:
+            self.outpipe.write('{} nil nil\n'.format(command['provides'].split().pop(0)))
+            self.outpipe.flush()
         else:
-            raise RuntimeError("bad command")
-finally:
-    if base is not None:
-        base.close()
+            # make sure we picked the package with the highest version
+            pkgs.sort
+            pkg = pkgs.pop()
+            self.outpipe.write('{} {}:{}-{} {}\n'.format(pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch))
+            self.outpipe.flush()
+
+    # FIXME: leaks memory and does not work
+    def flushcache(self):
+        try:
+            os.remove('/var/cache/dnf/@System.solv')
+        except OSError:
+            pass
+        self.sack.load_system_repo(build_cache=True)
+
+    def versioncompare(self, versions):
+        sack = self.sack  # This maybe ununsed, but the size effects might be desired
+        if (versions[0] is None) or (versions[1] is None):
+            self.outpipe.write('0\n')
+            self.outpipe.flush()
+        else:
+            evr_comparison = dnf.rpm.rpm.labelCompare(version_tuple(versions[0]), version_tuple(versions[1]))
+            self.outpipe.write('{}\n'.format(evr_comparison))
+            self.outpipe.flush()
+
+    # the design of this helper is that it should try to be 'brittle' and fail hard and exit in order
+    # to keep process tables clean.  additional error handling should probably be added to the retry loop
+    # on the ruby side.
+    def exit_handler(self, signal, frame):
+        if self.base is not None:
+            self.base.close()
+        sys.exit(0)
+
+    def dnf_input_loop(self):
+        while 1:
+            # stop the process if the parent proc goes away
+            ppid = os.getppid()
+            if ppid == 1:
+                raise RuntimeError("orphaned")
+
+            line = self.inpipe.readline()
+
+            # only way to detect EOF in python
+            if line == "":
+                break
+
+            try:
+                self.command = json.loads(line)
+            except ValueError:
+                raise RuntimeError("bad json parse")
+
+            if self.command['action'] == "whatinstalled":
+                self.query(self.command)
+            elif self.command['action'] == "whatavailable":
+                self.query(self.command)
+            elif self.command['action'] == "versioncompare":
+                self.versioncompare(self.command['versions'])
+            else:
+                raise RuntimeError("bad command")
+
+
+if __name__ == '__main__':
+    with AutoCloseDNFBase() as base:
+        dnf_wrapper = DNFWrapper(base)
+        dnf_wrapper.dnf_input_loop()

--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -118,9 +118,11 @@ class DNFWrapper(object):
             q = q.available()
 
         if 'epoch' in command:
-            # We assume that any glob is "*" so just omit the filter since the dnf libraries have no
-            # epoch__glob filter.  That means "?" wildcards in epochs will fail.  The workaround is to
-            # not use the version filter here but to put the version with all the globs in the package name.
+            # We assume that any glob is "*" so just omit the filter since the
+            # dnf libraries have no epoch__glob filter.  That means "?"
+            # wildcards in epochs will fail.  The workaround is to not use the
+            # version filter here but to put the version with all the globs in
+            # the package name.
             if not dnf.util.is_glob_pattern(command['epoch']):
                 q = q.filterm(epoch=int(command['epoch']))
         if 'version' in command:
@@ -174,9 +176,9 @@ class DNFWrapper(object):
             self.outpipe.write('{}\n'.format(evr_comparison))
             self.outpipe.flush()
 
-    # the design of this helper is that it should try to be 'brittle' and fail hard and exit in order
-    # to keep process tables clean.  additional error handling should probably be added to the retry loop
-    # on the ruby side.
+    # the design of this helper is that it should try to be 'brittle' and fail
+    # hard and exit in order to keep process tables clean.  additional error
+    # handling should probably be added to the retry loop on the ruby side.
     def exit_handler(self, signal, frame):
         if self.base is not None:
             self.base.close()

--- a/lib/chef/provider/package/yum/yum_helper.py
+++ b/lib/chef/provider/package/yum/yum_helper.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
 
-#
-# NOTE: this actually needs to run under python2.4 and centos 5.x through python3 and centos 7.x
-# please manually test changes on centos5 boxes or you will almost certainly break things.
-#
-
 import sys
 import yum
 import signal
@@ -19,222 +14,199 @@ import re
 from rpmUtils.miscutils import stringToVersion,compareEVR
 from rpmUtils.arch import getBaseArch, getArchList
 
-
-try: from yum.misc import string_to_prco_tuple
-except ImportError:
-    # RHEL5 compat
-    def string_to_prco_tuple(prcoString):
-        prco_split = prcoString.split()
-        n, f, v = prco_split
-        (prco_e, prco_v, prco_r) = stringToVersion(v)
-        return (n, f, (prco_e, prco_v, prco_r))
+from yum.misc import string_to_prco_tuple
 
 # hack to work around https://github.com/chef/chef/issues/7126
 # see https://bugzilla.redhat.com/show_bug.cgi?id=1396248
 if not hasattr(yum.packages.FakeRepository, 'compare_providers_priority'):
     yum.packages.FakeRepository.compare_providers_priority = 99
 
-base = None
 
 class MyYumBase(object):
-    def __init__(self):
-        self.base = yum.YumBase()
+    base = None
 
     def __enter__(self):
+        self.base = yum.YumBase()
         return self.base
 
     def __exit__(self, *args, **kwargs):
-        return self.base.closeRpmDB()
-
-def get_base():
-    global base
-    if base is None:
-        base = yum.YumBase()
-    setup_exit_handler()
-    return base
+        if self.base is not None:
+            return self.base.closeRpmDB()
+        self.base = None
 
 
-def versioncompare(versions):
-    arch_list = getArchList()
-    candidate_arch1 = versions[0].split(".")[-1]
-    candidate_arch2 = versions[1].split(".")[-1]
+class YumWrapper(object):
+    base = None
+    inpipe = None
+    outpipe = None
 
-    # The first version number passed to this method is always a valid nevra (the current version)
-    # If the second version number looks like it does not contain a valid arch
-    # then we'll chop the arch component (assuming it *is* a valid one) from the first version string
-    # so we're only comparing the evr portions.
-    if (candidate_arch2 not in arch_list) and (candidate_arch1 in arch_list):
-        final_version1 = versions[0].replace("." + candidate_arch1,"")
-    else:
-        final_version1 = versions[0]
+    def __init__(self, base):
+        self.base = base
+        signal.signal(signal.SIGINT, self.exit_handler)
+        signal.signal(signal.SIGHUP, self.exit_handler)
+        signal.signal(signal.SIGPIPE, self.exit_handler)
+        signal.signal(signal.SIGQUIT, self.exit_handler)
 
-    final_version2 = versions[1]
+        if len(sys.argv) < 3:
+            self.inpipe = sys.stdin
+            self.outpipe = sys.stdout
+        else:
+            self.inpipe = os.fdopen(int(sys.argv[1]), "r")
+            self.outpipe = os.fdopen(int(sys.argv[2]), "w")
 
-    (e1, v1, r1) = stringToVersion(final_version1)
-    (e2, v2, r2) = stringToVersion(final_version2)
+    # the design of this helper is that it should try to be 'brittle' and fail hard and exit in order
+    # to keep process tables clean.  additional error handling should probably be added to the retry loop
+    # on the ruby side.
+    def exit_handler(self, signal, frame):
+        if self.base is not None:
+            self.base.closeRpmDB()
+        sys.exit(0)
 
-    evr_comparison = compareEVR((e1, v1, r1), (e2, v2, r2))
-    outpipe.write("%(e)s\n" % { 'e': evr_comparison })
-    outpipe.flush()
+    def versioncompare(self, versions):
+        arch_list = getArchList()
+        candidate_arch1 = versions[0].split(".")[-1]
+        candidate_arch2 = versions[1].split(".")[-1]
 
-def install_only_packages(name):
-    name_in_installonlypkgs = False
-    with MyYumBase() as base:
-        name_in_installonlypkgs = name in base.conf.installonlypkgs
-    if name_in_installonlypkgs:
-        outpipe.write('True')
-    else:
-        outpipe.write('False')
-    outpipe.flush()
+        # The first version number passed to this method is always a valid nevra (the current version)
+        # If the second version number looks like it does not contain a valid arch
+        # then we'll chop the arch component (assuming it *is* a valid one) from the first version string
+        # so we're only comparing the evr portions.
+        if (candidate_arch2 not in arch_list) and (candidate_arch1 in arch_list):
+            final_version1 = versions[0].replace("." + candidate_arch1,"")
+        else:
+            final_version1 = versions[0]
 
-# python2.4 / centos5 compat
-try:
-    any
-except NameError:
-    def any(s):
-        for v in s:
-            if v:
-                return True
-        return False
+        final_version2 = versions[1]
 
-def query(command):
-    with MyYumBase() as my_base:
-        enabled_repos = my_base.repos.listEnabled()
+        (e1, v1, r1) = stringToVersion(final_version1)
+        (e2, v2, r2) = stringToVersion(final_version2)
 
-    # Handle any repocontrols passed in with our options
+        evr_comparison = compareEVR((e1, v1, r1), (e2, v2, r2))
+        self.outpipe.write("%(e)s\n".format({'e': evr_comparison}))
+        self.outpipe.flush()
 
-    if 'repos' in command:
-        for repo in command['repos']:
-            with MyYumBase() as base:
+    def install_only_packages(self, name):
+        name_in_installonlypkgs = False
+        name_in_installonlypkgs = name in self.base.conf.installonlypkgs
+        if name_in_installonlypkgs:
+            self.outpipe.write('True')
+        else:
+            self.outpipe.write('False')
+        self.outpipe.flush()
+
+    def query(self, command):
+        enabled_repos = self.base.repos.listEnabled()
+
+        # Handle any repocontrols passed in with our options
+
+        if 'repos' in command:
+            for repo in command['repos']:
                 if 'enable' in repo:
-                    base.repos.enableRepo(repo['enable'])
+                    self.base.repos.enableRepo(repo['enable'])
                 if 'disable' in repo:
-                    base.repos.disableRepo(repo['disable'])
+                    self.base.repos.disableRepo(repo['disable'])
 
-    args = { 'name': command['provides'] }
-    do_nevra = False
-    if 'epoch' in command:
-        args['epoch'] = command['epoch']
-        do_nevra = True
-    if 'version' in command:
-        args['ver'] = command['version']
-        do_nevra = True
-    if 'release' in command:
-        args['rel'] = command['release']
-        do_nevra = True
-    if 'arch' in command:
-        desired_arch = command['arch']
-        args['arch'] = command['arch']
-        do_nevra = True
-    else:
-        desired_arch = getBaseArch()
+        args = {'name': command['provides']}
+        do_nevra = False
+        if 'epoch' in command:
+            args['epoch'] = command['epoch']
+            do_nevra = True
+        if 'version' in command:
+            args['ver'] = command['version']
+            do_nevra = True
+        if 'release' in command:
+            args['rel'] = command['release']
+            do_nevra = True
+        if 'arch' in command:
+            desired_arch = command['arch']
+            args['arch'] = command['arch']
+            do_nevra = True
+        else:
+            desired_arch = getBaseArch()
 
-    obj = None
-    if command['action'] == "whatinstalled":
-        with MyYumBase() as base:
-            obj = base.rpmdb
-    else:
-        with MyYumBase() as base:
-            obj = base.pkgSack
+        obj = None
+        if command['action'] == "whatinstalled":
+            obj = self.base.rpmdb
+        else:
+            obj = self.base.pkgSack
 
-    # if we are given "name == 1.2.3" then we must use the getProvides() API.
-    #   - this means that we ignore arch and version properties when given prco tuples as a package_name
-    #   - in order to fix this, something would have to happen where getProvides was called first and
-    #     then the result was searchNevra'd.  please be extremely careful if attempting to fix that
-    #     since searchNevra does not support prco tuples.
-    if bool(re.search('\\s+', command['provides'])):
-        # handles flags (<, >, =, etc) and versions, but no wildcareds
-        # raises error for any invalid input like: 'FOO BAR BAZ' 
-        pkgs = obj.getProvides(*string_to_prco_tuple(command['provides']))
-    elif do_nevra:
-        # now if we're given version or arch properties explicitly, then we do a SearchNevra.
-        #  - this means that wildcard version in the package_name with an arch property will not work correctly
-        #  - again don't try to fix this just by pushing bugs around in the code, you would need to call
-        #    returnPackages and searchProvides and then apply the Nevra filters to those results.
-        pkgs = obj.searchNevra(**args)
-        if (command['action'] == "whatinstalled") and (not pkgs):
-          pkgs = obj.searchNevra(name=args['name'], arch=desired_arch)
-    else:
-        pats = [command['provides']]
-        pkgs = obj.returnPackages(patterns=pats)
+        # if we are given "name == 1.2.3" then we must use the getProvides() API.
+        #   - this means that we ignore arch and version properties when given prco tuples as a package_name
+        #   - in order to fix this, something would have to happen where getProvides was called first and
+        #     then the result was searchNevra'd.  please be extremely careful if attempting to fix that
+        #     since searchNevra does not support prco tuples.
+        if bool(re.search('\\s+', command['provides'])):
+            # handles flags (<, >, =, etc) and versions, but no wildcareds
+            # raises error for any invalid input like: 'FOO BAR BAZ' 
+            pkgs = obj.getProvides(*string_to_prco_tuple(command['provides']))
+        elif do_nevra:
+            # now if we're given version or arch properties explicitly, then we do a SearchNevra.
+            #  - this means that wildcard version in the package_name with an arch property will not work correctly
+            #  - again don't try to fix this just by pushing bugs around in the code, you would need to call
+            #    returnPackages and searchProvides and then apply the Nevra filters to those results.
+            pkgs = obj.searchNevra(**args)
+            if (command['action'] == "whatinstalled") and (not pkgs):
+                pkgs = obj.searchNevra(name=args['name'], arch=desired_arch)
+        else:
+            pats = [command['provides']]
+            pkgs = obj.returnPackages(patterns=pats)
+
+            if not pkgs:
+                # handles wildcards
+                pkgs = obj.searchProvides(command['provides'])
 
         if not pkgs:
-            # handles wildcards
-            pkgs = obj.searchProvides(command['provides'])
-
-    if not pkgs:
-        outpipe.write(command['provides'].split().pop(0)+' nil nil\n')
-        outpipe.flush()
-    else:
-        # make sure we picked the package with the highest version
-        pkg = ""
-        with MyYumBase() as base:
-            pkgs = base.bestPackagesFromList(pkgs,single_name=True)
-            pkg = pkgs.pop(0)
-        outpipe.write("%(n)s %(e)s:%(v)s-%(r)s %(a)s\n" % { 'n': pkg.name, 'e': pkg.epoch, 'v': pkg.version, 'r': pkg.release, 'a': pkg.arch })
-        outpipe.flush()
-
-    # Reset any repos we were passed in enablerepo/disablerepo to the original state in enabled_repos
-    if 'repos' in command:
-      for repo in command['repos']:
-        with MyYumBase() as base:
-            if 'enable' in repo:
-                if base.repos.getRepo(repo['enable']) not in enabled_repos:
-                    base.repos.disableRepo(repo['enable'])
-            if 'disable' in repo:
-                if base.repos.getRepo(repo['disable']) in enabled_repos:
-                    base.repos.enableRepo(repo['disable'])
-
-# the design of this helper is that it should try to be 'brittle' and fail hard and exit in order
-# to keep process tables clean.  additional error handling should probably be added to the retry loop
-# on the ruby side.
-def exit_handler(signal, frame):
-    if base is not None:
-        base.closeRpmDB()
-    sys.exit(0)
-
-def setup_exit_handler():
-    signal.signal(signal.SIGINT, exit_handler)
-    signal.signal(signal.SIGHUP, exit_handler)
-    signal.signal(signal.SIGPIPE, exit_handler)
-    signal.signal(signal.SIGQUIT, exit_handler)
-
-if len(sys.argv) < 3:
-  inpipe = sys.stdin
-  outpipe = sys.stdout
-else:
-  inpipe = os.fdopen(int(sys.argv[1]), "r")
-  outpipe = os.fdopen(int(sys.argv[2]), "w")
-
-try:
-    while 1:
-        # stop the process if the parent proc goes away
-        ppid = os.getppid()
-        if ppid == 1:
-            raise RuntimeError("orphaned")
-
-        setup_exit_handler()
-        line = inpipe.readline()
-
-        # only way to detect EOF in python
-        if line == "":
-            break
-
-        try:
-            command = json.loads(line)
-        except ValueError:
-            raise RuntimeError("bad json parse")
-
-        if command['action'] == "whatinstalled":
-            query(command)
-        elif command['action'] == "whatavailable":
-            query(command)
-        elif command['action'] == "versioncompare":
-            versioncompare(command['versions'])
-        elif command['action'] == "installonlypkgs":
-            install_only_packages(command['package'])
+            self.outpipe.write(command['provides'].split().pop(0)+' nil nil\n')
+            self.outpipe.flush()
         else:
-            raise RuntimeError("bad command")
-finally:
-    if base is not None:
-        base.closeRpmDB()
+            # make sure we picked the package with the highest version
+            pkgs = self.base.bestPackagesFromList(pkgs, single_name=True)
+            pkg = pkgs.pop(0)
+            self.outpipe.write("%(n)s %(e)s:%(v)s-%(r)s %(a)s\n" % { 'n': pkg.name, 'e': pkg.epoch, 'v': pkg.version, 'r': pkg.release, 'a': pkg.arch })
+            self.outpipe.flush()
+
+        # Reset any repos we were passed in enablerepo/disablerepo to the original state in enabled_repos
+        if 'repos' in command:
+            for repo in command['repos']:
+                if 'enable' in repo:
+                    if self.base.repos.getRepo(repo['enable']) not in enabled_repos:
+                        self.base.repos.disableRepo(repo['enable'])
+                if 'disable' in repo:
+                    if self.base.repos.getRepo(repo['disable']) in enabled_repos:
+                        self.base.repos.enableRepo(repo['disable'])
+
+
+    def yum_input_loop(self):
+        while 1:
+            # stop the process if the parent proc goes away
+            ppid = os.getppid()
+            if ppid == 1:
+                raise RuntimeError("orphaned")
+
+            line = self.inpipe.readline()
+
+            # only way to detect EOF in python
+            if line == "":
+                break
+
+            try:
+                command = json.loads(line)
+            except ValueError:
+                raise RuntimeError("bad json parse")
+
+            if command['action'] == "whatinstalled":
+                self.query(command)
+            elif command['action'] == "whatavailable":
+                self.query(command)
+            elif command['action'] == "versioncompare":
+                self.versioncompare(command['versions'])
+            elif command['action'] == "installonlypkgs":
+                self.install_only_packages(command['package'])
+            else:
+                raise RuntimeError("bad command")
+
+
+if __name__ == '__main__':
+    with MyYumBase() as base:
+        yum_wrapper = YumWrapper(base)
+        yum_wrapper.yum_input_loop()


### PR DESCRIPTION
## Description
This is a proposed example of how to fix the issue seen in bug report #11266 .

Yum is a backed by a database and seems to crash and leave the database
in the middle of a transaction. This has resulted in what appears to be
a corrupt yum database.

In order to get around this usages of the yum db now open, do minimal
work, and then close. The idea here is to do many small quick
transactions rather than one massive transaction.

## Related Issue
#11266 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
I have not completed the checklist below, because I would do additional refactoring before merging if the team even agrees that this would/could be a good idea.

- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
