### PR TITLE
Update existing entry in /etc/fstab with options and not create a new entry

### DIFF
--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -62,7 +62,7 @@ class Chef
             case line
             when /^[#\s]/
               next
-            when /^(#{device_fstab_regex})\s+#{Regexp.escape(@new_resource.mount_point)}\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)/
+            when %r{^(/?#{device_fstab_regex})\s+#{Regexp.escape(@new_resource.mount_point)}\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)}
               enabled = true
               @current_resource.device($1)
               @current_resource.fstype($2)
@@ -168,6 +168,7 @@ class Chef
             # and order will remain the same.
             edit_fstab
           else
+
             ::File.open("/etc/fstab", "a") do |fstab|
               fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
               logger.trace("#{@new_resource} is enabled at #{@new_resource.mount_point}")
@@ -254,7 +255,7 @@ class Chef
 
             found = false
             ::File.readlines("/etc/fstab").reverse_each do |line|
-              if !found && line =~ /^#{device_fstab_regex}\s+#{Regexp.escape(@new_resource.mount_point)}\s/
+              if !found && line =~ %r{^/?#{device_fstab_regex}\s+#{Regexp.escape(@new_resource.mount_point)}\s}
                 found = true
                 if remove
                   logger.trace("#{@new_resource} is removed from fstab")


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

This PR fixes the issue of making a duplicate entry in fstab instead of updating the options in case of remount

## Description
Following statement : - 
`devic node['filesystem']['by_mountpoint']['/tmp']['devices'][0].to_s` 

returns device name without front slash like this `tmp` and existing logic fails to match this with entry in fstab. which looks like this 
`/vagrant/hdat2cd_lite_71.iso /tmp auto loop 0 2`

By altering regular expression which is used to match the existing entry in fstab file here : - 

`/^(#{device_fstab_regex})\s+#{Regexp.escape(@new_resource.mount_point)}\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)/`

We are allowing logic to find an entry in fstab in case its there even if device name is missing '/' character initially

## Related Issue
Fixes the following issue 

https://github.com/chef/customer-bugs/issues/357
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
