### PR TITLE
Fix location and resource_name of unified_mode deprecation message

### DIFF
--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -54,7 +54,7 @@ class Chef
           resource_class.class_from_file(filename)
 
           unless resource_class.unified_mode
-            Chef.deprecated :unified_mode, "The #{resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`"
+            Chef.deprecated :unified_mode, "The #{resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
           end
 
           # Make a useful string for the class (rather than <Class:312894723894>)

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -54,7 +54,7 @@ class Chef
           resource_class.class_from_file(filename)
 
           unless resource_class.unified_mode
-            Chef.deprecated :unified_mode, "The #{resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
+            Chef.deprecated :unified_mode, "The #{resource_class.resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
           end
 
           # Make a useful string for the class (rather than <Class:312894723894>)


### PR DESCRIPTION
This changes the deprecation warning from:

```
Deprecated features used!
  The test_test resource in the test cookbook should declare `unified_mode true` at 1 location:
    - /Users/lamont/.asdf/installs/ruby/3.0.0/lib/ruby/3.0.0/forwardable.rb:238:in `setup_run_context'
   See https://docs.chef.io/deprecations_unified_mode/ for further details.
```

To:

```
Deprecated features used!
  The test_me resource in the test cookbook should declare `unified_mode true` at 1 location:
    - /Users/lamont/zero/local-mode-cache/cache/cookbooks/test/resources/test.rb
   See https://docs.chef.io/deprecations_unified_mode/ for further details.
```