### PR TITLE
Enable deprecation warnings in our specs

### DIFF
--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -160,13 +160,13 @@ class Chef
       def metadata_filenames
         return @metadata_filenames unless @metadata_filenames.empty?
 
-        if File.exists?(File.join(cookbook_path, UPLOADED_COOKBOOK_VERSION_FILE))
+        if File.exist?(File.join(cookbook_path, UPLOADED_COOKBOOK_VERSION_FILE))
           @uploaded_cookbook_version_file = File.join(cookbook_path, UPLOADED_COOKBOOK_VERSION_FILE)
         end
 
-        if File.exists?(File.join(cookbook_path, "metadata.json"))
+        if File.exist?(File.join(cookbook_path, "metadata.json"))
           @metadata_filenames << File.join(cookbook_path, "metadata.json")
-        elsif File.exists?(File.join(cookbook_path, "metadata.rb"))
+        elsif File.exist?(File.join(cookbook_path, "metadata.rb"))
           @metadata_filenames << File.join(cookbook_path, "metadata.rb")
         elsif uploaded_cookbook_version_file
           @metadata_filenames << uploaded_cookbook_version_file

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,9 @@ module Shell
   IRB = nil unless defined? IRB
 end
 
+# show the deprecation warnings
+Warning[:deprecated] = true
+
 $LOAD_PATH.unshift File.expand_path("..", __dir__)
 
 $LOAD_PATH.unshift File.expand_path("../chef-config/lib", __dir__)


### PR DESCRIPTION
This will give us a bit of a prewarning before Ruby breaks our code (assuming we exercise it with a spec)
Signed-off-by: Tim Smith <tsmith@chef.io>