### PR TITLE
Produce FIPS builds on Ubuntu as well

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -5,6 +5,7 @@ test-path: omnibus/omnibus-test.sh
 test-path-windows: omnibus/omnibus-test.ps1
 fips-platforms:
   - el-*-x86_64
+  - ubuntu-*-x86_64
   - windows-*
 builder-to-testers-map:
   aix-7.1-powerpc:


### PR DESCRIPTION
Ubuntu Pro has FIPS modules. We should enable FIPS builds here since
we're already held to legacy OpenSSL on Linux as is.

Signed-off-by: Tim Smith <tsmith@chef.io>