### PR TITLE
windows_printer: use powershell_exec to delete the printer instead of slower/double logging powershell_script

### DIFF
--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Doug Ireton (<doug@1strategy.com>)
 # Copyright:: 2012-2018, Nordstrom, Inc.
+# Copyright:: Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -149,12 +150,10 @@ class Chef
         end
 
         def delete_printer
-          declare_resource(:powershell_script, "Deleting printer: #{new_resource.device_id}") do
-            code <<-EOH
+          powershell_exec! <<-EOH
               $printer = Get-WMIObject -class Win32_Printer -EnableAllPrivileges -Filter "name = '#{new_resource.device_id}'"
               $printer.Delete()
-            EOH
-          end
+          EOH
         end
       end
     end

--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -103,11 +103,11 @@ class Chef
 
       action :delete, description: "Delete an existing printer. Note that this resource does not delete the associated printer port." do
         if printer_exists?
-          converge_by("Delete #{@new_resource}") do
-            delete_printer
+          converge_by("Delete #{new_resource.device_id}") do
+            powershell_exec!("Remove-Printer -Name '#{new_resource.device_id}'")
           end
         else
-          Chef::Log.info "#{@current_resource} doesn't exist - can't delete."
+          Chef::Log.info "#{new_resource.device_id} doesn't exist - can't delete."
         end
       end
 
@@ -144,13 +144,6 @@ class Chef
                           }
             EOH
           end
-        end
-
-        def delete_printer
-          powershell_exec! <<-EOH
-              $printer = Get-WMIObject -class Win32_Printer -EnableAllPrivileges -Filter "name = '#{new_resource.device_id}'"
-              $printer.Delete()
-          EOH
         end
       end
     end

--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -112,8 +112,6 @@ class Chef
       end
 
       action_class do
-        private
-
         # does the printer exist
         #
         # @param [String] name the name of the printer
@@ -133,7 +131,6 @@ class Chef
 
           declare_resource(:powershell_script, "Creating printer: #{new_resource.device_id}") do
             code <<-EOH
-
               Set-WmiInstance -class Win32_Printer `
                 -EnableAllPrivileges `
                 -Argument @{ DeviceID   = "#{new_resource.device_id}";


### PR DESCRIPTION
Minor improvement here to cleanup the logging when you delete and make it a bit faster.