### PR TITLE
Remove extraneous double mixin for the require.

### DIFF
--- a/knife/lib/chef/knife/ssl_fetch.rb
+++ b/knife/lib/chef/knife/ssl_fetch.rb
@@ -28,7 +28,7 @@ class Chef
         require "socket" unless defined?(Socket)
         require "uri" unless defined?(URI)
         require "openssl" unless defined?(OpenSSL)
-        require "chef/mixin/mixin/proxified_socket" unless defined?(Chef::Mixin::ProxifiedSocket)
+        require "chef/mixin/proxified_socket" unless defined?(Chef::Mixin::ProxifiedSocket)
 
         include Chef::Mixin::ProxifiedSocket
       end


### PR DESCRIPTION
## Description
There is a bad require call in knife/lib/chef/knife/ssl_fetch.rb where a path was accidentally doubled. This fixes that by removing the extraneous extra keyword.

## Related Issue
Fixes  knife ssl fetch broken with bad require call in ssl_fetch.rb [#11580](https://github.com/chef/chef/issues/11580)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
