### PR TITLE
Move most compliance validation to pre-run

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -235,6 +235,7 @@
     "cmds",
     "CMDS",
     "Cmnd",
+    "CMPL",
     "cname",
     "codepage",
     "coderanger",

--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -38,11 +38,12 @@ class Chef
       # Allow for connections to HTTPS endpoints using self-signed ssl certificates.
       "insecure" => nil,
 
-      # Controls verbosity of Chef InSpec runner.
+      # Controls verbosity of Chef InSpec runner. See less output when true.
       "quiet" => true,
 
       # Chef Inspec Compliance profiles to be used for scan of node.
       # See README.md for details
+      # MPTD - ^there is no README.md anymore^
       "profiles" => {},
 
       # Extra inputs passed to Chef InSpec to allow finer-grained control over behavior.

--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -42,8 +42,8 @@ class Chef
       "quiet" => true,
 
       # Chef Inspec Compliance profiles to be used for scan of node.
-      # See README.md for details
-      # MPTD - ^there is no README.md anymore^
+      # See Compliance Phase documentation for further details:
+      # https://docs.chef.io/chef_compliance_phase/#compliance-phase-configuration
       "profiles" => {},
 
       # Extra inputs passed to Chef InSpec to allow finer-grained control over behavior.

--- a/lib/chef/compliance/fetcher/automate.rb
+++ b/lib/chef/compliance/fetcher/automate.rb
@@ -46,13 +46,6 @@ class Chef
 
             config["token"] = Chef::Config[:data_collector][:token]
 
-            if config["token"].nil?
-              raise Inspec::FetcherFailure,
-                "No data-collector token set, which is required by the chef-automate fetcher. " \
-                "Set the `data_collector.token` configuration parameter in your client.rb " \
-                'or use the "chef-server-automate" reporter which does not require any ' \
-                "data-collector settings and uses #{ChefUtils::Dist::Server::PRODUCT} to fetch profiles."
-            end
           end
 
           new(profile_fetch_url, config)

--- a/lib/chef/compliance/reporter/automate.rb
+++ b/lib/chef/compliance/reporter/automate.rb
@@ -28,18 +28,28 @@ class Chef
           @token = Chef::Config[:data_collector][:token]
         end
 
-        # Method used in order to send the inspec report to the data_collector server
-        def send_report(report)
-          unless @entity_uuid && @run_id
-            Chef::Log.error "entity_uuid(#{@entity_uuid}) or run_id(#{@run_id}) can't be nil, not sending report to #{ChefUtils::Dist::Automate::PRODUCT}"
-            return false
+        def validate_config!
+          unless @entity_uuid
+            # TODO - this is a weird leakage of naming from the parent class
+            # but entity_uuid is never an attribute that the user can see;
+            # it is sourced from chef_guid, which we don't technically know about in this class -
+            # but telling the operator about a missing chef_guid is more helpful than telling
+            # them about a missing field they've never heard of. Better would be a dock link
+            # that described how to fix this situation.
+            raise "CMPL004: automate_reporter: chef_guid is not available and must be provided. Aborting because we cannot report the scan."
+          end
+
+          unless @run_id
+            raise "CMPL005: automate_reporter: run_id is not available, aborting because we cannot report the scan."
           end
 
           unless @url && @token
-            Chef::Log.warn "data_collector.token and data_collector.server_url must be defined in client.rb! Further information: https://docs.chef.io/chef_compliance_phase/#direct-reporting-to-chef-automate"
-            return false
+            raise "CMPL006: data_collector.token and data_collector.server_url must be configured in client.rb! Further information: https://docs.chef.io/chef_compliance_phase/#direct-reporting-to-chef-automate"
           end
+        end
 
