### PR TITLE
Remove the ruby-prof gem from omnibus packages

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -57,7 +57,7 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -68,7 +68,7 @@ steps:
 - label: "Unit Ubuntu 18.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -92,7 +92,7 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -103,7 +103,7 @@ steps:
 - label: "Unit Ubuntu 20.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -126,7 +126,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - yum install -y crontabs e2fsprogs
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -137,7 +137,7 @@ steps:
 - label: "Unit CentOS 7 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -161,7 +161,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cronie insserv-compat
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -173,7 +173,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cron insserv-compat
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -196,7 +196,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -210,7 +210,7 @@ steps:
 - label: "Unit Fedora :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package ruby_prof
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         cd kitchen-tests
         $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
-        bundle config set without 'omnibus_package ruby_prof'
+        bundle config set without 'omnibus_package'
         bundle install --jobs=3 --retry=3 --path=vendor/bundle
         gem install berkshelf --no-doc
         # berks emits a ruby warning when it loads net/http due to a previously
@@ -82,7 +82,7 @@ jobs:
       id: run
       run: |
         cd kitchen-tests
-        sudo /opt/chef/embedded/bin/bundle config set without 'omnibus_package ruby_prof'
+        sudo /opt/chef/embedded/bin/bundle config set without 'omnibus_package'
         sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3 --path=vendor/bundle
         sudo /opt/chef/embedded/bin/gem install berkshelf --no-doc
         sudo /opt/chef/embedded/bin/berks vendor cookbooks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   chefstyle:
     runs-on: ubuntu-latest
     env:
-      BUNDLE_WITHOUT: ruby_shadow:ruby_prof:omnibus_package
+      BUNDLE_WITHOUT: ruby_shadow:omnibus_package
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -38,11 +38,6 @@ group(:omnibus_package, :pry) do
   gem "pry-stack_explorer"
 end
 
-# Everything except AIX
-group(:ruby_prof) do
-  gem "ruby-prof"
-end
-
 # Everything except AIX and Windows
 group(:ruby_shadow) do
   # if ruby-shadow does a release that supports ruby-3.0 this can be removed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,8 +329,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
-    ruby-prof (1.4.3)
-    ruby-prof (1.4.3-x64-mingw32)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     rubyntlm (0.6.3)
@@ -449,7 +447,6 @@ DEPENDENCIES
   rake
   rb-readline
   rspec
-  ruby-prof
   ruby-shadow!
   webmock
 

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -8,11 +8,6 @@ group(:development, :test) do
   gem "chef-bin", path: "../chef-bin"
 end
 
-group(:ruby_prof) do
-  # ruby-prof 1.3.0 does not compile on our centos6 builders/kitchen testers
-  gem "ruby-prof", "< 1.3.0"
-end
-
 group(:omnibus_package, :pry) do
   gem "pry"
   gem "pry-byebug"


### PR DESCRIPTION
It's a 5 meg gem on windows and it serves very little value.

Signed-off-by: Tim Smith <tsmith@chef.io>