### PR TITLE
Fix bug causing systemd units to always re-enable and re-start

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -60,7 +60,7 @@ class Chef
           # Collect all the status information for a unit and return it at once
           # This may fail if we are managing a template unit (e.g. with '@'), in which case
           # we just ignore the error because unit status is irrelevant in that case
-          s = shell_out(*systemctl_cmd, "show", "-p", "UnitFileState", "-p", "ActiveState", new_resource.unit_name, systemctl_opts)
+          s = shell_out(*systemctl_cmd, "show", "-p", "UnitFileState", "-p", "ActiveState", new_resource.unit_name, **systemctl_opts)
           # e.g. /bin/systemctl --system show -p UnitFileState -p ActiveState syslog.socket
           # Returns something like:
           # ActiveState=inactive

--- a/spec/unit/provider/systemd_unit_spec.rb
+++ b/spec/unit/provider/systemd_unit_spec.rb
@@ -814,7 +814,7 @@ describe Chef::Provider::SystemdUnit, :linux_only do
 
       def with_systemctl_show(systemctl_path, instance, opts, stdout)
         systemctl_show = [systemctl_path, instance, "show", "-p", "UnitFileState", "-p", "ActiveState", unit_name]
-        expect(provider).to receive(:shell_out).with(*systemctl_show, opts).and_return(double(stdout: stdout, exitstatus: 0, error?: false))
+        expect(provider).to receive(:shell_out).with(*systemctl_show, **opts).and_return(double(stdout: stdout, exitstatus: 0, error?: false))
       end
 
       describe "systemd_unit_status" do
@@ -841,7 +841,7 @@ describe Chef::Provider::SystemdUnit, :linux_only do
           current_resource.unit_name("foo@.service")
           template_error = "Failed to get properties: Unit name foo@.service is neither a valid invocation ID nor unit name."
           systemctl_show = [systemctl_path, "--system", "show", "-p", "UnitFileState", "-p", "ActiveState", "foo@.service"]
-          expect(provider).to receive(:shell_out).with(*systemctl_show, {}).and_return(double(stdout: "", stderr: template_error, exitstatus: 1, error?: true))
+          expect(provider).to receive(:shell_out).with(*systemctl_show).and_return(double(stdout: "", stderr: template_error, exitstatus: 1, error?: true))
           expect(provider.systemd_unit_status).to eql({})
         end
       end


### PR DESCRIPTION
## Description

In #10925 the method of fetching the current systemd unit status was changed.
In this change a typo was introduced which caused the systemctl command which
should look like this

`/usr/bin/systemctl --system show -p UnitFileState -p ActiveState apache2.service`

to instead look like this

`/usr/bin/systemctl --system show -p UnitFileState -p ActiveState apache2.service {}`

The result is that instead of a response like this

```
ActiveState=active
UnitFileState=enabled
```

Chef gets

```
ActiveState=active
UnitFileState=enabled

ActiveState=inactive
UnitFileState=
```

which is the status of the service followed by the status of a bogus service called "{}"

This results in Chef always thinking that systemd unit's are not active and not enabled
and every Chef run attempts to enable and start the already enabled and started services.

This is the same type of issue that was fixed in #11497 which applied to the systemd provider. That bug was introduced in #10776.

This fixes the bug by expanding the splat with a preceding `**`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
