### PR TITLE
Make CLI one of the default reporters for Compliance Phase

### DIFF
--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -28,7 +28,7 @@ class Chef
       # Controls what is done with the resulting report after the Chef InSpec run.
       # Accepts a single string value or an array of multiple values.
       # Accepted values: 'chef-server-automate', 'chef-automate', 'json-file', 'audit-enforcer', 'cli'
-      "reporter" => "json-file",
+      "reporter" => %w{json-file cli},
 
       # Controls if Chef InSpec profiles should be fetched from Chef Automate or Chef Infra Server
       # in addition to the default fetch locations provided by Chef Inspec.

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -234,7 +234,7 @@ describe Chef::Compliance::Runner do
       inputs = runner.inspec_opts[:inputs]
 
       expect(inputs["tacos"]).to eq("lunch")
-      expect(inputs["chef_node"]["audit"]["reporter"]).to eq("json-file")
+      expect(inputs["chef_node"]["audit"]["reporter"]).to eq(%w{json-file cli})
       expect(inputs["chef_node"]["chef_environment"]).to eq("_default")
     end
   end


### PR DESCRIPTION
This makes it much easier to use out of the box by showing something
real in addition to saving a file to disk.

Signed-off-by: Tim Smith <tsmith@chef.io>