### PR TITLE
Lock cheffish to 17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ else
   gem "chef-bin" # rubocop:disable Bundler/DuplicatedGem
 end
 
-gem "cheffish", ">= 14"
+gem "cheffish", ">= 17"
 
 gem "chef-telemetry", ">=1.0.8" # 1.0.8 removes the http dep
 


### PR DESCRIPTION
We don't support <= 16 due to removal of the ChefFS parallelizer

