### PR TITLE
Cleanup windows_printer_port and allow updating the port

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_windows_printer.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_windows_printer.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook:: end_to_end
+# Recipe:: _windows_printer
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+#
+
+windows_printer_port "10.4.64.39" do
+  port_name "My awesome port"
+  snmp_enabled true
+  port_protocol 2
+end
+
+# change the port above
+windows_printer_port "10.4.64.39" do
+  port_name "My awesome port"
+  snmp_enabled false
+  port_protocol 2
+end
+
+# delete a port that doesn't exist
+windows_printer_port "10.4.64.37" do
+  action :delete
+end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -176,3 +176,5 @@ end
 windows_certificate "c:/mordor/ca.cert.pem" do
   store_name "ROOT"
 end
+
+include_recipe "::_windows_printer"

--- a/lib/chef/resource/windows_printer_port.rb
+++ b/lib/chef/resource/windows_printer_port.rb
@@ -72,7 +72,7 @@ class Chef
         description: "The port name."
 
       property :port_number, Integer,
-        description: "The port number.",
+        description: "The TCP port number.",
         default: 9100
 
       property :port_description, String,
@@ -132,7 +132,6 @@ class Chef
 
           # create the printer port using PowerShell
           powershell_exec! <<-EOH
-
               Set-WmiInstance -class Win32_TCPIPPrinterPort `
                 -EnableAllPrivileges `
                 -Argument @{ HostAddress = "#{new_resource.ipv4_address}";

--- a/lib/chef/resource/windows_printer_port.rb
+++ b/lib/chef/resource/windows_printer_port.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Doug Ireton <doug@1strategy.com>
 # Copyright:: 2012-2018, Nordstrom, Inc.
+# Copyright:: Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -130,8 +131,7 @@ class Chef
           port_name = new_resource.port_name || "IP_#{new_resource.ipv4_address}"
 
           # create the printer port using PowerShell
-          declare_resource(:powershell_script, "Creating printer port #{new_resource.port_name}") do
-            code <<-EOH
+          powershell_exec! <<-EOH
 
               Set-WmiInstance -class Win32_TCPIPPrinterPort `
                 -EnableAllPrivileges `
@@ -142,19 +142,16 @@ class Chef
                             Protocol    = "#{new_resource.port_protocol}";
                             SNMPEnabled = "$#{new_resource.snmp_enabled}";
                           }
-            EOH
-          end
+          EOH
         end
 
         def delete_printer_port
           port_name = new_resource.port_name || "IP_#{new_resource.ipv4_address}"
 
-          declare_resource(:powershell_script, "Deleting printer port: #{new_resource.port_name}") do
-            code <<-EOH
+          powershell_exec! <<-EOH
               $port = Get-WMIObject -class Win32_TCPIPPrinterPort -EnableAllPrivileges -Filter "name = '#{port_name}'"
               $port.Delete()
-            EOH
-          end
+          EOH
         end
       end
     end

--- a/lib/chef/resource/windows_printer_port.rb
+++ b/lib/chef/resource/windows_printer_port.rb
@@ -69,14 +69,17 @@ class Chef
         }
 
       property :port_name, String,
-        description: "The port name."
+        description: "The port name.",
+        default: lazy { |x| "IP_#{x.ipv4_address}" },
+        default_description: "The resource block name or the ipv4_address prepended with IP_."
 
       property :port_number, Integer,
         description: "The TCP port number.",
         default: 9100
 
       property :port_description, String,
-        description: "The description of the port."
+        desired_state: false,
+        deprecated: true
 
       property :snmp_enabled, [TrueClass, FalseClass],
         description: "Determines if SNMP is enabled on the port.",
@@ -87,70 +90,43 @@ class Chef
         validation_message: "port_protocol must be either 1 for RAW or 2 for LPR!",
         default: 1, equal_to: [1, 2]
 
-      PORTS_REG_KEY = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print\Monitors\Standard TCP/IP Port\Ports\\'.freeze unless defined?(PORTS_REG_KEY)
-
-      # @todo Set @current_resource port properties from registry
       load_current_value do |new_resource|
