### PR TITLE
Make sure we can run dep update on 2+ branches

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -18,7 +18,7 @@ function new_gem_included() {
   git diff | grep -E '^\+' | grep "${DEPNAME} (${EXPEDITOR_VERSION})"
 }
 
-branch="expeditor/${DEPNAME}_${EXPEDITOR_VERSION}"
+branch="expeditor/${EXPEDITOR_BRANCH}_${DEPNAME}_${EXPEDITOR_VERSION}"
 git checkout -b "$branch"
 
 tries=12


### PR DESCRIPTION
We need to make sure we create pr release branches. Right now the
chef-16 one gets the branch and then the master one uses that same
branch and the PR is busted.

Signed-off-by: Tim Smith <tsmith@chef.io>