### PR TITLE
Update tests to handle local omnibus packages from Buildkite artifacts api

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -20,8 +20,17 @@ If ([string]::IsNullOrEmpty($product)) { $product = "chef" }
 $version = "$Env:VERSION"
 If ([string]::IsNullOrEmpty($version)) { $version = "latest" }
 
-Write-Output "--- Installing $channel $product $version"
-$package_file = $(C:\opscode\omnibus-toolchain\bin\install-omnibus-product.ps1 -Product "$product" -Channel "$channel" -Version "$version" | Select-Object -Last 1)
+$package_file = "$Env:PACKAGE_FILE"
+If ([string]::IsNullOrEmpty($package_file)) { $package_file = "" }
+
+If ($package_file -eq "") {
+  Write-Output "--- Installing $channel $product $version"
+  $package_file = $(.omnibus-buildkite-plugin\install-omnibus-product.ps1 -Product "$product" -Channel "$channel" -Version "$version" | Select-Object -Last 1)
+} 
+Else {
+  Write-Output "--- Installing $product $version"
+  $package_file = $(.omnibus-buildkite-plugin\install-omnibus-product.ps1 -Package "$package_file" -Product "$product" -Version "$version" | Select-Object -Last 1)
+}
 
 Write-Output "--- Verifying omnibus package is signed"
 C:\opscode\omnibus-toolchain\bin\check-omnibus-package-signed.ps1 "$package_file"

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -4,11 +4,16 @@ set -ueo pipefail
 channel="${CHANNEL:-unstable}"
 product="${PRODUCT:-chef}"
 version="${VERSION:-latest}"
+package_file=${PACKAGE_FILE:-""}
 
 export INSTALL_DIR="/opt/$product"
 
 echo "--- Installing $channel $product $version"
-package_file="$("/opt/$TOOLCHAIN/bin/install-omnibus-product" -c "$channel" -P "$product" -v "$version" | tail -1)"
+if [[ -z $package_file ]]; then
+  package_file="$(.omnibus-buildkite-plugin/install-omnibus-product.sh -c "$channel" -P "$product" -v "$version" | tail -1)"
+else
+  .omnibus-buildkite-plugin/install-omnibus-product.sh -f "$package_file" -P "$product" -v "$version" &> /dev/null
+fi
 
 echo "--- Verifying omnibus package is signed"
 "/opt/$TOOLCHAIN/bin/check-omnibus-package-signed" "$package_file"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Updated tests to support the use of `skip-artifactory-platforms` within the shim pipeline definition where packages will be downloaded directly from the buildkite artifacts api.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
