### PR TITLE
Add a slow resources report to chef-client

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -310,7 +310,7 @@ class Chef
       logger.info "Forking #{ChefUtils::Dist::Infra::PRODUCT} instance to converge..."
       pid = fork do
         # Want to allow forked processes to finish converging when
-        # TERM singal is received (exit gracefully)
+        # TERM signal is received (exit gracefully)
         trap("TERM") do
           logger.debug("SIGTERM received during converge," +
             " finishing converge to exit normally (send SIGINT to terminate immediately)")

--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -301,7 +301,7 @@ class Chef::Application::Base < Chef::Application
     long: "--[no-]slow-report [COUNT]",
     description: "List the slowest resources at the end of the run (default: 10).",
     boolean: true,
-    default: true,
+    default: false,
     proc: lambda { |argument|
       if argument.nil?
         true

--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -297,6 +297,21 @@ class Chef::Application::Base < Chef::Application
     long: "--named-run-list NAMED_RUN_LIST",
     description: "Use a policyfile's named run list instead of the default run list."
 
+  option :slow_report,
+    long: "--[no-]slow-report [COUNT]",
+    description: "List the slowest resources at the end of the run (default: 10).",
+    boolean: true,
+    default: true,
+    proc: lambda { |argument|
+      if argument.nil?
+        true
+      elsif argument == false
+        false
+      else
+        Integer(argument)
+      end
+    }
+
   IMMEDIATE_RUN_SIGNAL = "1".freeze
   RECONFIGURE_SIGNAL = "H".freeze
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -863,6 +863,12 @@ class Chef
     end
 
     def start_profiling
+      if Chef::Config[:slow_report]
+        require_relative "handler/slow_report"
+
+        Chef::Config.report_handlers << Chef::Handler::SlowReport.new(Chef::Config[:slow_report])
+      end
+
       return unless Chef::Config[:profile_ruby]
 
       profiling_prereqs!

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -104,7 +104,6 @@ class Chef
       #
       def action_collection_registration(action_collection)
         @action_collection = action_collection
-        action_collection.register(self)
       end
 
       # - Creates and writes our NodeUUID back to the node object

--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -221,7 +221,8 @@ class Chef
       # Called before convergence starts
       def converge_start(run_context); end
 
-      # Callback hook for handlers to register their interest in the action_collection
+      # Callback hook for handlers to grab a reference to the action_collection
+      # (sent before compiling cookbooks, consumers can also find it off the run_context.action_collection)
       def action_collection_registration(action_collection); end
 
       # Called when the converge phase is finished.

--- a/lib/chef/handler.rb
+++ b/lib/chef/handler.rb
@@ -58,7 +58,7 @@ class Chef
     # FIXME: Chef::Handler should probably inherit from EventDispatch::Base
     # and should wire up to those events rather than the "notifications" system
     # which is hanging off of Chef::Client.  Those "notifications" could then be
-    # deprecated in favor of events, and this class could become decopled from
+    # deprecated in favor of events, and this class could become decoupled from
     # the Chef::Client object.
 
     def self.handler_for(*args)

--- a/lib/chef/handler.rb
+++ b/lib/chef/handler.rb
@@ -55,6 +55,12 @@ class Chef
   #
   class Handler
 
+    # FIXME: Chef::Handler should probably inherit from EventDispatch::Base
+    # and should wire up to those events rather than the "notifications" system
+    # which is hanging off of Chef::Client.  Those "notifications" could then be
+    # deprecated in favor of events, and this class could become decopled from
+    # the Chef::Client object.
+
     def self.handler_for(*args)
       if args.include?(:start)
         Chef::Config[:start_handlers] ||= []
@@ -207,17 +213,45 @@ class Chef
     # The Chef::Node for this client run
     def_delegator :@run_status, :node
 
-    ##
-    # :method: all_resources
+    # @return Array<Chef::Resource> all resources other than unprocessed
     #
-    # An Array containing all resources in the chef run's resource_collection
-    def_delegator :@run_status, :all_resources
+    def all_resources
+      @all_resources ||= action_collection&.filtered_collection(unprocessed: false)&.resources || []
+    end
 
-    ##
-    # :method: updated_resources
+    # @return Array<Chef::Resource> all updated resources
     #
-    # An Array containing all resources that were updated during the chef run
-    def_delegator :@run_status, :updated_resources
+    def updated_resources
+      @updated_resources ||= action_collection&.filtered_collection(up_to_date: false, skipped: false, failed: false, unprocessed: false)&.resources || []
+    end
+
+    # @return Array<Chef::Resource> all up_to_date resources
+    #
+    def up_to_date_resources
+      @up_to_date_resources ||= action_collection&.filtered_collection(updated: false, skipped: false, failed: false, unprocessed: false)&.resources || []
+    end
+
+    # @return Array<Chef::Resource> all failed resources
+    #
+    def failed_resources
+      @failed_resources ||= action_collection&.filtered_collection(updated: false, up_to_date: false, skipped: false, unprocessed: false)&.resources || []
+    end
+
+    # @return Array<Chef::Resource> all skipped resources
+    #
+    def skipped_resources
+      @skipped_resources ||= action_collection&.filtered_collection(updated: false, up_to_date: false, failed: false, unprocessed: false)&.resources || []
+    end
+
+    # Unprocessed resources are those which are left over in the outer recipe context when a run fails.
+    # Sub-resources of unprocessed resourced are impossible to capture because they would require processing
+    # the outer resource.
+    #
+    # @return Array<Chef::Resource> all unprocessed resources
+    #
+    def unprocessed_resources
+      @unprocessed_resources ||= action_collection&.filtered_collection(updated: false, up_to_date: false, failed: false, skipped: false)&.resources || []
+    end
 
     ##
     # :method: success?
@@ -231,6 +265,10 @@ class Chef
     #
     # Did the chef run fail? True if the chef run raised an uncaught exception
     def_delegator :@run_status, :failed?
+
+    def action_collection
+      @run_status.run_context.action_collection
+    end
 
     # The main entry point for report handling. Subclasses should override this
     # method with their own report handling logic.

--- a/lib/chef/handler/slow_report.rb
+++ b/lib/chef/handler/slow_report.rb
@@ -1,0 +1,57 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../handler"
+require "tty/table" unless defined?(TTY::Table)
+
+class Chef
+  class Handler
+    class SlowReport < ::Chef::Handler
+      attr_accessor :amount
+
+      def initialize(amount)
+        @amount = Integer(amount) rescue nil
+        @amount ||= 10
+      end
+
+      def report
+        top = all_resources.sort_by(&:elapsed_time).last(amount).reverse
+        data = top.map { |r| [ r.to_s, r.elapsed_time, r.cookbook_name, r.recipe_name, stripped_source_line(r) ] }
+        puts "\nTop #{count} slowest #{count == 1 ? "resource" : "resources"}:\n\n"
+        table = TTY::Table.new(%w{resource elapsed_time cookbook recipe source}, data)
+        rendered = table.render do |renderer|
+          renderer.border do
+            mid          "-"
+            mid_mid      " "
+          end
+        end
+        puts rendered
+        puts "\n"
+      end
+
+      def count
+        num = all_resources.count
+        num > amount ? amount : num
+      end
+
+      def stripped_source_line(resource)
+        # strip the leading path off of the source line
+        resource.source_line.gsub(%r{.*/cookbooks/}, "").gsub(%r{.*/chef-[0-9\.]+/}, "")
+      end
+    end
+  end
+end

--- a/lib/chef/handler/slow_report.rb
+++ b/lib/chef/handler/slow_report.rb
@@ -29,6 +29,11 @@ class Chef
       end
 
       def report
+        if count == 0
+          puts "\nNo resources to profile\n\n"
+          return
+        end
+
         top = all_resources.sort_by(&:elapsed_time).last(amount).reverse
         data = top.map { |r| [ r.to_s, r.elapsed_time, r.cookbook_name, r.recipe_name, stripped_source_line(r) ] }
         puts "\nTop #{count} slowest #{count == 1 ? "resource" : "resources"}:\n\n"

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -135,7 +135,6 @@ class Chef
 
     def action_collection_registration(action_collection)
       @action_collection = action_collection
-      action_collection.register(self) if reporting_enabled?
     end
 
     def post_reporting_data


### PR DESCRIPTION
By default it looks like this:

```
Starting Chef Infra Client, version 17.2.12
Patents: https://www.chef.io/patents
resolving cookbooks for run list: ["test"]
Synchronizing Cookbooks:
  - test (0.0.1)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 1 resources
Recipe: test::default
  * file[/tmp/foo.xzy] action create (up to date)

Running handlers:

Top 1 slowest resource:

resource           elapsed_time cookbook recipe  source
------------------ ------------ -------- ------- ----------------------------------------
file[/tmp/foo.xzy] 0.015114     test     default test/recipes/default.rb:2:in `from_file'

  - Chef::Handler::SlowReport
Running handlers complete
Chef Infra Client finished, 0/1 resources updated in 03 seconds
```

It supports `--no-slow-report` to turn it off.  It supports `--slow-report 20` to show the top 20.  By default it shows the top-10 slowest list (unless the chef run contains less than that).

Bit of other cleanup was done.  The ActionCollection now runs all the time, registration is no longer necessary.  And Chef::Handler objects now have easy access to the action_collection.  Writing a new report handler to surf through the action_collection should be substantially easier, and not require writing a full event handler thingy.