### PR TITLE
Resource property validation should be aware of action-specific reqs

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -305,7 +305,7 @@ class Chef
     #
     def required?(action = nil)
       if !action.nil? && options[:required].is_a?(Array)
-        options[:required].include?(action)
+        (options[:required] & Array(action)).any?
       else
         !!options[:required]
       end
@@ -424,7 +424,9 @@ class Chef
         end
       end
 
-      if value.nil? && required?
+      action = resource.respond_to?(:action) ? resource.action : nil
+
+      if value.nil? && required?(action)
         raise Chef::Exceptions::ValidationFailed, "#{name} is a required property"
       else
         value
@@ -453,7 +455,9 @@ class Chef
         Chef.deprecated(:property, options[:deprecated])
       end
 
-      if value.nil? && required?
+      action = resource.respond_to?(:action) ? resource.action : nil
+
+      if value.nil? && required?(action)
         raise Chef::Exceptions::ValidationFailed, "#{name} is a required property"
       else
         value

--- a/spec/unit/property/validation_spec.rb
+++ b/spec/unit/property/validation_spec.rb
@@ -600,6 +600,36 @@ describe "Chef::Resource.property validation" do
       it "does not fail if it is not specified, on running the doit2 action" do
         expect { resource.run_action(:doit2) }.not_to raise_error
       end
+
+      context "when an action does not require it" do
+        before do
+          resource.action(:doit2)
+        end
+
+        it "retrieval succeeds if x is not set when resource uses the doit2 action" do
+          expect { resource.x }.not_to raise_error
+        end
+
+        it "succeeds with set to nil when resource uses the doit2 action" do
+          expect { resource.x nil }.not_to raise_error
+        end
+      end
+
+      context "when an action requires it" do
+        before do
+          # NOTE: this is already the default action, but it doesn't
+          # hurt to be clear about the situation.
+          resource.action(:doit)
+        end
+
+        it "if x is not specified, retrieval fails for the doit action" do
+          expect { resource.x }.to raise_error Chef::Exceptions::ValidationFailed
+        end
+
+        it "value nil is not valid for the doit action (required means 'not nil')" do
+          expect { resource.x nil }.to raise_error Chef::Exceptions::ValidationFailed
+        end
+      end
     end
 
     with_property ":x, String, required: true" do


### PR DESCRIPTION
Signed-off-by: Steve Abatangle <sabat@area51.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The `get` and `set` methods in the Property class, meant to be used by resources, validate that a property is required if its value is nil. However, they don't check to see whether the property was required for the *specific action* the resource is using, so any use of `get` and `set` will throw an exception if used with a resource that doesn't use a required property, even when the property is not required for that action.

That's a vague explanation, so I'll get specific: the current version of the chef-client cookbook has a recipe (cron.rb) with a resource that does a delete. When you try to get that resource, it throws an exception, explaining that `:command` is a required property—but it's only required for the `:create` action, not for `:delete`. https://github.com/chef-cookbooks/chef-client/blob/master/recipes/cron.rb#L94-L96

This PR simply fixes that by passing the resource's action to the `required?` method, and allows the `required?` method to compare arrays of actions rather than just expecting a single action.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).