### PR TITLE
Skip the cron integration tests on macOS 11+

### DIFF
--- a/spec/functional/resource/cron_spec.rb
+++ b/spec/functional/resource/cron_spec.rb
@@ -19,7 +19,7 @@
 require "spec_helper"
 require "chef/mixin/shell_out"
 
-describe Chef::Resource::Cron, :requires_root, :unix_only do
+describe Chef::Resource::Cron, :requires_root, :unix_only, :not_macos_gte_11 do
 
   include Chef::Mixin::ShellOut
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -145,6 +145,7 @@ RSpec.configure do |config|
   config.filter_run_excluding macos_only: true unless macos?
   config.filter_run_excluding macos_1013: true unless macos_1013?
   config.filter_run_excluding macos_gte_1014: true unless macos_gte_1014?
+  config.filter_run_excluding not_macos_gte_11: true unless macos_gte_11?
   config.filter_run_excluding not_supported_on_aix: true if aix?
   config.filter_run_excluding not_supported_on_solaris: true if solaris?
   config.filter_run_excluding not_supported_on_gce: true if gce?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -122,6 +122,10 @@ def macos?
   RUBY_PLATFORM.include?("darwin")
 end
 
+def macos_gte_11?
+  macos? && !!(ohai[:platform_version].to_i >= 11)
+end
+
 def solaris?
   RUBY_PLATFORM.include?("solaris")
 end


### PR DESCRIPTION
These don't run due to security changes in the OS.

Signed-off-by: Tim Smith <tsmith@chef.io>