### PR TITLE
Use dist constants in rubygems provider for is_omnibus? method

### DIFF
--- a/chef-utils/lib/chef-utils/dist.rb
+++ b/chef-utils/lib/chef-utils/dist.rb
@@ -87,6 +87,11 @@ module ChefUtils
       EXEC = "chef-solo"
     end
 
+    class Workstation
+      # The suffix for Chef Workstion's /opt/chef-workstation or C:\\opscode\chef-workstation
+      DIR_SUFFIX = "chef-workstation"
+    end
+
     class Zero
       # chef-zero executable
       PRODUCT = "Chef Infra Zero"

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -421,11 +421,11 @@ class Chef
         end
 
         def is_omnibus?
-          if %r{/(opscode|chef|chefdk)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
+          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|chefdk)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true
-          elsif RbConfig::CONFIG["bindir"].sub(/^\w:/, "") == "/opscode/chef/embedded/bin"
+          elsif RbConfig::CONFIG["bindir"].sub(/^\w:/, "") == "/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/#{ChefUtils::Dist::Infra::SHORT}/embedded/bin"
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # windows, with the drive letter removed
             true

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -421,7 +421,7 @@ class Chef
         end
 
         def is_omnibus?
-          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|chef-workstation)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
+          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|#{ChefUtils::Dist::Workstation::DIR_SUFFIX})/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -421,7 +421,7 @@ class Chef
         end
 
         def is_omnibus?
-          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|chefdk)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
+          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|chef-workstation)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -470,10 +470,10 @@ describe Chef::Provider::Package::Rubygems do
       end
     end
 
-    context "when in omnibus chefdk" do
-      let(:bindir) { "/opt/chefdk/embedded/bin" }
+    context "when in omnibus chef-workstation" do
+      let(:bindir) { "/opt/chef-workstation/embedded/bin" }
 
-      it "recognizes chefdk as omnibus" do
+      it "recognizes chef-workstation as omnibus" do
         expect(provider.is_omnibus?).to be true
       end
     end


### PR DESCRIPTION
This resolves the following issue [1] which impacts community distributions when using the `gem_package` provider. Instead of using static names, use proper distribution constants which can be easily set by distributions.

TODO: We should update chefdk with Workstation constants once those are created.

[1] https://gitlab.com/cinc-project/distribution/client/-/issues/31

Signed-off-by: Lance Albertson <lance@osuosl.org>
