### PR TITLE
Fix Chef::Handler specs and slow report behavior

### DIFF
--- a/lib/chef/handler/slow_report.rb
+++ b/lib/chef/handler/slow_report.rb
@@ -34,10 +34,10 @@ class Chef
           return
         end
 
-        top = all_resources.sort_by(&:elapsed_time).last(amount).reverse
-        data = top.map { |r| [ r.to_s, r.elapsed_time, r.cookbook_name, r.recipe_name, stripped_source_line(r) ] }
+        top = all_records.sort_by(&:elapsed_time).last(amount).reverse
+        data = top.map { |r| [ r.new_resource.to_s, r.elapsed_time, r.action, r.new_resource.cookbook_name, r.new_resource.recipe_name, stripped_source_line(r.new_resource) ] }
         puts "\nTop #{count} slowest #{count == 1 ? "resource" : "resources"}:\n\n"
-        table = TTY::Table.new(%w{resource elapsed_time cookbook recipe source}, data)
+        table = TTY::Table.new(%w{resource elapsed_time action cookbook recipe source}, data)
         rendered = table.render do |renderer|
           renderer.border do
             mid          "-"
@@ -46,6 +46,10 @@ class Chef
         end
         puts rendered
         puts "\n"
+      end
+
+      def all_records
+        @all_records ||= action_collection&.filtered_collection(unprocessed: false) || []
       end
 
       def count

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -38,6 +38,8 @@ describe Chef::Handler do
       @run_context = Chef::RunContext.new(@node, {}, @events)
       @all_resources = [Chef::Resource::Cat.new("lolz"), Chef::Resource::ZenMaster.new("tzu")]
       @all_resources.first.updated_by_last_action true
+      @handler.instance_variable_set(:@all_resources, @all_resources)
+      @handler.instance_variable_set(:@updated_resources, [@all_resources.first])
       @run_context.resource_collection.all_resources.replace(@all_resources)
       @run_status.run_context = @run_context
       @start_time = Time.now
@@ -119,6 +121,8 @@ describe Chef::Handler do
       @run_context = Chef::RunContext.new(@node, {}, @events)
       @all_resources = [Chef::Resource::Cat.new("foo"), Chef::Resource::ZenMaster.new("moo")]
       @all_resources.first.updated_by_last_action true
+      @handler.instance_variable_set(:@all_resources, @all_resources)
+      @handler.instance_variable_set(:@updated_resources, [@all_resources.first])
       @run_context.resource_collection.all_resources.replace(@all_resources)
       @run_status.run_context = @run_context
       @start_time = Time.now
@@ -169,17 +173,19 @@ describe Chef::Handler do
   # and this would test the start handler
   describe "when running a start handler" do
     before do
+      @handler.instance_variable_set(:@all_resources, [])
+      @handler.instance_variable_set(:@updated_resources, [])
       @start_time = Time.now
       allow(Time).to receive(:now).and_return(@start_time)
       @run_status.start_clock
     end
 
     it "should not have all resources" do
-      expect(@handler.all_resources).to be_falsey
+      expect(@handler.all_resources).to be_empty
     end
 
     it "should not have updated resources" do
-      expect(@handler.updated_resources).to be_falsey
+      expect(@handler.updated_resources).to be_empty
     end
 
     it "has a shortcut for the start time" do


### PR DESCRIPTION
The slow report now walks through action records instead of
the resources and should have unique records for elapsed_time and
will report the slowest actions.