### PR TITLE
knife bootstrap windows: log_level should be updated as in client.rb

### DIFF
--- a/knife/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/knife/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -86,8 +86,8 @@ class Chef
             client_rb << "# Using default node name (fqdn)\n"
           end
 
-          if config[:config_log_level]
-            client_rb << %Q{log_level :#{config[:config_log_level]}\n}
+          if chef_config[:config_log_level]
+            client_rb << %Q{log_level :#{chef_config[:config_log_level]}\n}
           else
             client_rb << "log_level        :auto\n"
           end

--- a/knife/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/knife/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -169,7 +169,7 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
         echo.file_backup_path  "C:\\\\chef\\\\backup"
         echo.cache_options     ^({:path =^> "C:\\\\chef\\\\cache\\\\checksums", :skip_expires =^> true}^)
         echo.# Using default node name ^(fqdn^)
-        echo.log_level        :auto
+        echo.log_level :info
         echo.log_location       STDOUT
       EXPECTED
       expect(bootstrap_context.config_content).to eq expected


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

log_level while being set in client.rb was referring to wrong hash variable

## Description
` knife bootstrap -o winrm IPaddress -U 'USERNAME' -P 'PASSWORD' -c /.chef/config.rb -N NODENAME -V`
 " -V " verbose option plays a role in value of final log_level setting in client.rb
To set `log_level` it searches in `config[:config_log_level]` which is wrong hash variable, hence file being created with default log_level = auto always it should look for log_level in `chef_config[:config_log_level]`

## Related Issue
https://github.com/chef/chef/issues/11367

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
