### PR TITLE
Additional dist constants used in chef-cli and InSpec

### DIFF
--- a/chef-utils/lib/chef-utils/dist.rb
+++ b/chef-utils/lib/chef-utils/dist.rb
@@ -15,6 +15,25 @@ module ChefUtils
       PRODUCT = "Chef Automate"
     end
 
+    class Cli
+      # the chef-cli product name
+      PRODUCT = "Chef CLI"
+
+      # the chef-cli gem
+      GEM = "chef-cli"
+    end
+
+    class Habitat
+      # name of the Habitat product
+      PRODUCT = "Chef Habitat"
+
+      # A short designation for the product
+      SHORT = "habitat"
+
+      # The hab cli binary
+      EXEC = "hab"
+    end
+
     class Infra
       # When referencing a product directly, like Chef (Now Chef Infra)
       PRODUCT = "Chef Infra Client"
@@ -42,6 +61,17 @@ module ChefUtils
       # The suffix for Chef's /etc/chef, /var/chef and C:\\Chef directories
       # "chef" => /etc/cinc, /var/cinc, C:\\cinc
       DIR_SUFFIX = "chef"
+
+      # The client's gem
+      GEM = "chef"
+    end
+
+    class Inspec
+      # The InSpec product name
+      PRODUCT = "Chef InSpec"
+
+      # The inspec binary
+      EXEC = "inspec"
     end
 
     class Org
@@ -63,6 +93,9 @@ module ChefUtils
 
       # knife documentation page
       KNIFE_DOCS = "https://docs.chef.io/workstation/knife/"
+
+      # the name of the overall infra product
+      PRODUCT = "Chef Infra"
     end
 
     class Server
@@ -88,8 +121,14 @@ module ChefUtils
     end
 
     class Workstation
+      # The full marketing name of the product
+      PRODUCT = "Chef Workstation"
+
       # The suffix for Chef Workstation's /opt/chef-workstation or C:\\opscode\chef-workstation
       DIR_SUFFIX = "chef-workstation"
+
+      # Workstation banner/help text
+      DOCS = "https://docs.chef.io/workstation/"
     end
 
     class Zero


### PR DESCRIPTION
This starts the process of migrating chef-cli and eventually InSpec to using chef-utils for centralized dist constant management.

For chef-cli, all constants are set here [1] and will be replaced with what's included in this patch eventually. I excluded the "Chef Delivery" constant since it's set to EOL soon anyway.

Since it already references InSpec, I went ahead and ensured we included anything mentioned in inspec's dist.rb [2].

[1] https://github.com/chef/chef-cli/blob/77bb4462183db64f8677cbc6b884b85f91004aa1/lib/chef-cli/dist.rb
[2] https://github.com/inspec/inspec/blob/66a372d71539b9132789aeb92b62690087ed34f2/lib/inspec/dist.rb

Signed-off-by: Lance Albertson <lance@osuosl.org>
