### PR TITLE
Add warning for resources not running in unified_mode

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -249,6 +249,10 @@ class Chef
       target 32
     end
 
+    class UnifiedMode < Base
+      target 33
+    end
+
     class Generic < Base
       def url
         "https://docs.chef.io/chef_deprecations_client/"

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -53,6 +53,10 @@ class Chef
           resource_class.run_context = run_context
           resource_class.class_from_file(filename)
 
+          unless resource_class.unified_mode
+            Chef.deprecated :unified_mode, "The #{resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`"
+          end
+
           # Make a useful string for the class (rather than <Class:312894723894>)
           resource_class.instance_eval do
             define_singleton_method(:to_s) do

--- a/spec/data/lwrp/resources/bar.rb
+++ b/spec/data/lwrp/resources/bar.rb
@@ -1,2 +1,4 @@
+unified_mode true
+
 provides :lwrp_bar # This makes sure that we cover the case of lwrps using provides
 actions :pass_buck, :prepare_eyes, :watch_paint_dry

--- a/spec/data/lwrp/resources/buck_passer.rb
+++ b/spec/data/lwrp/resources/buck_passer.rb
@@ -1,3 +1,4 @@
+unified_mode true
 
 provides :buck_passer
 

--- a/spec/data/lwrp/resources/buck_passer_2.rb
+++ b/spec/data/lwrp/resources/buck_passer_2.rb
@@ -1,3 +1,4 @@
+unified_mode true
 
 default_action :pass_buck
 actions :pass_buck

--- a/spec/data/lwrp/resources/embedded_resource_accesses_providers_scope.rb
+++ b/spec/data/lwrp/resources/embedded_resource_accesses_providers_scope.rb
@@ -1,3 +1,4 @@
+unified_mode true
 
 default_action :twiddle_thumbs
 actions :twiddle_thumbs

--- a/spec/data/lwrp/resources/foo.rb
+++ b/spec/data/lwrp/resources/foo.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 actions :prepare_thumbs, :twiddle_thumbs
 default_action :pass_buck
 

--- a/spec/data/lwrp/resources/inline_compiler.rb
+++ b/spec/data/lwrp/resources/inline_compiler.rb
@@ -1,3 +1,4 @@
+unified_mode true
 
 default_action :test
 actions :test, :no_updates

--- a/spec/data/lwrp/resources/monkey_name_printer.rb
+++ b/spec/data/lwrp/resources/monkey_name_printer.rb
@@ -1,3 +1,4 @@
+unified_mode true
 
 property :monkey
 

--- a/spec/data/lwrp/resources/paint_drying_watcher.rb
+++ b/spec/data/lwrp/resources/paint_drying_watcher.rb
@@ -1,3 +1,4 @@
+unified_mode true
 
 default_action :prepare_eyes
 actions :prepare_eyes, :watch_paint_dry

--- a/spec/data/lwrp/resources/thumb_twiddler.rb
+++ b/spec/data/lwrp/resources/thumb_twiddler.rb
@@ -1,3 +1,4 @@
+unified_mode true
 
 default_action :prepare_thumbs
 actions :prepare_thumbs, :twiddle_thumbs

--- a/spec/data/lwrp/resources_with_default_attributes/nodeattr.rb
+++ b/spec/data/lwrp/resources_with_default_attributes/nodeattr.rb
@@ -1,1 +1,3 @@
+unified_mode true
+
 attribute :penguin, :kind_of => String, :default => node[:penguin_name]

--- a/spec/data/lwrp_const_scoping/resources/conflict.rb
+++ b/spec/data/lwrp_const_scoping/resources/conflict.rb
@@ -1,0 +1,1 @@
+unified_mode true

--- a/spec/data/lwrp_override/resources/foo.rb
+++ b/spec/data/lwrp_override/resources/foo.rb
@@ -1,4 +1,5 @@
 # Starting with Chef 12 reloading an LWRP shouldn't reload the file anymore
+unified_mode true
 
 actions :never_execute
 

--- a/spec/data/run_context/cookbooks/circular-dep1/resources/resource.rb
+++ b/spec/data/run_context/cookbooks/circular-dep1/resources/resource.rb
@@ -1,1 +1,2 @@
+unified_mode true
 LibraryLoadOrder.record('circular-dep1-resource')

