### PR TITLE
DNF provider update

### DIFF
--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -78,12 +78,12 @@ def version_tuple(versionstr):
 def versioncompare(versions):
     sack = get_sack()
     if (versions[0] is None) or (versions[1] is None):
-      outpipe.write('0\n')
-      outpipe.flush()
+        outpipe.write('0\n')
+        outpipe.flush()
     else:
-      evr_comparison = dnf.rpm.rpm.labelCompare(version_tuple(versions[0]), version_tuple(versions[1]))
-      outpipe.write('{}\n'.format(evr_comparison))
-      outpipe.flush()
+        evr_comparison = dnf.rpm.rpm.labelCompare(version_tuple(versions[0]), version_tuple(versions[1]))
+        outpipe.write('{}\n'.format(evr_comparison))
+        outpipe.flush()
 
 def query(command):
     sack = get_sack()
@@ -152,20 +152,21 @@ def setup_exit_handler():
     signal.signal(signal.SIGQUIT, exit_handler)
 
 if len(sys.argv) < 3:
-  inpipe = sys.stdin
-  outpipe = sys.stdout
+    inpipe = sys.stdin
+    outpipe = sys.stdout
 else:
-  inpipe = os.fdopen(int(sys.argv[1]), "r")
-  outpipe = os.fdopen(int(sys.argv[2]), "w")
+    os.set_blocking(int(sys.argv[1]), True)
+    inpipe = os.fdopen(int(sys.argv[1]), "r")
+    outpipe = os.fdopen(int(sys.argv[2]), "w")
 
 try:
+    setup_exit_handler()
     while 1:
         # stop the process if the parent proc goes away
         ppid = os.getppid()
         if ppid == 1:
             raise RuntimeError("orphaned")
 
-        setup_exit_handler()
         line = inpipe.readline()
 
         # only way to detect EOF in python

--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -52,7 +52,6 @@ class Chef
           end
 
           def start
-            ENV["PYTHONUNBUFFERED"] = "1"
             @inpipe, inpipe_write = IO.pipe
             outpipe_read, @outpipe = IO.pipe
             @stdin, @stdout, @stderr, @wait_thr = Open3.popen3("#{dnf_command} #{outpipe_read.fileno} #{inpipe_write.fileno}", outpipe_read.fileno => outpipe_read, inpipe_write.fileno => inpipe_write, close_others: false)
@@ -75,6 +74,7 @@ class Chef
               stderr.close unless stderr.nil?
               inpipe.close unless inpipe.nil?
               outpipe.close unless outpipe.nil?
+              @stdin = @stdout = @stderr = @inpipe = @outpipe = @wait_thr = nil
             end
           end
 
@@ -114,7 +114,7 @@ class Chef
             query_output = query(action, parameters)
             version = parse_response(query_output.lines.last)
             Chef::Log.trace "parsed #{version} from python helper"
-            restart unless repo_opts.empty?
+            reap unless repo_opts.empty?
             version
           end
 
@@ -148,10 +148,11 @@ class Chef
             with_helper do
               json = build_query(action, parameters)
               Chef::Log.trace "sending '#{json}' to python helper"
-              outpipe.syswrite json + "\n"
-              output = inpipe.sysread(4096).chomp
+              outpipe.puts json
+              outpipe.flush
+              output = inpipe.readline.chomp
               Chef::Log.trace "got '#{output}' from python helper"
-              return output
+              output
             end
           end
 
@@ -199,13 +200,13 @@ class Chef
               Chef::Log.trace "discarding output on stderr/stdout from python helper: #{output}"
             end
             ret
-          rescue EOFError, Errno::EPIPE, Timeout::Error, Errno::ESRCH => e
+          rescue => e
             output = drain_fds
-            if ( max_retries -= 1 ) > 0
+            restart
+            if ( max_retries -= 1 ) > 0 && !ENV["DNF_HELPER_NO_RETRIES"]
               unless output.empty?
                 Chef::Log.trace "discarding output on stderr/stdout from python helper: #{output}"
               end
-              restart
               retry
             else
               raise e if output.empty?

--- a/spec/functional/resource/dnf_package_spec.rb
+++ b/spec/functional/resource/dnf_package_spec.rb
@@ -18,12 +18,10 @@
 require "spec_helper"
 require "chef/mixin/shell_out"
 
