### PR TITLE
Use new_resource for load_current_value blocks

### DIFF
--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -101,25 +101,25 @@ class Chef
         default: false,
         desired_state: false
 
-      load_current_value do |desired|
-        Chef::Log.debug "#load_current_value: shelling out \"#{defaults_export_cmd(desired).join(" ")}\" to determine state"
-        state = shell_out(defaults_export_cmd(desired), user: desired.user)
+      load_current_value do |new_resource|
+        Chef::Log.debug "#load_current_value: shelling out \"#{defaults_export_cmd(new_resource).join(" ")}\" to determine state"
+        state = shell_out(defaults_export_cmd(new_resource), user: new_resource.user)
 
         if state.error? || state.stdout.empty?
-          Chef::Log.debug "#load_current_value: #{defaults_export_cmd(desired).join(" ")} returned stdout: #{state.stdout} and stderr: #{state.stderr}"
+          Chef::Log.debug "#load_current_value: #{defaults_export_cmd(new_resource).join(" ")} returned stdout: #{state.stdout} and stderr: #{state.stderr}"
           current_value_does_not_exist!
         end
 
         plist_data = ::Plist.parse_xml(state.stdout)
 
         # handle the situation where the key doesn't exist in the domain
-        if plist_data.key?(desired.key)
-          key desired.key
+        if plist_data.key?(new_resource.key)
+          key new_resource.key
         else
           current_value_does_not_exist!
         end
 
-        value plist_data[desired.key]
+        value plist_data[new_resource.key]
       end
 
       #

--- a/lib/chef/resource/plist.rb
+++ b/lib/chef/resource/plist.rb
@@ -64,20 +64,20 @@ class Chef
                              "utf-8" => "xml1",
                              "binary" => "binary1" }.freeze
 
-      load_current_value do |desired|
-        current_value_does_not_exist! unless ::File.exist? desired.path
-        entry desired.entry if entry_in_plist? desired.entry, desired.path
+      load_current_value do |new_resource|
+        current_value_does_not_exist! unless ::File.exist? new_resource.path
+        entry new_resource.entry if entry_in_plist? new_resource.entry, new_resource.path
 
-        setting = setting_from_plist desired.entry, desired.path
+        setting = setting_from_plist new_resource.entry, new_resource.path
         value convert_to_data_type_from_string(setting[:key_type], setting[:key_value])
 
-        file_type_cmd = shell_out "/usr/bin/file", "--brief", "--mime-encoding", "--preserve-date", desired.path
+        file_type_cmd = shell_out "/usr/bin/file", "--brief", "--mime-encoding", "--preserve-date", new_resource.path
         encoding file_type_cmd.stdout.chomp
 
-        file_owner_cmd = shell_out("/usr/bin/stat", "-f", "%Su", desired.path)
+        file_owner_cmd = shell_out("/usr/bin/stat", "-f", "%Su", new_resource.path)
         owner file_owner_cmd.stdout.chomp
 
-        file_group_cmd = shell_out("/usr/bin/stat", "-f", "%Sg", desired.path)
+        file_group_cmd = shell_out("/usr/bin/stat", "-f", "%Sg", new_resource.path)
         group file_group_cmd.stdout.chomp
       end
 

--- a/lib/chef/resource/windows_firewall_profile.rb
+++ b/lib/chef/resource/windows_firewall_profile.rb
@@ -81,8 +81,8 @@ class Chef
       property :allow_unicast_response, [true, false, String], equal_to: [true, false, "NotConfigured"], description: "Allow unicast responses to multicast and broadcast messages"
       property :display_notification, [true, false, String], equal_to: [true, false, "NotConfigured"], description: "Display a notification when firewall blocks certain activity"
 
-      load_current_value do |desired|
-        ps_get_net_fw_profile = load_firewall_state(desired.profile)
+      load_current_value do |new_resource|
+        ps_get_net_fw_profile = load_firewall_state(new_resource.profile)
         output = powershell_exec(ps_get_net_fw_profile)
         if output.result.empty?
           current_value_does_not_exist!

--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -86,8 +86,8 @@ class Chef
       PRINTERS_REG_KEY = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Print\Printers\\'.freeze unless defined?(PRINTERS_REG_KEY)
 
       # @todo Set @current_resource printer properties from registry
-      load_current_value do |desired|
-        name desired.name
+      load_current_value do |new_resource|
+        name new_resource.name
       end
 
       action :create, description: "Create a new printer and printer port, if one doesn't already" do

--- a/lib/chef/resource/windows_printer_port.rb
+++ b/lib/chef/resource/windows_printer_port.rb
@@ -89,10 +89,10 @@ class Chef
       PORTS_REG_KEY = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print\Monitors\Standard TCP/IP Port\Ports\\'.freeze unless defined?(PORTS_REG_KEY)
 
       # @todo Set @current_resource port properties from registry
-      load_current_value do |desired|
-        name desired.name
-        ipv4_address desired.ipv4_address
-        port_name desired.port_name || "IP_#{desired.ipv4_address}"
+      load_current_value do |new_resource|
+        name new_resource.name
+        ipv4_address new_resource.ipv4_address
+        port_name new_resource.port_name || "IP_#{new_resource.ipv4_address}"
       end
 
       action :create, description: "Create the printer port, if one doesn't already exist" do

