### PR TITLE
Update name of macos 11 in expeditor config

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -40,7 +40,7 @@ builder-to-testers-map:
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
-    - mac_os_x-11.0-x86_64
+    - mac_os_x-11-x86_64
   mac_os_x-11-arm64:
     - mac_os_x-11-arm64
   sles-12-s390x:


### PR DESCRIPTION
It's 11 not 11.0

Signed-off-by: Tim Smith <tsmith@chef.io>