### PR TITLE
Chef 16: Use dist constants in rubygems provider for is_omnibus? method

### DIFF
--- a/chef-utils/lib/chef-utils/dist.rb
+++ b/chef-utils/lib/chef-utils/dist.rb
@@ -87,6 +87,11 @@ module ChefUtils
       EXEC = "chef-solo"
     end
 
+    class Workstation
+      # The suffix for Chef Workstion's /opt/chef-workstation or C:\\opscode\chef-workstation
+      DIR_SUFFIX = "chef-workstation"
+    end
+
     class Zero
       # chef-zero executable
       PRODUCT = "Chef Infra Zero"

--- a/chef-utils/lib/chef-utils/dist.rb
+++ b/chef-utils/lib/chef-utils/dist.rb
@@ -88,7 +88,7 @@ module ChefUtils
     end
 
     class Workstation
-      # The suffix for Chef Workstion's /opt/chef-workstation or C:\\opscode\chef-workstation
+      # The suffix for Chef Workstation's /opt/chef-workstation or C:\\opscode\chef-workstation
       DIR_SUFFIX = "chef-workstation"
     end
 

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -423,11 +423,11 @@ class Chef
         end
 
         def is_omnibus?
-          if %r{/(opscode|chef|chefdk)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
+          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|chefdk)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true
-          elsif RbConfig::CONFIG["bindir"].sub(/^\w:/, "") == "/opscode/chef/embedded/bin"
+          elsif RbConfig::CONFIG["bindir"].sub(/^\w:/, "") == "/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/#{ChefUtils::Dist::Infra::SHORT}/embedded/bin"
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # windows, with the drive letter removed
             true

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -423,7 +423,7 @@ class Chef
         end
 
         def is_omnibus?
-          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|chef-workstation)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
+          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|#{ChefUtils::Dist::Workstation::DIR_SUFFIX})/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -423,7 +423,7 @@ class Chef
         end
 
         def is_omnibus?
-          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|chefdk)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
+          if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|chef-workstation)/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
             logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -482,10 +482,10 @@ describe Chef::Provider::Package::Rubygems do
       end
     end
 
-    context "when in omnibus chefdk" do
-      let(:bindir) { "/opt/chefdk/embedded/bin" }
+    context "when in omnibus chef-workstation" do
+      let(:bindir) { "/opt/chef-workstation/embedded/bin" }
 
-      it "recognizes chefdk as omnibus" do
+      it "recognizes chef-workstation as omnibus" do
         expect(provider.is_omnibus?).to be true
       end
     end


### PR DESCRIPTION
Backport of #11326

- Use dist constants in rubygems provider for `is_omnibus?` method
- Update to use chef-workstation instead of chefdk
- Create `ChefUtils::Dist::Workstation::DIR_SUFFIX` dist constant
