### PR TITLE
pass homebrew_path, owner props to homebrew_tap if installing cask

### DIFF
--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -54,7 +54,12 @@ class Chef
         default: lazy { find_homebrew_username }
 
       action :install, description: "Install an application that is packaged as a Homebrew cask." do
-        homebrew_tap "homebrew/cask" if new_resource.install_cask
+        if new_resource.install_cask
+          homebrew_tap "homebrew/cask" do
+            homebrew_path new_resource.homebrew_path
+            owner new_resource.owner
+          end
+        end
 
         unless casked?
           converge_by("install cask #{new_resource.cask_name} #{new_resource.options}") do
@@ -67,7 +72,12 @@ class Chef
       end
 
       action :remove, description: "Remove an application that is packaged as a Homebrew cask." do
-        homebrew_tap "homebrew/cask" if new_resource.install_cask
+        if new_resource.install_cask
+          homebrew_tap "homebrew/cask" do
+            homebrew_path new_resource.homebrew_path
+            owner new_resource.owner
+          end
+        end
 
         if casked?
           converge_by("uninstall cask #{new_resource.cask_name}") do


### PR DESCRIPTION
when `homebrew_cask` is used with a homebrew_path attribute, it will try to install homebrew/cask by default with default options. this can fail in instances of non-standard homebrew paths or for arm64 macs that dont use the default /usr/local installation path. so pass along homebrew_path and owner props to the cask install `homebrew_tap` resource.

Signed-off-by: Matt Kulka <mkulka@parchment.com>
