### PR TITLE
mount: Fix idempotentency for loopback mounts

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -861,6 +861,7 @@
     "logstring",
     "LONGLONG",
     "loopback",
+    "losetup",
     "lowercased",
     "LOWORD",
     "lpar",

--- a/lib/chef/provider/mount/linux.rb
+++ b/lib/chef/provider/mount/linux.rb
@@ -45,6 +45,14 @@ class Chef
             when /\A#{Regexp.escape(real_mount_point)}\s+#{device_mount_regex}\s/
               mounted = true
               logger.trace("Special device #{device_logstring} mounted as #{real_mount_point}")
+            # Permalink for loop type devices mount points https://rubular.com/r/a0bS4p2RvXsGxx
+            when %r{\A#{Regexp.escape(real_mount_point)}\s+\/dev\/loop+[0-9]+\s}
+              @loop_mount_points.each_line do |mount_point|
+                if mount_point.include? device_real
+                  mounted = true
+                  break
+                end
+              end
             # Permalink for multiple devices mounted to the same mount point(i.e. '/proc') https://rubular.com/r/a356yzspU7N9TY
             when %r{\A#{Regexp.escape(real_mount_point)}\s+([/\w])+\s}
               mounted = false

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -29,6 +29,7 @@ class Chef
         def initialize(new_resource, run_context)
           super
           @real_device = nil
+          initialize_loop_mounts
         end
         attr_accessor :real_device
 
@@ -38,6 +39,10 @@ class Chef
           @current_resource.device(@new_resource.device)
           mounted?
           enabled?
+        end
+
+        def initialize_loop_mounts
+          @loop_mount_points = shell_out!("losetup --list").stdout
         end
 
         def mountable?

--- a/spec/unit/provider/mount/linux_spec.rb
+++ b/spec/unit/provider/mount/linux_spec.rb
@@ -12,7 +12,7 @@ describe Chef::Provider::Mount::Linux do
     new_resource = Chef::Resource::Mount.new("/tmp/foo")
     new_resource.device      "/dev/sdz1"
     new_resource.device_type :device
-    new_resource.fstype      "ext3"
+    new_resource.fstype "ext3"
     new_resource.supports remount: false
     new_resource
   end
@@ -99,6 +99,18 @@ describe Chef::Provider::Mount::Linux do
       mount = "/tmp/foo //192.168.11.102/Share/backup[/backup] cifs rw\n"
       mount << "#{new_resource.mount_point} #{new_resource.device} type #{new_resource.fstype}\n"
       allow(provider).to receive(:shell_out!).and_return(double(stdout: mount))
+      provider.load_current_resource
+      expect(provider.current_resource.mounted).to be_truthy
+    end
+  end
+
+  context "to check if loop resource is mounted" do
+    it "should set mounted true in case of loop resource" do
+      new_resource.options "loop"
+      mount = "/tmp/foo /dev/loop16 iso660 cifs ro\n"
+      losetup = "/dev/loop16 0 0 1 1 /dev/sdz1 \n"
+      allow(provider).to receive(:shell_out!).with("findmnt -rn").and_return(double(stdout: mount))
+      allow(provider).to receive(:shell_out!).with("losetup --list").and_return(double(stdout: losetup))
       provider.load_current_resource
       expect(provider.current_resource.mounted).to be_truthy
     end


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

For the mount type `loop`, I have put in a check to verify the mount point already exists in the system or not.

## Description
This PR resolves issue - [#10918](https://github.com/chef/chef/issues/10918)
While iterating output of comman `findmnt -rn` for the mount of type `loop`  name of device is not included in the output. For example for a mount resource as following : - 

```
mount "/var/www/mnt/disk3" do
  device "/mnt/public/hdat2cd_lite_71.iso"
  device_type :device
  options "loop"
  action %i{mount enable}
end
```
Once the mount action is performed, the output of `findmnt -rn` will be

`/var/www/mnt/disk3 /dev/loop2 ext2 rw,relatime,seclabel`

Hence in this case we cannot verify if the mount point exist by using this Regexp. where `device_mount_regex` is the name of device.
`/\A#{Regexp.escape(real_mount_point)}\s+#{device_mount_regex}\s/`

This makes mount resource non-idempotent in case of `loop` type mount and we get an error like this : - 
```
[2021-01-21T19:57:25+00:00] TRACE: Special device 0 mounted as /var/www/mnt/disk1
[2021-01-21T19:57:25+00:00] TRACE: Found mount /mnt/public/hdat2cd_lite_71.iso to /var/www/mnt/disk3 in /etc/fstab
mount: /mnt/public/disk1.iso is already mounted
```
 I made a change in one of the case check with regular expression as - 

`%r{\A#{Regexp.escape(real_mount_point)}\s+([/\w])+\s}` 

I introduced an if condition for options provided as `loop or defaults` and now the mount operation is idempotent. Output when mount is performed second time on the same directory is : - 
```
  * mount[/var/www/mnt/disk3] action mount (up to date)
  * mount[/var/www/mnt/disk3] action enable (up to date)
 ```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
