### PR TITLE
Strip the __env_path variable in the which helper

### DIFF
--- a/chef-utils/lib/chef-utils/internal.rb
+++ b/chef-utils/lib/chef-utils/internal.rb
@@ -70,7 +70,7 @@ module ChefUtils
     #
     def __env_path
       if __transport_connection
-        __transport_connection.run_command("echo $PATH").stdout || ""
+        __transport_connection.run_command("echo $PATH").stdout.chomp || ""
       else
         ENV["PATH"] || ""
       end


### PR DESCRIPTION
```
[24] pry(#<Ohai::NamedPlugin::Virtualization>)> __env_path
=> "/bin:/sbin:/usr/bin:/usr/sbin\n"
```

This results in a busted /usr/sbin

```
[27] pry(#<Ohai::NamedPlugin::Virtualization>)> __env_path.split(File::PATH_SEPARATOR) + Array(extra_path)
=> ["/bin", "/sbin", "/usr/bin", "/usr/sbin\n", "/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
```

Signed-off-by: Tim Smith <tsmith@chef.io>