### PR TITLE
Make json-file compliance report path  visible

### DIFF
--- a/lib/chef/compliance/reporter/json_file.rb
+++ b/lib/chef/compliance/reporter/json_file.rb
@@ -1,4 +1,5 @@
 require_relative "../../json_compat"
+require_relative "../../log"
 
 class Chef
   module Compliance
@@ -9,8 +10,8 @@ class Chef
         end
 
         def send_report(report)
+          Chef::Log.info "Writing compliance report to #{@path}"
           FileUtils.mkdir_p(File.dirname(@path), mode: 0700)
-
           File.write(@path, Chef::JSONCompat.to_json(report))
         end
 

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -249,7 +249,6 @@ class Chef
         when "json-file"
           require_relative "reporter/json_file"
           path = node.dig("audit", "json_file", "location")
-          logger.info "Writing compliance report to #{path}"
           Chef::Compliance::Reporter::JsonFile.new(file: path)
         when "audit-enforcer"
           require_relative "reporter/compliance_enforcer"


### PR DESCRIPTION
We were previously logging it earlier in the run, and it could get lost
in backscroll.  With this change, we'll log it at/near the end, at the
time we write the report.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

closes #11108 