### PR TITLE
adds unix_bootstrap and windows_bootstrap path configs

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -392,8 +392,20 @@ module ChefConfig
     # Where chef's cache files should be stored
     default(:file_cache_path) { PathHelper.join(cache_path, "cache") }.writes_value { |path| expand_relative_paths(path) }
 
+    # Where chef's cache files should be stored, used for bootstrap on unix filesystems
+    default(:unix_bootstrap_file_cache_path) { PathHelper.join("/var", ChefUtils::Dist::Infra::DIR_SUFFIX, "cache", windows: false) }
+
+    # Where chef's cache files should be stored, used for bootstrap on windows filesystems
+    default(:windows_bootstrap_file_cache_path) { PathHelper.join("C:", ChefUtils::Dist::Infra::DIR_SUFFIX, "cache", windows: true) }
+
     # Where backups of chef-managed files should go
     default(:file_backup_path) { PathHelper.join(cache_path, "backup") }
+
+    # Where chef's backup files should be stored, used for bootstrap on unix filesystems
+    default(:unix_bootstrap_file_backup_path) { PathHelper.join("/var", ChefUtils::Dist::Infra::DIR_SUFFIX, "backup", windows: false) }
+
+    # Where chef's backup files should be stored, used for bootstrap on windows filesystems
+    default(:windows_bootstrap_file_backup_path) { PathHelper.join("C:", ChefUtils::Dist::Infra::DIR_SUFFIX, "backup", windows: true) }
 
     # The chef-client (or solo) lockfile.
     #

--- a/knife/lib/chef/knife/core/bootstrap_context.rb
+++ b/knife/lib/chef/knife/core/bootstrap_context.rb
@@ -171,12 +171,12 @@ class Chef
             client_rb << "fips true\n"
           end
 
-          unless chef_config[:file_cache_path].nil?
-            client_rb << "file_cache_path \"#{chef_config[:file_cache_path]}\"\n"
+          unless chef_config[:unix_bootstrap_file_cache_path].nil?
+            client_rb << "file_cache_path \"#{chef_config[:unix_bootstrap_file_cache_path]}\"\n"
           end
 
-          unless chef_config[:file_backup_path].nil?
-            client_rb << "file_backup_path \"#{chef_config[:file_backup_path]}\"\n"
+          unless chef_config[:unix_bootstrap_file_backup_path].nil?
+            client_rb << "file_backup_path \"#{chef_config[:unix_bootstrap_file_backup_path]}\"\n"
           end
 
           client_rb

--- a/knife/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/knife/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -71,8 +71,8 @@ class Chef
           client_rb = <<~CONFIG
             chef_server_url  "#{chef_config[:chef_server_url]}"
             validation_client_name "#{chef_config[:validation_client_name]}"
-            file_cache_path   "#{ChefConfig::PathHelper.escapepath(ChefConfig::Config.var_chef_dir(windows: true))}\\\\cache"
-            file_backup_path  "#{ChefConfig::PathHelper.escapepath(ChefConfig::Config.var_chef_dir(windows: true))}\\\\backup"
+            file_cache_path   "#{chef_config[:windows_bootstrap_file_cache_path]}"
+            file_backup_path  "#{chef_config[:windows_bootstrap_file_backup_path]}"
             cache_options     ({:path => "#{ChefConfig::PathHelper.escapepath(ChefConfig::Config.etc_chef_dir(windows: true))}\\\\cache\\\\checksums", :skip_expires => true})
           CONFIG
 

--- a/knife/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/knife/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -71,8 +71,8 @@ class Chef
           client_rb = <<~CONFIG
             chef_server_url  "#{chef_config[:chef_server_url]}"
             validation_client_name "#{chef_config[:validation_client_name]}"
-            file_cache_path   "#{chef_config[:windows_bootstrap_file_cache_path]}"
-            file_backup_path  "#{chef_config[:windows_bootstrap_file_backup_path]}"
+            file_cache_path   "#{ChefConfig::PathHelper.escapepath(chef_config[:windows_bootstrap_file_cache_path] || "")}"
+            file_backup_path  "#{ChefConfig::PathHelper.escapepath(chef_config[:windows_bootstrap_file_backup_path] || "")}"
             cache_options     ({:path => "#{ChefConfig::PathHelper.escapepath(ChefConfig::Config.etc_chef_dir(windows: true))}\\\\cache\\\\checksums", :skip_expires => true})
           CONFIG
 

--- a/knife/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/knife/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -80,16 +80,16 @@ describe Chef::Knife::Core::BootstrapContext do
     end
   end
 
-  describe "when file_cache_path is set" do
-    let(:chef_config) { { file_cache_path: "/home/opscode/cache" } }
-    it "sets file_cache_path in the generated config file" do
+  describe "when unix_bootstrap_file_cache_path is set" do
+    let(:chef_config) { { unix_bootstrap_file_cache_path: "/home/opscode/cache" } }
+    it "sets unix_bootstrap_file_cache_path in the generated config file" do
       expect(bootstrap_context.config_content).to include("file_cache_path \"/home/opscode/cache\"")
     end
   end
 
-  describe "when file_backup_path is set" do
-    let(:chef_config) { { file_backup_path: "/home/opscode/backup" } }
-    it "sets file_backup_path in the generated config file" do
+  describe "when unix_bootstrap_file_backup_path is set" do
+    let(:chef_config) { { unix_bootstrap_file_backup_path: "/home/opscode/backup" } }
+    it "sets unix_bootstrap_file_backup_path in the generated config file" do
       expect(bootstrap_context.config_content).to include("file_backup_path \"/home/opscode/backup\"")
     end
   end

--- a/knife/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/knife/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -165,8 +165,8 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
       expected = <<~EXPECTED
         echo.chef_server_url  "http://chef.example.com:4444"
         echo.validation_client_name "chef-validator-testing"
-        echo.file_cache_path   "C:\\\\chef\\\\cache"
-        echo.file_backup_path  "C:\\\\chef\\\\backup"
+        echo.file_cache_path   "c:/chef/cache"
+        echo.file_backup_path  "c:/chef/backup"
         echo.cache_options     ^({:path =^> "C:\\\\chef\\\\cache\\\\checksums", :skip_expires =^> true}^)
         echo.# Using default node name ^(fqdn^)
         echo.log_level        :auto

--- a/knife/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/knife/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -154,8 +154,8 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
           config_log_location: STDOUT,
           chef_server_url: "http://chef.example.com:4444",
           validation_client_name: "chef-validator-testing",
-          file_cache_path: "c:/chef/cache",
-          file_backup_path: "c:/chef/backup",
+          windows_bootstrap_file_cache_path: "c:/chef/cache",
+          windows_bootstrap_file_backup_path: "c:/chef/backup",
           cache_options: ({ path: "c:/chef/cache/checksums", skip_expires: true })
         )
       )


### PR DESCRIPTION
Adds bootstrap path configs

## Description

Adds bootstrap path configs, taking feedback from #11189 the goal is to fix a bug in bootstrap where the workstation pathing configs make it to the remote machine.

## Related Issue

#10964, https://github.com/chef/customer-bugs/issues/239, [#9094](https://github.com/chef/chef/issues/9094) and #10367

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
