### PR TITLE
Remove the legacy osc_compat mode

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -479,9 +479,7 @@ module ChefConfig
     # * "hosted_everything": ChefFS manages all object types as of the Chef 12
     #   Server, including RBAC objects and Policyfile objects (new to Chef 12).
     default :repo_mode do
-      if local_mode && !chef_zero.osc_compat
-        "hosted_everything"
-      elsif %r{/+organizations/.+}.match?(chef_server_url)
+      if local_mode || %r{/+organizations/.+}.match?(chef_server_url)
         "hosted_everything"
       else
         "everything"
@@ -505,16 +503,6 @@ module ChefConfig
       # what you want when using Chef Zero to serve a single Chef Repo. Setting
       # this to `false` enables multi-tenant.
       default :single_org, "chef"
-
-      # Whether Chef Zero should operate in a mode analogous to OSS Chef Server
-      # 11 (true) or Chef Server 12 (false). Chef Zero can still serve
-      # policyfile objects in Chef 11 mode, as long as `repo_mode` is set to
-      # "hosted_everything". The primary differences are:
-      # * Chef 11 mode doesn't support multi-tenant, so there is no
-      #   distinction between global and org-specific objects (since there are
-      #   no orgs).
-      # * Chef 11 mode doesn't expose RBAC objects
-      default :osc_compat, false
     end
 
     # RFCxxx Target Mode support, value is the name of a remote device to Chef against

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -612,15 +612,6 @@ RSpec.describe ChefConfig::Config do
             it "defaults to 'hosted_everything'" do
               expect(ChefConfig::Config[:repo_mode]).to eq("hosted_everything")
             end
-
-            context "and osc_compat is enabled" do
-
-              before { ChefConfig::Config.chef_zero.osc_compat = true }
-
-              it "defaults to 'everything'" do
-                expect(ChefConfig::Config[:repo_mode]).to eq("everything")
-              end
-            end
           end
 
           context "when local mode is not enabled" do

--- a/knife/spec/integration/chef_fs_data_store_spec.rb
+++ b/knife/spec/integration/chef_fs_data_store_spec.rb
@@ -31,10 +31,6 @@ describe "ChefFSDataStore tests", :workstation do
   let(:cookbook_z_100_metadata_rb) { cb_metadata("z", "1.0.0") }
 
   describe "with repo mode 'hosted_everything' (default)" do
-    before do
-      Chef::Config.chef_zero.osc_compat = false
-    end
-
     when_the_repository "has one of each thing" do
       before do
         file "clients/x.json", {}
@@ -427,7 +423,6 @@ describe "ChefFSDataStore tests", :workstation do
   describe "with repo mode 'everything'" do
     before do
       Chef::Config.repo_mode = "everything"
-      Chef::Config.chef_zero.osc_compat = true
     end
 
     when_the_repository "has one of each thing" do

--- a/knife/spec/integration/delete_spec.rb
+++ b/knife/spec/integration/delete_spec.rb
@@ -963,7 +963,7 @@ describe "knife delete", :workstation do
     end
   end
 
-  when_the_chef_server "is in Enterprise mode", osc_compat: false, single_org: false do
+  when_the_chef_server "is in Enterprise mode", single_org: false do
     before do
       organization "foo" do
         container "x", {}

--- a/knife/spec/integration/download_spec.rb
+++ b/knife/spec/integration/download_spec.rb
@@ -1114,7 +1114,7 @@ describe "knife download", :workstation do
     end
   end
 
-  when_the_chef_server "is in Enterprise mode", osc_compat: false, single_org: false do
+  when_the_chef_server "is in Enterprise mode", single_org: false do
     before do
       user "foo", {}
       user "bar", {}

--- a/knife/spec/integration/list_spec.rb
+++ b/knife/spec/integration/list_spec.rb
@@ -639,7 +639,7 @@ describe "knife list", :workstation do
     end
   end
 
-  when_the_chef_server "is in Enterprise mode", osc_compat: false, single_org: false do
+  when_the_chef_server "is in Enterprise mode", single_org: false do
     before do
       organization "foo"
     end

--- a/knife/spec/integration/upload_spec.rb
+++ b/knife/spec/integration/upload_spec.rb
@@ -1351,7 +1351,7 @@ describe "knife upload", :workstation do
     end
   end
 
-  when_the_chef_server "is in Enterprise mode", osc_compat: false, single_org: false do
+  when_the_chef_server "is in Enterprise mode", single_org: false do
     before do
       user "foo", {}
       user "bar", {}

--- a/lib/chef/chef_fs/config.rb
+++ b/lib/chef/chef_fs/config.rb
@@ -146,8 +146,8 @@ class Chef
 
         if @chef_config[:repo_mode] == "everything" && is_hosted? && !ui.nil?
           ui.warn %Q{You have repo_mode set to 'everything', but your chef_server_url
-              looks like it might be a hosted setup.  If this is the case please use
-              hosted_everything or allow repo_mode to default}
+              looks like it might be Chef Infra Server 12+ or Hosted Chef. If this is
+              the case please use 'hosted_everything' or allow repo_mode to default}
         end
         # Default to getting *everything* from the server.
         unless @chef_config[:repo_mode]

--- a/lib/chef/chef_fs/config.rb
+++ b/lib/chef/chef_fs/config.rb
@@ -147,7 +147,7 @@ class Chef
         if @chef_config[:repo_mode] == "everything" && is_hosted? && !ui.nil?
           ui.warn %Q{You have repo_mode set to 'everything', but your chef_server_url
               looks like it might be Chef Infra Server 12+ or Hosted Chef. If this is
-              the case please use 'hosted_everything' or allow repo_mode to default}
+              the case, use 'hosted_everything' or allow 'repo_mode' to default.}
         end
         # Default to getting *everything* from the server.
         unless @chef_config[:repo_mode]

--- a/lib/chef/local_mode.rb
+++ b/lib/chef/local_mode.rb
@@ -63,7 +63,6 @@ class Chef
         server_options = {}
         server_options[:data_store] = data_store
         server_options[:log_level] = Chef::Log.level
-        server_options[:osc_compat] = Chef::Config.chef_zero.osc_compat
         server_options[:single_org] = Chef::Config.chef_zero.single_org
 
         server_options[:host] = Chef::Config.chef_zero.host


### PR DESCRIPTION
This provides compatibility with Chef Server 11. It's time to remove
this.

Signed-off-by: Tim Smith <tsmith@chef.io>