--- a/spec/data/run_context/cookbooks/circular-dep2/resources/resource.rb
+++ b/spec/data/run_context/cookbooks/circular-dep2/resources/resource.rb
@@ -1,1 +1,2 @@
+unified_mode true
 LibraryLoadOrder.record('circular-dep2-resource')

--- a/spec/data/run_context/cookbooks/dependency1/resources/resource.rb
+++ b/spec/data/run_context/cookbooks/dependency1/resources/resource.rb
@@ -1,1 +1,2 @@
+unified_mode true
 LibraryLoadOrder.record('dependency1-resource')

--- a/spec/data/run_context/cookbooks/dependency2/resources/resource.rb
+++ b/spec/data/run_context/cookbooks/dependency2/resources/resource.rb
@@ -1,1 +1,2 @@
+unified_mode true
 LibraryLoadOrder.record('dependency2-resource')

--- a/spec/data/run_context/cookbooks/no-default-attr/resources/resource.rb
+++ b/spec/data/run_context/cookbooks/no-default-attr/resources/resource.rb
@@ -1,1 +1,2 @@
+unified_mode true
 LibraryLoadOrder.record('no-default-attr-resource')

--- a/spec/data/run_context/cookbooks/test-with-circular-deps/resources/resource.rb
+++ b/spec/data/run_context/cookbooks/test-with-circular-deps/resources/resource.rb
@@ -1,1 +1,3 @@
+unified_mode true
+
 LibraryLoadOrder.record('test-with-circular-deps-resource')

--- a/spec/data/run_context/cookbooks/test-with-deps/resources/resource.rb
+++ b/spec/data/run_context/cookbooks/test-with-deps/resources/resource.rb
@@ -1,1 +1,2 @@
+unified_mode true
 LibraryLoadOrder.record('test-with-deps-resource')

--- a/spec/data/run_context/cookbooks/test/resources/resource.rb
+++ b/spec/data/run_context/cookbooks/test/resources/resource.rb
@@ -1,1 +1,3 @@
+unified_mode true
+
 LibraryLoadOrder.record('test-resource')

--- a/spec/integration/recipes/accumulator_spec.rb
+++ b/spec/integration/recipes/accumulator_spec.rb
@@ -31,6 +31,8 @@ describe "Accumulators" do
     before do
       directory "cookbooks/x" do
         file "resources/email_alias.rb", <<-EOM
+          unified_mode true
+
           provides :email_alias
           resource_name :email_alias
 
@@ -54,6 +56,8 @@ describe "Accumulators" do
         EOM
 
         file "resources/nested.rb", <<-EOM
+          unified_mode true
+
           provides :nested
           resource_name :nested
 
@@ -70,6 +74,8 @@ describe "Accumulators" do
         EOM
 
         file "resources/doubly_nested.rb", <<-EOM
+          unified_mode true
+
           provides :doubly_nested
           resource_name :doubly_nested
 
@@ -133,6 +139,8 @@ describe "Accumulators" do
     before do
       directory "cookbooks/x" do
         file "resources/email_alias.rb", <<-EOM
+          unified_mode true
+
           provides :email_alias
           resource_name :email_alias
 
@@ -156,6 +164,8 @@ describe "Accumulators" do
         EOM
 
         file "resources/nested.rb", <<-EOM
+          unified_mode true
+
           provides :nested
           resource_name :nested
 
@@ -172,6 +182,8 @@ describe "Accumulators" do
         EOM
 
         file "resources/doubly_nested.rb", <<-EOM
+          unified_mode true
+
           provides :doubly_nested
           resource_name :doubly_nested
 

--- a/spec/integration/recipes/lwrp_inline_resources_spec.rb
+++ b/spec/integration/recipes/lwrp_inline_resources_spec.rb
@@ -118,6 +118,8 @@ describe "LWRPs with inline resources" do
       directory "cookbooks/x" do
 
         file "resources/do_nothing.rb", <<-EOM
+          unified_mode true
+
           actions :create, :nothing
           default_action :create
         EOM
