### PR TITLE
Treat 32bit-on-64bit the same as 32bit

### DIFF
--- a/lib/chef/win32/api.rb
+++ b/lib/chef/win32/api.rb
@@ -43,7 +43,7 @@ class Chef
 
         host.ffi_convention :stdcall
 
-        win64 = ENV["PROCESSOR_ARCHITECTURE"] == "AMD64" || ENV["PROCESSOR_ARCHITEW6432"] == "AMD64"
+        win64 = ENV["PROCESSOR_ARCHITECTURE"] == "AMD64"
 
         # Windows-specific type defs (ms-help://MS.MSDNQTR.v90.en/winprog/winprog/windows_data_types.htm):
         host.typedef :ushort,  :ATOM # Atom ~= Symbol: Atom table stores strings and corresponding identifiers. Application


### PR DESCRIPTION
32-on-64 also needs "long" instead of "int64" the same as 32-bit.

(which seems backwards to me, but this gets our tests all green)
