### PR TITLE
Make deprecation warning message more explicit

### DIFF
--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -56,7 +56,8 @@ class Chef
         # Print out deprecations.
         unless deprecations.empty?
           puts_line ""
-          puts_line "Deprecated features used!"
+          puts_line "Deprecation warnings that must be addressed before upgrading to Chef Infra #{Chef::VERSION.to_i + 1}:"
+          puts_line ""
           deprecations.each do |message, details|
             locations = details[:locations]
             if locations.size == 1

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -54,7 +54,7 @@ class Chef
           resource_class.class_from_file(filename)
 
           unless resource_class.unified_mode
-            Chef.deprecated :unified_mode, "The #{resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`"
+            Chef.deprecated :unified_mode, "The #{resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
           end
 
           # Make a useful string for the class (rather than <Class:312894723894>)

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -54,7 +54,7 @@ class Chef
           resource_class.class_from_file(filename)
 
           unless resource_class.unified_mode
-            Chef.deprecated :unified_mode, "The #{resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
+            Chef.deprecated :unified_mode, "The #{resource_class.resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
           end
 
           # Make a useful string for the class (rather than <Class:312894723894>)


### PR DESCRIPTION
There was some confusion around this message, make it clear
that it is a warning, and that the timeframe for fixing the
issues is before the next major version drops.
