### PR TITLE
Allow FIPS 140-2 OpenSSL FOM to build on PPC EL platforms

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -5,6 +5,7 @@ test-path: omnibus/omnibus-test.sh
 test-path-windows: omnibus/omnibus-test.ps1
 fips-platforms:
   - el-*-x86_64
+  - el-*-ppc64*
   - ubuntu-*-x86_64
   - windows-*
 builder-to-testers-map:


### PR DESCRIPTION
Resolves https://github.com/chef/customer-bugs/issues/257