### PR TITLE
Fix yum specs

### DIFF
--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -76,6 +76,7 @@ class Chef
               stderr.close unless stderr.nil?
               inpipe.close unless inpipe.nil?
               outpipe.close unless outpipe.nil?
+              stdin = stdout = stderr = inpipe = outpipe = wait_thr = nil
             end
           end
 

--- a/spec/unit/provider/package/yum/python_helper_spec.rb
+++ b/spec/unit/provider/package/yum/python_helper_spec.rb
@@ -21,6 +21,7 @@ require "spec_helper"
 
 describe Chef::Provider::Package::Yum::PythonHelper do
   let(:helper) { Chef::Provider::Package::Yum::PythonHelper.instance }
+  before(:each) { Singleton.__init__(Chef::Provider::Package::Yum::PythonHelper) }
 
   it "propagates stacktraces on stderr from the forked subprocess", :rhel do
     allow(helper).to receive(:yum_command).and_return("ruby -e 'raise \"your hands in the air\"'")


### PR DESCRIPTION
Reset the singleton instance before starting the test, because
singletons.

Also better clears up some internal state when the daemon gets reaped
