### PR TITLE
omit cheffs tests from ruby 2.7

### DIFF
--- a/spec/unit/chef_fs/diff_spec.rb
+++ b/spec/unit/chef_fs/diff_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 require "chef/chef_fs/file_pattern"
 require "chef/chef_fs/command_line"
 
-describe "diff", uses_diff: true do
+describe "diff", uses_diff: true, ruby: ">= 3.0" do
   include FileSystemSupport
 
   # Removes the date stamp from the diff and replaces it with ' DATE'

--- a/spec/unit/chef_fs/file_system_spec.rb
+++ b/spec/unit/chef_fs/file_system_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 require "chef/chef_fs/file_system"
 require "chef/chef_fs/file_pattern"
 
-describe Chef::ChefFS::FileSystem do
+describe Chef::ChefFS::FileSystem, ruby: ">= 3.0" do
   include FileSystemSupport
 
   context "with empty filesystem" do


### PR DESCRIPTION
ruby 2.7 is buggy and will always be buggy:

https://bugs.ruby-lang.org/issues/16852

ruby 3.0 is fixed.