-# run this test only for following platforms.
-# TODO: 2021-04-23 we removed 'fedora' from this list because our fedora functional tests
-#                  are consistently timing out in BuildKite.  Once we've addressed this (see issue chef/11414)
-#                  we will re-add the platform.
-exclude_test = !(%w{rhel amazon}.include?(ohai[:platform_family]) && File.exist?("/usr/bin/dnf"))
+# test on any fedora-ish platform with dnf
+exclude_test = !(%w{rhel amazon fedora}.include?(OHAI_SYSTEM[:platform_family]) && File.exist?("/usr/bin/dnf"))
 describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
+  include RecipeDSLHelper
   include Chef::Mixin::ShellOut
 
   # NOTE: every single test here either needs to explicitly call flush_cache or needs to explicitly
@@ -33,7 +31,7 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
   def flush_cache
     # needed on at least fc23/fc24 sometimes to deal with the dnf cache getting out of sync with the rpm db
     FileUtils.rm_f "/var/cache/dnf/@System.solv"
-    Chef::Resource::DnfPackage.new("shouldnt-matter", run_context).run_action(:flush_cache)
+    Chef::Provider::Package::Dnf::PythonHelper.instance.reap
   end
 
   def preinstall(*rpms)
@@ -43,11 +41,17 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
     flush_cache
   end
 
+  def expect_matching_installed_version(version)
+    expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(version)
+  end
+
   before(:all) do
     shell_out!("dnf -y install dnf-plugins-core")
   end
 
   before(:each) do
+    # force errors to fail and not retry
+    ENV["DNF_HELPER_NO_RETRIES"] = "true"
     File.open("/etc/yum.repos.d/chef-dnf-localtesting.repo", "w+") do |f|
       f.write <<~EOF
         [chef-dnf-localtesting]
@@ -57,6 +61,7 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         gpgcheck=0
       EOF
     end
+    # ensure we don't have any stray chef_rpms installed
     shell_out!("rpm -qa --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' | grep chef_rpm | xargs -r rpm -e")
     # next line is useful cleanup if you happen to have been testing both yum + dnf func tests on the same box and
     # have some yum garbage left around
@@ -68,64 +73,71 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
     FileUtils.rm_f "/etc/yum.repos.d/chef-dnf-localtesting.repo"
   end
 
-  let(:run_context) do
-    Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
-  end
-
-  let(:package_name) { "chef_rpm" }
-  let(:dnf_package) { Chef::Resource::DnfPackage.new(package_name, run_context) }
+  let(:default_options) { "--nogpgcheck --disablerepo=* --enablerepo=chef-dnf-localtesting" }
 
   def pkg_arch
-    ohai[:kernel][:machine]
+    OHAI_SYSTEM[:kernel][:machine]
   end
 
   describe ":install" do
     context "vanilla use case" do
-      let(:package_name) { "chef_rpm" }
-
       it "installs if the package is not installed" do
         flush_cache
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
       end
 
       it "does not install if the package is installed" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "does not install twice" do
         flush_cache
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
       end
 
       it "does not install if the prior version package is installed" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "does not install if the i686 package is installed", :intel_64bit do
         skip "FIXME: do nothing, or install the #{pkg_arch} version?"
         preinstall("chef_rpm-1.10-1.i686.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.i686$")
       end
 
       it "does not install if the prior version i686 package is installed", :intel_64bit do
         skip "FIXME: do nothing, or install the #{pkg_arch} version?"
         preinstall("chef_rpm-1.2-1.i686.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.i686$")
       end
     end
@@ -134,72 +146,81 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       %w{1.10 1* 1.10-1 1*-1 1.10-* 1*-* 0:1.10 0:1* 0:1.10-1 0:1*-1 *:1.10-* *:1*-*}.each do |vstring|
         it "installs the rpm when #{vstring} is in the package_name" do
           flush_cache
-          dnf_package.package_name("chef_rpm-#{vstring}")
-          dnf_package.run_action(:install)
-          expect(dnf_package.updated_by_last_action?).to be true
+          dnf_package "chef_rpm-#{vstring}" do
+            options default_options
+            action :install
+          end.should_be_updated
         end
 
         it "is idempotent when #{vstring} is in the package_name" do
           preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-          dnf_package.package_name("chef_rpm-#{vstring}")
-          dnf_package.run_action(:install)
-          expect(dnf_package.updated_by_last_action?).to be false
+          dnf_package "chef_rpm-#{vstring}" do
+            options default_options
+            action :install
+          end.should_not_be_updated
         end
 
         it "installs the rpm when #{vstring} is in the version property" do
           flush_cache
-          dnf_package.package_name("chef_rpm")
-          dnf_package.version(vstring)
-          dnf_package.run_action(:install)
-          expect(dnf_package.updated_by_last_action?).to be true
+          dnf_package "chef_rpm" do
+            options default_options
+            version vstring
+            action :install
+          end.should_be_updated
         end
 
         it "is idempotent when #{vstring} is in the version property" do
           preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-          dnf_package.package_name("chef_rpm")
