### PR TITLE
Chef 16: Add centos_stream_platform? helper

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/platform.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform.rb
@@ -17,13 +17,11 @@
 #
 
 require_relative "../internal"
-require_relative "train_helpers"
 
 module ChefUtils
   module DSL
     module Platform
       include Internal
-      include TrainHelpers
 
       # NOTE: if you are adding new platform helpers they should all have the `_platform?` suffix.
       #       DO NOT add new short aliases without the suffix (they will be deprecated in the future)
@@ -127,12 +125,13 @@ module ChefUtils
 
       # Determine if the current node is CentOS Stream.
       #
+      # @param [Chef::Node] node the node to check
       # @since 17.0
       #
       # @return [Boolean]
       #
-      def centos_stream_platform?
-        file_exist?("/etc/os-release") && file_read("/etc/os-release").match?("CentOS Stream")
+      def centos_stream_platform?(node = __getnode)
+        node.dig("lsb", "id") == "CentOSStream"
       end
 
       # Determine if the current node is Oracle Linux.

--- a/chef-utils/lib/chef-utils/dsl/platform.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform.rb
@@ -17,11 +17,13 @@
 #
 
 require_relative "../internal"
+require_relative "train_helpers"
 
 module ChefUtils
   module DSL
     module Platform
       include Internal
+      include TrainHelpers
 
       # NOTE: if you are adding new platform helpers they should all have the `_platform?` suffix.
       #       DO NOT add new short aliases without the suffix (they will be deprecated in the future)
@@ -122,6 +124,16 @@ module ChefUtils
       end
       # chef-sugar backcompat method
       alias_method :centos?, :centos_platform?
+
+      # Determine if the current node is CentOS Stream.
+      #
+      # @since 17.0
+      #
+      # @return [Boolean]
+      #
+      def centos_stream_platform?
+        file_exist?("/etc/os-release") && file_read("/etc/os-release").match?("CentOS Stream")
+      end
 
       # Determine if the current node is Oracle Linux.
       #

--- a/chef-utils/lib/chef-utils/dsl/platform.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform.rb
@@ -126,7 +126,7 @@ module ChefUtils
       # Determine if the current node is CentOS Stream.
       #
       # @param [Chef::Node] node the node to check
-      # @since 17.0
+      # @since 16.13
       #
       # @return [Boolean]
       #

--- a/chef-utils/lib/chef-utils/dsl/platform.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform.rb
@@ -131,7 +131,11 @@ module ChefUtils
       # @return [Boolean]
       #
       def centos_stream_platform?(node = __getnode)
-        node.dig("lsb", "id") == "CentOSStream"
+        if node["os_release"]
+          node.dig("os_release", "name") == "CentOS Stream"
+        else
+          node.dig("lsb", "id") == "CentOSStream"
+        end
       end
 
       # Determine if the current node is Oracle Linux.

--- a/chef-utils/spec/unit/dsl/platform_spec.rb
+++ b/chef-utils/spec/unit/dsl/platform_spec.rb
@@ -145,9 +145,16 @@ RSpec.describe ChefUtils::DSL::Platform do
     platform_reports_true_for(:centos?, :centos_platform?)
   end
 
-  context "on centos stream" do
+  context "on centos stream w/o os_release" do
     let(:options) { { platform: "centos" } }
-    let(:node) { { "platform" => "centos", "platform_version" => "8", "platform_family" => "rhel", "os" => "linux", "lsb" => { "id" => "CentOSStream" } } }
+    let(:node) { { "platform" => "centos", "platform_version" => "8", "platform_family" => "rhel", "os" => "linux", "lsb" => { "id" => "CentOSStream" }, "os_release" => nil } }
+
+    platform_reports_true_for(:centos?, :centos_platform?, :centos_stream_platform?)
+  end
+
+  context "on centos stream w/ os_release" do
+    let(:options) { { platform: "centos" } }
+    let(:node) { { "platform" => "centos", "platform_version" => "8", "platform_family" => "rhel", "os" => "linux", "os_release" => { "name" => "CentOS Stream" } } }
 
     platform_reports_true_for(:centos?, :centos_platform?, :centos_stream_platform?)
   end

--- a/chef-utils/spec/unit/dsl/platform_spec.rb
+++ b/chef-utils/spec/unit/dsl/platform_spec.rb
@@ -21,67 +21,34 @@ require "fauxhai"
 
 def platform_reports_true_for(*args)
   args.each do |method|
-    if method.match?("centos_stream_platform")
-      it "reports true for #{method} on the module given a node" do
-        expect(described_class.send(method)).to be true
-      end
-      it "reports true for #{method} when mixed into a class with a node" do
-        expect(thing_with_a_node.send(method)).to be true
-      end
-      it "reports true for #{method} when mixed into a class with a run_context" do
-        expect(thing_with_a_run_context.send(method)).to be true
-      end
-      it "reports true for #{method} when mixed into a class with the dsl" do
-        expect(thing_with_the_dsl.send(method)).to be true
-      end
-      it "reports true for #{method} on the main class give a node" do
-        expect(ChefUtils.send(method)).to be true
-      end
-    else
-      it "reports true for #{method} on the module given a node" do
-        expect(described_class.send(method, node)).to be true
-      end
-      it "reports true for #{method} when mixed into a class with a node" do
-        expect(thing_with_a_node.send(method, node)).to be true
-      end
-      it "reports true for #{method} when mixed into a class with a run_context" do
-        expect(thing_with_a_run_context.send(method, node)).to be true
-      end
-      it "reports true for #{method} when mixed into a class with the dsl" do
-        expect(thing_with_the_dsl.send(method, node)).to be true
-      end
-      it "reports true for #{method} on the main class give a node" do
-        expect(ChefUtils.send(method, node)).to be true
-      end
+    it "reports true for #{method} on the module given a node" do
+      expect(described_class.send(method, node)).to be true
+    end
+    it "reports true for #{method} when mixed into a class with a node" do
+      expect(thing_with_a_node.send(method, node)).to be true
+    end
+    it "reports true for #{method} when mixed into a class with a run_context" do
+      expect(thing_with_a_run_context.send(method, node)).to be true
+    end
+    it "reports true for #{method} when mixed into a class with the dsl" do
+      expect(thing_with_the_dsl.send(method, node)).to be true
+    end
+    it "reports true for #{method} on the main class give a node" do
+      expect(ChefUtils.send(method, node)).to be true
     end
   end