--- a/lib/chef/resource/windows_security_policy.rb
+++ b/lib/chef/resource/windows_security_policy.rb
@@ -83,19 +83,19 @@ class Chef
       property :secvalue, String, required: true,
       description: "Policy value to be set for policy name."
 
-      load_current_value do |desired|
+      load_current_value do |new_resource|
         current_state = load_security_options
 
-        if desired.secoption == "ResetLockoutCount"
-          if desired.secvalue.to_i > 30
+        if new_resource.secoption == "ResetLockoutCount"
+          if new_resource.secvalue.to_i > 30
             raise Chef::Exceptions::ValidationFailed, "The \"ResetLockoutCount\" value cannot be greater than 30 minutes"
           end
         end
-        if (desired.secoption == "ResetLockoutCount" || desired.secoption == "LockoutDuration") && current_state["LockoutBadCount"] == "0"
-          raise Chef::Exceptions::ValidationFailed, "#{desired.secoption} cannot be set unless the \"LockoutBadCount\" security policy has been set to a non-zero value"
+        if (new_resource.secoption == "ResetLockoutCount" || new_resource.secoption == "LockoutDuration") && current_state["LockoutBadCount"] == "0"
+          raise Chef::Exceptions::ValidationFailed, "#{new_resource.secoption} cannot be set unless the \"LockoutBadCount\" security policy has been set to a non-zero value"
         end
 
-        secvalue current_state[desired.secoption.to_s]
+        secvalue current_state[new_resource.secoption.to_s]
       end
 
       action :set, description: "Set the Windows security policy" do

--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -118,11 +118,11 @@ class Chef
       # Specifies which files and folders in the SMB share are visible to users. AccessBased: SMB does not the display the files and folders for a share to a user unless that user has rights to access the files and folders. By default, access-based enumeration is disabled for new SMB shares. Unrestricted: SMB displays files and folders to a user even when the user does not have permission to access the items.
       # property :folder_enumeration_mode, String, equal_to: %(AccessBased Unrestricted)
 
-      load_current_value do |desired|
+      load_current_value do |new_resource|
         # this command selects individual objects because EncryptData & CachingMode have underlying
         # types that get converted to their Integer values by ConvertTo-Json & we need to make sure
         # those get written out as strings
-        share_state_cmd = "Get-SmbShare -Name '#{desired.share_name}' | Select-Object Name,Path, Description, Temporary, CATimeout, ContinuouslyAvailable, ConcurrentUserLimit, EncryptData"
+        share_state_cmd = "Get-SmbShare -Name '#{new_resource.share_name}' | Select-Object Name,Path, Description, Temporary, CATimeout, ContinuouslyAvailable, ConcurrentUserLimit, EncryptData"
 
         Chef::Log.debug("Running '#{share_state_cmd}' to determine share state'")
         ps_results = powershell_exec(share_state_cmd)
@@ -146,14 +146,14 @@ class Chef
         encrypt_data results["EncryptData"]
         # folder_enumeration_mode results['FolderEnumerationMode']
 
-        perm_state_cmd = %{Get-SmbShareAccess -Name "#{desired.share_name}" | Select-Object AccountName,AccessControlType,AccessRight}
+        perm_state_cmd = %{Get-SmbShareAccess -Name "#{new_resource.share_name}" | Select-Object AccountName,AccessControlType,AccessRight}
 
         Chef::Log.debug("Running '#{perm_state_cmd}' to determine share permissions state'")
         ps_perm_results = powershell_exec(perm_state_cmd)
 
         # we raise here instead of warning like above because we'd only get here if the above Get-SmbShare
         # command was successful and that continuing would leave us with 1/2 known state
-        raise "Could not determine #{desired.share_name} share permissions by running '#{perm_state_cmd}'" if ps_perm_results.error?
+        raise "Could not determine #{new_resource.share_name} share permissions by running '#{perm_state_cmd}'" if ps_perm_results.error?
 
         Chef::Log.debug("The Get-SmbShareAccess results were #{ps_perm_results.result}")
 

--- a/lib/chef/resource/windows_shortcut.rb
+++ b/lib/chef/resource/windows_shortcut.rb
@@ -57,11 +57,11 @@ class Chef
       property :iconlocation, String,
         description: "Icon to use for the shortcut. Accepts the format of `path, index`, where index is the icon file to use. See Microsoft's [documentation](https://msdn.microsoft.com/en-us/library/3s9bx7at.aspx) for details"
 
-      load_current_value do |desired|
+      load_current_value do |new_resource|
         require "win32ole" if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
 
-        link = WIN32OLE.new("WScript.Shell").CreateShortcut(desired.shortcut_name)
-        name desired.shortcut_name
+        link = WIN32OLE.new("WScript.Shell").CreateShortcut(new_resource.shortcut_name)
+        name new_resource.shortcut_name
         target(link.TargetPath)
         arguments(link.Arguments)
         description(link.Description)


### PR DESCRIPTION
## Description

Resolves a lack of continuity of the use of the `#load_current_value` API. Both the [chef docs](https://docs.chef.io/custom_resources/#load_current_value) and the [caller](https://github.com/chef/chef/blob/4d3b847aee1b917bb139862c623e9633d180fb31/lib/chef/resource/action_class.rb#L49) of `#load_current_value` both refer to `new_resource` (not `desired`).

Well this is confusing, I just saw that on the same set of docs it references `desired`, see [here](https://docs.chef.io/custom_resources/#multiple-properties).

## Related Issue

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
