### PR TITLE
Remove comment no longer relevant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,5 @@
 source "https://rubygems.org"
 
-# Note we do not use the gemspec DSL which restricts to the
-# gemspec for the current platform and filters out other platforms
-# during a bundle lock operation. We actually want dependencies from
-# both of our gemspecs. Also note this this mimics gemspec behavior
-# of bundler versions prior to 1.12.0 (https://github.com/bundler/bundler/commit/193a14fe5e0d56294c7b370a0e59f93b2c216eed)
 gem "chef", path: "."
 
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "master"


### PR DESCRIPTION
## Description

Since
https://github.com/rubygems/rubygems/commit/58f74018dfef25704a42f38467094c4c1391e54f,
the previous behaviour of gemspec was restored, so the comment is no
longer relevant on recent bundler versions.

## Related Issue

None.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
