### PR TITLE
Update Hostname resource to account for newer versions of PowerShell being standard

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -286,6 +286,7 @@
     "createhomedir",
     "Createobject",
     "creds",
+    "Credentials",
     "Cribbs",
     "crlfile",
     "crlnum",

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -269,14 +269,21 @@ class Chef
           unless Socket.gethostbyname(Socket.gethostname).first == new_resource.hostname
             converge_by "set hostname to #{new_resource.hostname}" do
               powershell_exec! <<~EOH
-                if ([string]::IsNullOrEmpty(#{new_resource.windows_domain_username})){
+                if ([string]::IsNullOrEmpty(#{new_resource.domain_user})){
                   Rename-Computer -NewName #{new_resource.hostname}
                 }
                 else {
+<<<<<<< HEAD
                   $user = #{new_resource.windows_domain_username}
                   $securepassword = #{new_resource.windows_user_password} | Convertto-SecureString -AsPlainText -Force
                   $Credentials = New-Object System.Management.Automation.PSCredential -Argumentlist ($user, $securepassword)
                   Rename-Computer -NewName #{new_resource.hostname} -DomainCredential $Credemtials
+=======
+                  $user = #{new_resource.domain_user}
+                  $secure_password = #{new_resource.domain_password} | Convertto-SecureString -AsPlainText -Force
+                  $Credentials = New-Object System.Management.Automation.PSCredential -Argumentlist ($user, $secure_password)
+                  Rename-Computer -NewName #{new_resource.hostname} -DomainCredential $Credentials
+>>>>>>> a9412d86d0... the spelling mistakes are killing me. Corrected calling the correct property names for the Windows domain user
                 }
               EOH
             end

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -58,8 +58,8 @@ class Chef
         ```ruby
         hostname 'renaming a domain-joined computer' do
           hostname 'Foo'
-          windows_domain_username 'Domain\Someone'
-          windows_user_password 'SomePassword'
+          domain_user 'Domain\Someone'
+          domain_password 'SomePassword'
         end
         ```
       DOC
@@ -89,10 +89,10 @@ class Chef
         description: "Determines whether or not Windows should be reboot after changing the hostname, as this is required for the change to take effect.",
         default: true
 
-      property :windows_domain_username, String,
+      property :domain_user, String,
         description: "The domain username with permissions to change the local hostname. Specified in the form of 'Domain\User'"
 
-      property :windows_user_password, String,
+      property :domain_password, String,
         description: "The password associated with the domain user account"
 
       action_class do
@@ -273,17 +273,10 @@ class Chef
                   Rename-Computer -NewName #{new_resource.hostname}
                 }
                 else {
-<<<<<<< HEAD
-                  $user = #{new_resource.windows_domain_username}
-                  $securepassword = #{new_resource.windows_user_password} | Convertto-SecureString -AsPlainText -Force
-                  $Credentials = New-Object System.Management.Automation.PSCredential -Argumentlist ($user, $securepassword)
-                  Rename-Computer -NewName #{new_resource.hostname} -DomainCredential $Credemtials
-=======
                   $user = #{new_resource.domain_user}
                   $secure_password = #{new_resource.domain_password} | Convertto-SecureString -AsPlainText -Force
                   $Credentials = New-Object System.Management.Automation.PSCredential -Argumentlist ($user, $secure_password)
                   Rename-Computer -NewName #{new_resource.hostname} -DomainCredential $Credentials
->>>>>>> a9412d86d0... the spelling mistakes are killing me. Corrected calling the correct property names for the Windows domain user
                 }
               EOH
             end


### PR DESCRIPTION
Updated the Windows code to use Rename-Computer instead of WMI, added properties for a domain username and password.

Signed-off-by: John McCrae <jmccrae@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
