### PR TITLE
Fix incorrect require_relative causing failures in `knife org user add`

### DIFF
--- a/knife/lib/chef/knife/org_user_add.rb
+++ b/knife/lib/chef/knife/org_user_add.rb
@@ -29,7 +29,7 @@ class Chef
         description: "Add user to admin group"
 
       deps do
-        require_relative "../org"
+        require "chef/org"
       end
 
       def run


### PR DESCRIPTION
Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

This fixes the following error when using `knife org user add`: 
```
[redacted]/lib/chef/knife/org_user_add.rb:32:in `require_relative': cannot load such file -- /[redacted]/lib/chef/org (LoadError)
```