+        # Method used in order to send the inspec report to the data_collector server
+        def send_report(report)
           headers = {
             "Content-Type" => "application/json",
             "x-data-collector-auth" => "version=1.0",

--- a/lib/chef/compliance/reporter/chef_server_automate.rb
+++ b/lib/chef/compliance/reporter/chef_server_automate.rb
@@ -30,11 +30,6 @@ class Chef
         end
 
         def send_report(report)
-          unless @entity_uuid && @run_id
-            Chef::Log.error "entity_uuid(#{@entity_uuid}) or run_id(#{@run_id}) can't be nil, not sending report to #{ChefUtils::Dist::Automate::PRODUCT}"
-            return false
-          end
-
           automate_report = truncate_controls_results(enriched_report(report), @control_results_limit)
 
           report_size = Chef::JSONCompat.to_json(automate_report, validate_utf8: false).bytesize
@@ -49,6 +44,16 @@ class Chef
             return true
           end
           false
+        end
+
+        def validate_config!
+          unless @entity_uuid
+            raise "CMPL007: chef_server_automate reporter: chef_guid is not available and must be provided. Aborting because we cannot report the scan"
+          end
+
+          unless @run_id
+            raise "CMPL008: chef_server_automate reporter: run_id is not available, aborting because we cannot report the scan."
+          end
         end
 
         def http_client
@@ -80,7 +85,7 @@ class Chef
           when /404/
             Chef::Log.error "Object does not exist on remote server."
           when /413/
-            Chef::Log.error "You most likely hit the erchef request size in #{ChefUtils::Dist::Server::PRODUCT} that defaults to ~2MB. To increase this limit see the Compliance Phase troubleshooting documentation (http://docs.chef.io/chef_compliance_phase/#troubleshooting) or the Chef Infra Server configuration documentation (https://docs.chef.io/server/config_rb_server/)"
+            Chef::Log.error "You most likely hit the request size limit in #{ChefUtils::Dist::Server::PRODUCT} that defaults to ~2MB. To increase this limit see the Compliance Phase troubleshooting documentation (http://docs.chef.io/chef_compliance_phase/#troubleshooting) or the Chef Infra Server configuration documentation (https://docs.chef.io/server/config_rb_server/)"
           when /429/
             Chef::Log.error "This error typically means the data sent was larger than #{ChefUtils::Dist::Automate::PRODUCT}'s limit (4 MB). Run InSpec locally to identify any controls producing large diffs."
           end

--- a/lib/chef/compliance/reporter/cli.rb
+++ b/lib/chef/compliance/reporter/cli.rb
@@ -22,6 +22,10 @@ class Chef
           puts output.join("\n")
         end
 
+        def validate_config!
+          true
+        end
+
         private
 
         # pastel.decorate is a lightweight replacement for highline.color

--- a/lib/chef/compliance/reporter/compliance_enforcer.rb
+++ b/lib/chef/compliance/reporter/compliance_enforcer.rb
@@ -14,6 +14,10 @@ class Chef
           end
           true
         end
+
+        def validate_config!
+          true
+        end
       end
     end
   end

--- a/lib/chef/compliance/reporter/json_file.rb
+++ b/lib/chef/compliance/reporter/json_file.rb
@@ -13,6 +13,12 @@ class Chef
 
           File.write(@path, Chef::JSONCompat.to_json(report))
         end
+
+        def validate_config!
+          if @path.nil? || @path.class != String || @path.empty?
+            raise "CMPL007: json_file reporter: node['audit']['json_file']['location'] must contain a file path"
+          end
+        end
       end
     end
   end

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -46,7 +46,7 @@ class Chef
       end
 
       def converge_start(run_context)
-        # With all attributes - including cookook - loaded, we now have enough data to validate
+        # With all attributes - including cookbook - loaded, we now have enough data to validate
         # configuration.  Because the converge is best coupled with the associated compliance run, these validations
         # will raise (and abort the converge) if the compliance phase configuration is incorrect/will
         # prevent compliance phase from completing and submitting its report to all configured reporters.

--- a/spec/unit/compliance/fetcher/automate_spec.rb
+++ b/spec/unit/compliance/fetcher/automate_spec.rb
@@ -29,14 +29,6 @@ describe Chef::Compliance::Fetcher::Automate do
         expect(res.target).to eq(expected)
       end
 
-      it "raises an exception with no data collector token" do
-        Chef::Config[:data_collector].delete(:token)
-
-        expect {
-          Chef::Compliance::Fetcher::Automate.resolve("compliance://namespace/profile_name")
-        }.to raise_error(/No data-collector token set/)
-      end
-
       it "includes the data collector token" do
         expect(Chef::Compliance::Fetcher::Automate).to receive(:new).with(
           "https://automate.test/compliance/profiles/namespace/profile_name/tar",
@@ -106,14 +98,6 @@ describe Chef::Compliance::Fetcher::Automate do
         expect(res).to be_kind_of(Chef::Compliance::Fetcher::Automate)
         expected = "https://profile.server.test/profiles/profile_name/1.2.3"
         expect(res.target).to eq(expected)
-      end
-
-      it "raises an exception with no data collector token" do
-        Chef::Config[:data_collector].delete(:token)
-
-        expect {
-          Chef::Compliance::Fetcher::Automate.resolve(compliance: "namespace/profile_name")
-        }.to raise_error(Inspec::FetcherFailure, /No data-collector token set/)
       end
 
       it "includes the data collector token" do

--- a/spec/unit/compliance/reporter/chef_server_automate_spec.rb
+++ b/spec/unit/compliance/reporter/chef_server_automate_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
+require "chef/compliance/reporter/chef_server_automate"
 
 describe Chef::Compliance::Reporter::ChefServerAutomate do
   before do
+    # Isn't this already done globally in
     WebMock.disable_net_connect!
 
     Chef::Config[:client_key] = File.expand_path("../../../data/ssl/private_key.pem", __dir__)
@@ -174,4 +176,22 @@ describe Chef::Compliance::Reporter::ChefServerAutomate do
 
     expect(report_stub).to have_been_requested
   end
+
+  describe "#validate_config!" do
+    it "raises CMPL007 when entity_uuid is not present" do
+      opts.delete(:entity_uuid)
+      expect { reporter.validate_config! }.to raise_error(/^CMPL007/)
+    end
+
+    it "raises CMPL008 when run_id is not present" do
+      opts.delete(:run_id)
+      expect { reporter.validate_config! }.to raise_error(/^CMPL008/)
+    end
+
+    it "otherwise passes" do
+      reporter.validate_config!
+    end
+
+  end
+
 end

--- a/spec/unit/compliance/reporter/compliance_enforcer_spec.rb
+++ b/spec/unit/compliance/reporter/compliance_enforcer_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "chef/compliance/reporter/compliance_enforcer"
 
 describe Chef::Compliance::Reporter::AuditEnforcer do
   let(:reporter) { Chef::Compliance::Reporter::AuditEnforcer.new }


### PR DESCRIPTION
Because it is important that when possible, the compliance run
get associated with the converge  that preceded it (via run-id) this PR updates
compliance mode to pre-validate for most common issues before the
converge occurs.

This is a change of behavior, in that previously we would
wait until it was time to send the report after the converge before
validating, which would cause the report to not get captured for current
converge (run-id) if config errors were present.

This also adds error numbers to each of the failure conditions we
detect, in order to simplify providing the operator help with resolving
the errors.

Resolves #11106 and #11105

## Types of changes
- [x] Chore (non-breaking change that does not add functionality or fix an issue)


