### PR TITLE
Fix systemd service state detection

### DIFF
--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -80,7 +80,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     @systemd_service_status ||= begin
       # Collect all the status information for a service and returns it at once
       options, args = get_systemctl_options_args
-      s = shell_out!(systemctl_path, args, "show", "-p", "UnitFileState", "-p", "ActiveState", new_resource.service_name, options)
+      s = shell_out!(systemctl_path, args, "show", "-p", "UnitFileState", "-p", "ActiveState", new_resource.service_name, **options)
       # e.g. /bin/systemctl --system show  -p UnitFileState -p ActiveState sshd.service
       # Returns something like:
       # ActiveState=active

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -313,7 +313,7 @@ describe Chef::Provider::Service::Systemd do
 
       def with_systemctl_show(systemctl_path, stdout)
         systemctl_show = [systemctl_path, "--system", "show", "-p", "UnitFileState", "-p", "ActiveState", service_name]
-        expect(provider).to receive(:shell_out!).with(*systemctl_show, {}).and_return(double(stdout: stdout, exitstatus: 0, error?: false))
+        expect(provider).to receive(:shell_out!).with(*systemctl_show).and_return(double(stdout: stdout, exitstatus: 0, error?: false))
       end
 
       describe "systemd_service_status" do
@@ -341,7 +341,7 @@ describe Chef::Provider::Service::Systemd do
 
         it "should error if '#{systemctl_path} --system show -p UnitFileState -p ActiveState service_name' returns non 0" do
           systemctl_show = [systemctl_path, "--system", "show", "-p", "UnitFileState", "-p", "ActiveState", service_name]
-          allow(provider).to receive(:shell_out!).with(*systemctl_show, {}).and_return(shell_out_failure)
+          allow(provider).to receive(:shell_out!).with(*systemctl_show).and_return(shell_out_failure)
           expect { provider.systemd_service_status }.to raise_error(Chef::Exceptions::Service)
         end
       end


### PR DESCRIPTION
Resolves #11496

This adds a missing double splat which is required when using Ruby 3.0.

I confirmed this fixes an issue I was noticing while working on the etcd cookbook.

Signed-off-by: Lance Albertson <lance@osuosl.org>
