### PR TITLE
Bootstrap: Fix for performing sudo operations once sudo password ente…

### DIFF
--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -20,6 +20,7 @@ require_relative "../knife"
 require_relative "data_bag_secret_options"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 require "license_acceptance/cli_flags/mixlib_cli"
+
 module LicenseAcceptance
   autoload :Acceptor, "license_acceptance/acceptor"
 end
@@ -705,6 +706,8 @@ class Chef
           ui.warn("#{e.message} - trying with pty request")
           conn_options[:pty] = true # ensure we can talk to systems with requiretty set true in sshd config
           retry
+        elsif e.reason == :sudo_missing_terminal
+          ui.error "Sudo password is required for this operation. Please enter password using -P or --ssh-password option"
         elsif config[:use_sudo_password] && (e.reason == :sudo_password_required || e.reason == :bad_sudo_password) && limit < 3
           ui.warn("Failed to authenticate #{conn_options[:user]} to #{server_name} - #{e.message} \n sudo: #{limit} incorrect password attempt")
           sudo_password = ui.ask("Enter sudo password for #{conn_options[:user]}@#{server_name}:", echo: false)

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -2050,6 +2050,19 @@ describe Chef::Knife::Bootstrap do
         expect { knife.do_connect({}) }.to raise_error(expected_error)
       end
     end
+
+    context "when a train sudo error is thrown for missing terminal" do
+      let(:ui_error_msg) { "Sudo password is required for this operation. Please enter password using -P or --ssh-password option" }
+      let(:expected_error) { Train::UserError.new(ui_error_msg, :sudo_missing_terminal) }
+      before do
+        allow(connection).to receive(:connect!).and_raise(expected_error)
+      end
+      it "outputs user friendly error message" do
+        expect { knife.do_connect({}) }.not_to raise_error
+        expect(stderr.string).to include(ui_error_msg)
+      end
+    end
+
   end
 
   describe "validate_winrm_transport_opts!" do


### PR DESCRIPTION
…red by user

Signed-off-by: smriti <sgarg@msystechnologies.com>

## Description

`knife bootstrap --use-sudo-password` command if is executed for systems where sudo password is used for every operation. A default train error is shown to user as of now. 

With current change we are handling `Train::UserError` in knife code and display a user friendly error message with instructions which will help user to perform `knife bootstrap` operation successfully. 

## Related Issue
https://github.com/chef/chef/issues/11359

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
