### PR TITLE
Revert "Bump omnibus-software from `0dcaeb1` to `810a6c4` in /omnibus"

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 810a6c469aefab77a577e222317e796159ee81ca
+  revision: 0dcaeb1940283bcb98c00dcfe9bb2821726ffa0a
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.445.0)
-    aws-sdk-core (3.114.0)
+    aws-partitions (1.442.0)
+    aws-sdk-core (3.113.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.93.1)
+    aws-sdk-s3 (1.93.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -101,6 +101,54 @@ GEM
       tty-screen (~> 0.6)
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
+    chef (16.11.7-universal-mingw32)
+      addressable
+      bcrypt_pbkdf (~> 1.1)
+      bundler (>= 1.10)
+      chef-config (= 16.11.7)
+      chef-utils (= 16.11.7)
+      chef-vault
+      chef-zero (>= 14.0.11)
+      diff-lcs (>= 1.2.4, < 1.4.0)
+      ed25519 (~> 1.2)
+      erubis (~> 2.7)
+      ffi (>= 1.9.25)
+      ffi-libarchive (~> 1.0, >= 1.0.3)
+      ffi-yajl (~> 2.2)
+      highline (>= 1.6.9, < 3)
+      iniparse (~> 1.4)
+      inspec-core (~> 4.23)
+      iso8601 (>= 0.12.1, < 0.14)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-authentication (>= 2.1, < 4)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      mixlib-log (>= 2.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
+      net-sftp (>= 2.1.2, < 4.0)
+      net-ssh (>= 5.1, < 7)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (~> 16.0)
+      pastel
+      plist (~> 3.2)
+      proxifier (~> 1.0)
+      syslog-logger (~> 1.6)
+      train-core (~> 3.2, >= 3.2.28)
+      train-winrm (>= 0.2.5)
+      tty-prompt (~> 0.21)
+      tty-screen (~> 0.6)
+      tty-table (~> 0.11)
+      uuidtools (>= 2.1.5, < 3.0)
+      win32-api (~> 1.5.3)
+      win32-certstore (~> 0.5.0)
+      win32-event (~> 0.6.1)
+      win32-eventlog (= 0.6.3)
+      win32-mmap (~> 0.4.1)
+      win32-mutex (~> 0.4.2)
+      win32-process (~> 0.9)
+      win32-service (>= 2.1.5, < 3.0)
+      win32-taskscheduler (~> 2.0)
+      wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
     chef-config (16.11.7)
       addressable
@@ -141,6 +189,8 @@ GEM
     ffi (1.15.0-x86-mingw32)
     ffi-libarchive (1.0.17)
       ffi (~> 1.0)
+    ffi-win32-extensions (1.0.4)
+      ffi
     ffi-yajl (2.4.0)
       libyajl2 (>= 1.2)
     fuzzyurl (0.9.0)
@@ -177,6 +227,7 @@ GEM
       tty-table (~> 0.10)
     iostruct (0.0.4)
     ipaddress (0.8.3)
+    iso8601 (0.13.0)
     jmespath (1.4.0)
     json (2.5.1)
     kitchen-vagrant (1.8.0)
@@ -212,6 +263,11 @@ GEM
     mixlib-log (3.0.9)
     mixlib-shellout (3.2.5)
       chef-utils
+    mixlib-shellout (3.2.5-universal-mingw32)
+      chef-utils
+      ffi-win32-extensions (~> 1.0.3)
+      win32-process (~> 0.9)
+      wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
     molinillo (0.7.0)
     multi_json (1.15.0)
@@ -295,6 +351,7 @@ GEM
       unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
+    structured_warnings (0.4.0)
     syslog-logger (1.6.8)
     test-kitchen (2.11.2)
       bcrypt_pbkdf (~> 1.0)
@@ -314,7 +371,7 @@ GEM
     toml-rb (2.0.1)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.3.0)
-    train-core (3.6.2)
+    train-core (3.6.0)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)
@@ -347,6 +404,28 @@ GEM
     unicode_utils (1.4.0)
     uuidtools (2.2.0)
     webrick (1.7.0)
+    win32-api (1.5.3-universal-mingw32)
+    win32-certstore (0.5.3)
+      ffi
+      mixlib-shellout
+    win32-event (0.6.3)
+      win32-ipc (>= 0.6.0)
+    win32-eventlog (0.6.3)
+      ffi
+    win32-ipc (0.7.0)
+      ffi
+    win32-mmap (0.4.2)
+      ffi
+    win32-mutex (0.4.3)
+      win32-ipc (>= 0.6.0)
+    win32-process (0.9.0)
+      ffi (>= 1.0.0)
+    win32-service (2.2.0)
+      ffi
+      ffi-win32-extensions
+    win32-taskscheduler (2.0.4)
+      ffi
+      structured_warnings
     winrm (2.3.6)
       builder (>= 2.1.2)
       erubi (~> 1.8)


### PR DESCRIPTION
This reverts commit e5d273f8c70adb18d553faf996da9d36298666b0.


## Description
Windows buildings failing on require 'win32/process'

## Related Issue
fixes. [https://github.com/chef/chef-workstation/issues/1893](url)

