### PR TITLE
Use our config in RuboCop to prevent pulling in others

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         ruby-version: 2.7
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
-    - run: bundle exec rake style
+    - run: bundle exec chefstyle -c .rubocop.yml
 
   spellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Due to https://github.com/rubocop/rubocop/issues/9832 we're pulling in
configs from vendor dirs in the GitHub Actions job. If you set it with
-c you avoid that.

Signed-off-by: Tim Smith <tsmith@chef.io>