### PR TITLE
Build FreeBSD 13 on FreeBSD 13

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -37,6 +37,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
+  freebsd-13-amd64:
     - freebsd-13-amd64
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64


### PR DESCRIPTION
This works around our ncurses issue short of a better fix.

Signed-off-by: Tim Smith <tsmith@chef.io>