### PR TITLE
Remove pipeline-specific logic from test scripts

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -1,35 +1,9 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$channel = "$Env:CHANNEL"
-If ([string]::IsNullOrEmpty($channel)) { $channel = "unstable" }
-
-$product = "$Env:PRODUCT"
-If ([string]::IsNullOrEmpty($product)) { $product = "chef" }
-
-$version = "$Env:VERSION"
-If ([string]::IsNullOrEmpty($version)) { $version = "latest" }
-
-$package_file = "$Env:PACKAGE_FILE"
-If ([string]::IsNullOrEmpty($package_file)) { $package_file = "" }
-
-If ($package_file -eq "") {
-  Write-Output "--- Installing $channel $product $version"
-  $package_file = $(.omnibus-buildkite-plugin\install-omnibus-product.ps1 -Product "$product" -Channel "$channel" -Version "$version" | Select-Object -Last 1)
-} 
-Else {
-  Write-Output "--- Installing $product $version"
-  $package_file = $(.omnibus-buildkite-plugin\install-omnibus-product.ps1 -Package "$package_file" -Product "$product" -Version "$version" | Select-Object -Last 1)
-}
-
-Write-Output "--- Verifying omnibus package is signed"
-C:\opscode\omnibus-toolchain\bin\check-omnibus-package-signed.ps1 "$package_file"
-
-Write-Output "--- Running verification for $channel $product $version"
-
 # We don't want to add the embedded bin dir to the main PATH as this
 # could mask issues in our binstub shebangs.
-$embedded_bin_dir = "C:\opscode\$product\embedded\bin"
+$embedded_bin_dir = "C:\opscode\chef\embedded\bin"
 
 # Set TEMP and TMP environment variables to a short path because buildkite-agent user's default path is so long it causes tests to fail
 $Env:TEMP = "C:\cheftest"
@@ -59,7 +33,7 @@ ForEach ($b in
 ) {
   Write-Output "Checking for existence of binfile $b..."
 
-  If (Test-Path -PathType Leaf -Path "C:\opscode\$product\bin\$b") {
+  If (Test-Path -PathType Leaf -Path "C:\opscode\chef\bin\$b") {
     Write-Output "Found $b!"
   }
   Else {
@@ -68,7 +42,7 @@ ForEach ($b in
   }
 }
 
-$Env:PATH = "C:\opscode\$product\bin;$Env:PATH"
+$Env:PATH = "C:\opscode\chef\bin;$Env:PATH"
 
 chef-client --version
 
@@ -78,7 +52,7 @@ chef-client --version
 & $embedded_bin_dir\bundle.bat --version
 & $embedded_bin_dir\rspec.bat --version
 
-$Env:PATH = "C:\opscode\$product\bin;C:\opscode\$product\embedded\bin;$Env:PATH"
+$Env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;$Env:PATH"
 
 # Test against the vendored chef gem (cd into the output of "gem which chef")
 $chefdir = gem which chef

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -1,38 +1,6 @@
 #!/bin/bash
 set -ueo pipefail
 
-channel="${CHANNEL:-unstable}"
-product="${PRODUCT:-chef}"
-version="${VERSION:-latest}"
-package_file=${PACKAGE_FILE:-""}
-
-export INSTALL_DIR="/opt/$product"
-
-echo "--- Installing $channel $product $version"
-if [[ -z $package_file ]]; then
-  package_file="$(.omnibus-buildkite-plugin/install-omnibus-product.sh -c "$channel" -P "$product" -v "$version" | tail -1)"
-else
-  .omnibus-buildkite-plugin/install-omnibus-product.sh -f "$package_file" -P "$product" -v "$version" &> /dev/null
-fi
-
-echo "--- Verifying omnibus package is signed"
-"/opt/$TOOLCHAIN/bin/check-omnibus-package-signed" "$package_file"
-
-sudo rm -f "$package_file"
-
-echo "--- Verifying ownership of package files"
-
-NONROOT_FILES="$(find "$INSTALL_DIR" ! -user 0 -print)"
-if [[ "$NONROOT_FILES" == "" ]]; then
-  echo "Packages files are owned by root.  Continuing verification."
-else
-  echo "Exiting with an error because the following files are not owned by root:"
-  echo "$NONROOT_FILES"
-  exit 1
-fi
-
-echo "--- Running verification for $channel $product $version"
-
 # Our tests hammer YUM pretty hard and the EL6 testers get corrupted
 # after some period of time. Rebuilding the RPM database clears
 # up the underlying corruption. We'll do this each test run just to
@@ -56,16 +24,12 @@ mkdir -p "$TMPDIR"
 # Verify that we kill any orphaned test processes. Kill any orphaned rspec processes.
 sudo kill -9 $(ps ax | grep 'rspec' | grep -v grep | awk '{ print $1 }') || true
 
-PATH="/opt/$product/bin:$PATH"
-export PATH
-
-BIN_DIR="/opt/$product/bin"
-export BIN_DIR
+export PATH="/opt/chef/bin:$PATH"
+export BIN_DIR="/opt/chef/bin"
 
 # We don't want to add the embedded bin dir to the main PATH as this
 # could mask issues in our binstub shebangs.
-EMBEDDED_BIN_DIR="/opt/$product/embedded/bin"
-export EMBEDDED_BIN_DIR
+export EMBEDDED_BIN_DIR="/opt/chef/embedded/bin"
 
 # If we are on Mac our symlinks are located under /usr/local/bin
 # otherwise they are under /usr/bin
@@ -139,10 +103,10 @@ export FORCE_FFI_YAJL
 # most platforms provide "infocmp" by default via an "ncurses" package but SLES 11 and 12 provide it via "ncurses-devel" which
 # isn't typically installed. omnibus-toolchain has "infocmp" built-in so we add omnibus-toolchain to the PATH to ensure
 # tests will function properly.
-PATH="/opt/$TOOLCHAIN/bin:/usr/local/bin:/opt/$TOOLCHAIN/embedded/bin:$PATH"
+export PATH="/opt/${TOOLCHAIN:-omnibus-toolchain}/bin:/usr/local/bin:/opt/${TOOLCHAIN:-omnibus-toolchain}/embedded/bin:$PATH"
 
 # add chef's bin paths to PATH to ensure tests function properly
-PATH="/opt/$product/bin:/opt/$product/embedded/bin:$PATH"
+export PATH="/opt/chef/bin:/opt/chef/embedded/bin:$PATH"
 
 gem_list="$(gem which chef)"
 lib_dir="$(dirname "$gem_list")"


### PR DESCRIPTION
This logic has been moved into the Omnibus Buildkite Plugin.
These scripts can now be used outside of the Buildkite pipelines.

Signed-off-by: Tom Duffield <github@tomduffield.com>