### PR TITLE
Reset the DNF helper to greenify tests

### DIFF
--- a/spec/unit/provider/package/dnf/python_helper_spec.rb
+++ b/spec/unit/provider/package/dnf/python_helper_spec.rb
@@ -25,6 +25,7 @@ describe Chef::Provider::Package::Dnf::PythonHelper, :requires_root, external: e
   let(:helper) { Chef::Provider::Package::Dnf::PythonHelper.instance }
 
   it "propagates stacktraces on stderr from the forked subprocess", :rhel do
+    Singleton.__init__(Chef::Provider::Package::Dnf::PythonHelper)
     allow(helper).to receive(:dnf_command).and_return("ruby -e 'raise \"your hands in the air\"'")
     expect { helper.package_query(:whatprovides, "tcpdump") }.to raise_error(/your hands in the air/)
   end


### PR DESCRIPTION
More stable helper now survives the func tests and now throws this test off.