@@ -127,6 +129,8 @@ describe "LWRPs with inline resources" do
         EOM
 
         file "resources/my_machine.rb", <<-EOM
+          unified_mode true
+
           actions :create, :nothing
           default_action :create
         EOM

--- a/spec/integration/recipes/lwrp_spec.rb
+++ b/spec/integration/recipes/lwrp_spec.rb
@@ -24,6 +24,8 @@ describe "LWRPs" do
       directory "cookbooks/l-w-r-p" do
 
         file "resources/foo.rb", <<~EOM
+          unified_mode true
+
           default_action :create
         EOM
         file "providers/foo.rb", <<~EOM

--- a/spec/integration/recipes/notifies_spec.rb
+++ b/spec/integration/recipes/notifies_spec.rb
@@ -63,6 +63,8 @@ describe "notifications" do
       directory "cookbooks/x" do
 
         file "resources/notifying_test.rb", <<~EOM
+          unified_mode true
+
           default_action :run
           provides :notifying_test
           resource_name :notifying_test
@@ -105,6 +107,8 @@ describe "notifications" do
       directory "cookbooks/x" do
 
         file "resources/notifying_test.rb", <<~EOM
+          unified_mode true
+
           default_action :run
           provides :notifying_test
           resource_name :notifying_test
@@ -152,6 +156,8 @@ describe "notifications" do
       directory "cookbooks/x" do
 
         file "resources/notifying_test.rb", <<~EOM
+          unified_mode true
+
           default_action :run
           provides :notifying_test
           resource_name :notifying_test
@@ -237,6 +243,8 @@ describe "notifications" do
       directory "cookbooks/x" do
 
         file "resources/notifying_test.rb", <<~EOM
+          unified_mode true
+
           default_action :run
           provides :notifying_test
           resource_name :notifying_test
@@ -278,6 +286,8 @@ describe "notifications" do
       directory "cookbooks/x" do
 
         file "resources/notifying_test.rb", <<~EOM
+          unified_mode true
+
           default_action :run
           provides :notifying_test
           resource_name :notifying_test
@@ -319,6 +329,8 @@ describe "notifications" do
       directory "cookbooks/x" do
 
         file "resources/notifying_test.rb", <<~EOM
+          unified_mode true
+
           default_action :run
           provides :notifying_test
           resource_name :notifying_test
@@ -357,6 +369,8 @@ describe "notifications" do
       directory "cookbooks/x" do
 
         file "resources/cloning_test.rb", <<~EOM
+          unified_mode true
+
           default_action :run
           provides :cloning_test
           resource_name :cloning_test

--- a/spec/integration/recipes/notifying_block_spec.rb
+++ b/spec/integration/recipes/notifying_block_spec.rb
@@ -68,6 +68,7 @@ describe "notifying_block" do
     before do
       directory "cookbooks/x" do
         file "resources/nb_test.rb", <<-EOM
+          unified_mode true
           default_action :run
           provides :nb_test
           resource_name :nb_test

--- a/spec/integration/recipes/use_partial_spec.rb
+++ b/spec/integration/recipes/use_partial_spec.rb
@@ -37,6 +37,7 @@ describe "notifying_block" do
           end
         EOM
         file "resources/thing.rb", <<-EOM
+          unified_mode true
           provides :thing
           use "shared_properties"
           action_class do
@@ -80,6 +81,8 @@ describe "notifying_block" do
         EOM
         # this tests relative pathing, including the underscore and including the trailing .rb all work
         file "resources/thing.rb", <<-EOM
+          unified_mode true
+
           provides :thing
           use "../partials/_shared_properties.rb"
           action_class do

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -576,7 +576,7 @@ describe "LWRP" do
       @tmpdir = File.join(@tmpparent, "lwrp")
       Dir.mkdir(@tmpdir)
       resource_path = File.join(@tmpdir, "once.rb")
-      IO.write(resource_path, "default_action :create")
+      IO.write(resource_path, "unified_mode true\ndefault_action :create")
       @test_lwrp_class = Chef::Resource::LWRPBase.build_from_file("lwrp", resource_path, nil)
     end
 


### PR DESCRIPTION
This also adds coverage in a way for crazy different ways of writing resources and that they just work correctly in unified_mode.