### PR TITLE
Silence `bundle install` warning when installing gems for cookbooks

### DIFF
--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -72,7 +72,7 @@ class Chef
                   cmd = [ "bundle", "install", Chef::Config[:gem_installer_bundler_options] ]
                   env = {
                     "PATH" => path_with_prepended_ruby_bin,
-                    "BUNDLE_SILENCE_ROOT_WARNING" => "1"
+                    "BUNDLE_SILENCE_ROOT_WARNING" => "1",
                   }
                   so = shell_out!(cmd, cwd: dir, env: env)
                   Chef::Log.info(so.stdout)

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -70,7 +70,11 @@ class Chef
                 unless Chef::Config[:skip_gem_metadata_installation]
                   # Add additional options to bundle install
                   cmd = [ "bundle", "install", Chef::Config[:gem_installer_bundler_options] ]
-                  so = shell_out!(cmd, cwd: dir, env: { "PATH" => path_with_prepended_ruby_bin })
+                  env = {
+                    "PATH" => path_with_prepended_ruby_bin,
+                    "BUNDLE_SILENCE_ROOT_WARNING" => "1"
+                  }
+                  so = shell_out!(cmd, cwd: dir, env: env)
                   Chef::Log.info(so.stdout)
                 end
               end


### PR DESCRIPTION
Signed-off-by: Joseph J. Nuspl Jr. <nuspl@nvwls.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

If a cookbook depends on a gem, chef-client uses `bundle install`. Since it is running as root, you get a scary sounding log message
```
[2021-05-08T15:03:38+00:00] INFO: Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
```

Since it is safe, we should silence the warning.

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
