### PR TITLE
Fix a typo setting up cookbook_name value in templates

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -274,7 +274,6 @@
     "cookiecurse",
     "Cookstyle",
     "cookstyle",
-    "coookbook",
     "copypasta",
     "coreutils",
     "Cowie",

--- a/lib/chef/provider/template/content.rb
+++ b/lib/chef/provider/template/content.rb
@@ -63,7 +63,7 @@ class Chef
           context[:template_finder] = template_finder
 
           # helper variables
-          context[:cookbook_name] = new_resource.cookbook_name unless context.keys.include?(:coookbook_name)
+          context[:cookbook_name] = new_resource.cookbook_name unless context.keys.include?(:cookbook_name)
           context[:recipe_name] = new_resource.recipe_name unless context.keys.include?(:recipe_name)
           context[:recipe_line_string] = new_resource.source_line unless context.keys.include?(:recipe_line_string)
           context[:recipe_path] = new_resource.source_line_file unless context.keys.include?(:recipe_path)


### PR DESCRIPTION
There was an extra o in the logic in this setup

Signed-off-by: Tim Smith <tsmith@chef.io>