-        name new_resource.name
-        ipv4_address new_resource.ipv4_address
-        port_name new_resource.port_name || "IP_#{new_resource.ipv4_address}"
+        port_data = powershell_exec(%Q{Get-WmiObject -Class Win32_TCPIPPrinterPort -Filter "Name='#{new_resource.port_name}'"}).result
+
+        if port_data.empty?
+          current_value_does_not_exist!
+        else
+          ipv4_address port_data["HostAddress"]
+          port_name port_data["Name"]
+          snmp_enabled port_data["SNMPEnabled"]
+          port_protocol port_data["Protocol"]
+          port_number port_data["PortNumber"]
+        end
       end
 
-      action :create, description: "Create the printer port, if one doesn't already exist." do
-        if port_exists?
-          Chef::Log.info "#{@new_resource} already exists - nothing to do."
-        else
-          converge_by("Create #{@new_resource}") do
-            create_printer_port
-          end
+      action :create, description: "Create or update the printer port." do
+        converge_if_changed do
+          # create the printer port using PowerShell
+          powershell_exec! <<-EOH
+          Set-WmiInstance -class Win32_TCPIPPrinterPort `
+            -EnableAllPrivileges `
+            -Argument @{ HostAddress = "#{new_resource.ipv4_address}";
+                        Name        = "#{new_resource.port_name}";
+                        PortNumber  = "#{new_resource.port_number}";
+                        Protocol    = "#{new_resource.port_protocol}";
+                        SNMPEnabled = "$#{new_resource.snmp_enabled}";
+                      }
+          EOH
         end
       end
 
       action :delete, description: "Delete an existing printer port." do
-        if port_exists?
-          converge_by("Delete #{@new_resource}") do
-            delete_printer_port
+        if current_resource
+          converge_by("Delete #{new_resource.port_name}") do
+            powershell_exec!("Remove-PrinterPort -Name #{new_resource.port_name}")
           end
         else
-          Chef::Log.info "#{@current_resource} doesn't exist - can't delete."
-        end
-      end
-
-      action_class do
-        private
-
-        def port_exists?
-          name = new_resource.port_name || "IP_#{new_resource.ipv4_address}"
-          port_reg_key = PORTS_REG_KEY + name
-
-          logger.trace "Checking to see if this reg key exists: '#{port_reg_key}'"
-          registry_key_exists?(port_reg_key)
-        end
-
-        def create_printer_port
-          port_name = new_resource.port_name || "IP_#{new_resource.ipv4_address}"
-
-          # create the printer port using PowerShell
-          powershell_exec! <<-EOH
-              Set-WmiInstance -class Win32_TCPIPPrinterPort `
-                -EnableAllPrivileges `
-                -Argument @{ HostAddress = "#{new_resource.ipv4_address}";
-                            Name        = "#{port_name}";
-                            Description = "#{new_resource.port_description}";
-                            PortNumber  = "#{new_resource.port_number}";
-                            Protocol    = "#{new_resource.port_protocol}";
-                            SNMPEnabled = "$#{new_resource.snmp_enabled}";
-                          }
-          EOH
-        end
-
-        def delete_printer_port
-          port_name = new_resource.port_name || "IP_#{new_resource.ipv4_address}"
-
-          powershell_exec! <<-EOH
-              $port = Get-WMIObject -class Win32_TCPIPPrinterPort -EnableAllPrivileges -Filter "name = '#{port_name}'"
-              $port.Delete()
-          EOH
+          Chef::Log.info "#{new_resource.port_name} doesn't exist - can't delete."
         end
       end
     end


### PR DESCRIPTION
- Avoid double logging caused by converge_by and powershell_script
- Remove all the slow use of powershell_script
- Set the default for portname on the resource instead of calculating it the same in 3 places
- Load the state fully / remove the exists? method
- Delete the power with the powershell cmdlet
- Add updating to the create action
- Deprecate the description property which never did anything

<img width="605" alt="image" src="https://user-images.githubusercontent.com/1015200/120938233-a50f4e00-c6c6-11eb-96d0-6290d11f4659.png">


Signed-off-by: Tim Smith <tsmith@chef.io>