### PR TITLE
Update the Buildkite pipeline for the macOS 11 builder naming

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -38,7 +38,7 @@ builder-to-testers-map:
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
-    - mac_os_x-11.0-x86_64
+    - mac_os_x-11-x86_64
   sles-12-s390x:
     - sles-12-s390x
     - sles-15-s390x


### PR DESCRIPTION
This changed

Signed-off-by: Tim Smith <tsmith@chef.io>