### PR TITLE
Enables kernel2 habitat package builds/promotions

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,5 +1,6 @@
 [chef-infra-client]
 build_targets = [
   "x86_64-linux",
+  "x86_64-linux-kernel2",
   "x86_64-windows"
 ]

--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -21,6 +21,18 @@ steps:
         privileged: true
         single-use: true
 
+- label: ":linux: Validate Linux (kernel2)"
+  commands:
+    - sudo ./.expeditor/scripts/install-hab.sh x86_64-linux-kernel2
+    - 'echo "--- :hammer_and_wrench: Installing $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2"'
+    - sudo hab pkg install $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2
+    - sudo ./habitat/tests/test.sh $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2
+  expeditor:
+    executor:
+      linux:
+        privileged: true
+        single-use: true
+
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
     - powershell -File ./.expeditor/scripts/ensure-minimum-viable-hab.ps1

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -324,6 +324,17 @@ steps:
         privileged: true
         single-use: true
 
+- label: ":habicat: Linux plan (kernel2)"
+  commands:
+    - sudo ./.expeditor/scripts/install-hab.sh 'x86_64-linux-kernel2'
+    - sudo ./.expeditor/scripts/verify-plan.sh
+  timeout_in_minutes: 60
+  expeditor:
+    executor:
+      linux:
+        privileged: true
+        single-use: true
+
 - label: ":habicat: Windows plan"
   commands:
     - ./.expeditor/scripts/verify-plan.ps1


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Re-enables the publishing of `kernel2` Habitat packages to allow for Chef Infra Client 17 deployments of Effortless Infra scaffolding with `chef/scaffolding-chef-infra`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
