### PR TITLE
windows_firewall_rule: allow for multiple remote addresses

### DIFF
--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -43,11 +43,11 @@ class Chef
 
       ```ruby
       windows_firewall_rule 'MyRule' do
-        description          "testing out remote address arrays"
+        description          'Testing out remote address arrays'
         enabled              false
         local_port           1434
         remote_address       %w(10.17.3.101 172.7.7.53)
-        protocol             "TCP"
+        protocol             'TCP'
         action               :create
       end
       ```
@@ -111,6 +111,7 @@ class Chef
         description: "The local port the firewall rule applies to."
 
       property :remote_address, [String, Array],
+        coerce: proc { |d| d.is_a?(String) ? d.split(/\s*,\s*/).sort : Array(d).sort.map(&:to_s) },
         description: "The remote address(es) the firewall rule applies to."
 
       property :remote_port, [String, Integer, Array],

--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -39,6 +39,19 @@ class Chef
       end
       ```
 
+      **Configuring multiple remote-address ports on a rule**:
+
+      ```ruby
+      windows_firewall_rule 'MyRule' do
+        description          "testing out remote address arrays"
+        enabled              false
+        local_port           1434
+        remote_address       %w(10.17.3.101 172.7.7.53)
+        protocol             "TCP"
+        action               :create
+      end
+      ```
+
       **Allow protocol ICMPv6 with ICMP Type**:
 
       ```ruby
@@ -97,8 +110,8 @@ class Chef
         coerce: proc { |d| d.is_a?(String) ? d.split(/\s*,\s*/).sort : Array(d).sort.map(&:to_s) },
         description: "The local port the firewall rule applies to."
 
-      property :remote_address, String,
-        description: "The remote address the firewall rule applies to."
+      property :remote_address, [String, Array],
+        description: "The remote address(es) the firewall rule applies to."
 
       property :remote_port, [String, Integer, Array],
         # split various formats of comma separated lists and provide a sorted array of strings to match PS output
@@ -172,7 +185,7 @@ class Chef
         group state["group"]
         local_address state["local_address"]
         local_port Array(state["local_port"]).sort
-        remote_address state["remote_address"]
+        remote_address Array(state["remote_address"]).sort
         remote_port Array(state["remote_port"]).sort
         direction state["direction"]
         protocol state["protocol"]
@@ -227,7 +240,7 @@ class Chef
           cmd << " -Description '#{new_resource.description}'" if new_resource.description
           cmd << " -LocalAddress '#{new_resource.local_address}'" if new_resource.local_address
           cmd << " -LocalPort '#{new_resource.local_port.join("', '")}'" if new_resource.local_port
-          cmd << " -RemoteAddress '#{new_resource.remote_address}'" if new_resource.remote_address
+          cmd << " -RemoteAddress '#{new_resource.remote_address.join("', '")}'" if new_resource.remote_address
           cmd << " -RemotePort '#{new_resource.remote_port.join("', '")}'" if new_resource.remote_port
           cmd << " -Direction '#{new_resource.direction}'" if new_resource.direction
           cmd << " -Protocol '#{new_resource.protocol}'" if new_resource.protocol

--- a/spec/unit/resource/windows_firewall_rule_spec.rb
+++ b/spec/unit/resource/windows_firewall_rule_spec.rb
@@ -85,7 +85,7 @@ describe Chef::Resource::WindowsFirewallRule do
 
   it "the remote_address property accepts strings" do
     resource.remote_address("8.8.4.4")
-    expect(resource.remote_address).to eql("8.8.4.4")
+    expect(resource.remote_address).to eql(["8.8.4.4"])
   end
 
   it "the remote_address property accepts comma separated lists" do

--- a/spec/unit/resource/windows_firewall_rule_spec.rb
+++ b/spec/unit/resource/windows_firewall_rule_spec.rb
@@ -88,6 +88,11 @@ describe Chef::Resource::WindowsFirewallRule do
     expect(resource.remote_address).to eql("8.8.4.4")
   end
 
+  it "the remote_address property accepts comma separated lists" do
+    resource.remote_address(['10.17.3.101', '172.7.7.53'])
+    expect(resource.remote_address).to eql(%w{10.17.3.101 172.7.7.53})
+  end
+
   it "the remote_port property accepts strings" do
     resource.remote_port("8081")
     expect(resource.remote_port).to eql(["8081"])
@@ -223,8 +228,8 @@ describe Chef::Resource::WindowsFirewallRule do
   end
 
   it "aliases :remoteip to :remote_address" do
-    resource.remoteip("8.8.8.8")
-    expect(resource.remote_address).to eql("8.8.8.8")
+    resource.remoteip(["8.8.8.8"])
+    expect(resource.remote_address).to eql(["8.8.8.8"])
   end
 
   it "aliases :localport to :local_port" do
@@ -288,7 +293,7 @@ describe Chef::Resource::WindowsFirewallRule do
       end
 
       it "sets RemoteAddress" do
-        resource.remote_address("8.8.8.8")
+        resource.remote_address(["8.8.8.8"])
         expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -RemoteAddress '8.8.8.8' -Direction 'inbound' -Protocol 'TCP' -IcmpType 'Any' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
@@ -365,7 +370,7 @@ describe Chef::Resource::WindowsFirewallRule do
         resource.group("new group")
         resource.local_address("192.168.40.40")
         resource.local_port("80")
-        resource.remote_address("8.8.4.4")
+        resource.remote_address(["8.8.4.4"])
         resource.remote_port("8081")
         resource.direction(:outbound)
         resource.protocol("UDP")
@@ -416,7 +421,7 @@ describe Chef::Resource::WindowsFirewallRule do
       end
 
       it "sets RemoteAddress" do
-        resource.remote_address("8.8.8.8")
+        resource.remote_address(["8.8.8.8"])
         expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -NewDisplayName 'test_rule' -RemoteAddress '8.8.8.8' -Direction 'inbound' -Protocol 'TCP' -IcmpType 'Any' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
@@ -487,7 +492,7 @@ describe Chef::Resource::WindowsFirewallRule do
         resource.displayname("some cool display name")
         resource.local_address("192.168.40.40")
         resource.local_port("80")
-        resource.remote_address("8.8.4.4")
+        resource.remote_address(["8.8.4.4"])
         resource.remote_port("8081")
         resource.direction(:outbound)
         resource.protocol("UDP")

--- a/spec/unit/resource/windows_firewall_rule_spec.rb
+++ b/spec/unit/resource/windows_firewall_rule_spec.rb
@@ -89,7 +89,7 @@ describe Chef::Resource::WindowsFirewallRule do
   end
 
   it "the remote_address property accepts comma separated lists" do
-    resource.remote_address(['10.17.3.101', '172.7.7.53'])
+    resource.remote_address(["10.17.3.101", "172.7.7.53"])
     expect(resource.remote_address).to eql(%w{10.17.3.101 172.7.7.53})
   end
 


### PR DESCRIPTION
Updated the spec file to account for the change in data types

Signed-off-by: John McCrae <john.mccrae@progress.com>