### PR TITLE
Report compliance runner not enabled if the node is not available

### DIFF
--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -17,6 +17,8 @@ class Chef
       def_delegators :node, :logger
 
       def enabled?
+        return false if @node.nil?
+
         # Did we parse the libraries file from the audit cookbook?  This class dates back to when Chef Automate was
         # renamed from Chef Visibility in 2017, so should capture all modern versions of the audit cookbook.
         audit_cookbook_present = defined?(::Reporter::ChefAutomate)

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -12,6 +12,12 @@ describe Chef::Compliance::Runner do
   end
 
   describe "#enabled?" do
+    context "when the node is not available" do
+      let(:runner) { described_class.new }
+      it "is false because it needs the node to answer that question" do
+        expect(runner).not_to be_enabled
+      end
+    end
 
     it "is true if the node attributes have audit profiles and the audit cookbook is not present, and the compliance mode attribute is nil" do
       node.normal["audit"]["profiles"]["ssh"] = { 'compliance': "base/ssh" }


### PR DESCRIPTION
The `#enabled?` method needs a node object  to answer the question,
and the node object is not always available to it
(for example, `#run_failed` when config is wrong).

Fixes #11289 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
