### PR TITLE
Update validation on the ResetLockoutCount to limit it to LockoutDuration rather than limiting it to 30 minutes

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -39,12 +39,12 @@ windows_security_policy "LockoutBadCount" do
 end
 
 windows_security_policy "LockoutDuration" do
-  secvalue "30"
+  secvalue "120"
   action :set
 end
 
 windows_security_policy "ResetLockoutCount" do
-  secvalue "15"
+  secvalue "90"
   action :set
 end
 

--- a/lib/chef/resource/windows_security_policy.rb
+++ b/lib/chef/resource/windows_security_policy.rb
@@ -90,8 +90,8 @@ class Chef
         current_state = load_security_options
 
         if new_resource.secoption == "ResetLockoutCount"
-          if new_resource.secvalue.to_i > 30
-            raise Chef::Exceptions::ValidationFailed, "The \"ResetLockoutCount\" value cannot be greater than 30 minutes"
+          if new_resource.secvalue.to_i > current_state["LockoutDuration"].to_i
+            raise Chef::Exceptions::ValidationFailed, "The \"ResetLockoutCount\" value cannot be greater than the value currently set for \"LockoutDuration\""
           end
         end
         if (new_resource.secoption == "ResetLockoutCount" || new_resource.secoption == "LockoutDuration") && current_state["LockoutBadCount"] == "0"


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The `net account /LockoutWindow` command which underlies the setting of the ResetLockoutCount property is not limited to 30 minutes.  That is a default because it is the default for the LockoutDuration setting.  This update changes the validation for the ResetLockoutCount security policy so that it is limited by the LockoutDuration setting and not the 30 minute default.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