-          dnf_package.version(vstring)
-          dnf_package.run_action(:install)
-          expect(dnf_package.updated_by_last_action?).to be false
+          dnf_package "chef_rpm" do
+            options default_options
+            version vstring
+            action :install
+          end.should_not_be_updated
         end
 
         it "upgrades the rpm when #{vstring} is in the package_name" do
           flush_cache
-          dnf_package.package_name("chef_rpm-#{vstring}")
-          dnf_package.run_action(:upgrade)
-          expect(dnf_package.updated_by_last_action?).to be true
+          dnf_package "chef_rpm-#{vstring}" do
+            options default_options
+            action :upgrade
+          end.should_be_updated
         end
 
         it "is idempotent when #{vstring} is in the package_name" do
           preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-          dnf_package.package_name("chef_rpm-#{vstring}")
-          dnf_package.run_action(:upgrade)
-          expect(dnf_package.updated_by_last_action?).to be false
+          dnf_package "chef_rpm-#{vstring}" do
+            options default_options
+            action :upgrade
+          end.should_not_be_updated
         end
 
         it "upgrades the rpm when #{vstring} is in the version property" do
           flush_cache
-          dnf_package.package_name("chef_rpm")
-          dnf_package.version(vstring)
-          dnf_package.run_action(:upgrade)
-          expect(dnf_package.updated_by_last_action?).to be true
+          dnf_package "chef_rpm" do
+            options default_options
+            version vstring
+            action :upgrade
+          end.should_be_updated
         end
 
         it "is idempotent when #{vstring} is in the version property" do
           preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-          dnf_package.package_name("chef_rpm")
-          dnf_package.version(vstring)
-          dnf_package.run_action(:upgrade)
-          expect(dnf_package.updated_by_last_action?).to be false
+          dnf_package "chef_rpm" do
+            options default_options
+            version vstring
+            action :upgrade
+          end.should_not_be_updated
         end
       end
 
       %w{1.2 1* 1.2-1 1*-1 1.2-* 1*-* 0:1.2 0:1* 0:1.2-1 0:1*-1 *:1.2-* *:1*-*}.each do |vstring|
         it "is idempotent when #{vstring} is in the version property and there is a candidate version" do
           preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-          dnf_package.package_name("chef_rpm")
-          dnf_package.version(vstring)
-          dnf_package.run_action(:install)
-          expect(dnf_package.updated_by_last_action?).to be false
+          dnf_package "chef_rpm" do
+            options default_options
+            version vstring
+            action :install
+          end.should_not_be_updated
           expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
         end
       end
@@ -207,10 +228,11 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       %w{1.2 1.2-1 1.2-* 0:1.2 0:1.2-1 *:1.2-*}.each do |vstring|
         it "is idempotent when #{vstring} is in the version property on upgrade and it doesn't match the candidate version" do
           preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-          dnf_package.package_name("chef_rpm")
-          dnf_package.version(vstring)
-          dnf_package.run_action(:upgrade)
-          expect(dnf_package.updated_by_last_action?).to be false
+          dnf_package "chef_rpm" do
+            options default_options
+            version vstring
+            action :upgrade
+          end.should_not_be_updated
           expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
         end
       end
@@ -218,13 +240,17 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       %w{1* 1*-1 1*-* 0:1* 0:1*-1 *:1*-*}.each do |vstring|
         it "upgrades when #{vstring} is in the version property on upgrade and it matches the candidate version" do
           preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-          dnf_package.package_name("chef_rpm")
-          dnf_package.version(vstring)
-          dnf_package.run_action(:upgrade)
-          expect(dnf_package.updated_by_last_action?).to be true
+          dnf_package "chef_rpm" do
+            options default_options
+            version vstring
+            action :upgrade
+          end.should_be_updated
           expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-          dnf_package.run_action(:upgrade)
-          expect(dnf_package.updated_by_last_action?).to be false
+          dnf_package "chef_rpm" do
+            options default_options
+            version vstring
+            action :upgrade
+          end.should_not_be_updated
         end
       end
     end
@@ -232,82 +258,106 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
     context "with versions or globs in the name" do
       it "works with a version" do
         flush_cache
-        dnf_package.package_name("chef_rpm-1.10")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.10" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.10" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "works with an older version" do
         flush_cache
