### PR TITLE
windows_security_policy: Add AuditPolicyChange and LockoutDuration capabilities

### DIFF
--- a/lib/chef/resource/windows_security_policy.rb
+++ b/lib/chef/resource/windows_security_policy.rb
@@ -28,6 +28,7 @@ class Chef
 
       # The valid policy_names options found here
       # https://github.com/ChrisAWalker/cSecurityOptions under 'AccountSettings'
+      # This needs to be revisited - the list at the link above is non-exhaustive and is missing a couple of items
       policy_names = %w{LockoutDuration
                         MaximumPasswordAge
                         MinimumPasswordAge

--- a/lib/chef/resource/windows_security_policy.rb
+++ b/lib/chef/resource/windows_security_policy.rb
@@ -36,6 +36,8 @@ class Chef
                         PasswordHistorySize
                         LockoutBadCount
                         ResetLockoutCount
+                        AuditPolicyChange
+                        LockoutDuration
                         RequireLogonToChangePassword
                         ForceLogoffWhenHourExpire
                         NewAdministratorName


### PR DESCRIPTION
'LockoutThreshold' is actually implemented by Windows as LockoutBadCouunt. What shows up in an Account Lockout Policy is Account Lockout Threshold but what gets written to disk when you change it is LockoutBadCount. That item is available in the list of existing policy objects. I updated the code to add AuditPolicyChange; that was missing. I also added ResetLockoutCount which pairs with the Lockout Threshold so users aren't permanently locked out. The last item, LockoutObservationWindow, does not appear in a Security Policy as exported by secedit but you can get to it via PowerShell. It is part of a customized fine grain password policy. [Read more here:](http://woshub.com/fine-grained-password-policy-in-windows-server-2012-r2/) 

Signed-off-by: John McCrae <jmccrae@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