-  (PLATFORM_HELPERS - ChefUtils::DSL::TrainHelpers.methods - args).each do |method|
-    if method.match?("centos_stream_platform")
-      it "reports false for #{method} on the module given a node" do
-        expect(described_class.send(method)).to be false
-      end
-      it "reports false for #{method} when mixed into a class with a node" do
-        expect(thing_with_a_node.send(method)).to be false
-      end
-      it "reports false for #{method} when mixed into a class with the dsl" do
-        expect(thing_with_the_dsl.send(method)).to be false
-      end
-      it "reports false for #{method} on the main class give a node" do
-        expect(ChefUtils.send(method)).to be false
-      end
-    else
-      it "reports false for #{method} on the module given a node" do
-        expect(described_class.send(method, node)).to be false
-      end
-      it "reports false for #{method} when mixed into a class with a node" do
-        expect(thing_with_a_node.send(method, node)).to be false
-      end
-      it "reports false for #{method} when mixed into a class with the dsl" do
-        expect(thing_with_the_dsl.send(method, node)).to be false
-      end
-      it "reports false for #{method} on the main class give a node" do
-        expect(ChefUtils.send(method, node)).to be false
-      end
+  (PLATFORM_HELPERS - args).each do |method|
+    it "reports false for #{method} on the module given a node" do
+      expect(described_class.send(method, node)).to be false
+    end
+    it "reports false for #{method} when mixed into a class with a node" do
+      expect(thing_with_a_node.send(method, node)).to be false
+    end
+    it "reports false for #{method} when mixed into a class with the dsl" do
+      expect(thing_with_the_dsl.send(method, node)).to be false
+    end
+    it "reports false for #{method} on the main class give a node" do
+      expect(ChefUtils.send(method, node)).to be false
     end
   end
 end
@@ -126,7 +93,7 @@ RSpec.describe ChefUtils::DSL::Platform do
 
   ( HELPER_MODULES - [ described_class ] ).each do |klass|
     it "does not have methods that collide with #{klass}" do
-      expect((klass.methods - Module.methods - ChefUtils::DSL::TrainHelpers.methods ) & PLATFORM_HELPERS).to be_empty
+      expect((klass.methods - Module.methods) & PLATFORM_HELPERS).to be_empty
     end
   end
 
@@ -176,6 +143,13 @@ RSpec.describe ChefUtils::DSL::Platform do
     let(:options) { { platform: "centos" } }
 
     platform_reports_true_for(:centos?, :centos_platform?)
+  end
+
+  context "on centos stream" do
+    let(:options) { { platform: "centos" } }
+    let(:node) { { "platform" => "centos", "platform_version" => "8", "platform_family" => "rhel", "os" => "linux", "lsb" => { "id" => "CentOSStream" } } }
+
+    platform_reports_true_for(:centos?, :centos_platform?, :centos_stream_platform?)
   end
 
   context "on clearos" do
@@ -268,50 +242,4 @@ RSpec.describe ChefUtils::DSL::Platform do
     platform_reports_true_for(:opensuse_platform?, :opensuseleap_platform?, :opensuse?, :leap_platform?)
   end
 
-end
-
-RSpec.describe ChefUtils::DSL::Platform do
-  class PlatformTestClass
-    include ChefUtils::DSL::Platform
-  end
-
-  let(:test_instance) { PlatformTestClass.new }
-
-  let(:os_release_stream) do
-    <<~OS_RELEASE
-      NAME="CentOS Stream"
-      VERSION="8"
-      ID="centos"
-      ID_LIKE="rhel fedora"
-      VERSION_ID="8"
-      PRETTY_NAME="CentOS Stream 8"
-    OS_RELEASE
-  end
-
-  let(:os_release_centos) do
-    <<~OS_RELEASE
-      NAME="CentOS Linux"
-      VERSION="8"
-      ID="centos"
-      ID_LIKE="rhel fedora"
-      VERSION_ID="8"
-      PRETTY_NAME="CentOS Linux 8"
-    OS_RELEASE
-  end
-
-  context "on centos stream" do
-    it "returns true if on centos_stream_platform?" do
-      expect(File).to receive(:exist?).with("/etc/os-release").and_return(true)
-      expect(File).to receive(:open).with("/etc/os-release").and_return(StringIO.new(os_release_stream))
-      expect(test_instance.centos_stream_platform?).to be true
-    end
-  end
-
-  context "on centos linux" do
-    it "returns false if on centos_stream_platform?" do
-      expect(File).to receive(:exist?).with("/etc/os-release").and_return(true)
-      expect(File).to receive(:open).with("/etc/os-release").and_return(StringIO.new(os_release_centos))
-      expect(test_instance.centos_stream_platform?).to be false
-    end
-  end
 end


### PR DESCRIPTION
Backport of #11296

- Add `centos_stream_platform?` helper
- Switch to using lsb/id node data for `centos_stream_platform?` helper
- Fall back to `lsb` data if `os_release` data is missing