-        dnf_package.package_name("chef_rpm-1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.2" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "works with an evra" do
         flush_cache
-        dnf_package.package_name("chef_rpm-0:1.2-1.#{pkg_arch}")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-0:1.2-1.#{pkg_arch}" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-0:1.2-1.#{pkg_arch}" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "works with version and release" do
         flush_cache
-        dnf_package.package_name("chef_rpm-1.2-1")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.2-1" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.2-1" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "works with a version glob" do
         flush_cache
-        dnf_package.package_name("chef_rpm-1*")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1*" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1*" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "works with a name glob + version glob" do
         flush_cache
-        dnf_package.package_name("chef_rp*-1*")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rp*-1*" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rp*-1*" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "upgrades when the installed version does not match the version string" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm-1.10")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.10" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.10" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "downgrades when the installed version is higher than the package_name version" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm-1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.2" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
     end
 
@@ -315,68 +365,92 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
     context "with version property" do
       it "matches the full version" do
         flush_cache
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1.10")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10"
+          action :install
+        end.should_not_be_updated
       end
 
       it "matches with a glob" do
         flush_cache
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1*")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1*"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1*"
+          action :install
+        end.should_not_be_updated
       end
 
       it "matches the vr" do
         flush_cache
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1.10-1")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10-1"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10-1"
+          action :install
+        end.should_not_be_updated
       end
 
       it "matches the evr" do
         flush_cache
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("0:1.10-1")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "0:1.10-1"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "0:1.10-1"
+          action :install
+        end.should_not_be_updated
       end
 
       it "matches with a vr glob", :rhel_gte_8 do
         flush_cache
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1.10-1*")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10-1*"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10-1*"
+          action :install
+        end.should_not_be_updated
       end
 
       it "matches with an evr glob", :rhel_gte_8 do
         flush_cache
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("0:1.10-1*")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "0:1.10-1*"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "0:1.10-1*"
+          action :install
+        end.should_not_be_updated
       end
     end
 
@@ -384,274 +458,345 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       it "downgrades the package when allow_downgrade" do
         flush_cache
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1.2-1")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.2-1"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.2-1"
+          action :install
+        end.should_not_be_updated
       end
     end
 
     context "with arches", :intel_64bit do
       it "installs with 64-bit arch in the name" do
         flush_cache
-        dnf_package.package_name("chef_rpm.#{pkg_arch}")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "installs with 32-bit arch in the name" do
         flush_cache
-        dnf_package.package_name("chef_rpm.i686")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm.i686" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.i686$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.i686" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "installs with 64-bit arch in the property" do
         flush_cache
-        dnf_package.package_name("chef_rpm")
-        dnf_package.arch((pkg_arch).to_s)
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          arch pkg_arch
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          arch pkg_arch
+          action :install
+        end.should_not_be_updated
       end
 
       it "installs with 32-bit arch in the property" do
         flush_cache
-        dnf_package.package_name("chef_rpm")
-        dnf_package.arch("i686")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          arch "i686"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.i686$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          arch "i686"
+          action :install
+        end.should_not_be_updated
       end
 
       it "installs when the 32-bit arch is in the name and the version is in the property" do
         flush_cache
-        dnf_package.package_name("chef_rpm.i686")
-        dnf_package.version("1.10-1")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm.i686" do
+          options default_options
+          version "1.10-1"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.i686$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.i686" do
+          options default_options
+          version "1.10-1"
+          action :install
+        end.should_not_be_updated
       end
 
       it "installs when the 64-bit arch is in the name and the version is in the property" do
         flush_cache
-        dnf_package.package_name("chef_rpm.#{pkg_arch}")
-        dnf_package.version("1.10-1")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          version "1.10-1"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          version "1.10-1"
+          action :install
+        end.should_not_be_updated
       end
     end
 
     context "with constraints" do
       it "with nothing installed, it installs the latest version" do
         flush_cache
-        dnf_package.package_name("chef_rpm >= 1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm >= 1.2" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm >= 1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "when it is met, it does nothing" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm >= 1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm >= 1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "when it is met, it does nothing" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm >= 1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm >= 1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
       end
 
       it "with nothing installed, it installs the latest version" do
         flush_cache
-        dnf_package.package_name("chef_rpm > 1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "when it is not met by an installed rpm, it upgrades" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm > 1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "with an equality constraint, when it is not met by an installed rpm, it upgrades" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm = 1.10")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm = 1.10" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm = 1.10" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "with an equality constraint, when it is met by an installed rpm, it does nothing" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm = 1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm = 1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "when it is met by an installed rpm, it does nothing" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm > 1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
       end
 
       it "when there is no solution to the contraint" do
         flush_cache
-        dnf_package.package_name("chef_rpm > 2.0")
-        expect { dnf_package.run_action(:install) }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
+        expect {
+          dnf_package "chef_rpm > 2.0"
+        }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
       end
 
       it "when there is no solution to the contraint but an rpm is preinstalled" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm > 2.0")
-        expect { dnf_package.run_action(:install) }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
+        expect {
+          dnf_package "chef_rpm > 2.0"
+        }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
       end
 
       it "with a less than constraint, when nothing is installed, it installs" do
         flush_cache
-        dnf_package.package_name("chef_rpm < 1.10")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "with a less than constraint, when the install version matches, it does nothing" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm < 1.10")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "with a less than constraint, when the install version fails, it should downgrade" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm < 1.10")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
     end
 
     context "with source arguments" do
       it "raises an exception when the package does not exist" do
         flush_cache
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/this-file-better-not-exist.rpm")
-        expect { dnf_package.run_action(:install) }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
+        expect {
+          dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/this-file-better-not-exist.rpm"
+        }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
       end
 
       it "does not raise a hard exception in why-run mode when the package does not exist" do
         Chef::Config[:why_run] = true
         flush_cache
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/this-file-better-not-exist.rpm")
-        dnf_package.run_action(:install)
-        expect { dnf_package.run_action(:install) }.not_to raise_error
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/this-file-better-not-exist.rpm" do
+          options default_options
+          action :install
+        end
       end
 
       it "installs the package when using the source argument" do
         flush_cache
-        dnf_package.name "something"
-        dnf_package.package_name "somethingelse"
-        dnf_package.source("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "something" do
+          source("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
+          options default_options
+          package_name "somethingelse"
+          name "something"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "something" do
+          source("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
+          options default_options
+          package_name "somethingelse"
+          name "something"
+          action :install
+        end.should_not_be_updated
       end
 
       it "installs the package when the name is a path to a file" do
         flush_cache
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "downgrade on a local file with allow_downgrade true works" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.version "1.2-1"
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          version "1.2-1"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          version "1.2-1"
+          action :install
+        end.should_not_be_updated
       end
 
       it "does not downgrade the package with :install" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
       end
 
       it "does not upgrade the package with :install" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.10-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "is idempotent when the package is already installed" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "is idempotent when the package is already installed and there is a version string" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.version "1.2-1"
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          version "1.2-1"
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
     end
@@ -660,142 +805,183 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       it "works when a package is installed" do
         FileUtils.rm_f "/etc/yum.repos.d/chef-dnf-localtesting.repo"
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options "--nogpgcheck --disablerepo=*"
+          action :install
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "works with a local source" do
         FileUtils.rm_f "/etc/yum.repos.d/chef-dnf-localtesting.repo"
         flush_cache
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options "--nogpgcheck --disablerepo=*"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options "--nogpgcheck --disablerepo=*"
+          action :install
+        end.should_not_be_updated
       end
     end
 
     context "multipackage with arches", :intel_64bit do
       it "installs two rpms" do
         flush_cache
-        dnf_package.package_name([ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] )
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package [ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package [ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "does nothing if both are installed" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm", "chef_rpm-1.10-1.i686.rpm")
         flush_cache
-        dnf_package.package_name([ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] )
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package [ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "installs the second rpm if the first is installed" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name([ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] )
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package [ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package [ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       it "installs the first rpm if the second is installed" do
         preinstall("chef_rpm-1.10-1.i686.rpm")
-        dnf_package.package_name([ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] )
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package [ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] do
+          options default_options
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package [ "chef_rpm.#{pkg_arch}", "chef_rpm.i686" ] do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       # unlikely to work consistently correct, okay to deprecate the arch-array in favor of the arch in the name
       it "installs two rpms with multi-arch" do
         flush_cache
-        dnf_package.package_name(%w{chef_rpm chef_rpm} )
-        dnf_package.arch([pkg_arch, "i686"])
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package %w{chef_rpm chef_rpm} do
+          options default_options
+          arch [pkg_arch, "i686"]
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package %w{chef_rpm chef_rpm} do
+          options default_options
+          arch [pkg_arch, "i686"]
+          action :install
+        end.should_not_be_updated
       end
 
       # unlikely to work consistently correct, okay to deprecate the arch-array in favor of the arch in the name
       it "installs the second rpm if the first is installed (muti-arch)" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name(%w{chef_rpm chef_rpm} )
-        dnf_package.arch([pkg_arch, "i686"])
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package %w{chef_rpm chef_rpm} do
+          options default_options
+          arch [pkg_arch, "i686"]
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package %w{chef_rpm chef_rpm} do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       # unlikely to work consistently correct, okay to deprecate the arch-array in favor of the arch in the name
       it "installs the first rpm if the second is installed (muti-arch)" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name(%w{chef_rpm chef_rpm} )
-        dnf_package.arch([pkg_arch, "i686"])
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package %w{chef_rpm chef_rpm} do
+          options default_options
+          arch [pkg_arch, "i686"]
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package %w{chef_rpm chef_rpm} do
+          options default_options
+          action :install
+        end.should_not_be_updated
       end
 
       # unlikely to work consistently correct, okay to deprecate the arch-array in favor of the arch in the name
       it "does nothing if both are installed (muti-arch)" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm", "chef_rpm-1.10-1.i686.rpm")
-        dnf_package.package_name(%w{chef_rpm chef_rpm} )
-        dnf_package.arch([pkg_arch, "i686"])
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package %w{chef_rpm chef_rpm} do
+          options default_options
+          arch [pkg_arch, "i686"]
+          action :install
+        end.should_not_be_updated
       end
     end
 
     context "repo controls" do
       it "should fail with the repo disabled" do
         flush_cache
-        dnf_package.options("--disablerepo=chef-dnf-localtesting")
-        expect { dnf_package.run_action(:install) }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
+        expect {
+          dnf_package "chef_rpm" do
+            options "--nogpgcheck --disablerepo=chef-dnf-localtesting"
+            action :install
+          end
+        }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
       end
 
       it "should work with disablerepo first" do
         flush_cache
-        dnf_package.options(["--disablerepo=*", "--enablerepo=chef-dnf-localtesting"])
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options ["--nogpgcheck", "--disablerepo=*", "--enablerepo=chef-dnf-localtesting"]
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options ["--nogpgcheck", "--disablerepo=*", "--enablerepo=chef-dnf-localtesting"]
+          action :install
+        end.should_not_be_updated
       end
 
       it "should work to enable a disabled repo" do
         shell_out!("dnf config-manager --set-disabled chef-dnf-localtesting")
         flush_cache
-        expect { dnf_package.run_action(:install) }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
+        expect {
+          dnf_package "chef_rpm" do
+            options "--nogpgcheck"
+            action :install
+          end
+        }.to raise_error(Chef::Exceptions::Package, /No candidate version available/)
         flush_cache
-        dnf_package.options("--enablerepo=chef-dnf-localtesting")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options "--nogpgcheck --enablerepo=chef-dnf-localtesting"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options "--nogpgcheck --enablerepo=chef-dnf-localtesting"
+          action :install
+        end.should_not_be_updated
       end
 
       it "when an idempotent install action is run, does not leave repos disabled" do
@@ -805,19 +991,22 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         # accomplishes both those goals (it would be easier if we had other rpms in this repo, but with
         # one rpm we need to do this).
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.options("--disablerepo=chef-dnf-localtesting")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options "--nogpgcheck --disablerepo=chef-dnf-localtesting"
+          action :upgrade
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
         # now we're still using the same cache in the dnf_helper.py cache and we test to see if the
         # repo that we temporarily disabled is enabled on this pass.
-        dnf_package.package_name("chef_rpm-1.10-1.#{pkg_arch}")
-        dnf_package.options(nil)
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.10-1.#{pkg_arch}" do
+          options "--nogpgcheck"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.10-1.#{pkg_arch}" do
+          options "--nogpgcheck"
+          action :install
+        end.should_not_be_updated
       end
     end
   end
@@ -826,76 +1015,102 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
     context "downgrades" do
       it "just work with DNF" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.version("1.2")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.2"
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.2"
+          action :install
+        end.should_not_be_updated
       end
 
       it "throws a deprecation warning with allow_downgrade" do
         Chef::Config[:treat_deprecation_warnings_as_errors] = false
-        expect(Chef).to receive(:deprecated).with(:dnf_package_allow_downgrade, /^the allow_downgrade property on the dnf_package provider is not used/)
+        expect(Chef).to receive(:deprecated).at_least(:once).with(:dnf_package_allow_downgrade, /^the allow_downgrade property on the dnf_package provider is not used/)
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.version("1.2")
-        dnf_package.allow_downgrade true
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.2"
+          allow_downgrade true
+          action :install
+        end.should_be_updated
         expect(shell_out("rpm -q chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.2"
+          allow_downgrade true
+          action :install
+        end.should_not_be_updated
       end
     end
 
     context "with source arguments" do
       it "installs the package when using the source argument" do
         flush_cache
-        dnf_package.name "something"
-        dnf_package.package_name "somethingelse"
-        dnf_package.source("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "something" do
+          options default_options
+          package_name "somethingelse"
+          source("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "something" do
+          options default_options
+          package_name "somethingelse"
+          source("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "installs the package when the name is a path to a file" do
         flush_cache
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "downgrades the package when allow_downgrade is true" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "upgrades the package" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.10-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.10-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "is idempotent when the package is already installed" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
     end
@@ -904,295 +1119,382 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       it "works when a package is installed" do
         FileUtils.rm_f "/etc/yum.repos.d/chef-dnf-localtesting.repo"
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options "--nogpgcheck --disablerepo=*"
+          action :upgrade
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "works with a local source" do
         FileUtils.rm_f "/etc/yum.repos.d/chef-dnf-localtesting.repo"
         flush_cache
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options "--nogpgcheck --disablerepo=*"
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
     end
 
     context "version pinning" do
       it "with a full version pin it installs a later package" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1.10-1")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10-1"
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10-1"
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a full version pin in the name it downgrades the package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1.2-1")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.2-1"
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.2-1"
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a partial (no release) version pin it installs a later package" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1.10")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10"
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version "1.10"
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a partial (no release) version pin in the name it downgrades the package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm")
-        dnf_package.version("1.2")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          version("1.2")
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          version("1.2")
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a full version pin it installs a later package" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm-1.10-1")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.10-1" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.10-1" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a full version pin in the name it downgrades the package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm-1.2-1")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.2-1" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.2-1" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a partial (no release) version pin it installs a later package" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm-1.10")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.10" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.10" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a partial (no release) version pin in the name it downgrades the package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm-1.2")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm-1.2" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm-1.2" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a prco equality pin in the name it upgrades a prior package" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm = 1.10")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm = 1.10" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm = 1.10" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a prco equality pin in the name it downgrades a later package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm = 1.2")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm = 1.2" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm = 1.2" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a > pin in the name and no rpm installed it installs" do
         flush_cache
-        dnf_package.package_name("chef_rpm > 1.2")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a < pin in the name and no rpm installed it installs" do
         flush_cache
-        dnf_package.package_name("chef_rpm < 1.10")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a > pin in the name and matching rpm installed it does nothing" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm > 1.2")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
       end
 
       it "with a < pin in the name and no rpm installed it installs" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm < 1.10")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
       it "with a > pin in the name and non-matching rpm installed it upgrades" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm > 1.2")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm > 1.2" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
 
       it "with a < pin in the name and non-matching rpm installed it downgrades" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm < 1.10")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :upgrade
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-        dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm < 1.10" do
+          options default_options
+          action :upgrade
+        end.should_not_be_updated
       end
     end
   end
 
   describe ":remove" do
     context "vanilla use case" do
-      let(:package_name) { "chef_rpm" }
       it "does nothing if the package is not installed" do
         flush_cache
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
       end
 
       it "removes the package if the package is installed" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
       end
 
       it "does not remove the package twice" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
       end
 
       it "removes the package if the prior version package is installed" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
       end
 
       it "removes the package if the i686 package is installed", :intel_64bit do
         skip "FIXME: should this be fixed or is the current behavior correct?"
         preinstall("chef_rpm-1.10-1.i686.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
       end
 
       it "removes the package if the prior version i686 package is installed", :intel_64bit do
         skip "FIXME: should this be fixed or is the current behavior correct?"
         preinstall("chef_rpm-1.2-1.i686.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
       end
     end
 
     context "with 64-bit arch", :intel_64bit do
-      let(:package_name) { "chef_rpm.#{pkg_arch}" }
       it "does nothing if the package is not installed" do
         flush_cache
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
       end
 
       it "removes the package if the package is installed" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
       end
 
       it "removes the package if the prior version package is installed" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
       end
 
       it "does nothing if the i686 package is installed" do
         preinstall("chef_rpm-1.10-1.i686.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.i686$")
       end
 
       it "does nothing if the prior version i686 package is installed" do
         preinstall("chef_rpm-1.2-1.i686.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.#{pkg_arch}" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.i686$")
       end
     end
 
     context "with 32-bit arch", :intel_64bit do
-      let(:package_name) { "chef_rpm.i686" }
       it "removes only the 32-bit arch if both are installed" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm", "chef_rpm-1.10-1.i686.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm.i686" do
+          options default_options
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm.i686" do
+          options default_options
+          action :remove
+        end.should_not_be_updated
       end
     end
 
@@ -1200,11 +1502,15 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       it "works when a package is installed" do
         FileUtils.rm_f "/etc/yum.repos.d/chef-dnf-localtesting.repo"
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be true
+        dnf_package "chef_rpm" do
+          options "--nogpgcheck --disablerepo=*"
+          action :remove
+        end.should_be_updated
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
-        dnf_package.run_action(:remove)
-        expect(dnf_package.updated_by_last_action?).to be false
+        dnf_package "chef_rpm" do
+          options "--nogpgcheck --disablerepo=*"
+          action :remove
+        end.should_not_be_updated
       end
     end
   end
@@ -1220,61 +1526,75 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
 
     it "locks an rpm" do
       flush_cache
-      dnf_package.package_name("chef_rpm")
-      dnf_package.run_action(:lock)
-      expect(dnf_package.updated_by_last_action?).to be true
+      dnf_package "chef_rpm" do
+        options default_options
+        action :lock
+      end.should_be_updated
       expect(shell_out("dnf versionlock list").stdout.chomp).to match("^chef_rpm-0:")
-      dnf_package.run_action(:lock)
-      expect(dnf_package.updated_by_last_action?).to be false
+      dnf_package "chef_rpm" do
+        options default_options
+        action :lock
+      end.should_not_be_updated
     end
 
     it "does not lock if its already locked" do
       flush_cache
       shell_out!("dnf versionlock add chef_rpm")
-      dnf_package.package_name("chef_rpm")
-      dnf_package.run_action(:lock)
-      expect(dnf_package.updated_by_last_action?).to be false
+      dnf_package "chef_rpm" do
+        options default_options
+        action :lock
+      end.should_not_be_updated
       expect(shell_out("dnf versionlock list").stdout.chomp).to match("^chef_rpm-0:")
     end
 
     it "unlocks an rpm" do
       flush_cache
       shell_out!("dnf versionlock add chef_rpm")
-      dnf_package.package_name("chef_rpm")
-      dnf_package.run_action(:unlock)
-      expect(dnf_package.updated_by_last_action?).to be true
+      dnf_package "chef_rpm" do
+        options default_options
+        action :unlock
+      end.should_be_updated
       expect(shell_out("dnf versionlock list").stdout.chomp).not_to match("^chef_rpm-0:")
-      dnf_package.run_action(:unlock)
-      expect(dnf_package.updated_by_last_action?).to be false
+      dnf_package "chef_rpm" do
+        options default_options
+        action :unlock
+      end.should_not_be_updated
     end
 
     it "does not unlock an already locked rpm" do
       flush_cache
-      dnf_package.package_name("chef_rpm")
-      dnf_package.run_action(:unlock)
-      expect(dnf_package.updated_by_last_action?).to be false
+      dnf_package "chef_rpm" do
+        options default_options
+        action :unlock
+      end.should_not_be_updated
       expect(shell_out("dnf versionlock list").stdout.chomp).not_to match("^chef_rpm-0:")
     end
 
     it "check that we can lock based on provides" do
       flush_cache
-      dnf_package.package_name("chef_rpm_provides")
-      dnf_package.run_action(:lock)
-      expect(dnf_package.updated_by_last_action?).to be true
+      dnf_package "chef_rpm_provides" do
+        options default_options
+        action :lock
+      end.should_be_updated
       expect(shell_out("dnf versionlock list").stdout.chomp).to match("^chef_rpm-0:")
-      dnf_package.run_action(:lock)
-      expect(dnf_package.updated_by_last_action?).to be false
+      dnf_package "chef_rpm_provides" do
+        options default_options
+        action :lock
+      end.should_not_be_updated
     end
 
     it "check that we can unlock based on provides" do
       flush_cache
       shell_out!("dnf versionlock add chef_rpm")
-      dnf_package.package_name("chef_rpm_provides")
-      dnf_package.run_action(:unlock)
-      expect(dnf_package.updated_by_last_action?).to be true
+      dnf_package "chef_rpm_provides" do
+        options default_options
+        action :unlock
+      end.should_be_updated
       expect(shell_out("dnf versionlock list").stdout.chomp).not_to match("^chef_rpm-0:")
-      dnf_package.run_action(:unlock)
-      expect(dnf_package.updated_by_last_action?).to be false
+      dnf_package "chef_rpm_provides" do
+        options default_options
+        action :unlock
+      end.should_not_be_updated
     end
   end
 end


### PR DESCRIPTION
- stabilization fixes to the provider
- we now no longer retry in specs and fail on any errors
- we disable all the repos in the specs for speed
- we only reap the daemon to flush the cache in the specs
- we also only reap the daemon after having setup repos
- all the func specs have been converted to inline resources
- all the i/o is now blocking+flushing instead of nonblocking+confusing
  (how did it all ever work?  why did i use nonblocking i/o?)