### PR TITLE
Support recipes that and in .yaml as well as .yml

### DIFF
--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -140,9 +140,12 @@ class Chef
     def recipe_yml_filenames_by_name
       @recipe_ym_filenames_by_name ||= begin
         name_map = yml_filenames_by_name(files_for("recipes"))
-        root_alias = cookbook_manifest.root_files.find { |record| record[:name] == "root_files/recipe.yml" }
+        root_alias = cookbook_manifest.root_files.find { |record|
+          record[:name] == "root_files/recipe.yml" ||
+            record[:name] == "root_files/recipe.yaml"
+        }
         if root_alias
-          Chef::Log.error("Cookbook #{name} contains both recipe.yml and and recipes/default.yml, ignoring recipes/default.yml") if name_map["default"]
+          Chef::Log.error("Cookbook #{name} contains both recipe.yml and recipes/default.yml, ignoring recipes/default.yml") if name_map["default"]
           name_map["default"] = root_alias[:full_path]
         end
         name_map
@@ -583,7 +586,7 @@ class Chef
     end
 
     def yml_filenames_by_name(records)
-      records.select { |record| record[:name] =~ /\.yml$/ }.inject({}) { |memo, record| memo[File.basename(record[:name], ".yml")] = record[:full_path]; memo }
+      records.select { |record| record[:name] =~ /\.(y[a]?ml)$/ }.inject({}) { |memo, record| memo[File.basename(record[:name], File.extname(record[:name]))] = record[:full_path]; memo }
     end
 
     def file_vendor

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -138,7 +138,7 @@ class Chef
     end
 
     def recipe_yml_filenames_by_name
-      @recipe_ym_filenames_by_name ||= begin
+      @recipe_yml_filenames_by_name ||= begin
         name_map = yml_filenames_by_name(files_for("recipes"))
         root_alias = cookbook_manifest.root_files.find { |record|
           record[:name] == "root_files/recipe.yml" ||
@@ -585,8 +585,27 @@ class Chef
       records.select { |record| record[:name] =~ /\.rb$/ }.inject({}) { |memo, record| memo[File.basename(record[:name], ".rb")] = record[:full_path]; memo }
     end
 
+    # Filters YAML files from the superset of provided files.
+    # Checks for duplicate basenames with differing extensions (eg yaml v yml)
+    # and raises error if any are detected.
+    # This prevents us from arbitrarily the ".yaml" or ".yml" version when both are present,
+    # because we don't know which is correct.
+    # This method runs in O(n^2) where N = number of yml files present. This number should be consistently
+    # low enough that there's no noticeable perf impact.
     def yml_filenames_by_name(records)
-      records.select { |record| record[:name] =~ /\.(y[a]?ml)$/ }.inject({}) { |memo, record| memo[File.basename(record[:name], File.extname(record[:name]))] = record[:full_path]; memo }
+      yml_files = records.select { |record| record[:name] =~ /\.(y[a]?ml)$/ }
+      result = yml_files.inject({}) do |acc, record|
+        filename = record[:name]
+        base_dup_name = File.join(File.dirname(filename), File.basename(filename, File.extname(filename)))
+        yml_files.each do |other|
+          if other[:name] =~ /#{(File.extname(filename) == ".yml") ? "#{base_dup_name}.yaml" : "#{base_dup_name}.yml"}$/
+            raise Chef::Exceptions::AmbiguousYAMLFile.new("Cookbook #{name}@#{version} contains ambiguous files: #{filename} and #{other[:name]}. Please update the cookbook to remove the incorrect file.")
+          end
+        end
+        acc[File.basename(record[:name], File.extname(record[:name]))] = record[:full_path]
+        acc
+      end
+      result
     end
 
     def file_vendor

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -174,6 +174,9 @@ class Chef
     class CannotDetermineWindowsInstallerType < Package; end
     class NoWindowsPackageSource < Package; end
 
+    # for example, if both recipes/default.yml, recipes/default.yaml are present
+    class AmbiguousYAMLFile < RuntimeError; end
+
     # Can not create staging file during file deployment
     class FileContentStagingError < RuntimeError
       def initialize(errors)

--- a/spec/unit/cookbook_version_spec.rb
+++ b/spec/unit/cookbook_version_spec.rb
@@ -41,7 +41,44 @@ describe Chef::CookbookVersion do
     it "has empty metadata" do
       expect(cookbook_version.metadata).to eq(Chef::Cookbook::Metadata.new)
     end
+  end
 
+  describe "#recipe_yml_filenames_by_name" do
+    let(:cookbook_version) { Chef::CookbookVersion.new("name", "/tmp/name") }
+
+    def files_for_recipe(extension)
+      [
+        { name: "recipes/default.#{extension}", full_path: "/home/user/repo/cookbooks/test/recipes/default.#{extension}" },
+        { name: "recipes/other.#{extension}", full_path: "/home/user/repo/cookbooks/test/recipes/other.#{extension}" },
+      ]
+    end
+    %w{yml yaml}.each do |extension|
+
+      context "and YAML files are present including a recipes/default.#{extension}" do
+        before(:each) do
+          allow(cookbook_version).to receive(:files_for).with("recipes").and_return(files_for_recipe(extension))
+        end
+
+        context "and manifest does not include a root_files/recipe.#{extension}" do
+          it "returns all YAML recipes with a correct default of default.#{extension}" do
+            expect(cookbook_version.recipe_yml_filenames_by_name).to eq({ "default" => "/home/user/repo/cookbooks/test/recipes/default.#{extension}",
+                                                                        "other" => "/home/user/repo/cookbooks/test/recipes/other.#{extension}" })
+          end
+        end
+
+        context "and manifest also includes a root_files/recipe.#{extension}" do
+          let(:root_files) { [{ name: "root_files/recipe.#{extension}", full_path: "/home/user/repo/cookbooks/test/recipe.#{extension}" } ] }
+          before(:each) do
+            allow(cookbook_version.cookbook_manifest).to receive(:root_files).and_return(root_files)
+          end
+
+          it "returns all YAML recipes with a correct default of recipe.#{extension}" do
+            expect(cookbook_version.recipe_yml_filenames_by_name).to eq({ "default" => "/home/user/repo/cookbooks/test/recipe.#{extension}",
+                                                                         "other" => "/home/user/repo/cookbooks/test/recipes/other.#{extension}" })
+          end
+        end
+      end
+    end
   end
 
   describe "with a cookbook directory named tatft" do


### PR DESCRIPTION
This adds support for recipe files that end in the '.yaml'
extension in addition to existing support for '.yml', because
both are valid and common extensions for yaml files.

Of note is that the message we log when a recipes/default.y[a]ml
and a root_files/recipe.y[a]ml both exist will be slightly off, in that
we don't capture the actual extension of each file. This seems to be
more complexity than it was worth, for a message that is shown at the
beginning of the run and largely ignored.

I also tried to add a bit of localized unit testing for
`recipe_yml_filenames_by_name` because we didn't before.  Mostly focuses
on this use case (yaml, yml both work) but we could probalby improve
that by including tests for a mix of yaml/yml files.

In addition, we will now fail the run when a cookbook contains two same-named 
YAML files with different extensions. THis is because we don't know which one to use - 
either one is a valid YAML file extension. Instead of picking one
arbitrarily we'll fail with an error explaining how to resolve it. 

For example if the cookbook contains both recipes/default.yaml and recipes/default.yml 
it will fail with the following output:
```
Cookbook test1@0.1.0 contains ambiguous files: recipes/default.yaml and recipes/default.yml. Please update the cookbook to remove the incorrect file.
```


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

Fixes #11354 
