### PR TITLE
Remove profile-ruby tests

### DIFF
--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -349,26 +349,6 @@ describe "chef-client" do
       expect(result.stdout).to include("Run List is [recipe[x::default]]")
       result.error!
     end
-
-    it "should complete with success when using --profile-ruby and output a profile file", :not_supported_on_aix do
-      file "config/client.rb", <<~EOM
-        local_mode true
-        cookbook_path "#{path_to("cookbooks")}"
-      EOM
-      result = shell_out!("#{chef_client} -c \"#{path_to("config/client.rb")}\" -o 'x::default' -z --profile-ruby", cwd: chef_dir)
-      result.error!
-      expect(File.exist?(path_to("config/local-mode-cache/cache/graph_profile.out"))).to be true
-    end
-
-    it "doesn't produce a profile when --profile-ruby is not present" do
-      file "config/client.rb", <<~EOM
-        local_mode true
-        cookbook_path "#{path_to("cookbooks")}"
-      EOM
-      result = shell_out!("#{chef_client} -c \"#{path_to("config/client.rb")}\" -o 'x::default' -z", cwd: chef_dir)
-      result.error!
-      expect(File.exist?(path_to("config/local-mode-cache/cache/graph_profile.out"))).to be false
-    end
   end
 
   when_the_repository "has a cookbook that outputs some node attributes" do


### PR DESCRIPTION
This test requires the gem and we removed the gem so we need to remove
the test

Signed-off-by: Tim Smith <tsmith@chef.io>