### PR TITLE
Add ed25519 gem back to the omnibus install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group(:omnibus_package) do
   gem "rb-readline"
   gem "inspec-core-bin", "~> 4.24" # need to provide the binaries for inspec
   gem "chef-vault"
+  gem "ed25519", "~> 1.2" # to make it possible to install knife into chef. Remove this in Chef 18
 end
 
 group(:omnibus_package, :pry) do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,11 +152,12 @@ GEM
       chef-zero (>= 14.0)
       net-ssh
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
     debug_inspector (1.1.0)
     diff-lcs (1.3)
+    ed25519 (1.2.4)
     erubi (1.10.0)
     erubis (2.7.0)
     faraday (1.4.2)
@@ -414,6 +415,7 @@ DEPENDENCIES
   chef-vault
   cheffish (>= 17)
   chefstyle!
+  ed25519 (~> 1.2)
   fauxhai-ng
   inspec-core-bin (~> 4.24)
   ohai!
@@ -426,4 +428,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.4
+   2.2.19


### PR DESCRIPTION
This lets folks workaround not having knife by installing it back on
windows. This gets removed in 18.

Signed-off-by: Tim Smith <tsmith@chef.io>