### PR TITLE
Support attribute block/allow list in data collector

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -1007,7 +1007,7 @@ module ChefConfig
     default :blocked_normal_attributes, nil
     default :blocked_override_attributes, nil
 
-    # deprecated config options that will be removed in Chef Infra Client 17
+    # deprecated config options that will be removed in Chef Infra Client 18
     default :automatic_attribute_blacklist, nil
     default :default_attribute_blacklist, nil
     default :normal_attribute_blacklist, nil

--- a/lib/chef/data_collector/run_end_message.rb
+++ b/lib/chef/data_collector/run_end_message.rb
@@ -51,7 +51,7 @@ class Chef
             "id" => run_status&.run_id,
             "message_version" => "1.1.0",
             "message_type" => "run_converge",
-            "node" => node || {},
+            "node" => node&.data_for_save || {},
             "node_name" => node&.name || data_collector.node_name,
             "organization_name" => organization,
             "resources" => all_action_records(action_collection),

--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -253,6 +253,10 @@ class Chef
       target 33
     end
 
+    class AttributeWhitelistConfiguration < Base
+      target 34
+    end
+
     class Generic < Base
       def url
         "https://docs.chef.io/chef_deprecations_client/"

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -712,7 +712,7 @@ class Chef
     # @param [String] level the attribute level
     def allowlist_or_whitelist_config(level)
       if Chef::Config["#{level}_attribute_whitelist".to_sym]
-        Chef.deprecated(:attribute_blacklist_configuration, "Attribute whitelist configurations have been deprecated. Use the allowed_LEVEL_attribute configs instead")
+        Chef.deprecated(:attribute_whitelist_configuration, "Attribute whitelist configurations have been deprecated. Use the allowed_LEVEL_attribute configs instead")
         Chef::Config["#{level}_attribute_whitelist".to_sym]
       else
         Chef::Config["allowed_#{level}_attributes".to_sym]


### PR DESCRIPTION

With this change the attribute block and allow list filtering has been extended to the Automate data collector. This will make captured attributes consistent across Automate and Chef Infra Server. 

Fixes #10895
