### PR TITLE
Update the download URL for windows msi

### DIFF
--- a/knife/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/knife/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -294,11 +294,10 @@ class Chef
           "%TEMP%\\#{ChefUtils::Dist::Infra::CLIENT}-latest.msi"
         end
 
-        # Build a URL to query www.chef.io that will redirect to the correct
-        # Chef Infra msi download.
+        # Build a URL that will redirect to the correct Chef Infra msi download.
         def msi_url(machine_os = nil, machine_arch = nil, download_context = nil)
           if config[:msi_url].nil? || config[:msi_url].empty?
-            url = "https://www.chef.io/chef/download?p=windows"
+            url = "https://omnitruck.chef.io/chef/download?p=windows"
             url += "&pv=#{machine_os}" unless machine_os.nil?
             url += "&m=#{machine_arch}" unless machine_arch.nil?
             url += "&DownloadContext=#{download_context}" unless download_context.nil?

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -204,19 +204,19 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
       end
 
       it "returns a chef.io msi url with minimal url parameters" do
-        reference_url = "https://www.chef.io/chef/download?p=windows&channel=stable&v=something"
+        reference_url = "https://omnitruck.chef.io/chef/download?p=windows&channel=stable&v=something"
         expect(bootstrap_context.msi_url).to eq(reference_url)
       end
 
       it "returns a chef.io msi url with provided url parameters substituted" do
-        reference_url = "https://www.chef.io/chef/download?p=windows&pv=machine&m=arch&DownloadContext=ctx&channel=stable&v=something"
+        reference_url = "https://omnitruck.chef.io/chef/download?p=windows&pv=machine&m=arch&DownloadContext=ctx&channel=stable&v=something"
         expect(bootstrap_context.msi_url("machine", "arch", "ctx")).to eq(reference_url)
       end
 
       context "when a channel is provided in config" do
         let(:config) { { channel: "current" } }
         it "returns a chef.io msi url with the requested channel" do
-          reference_url = "https://www.chef.io/chef/download?p=windows&channel=current&v=something"
+          reference_url = "https://omnitruck.chef.io/chef/download?p=windows&channel=current&v=something"
           expect(bootstrap_context.msi_url).to eq(reference_url)
         end
       end


### PR DESCRIPTION
www.chef.io/chef/download has been deprecated; we should be using
omnitruck.chef.io/chef/download.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
