### PR TITLE
Added new property fqdn and made sure hosts entry includes the same

### DIFF
--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -50,6 +50,10 @@ class Chef
         description: "An optional property to set the hostname if it differs from the resource block's name.",
         name_property: true
 
+      property :fqdn, String,
+        description: "An optional property to set the fqdn if it differs from the resource block's hostname.",
+        introduced: "17.0"
+
       property :ipaddress, String,
         description: "The IP address to use when configuring the hosts file.",
         default: lazy { node["ipaddress"] }, default_description: "The node's IP address as determined by Ohai."
@@ -115,7 +119,9 @@ class Chef
 
           # make sure node['fqdn'] resolves via /etc/hosts
           unless new_resource.ipaddress.nil?
-            newline = "#{new_resource.ipaddress} #{new_resource.hostname}"
+            newline = "#{new_resource.ipaddress}"
+            newline << " #{new_resource.fqdn}" unless new_resource.fqdn.to_s.empty?
+            newline << " #{new_resource.hostname}"
             newline << " #{new_resource.aliases.join(" ")}" if new_resource.aliases && !new_resource.aliases.empty?
             newline << " #{new_resource.hostname[/[^\.]*/]}"
             r = append_replacing_matching_lines("/etc/hosts", /^#{new_resource.ipaddress}\s+|\s+#{new_resource.hostname}\s+/, newline)


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

- Create a new property with name 'fqdn'
- While creating a entry in `/etc/hosts` file made sure `fqdn` is considered
- If `fqdn` is not passed by user, it works the same as now.

for resource without specifying fqdn like - 
```
hostname 'aws-ubuntu-1804.kitchen' do
  aliases ['aws-ubuntu-1804.kitchen.example.com']
  ipaddress node['ipaddress']
end
```
output - for command `hostname -f` 

`aws-ubuntu-1804.kitchen`

but with fqdn property like : - 

```
hostname 'aws-ubuntu-1804.kitchen' do
  fqdn 'aws-ubuntu-1804.kitchen.example.com'
  ipaddress node['ipaddress']
end
```
output for command `hostname -f` is 

`aws-ubuntu-1804.kitchen.example.com`


## Related Issue
[Issue 10694](https://github.com/chef/chef/issues/10694)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
