### PR TITLE
Knife upload: bad error message when a recipe has a syntax error

### DIFF
--- a/lib/chef/cookbook/syntax_check.rb
+++ b/lib/chef/cookbook/syntax_check.rb
@@ -248,8 +248,8 @@ class Chef
       # Debugs ruby syntax errors by printing the path to the file and any
       # diagnostic info given in +error_message+
       def invalid_ruby_file(ruby_file, error_message)
-        file_relative_path = ruby_file[/^#{Regexp.escape(cookbook_path + File::Separator)}(.*)/, 1]
-        Chef::Log.fatal("Cookbook file #{file_relative_path} has a ruby syntax error:")
+        file_relative_path = File.basename(ruby_file)
+        Chef::Log.fatal("Cookbook file #{file_relative_path} has a ruby syntax error.")
         error_message.each_line { |l| Chef::Log.fatal(l.chomp) }
         false
       end

--- a/lib/chef/cookbook/syntax_check.rb
+++ b/lib/chef/cookbook/syntax_check.rb
@@ -248,7 +248,7 @@ class Chef
       # Debugs ruby syntax errors by printing the path to the file and any
       # diagnostic info given in +error_message+
       def invalid_ruby_file(ruby_file, error_message)
-        file_relative_path = File.basename(ruby_file)
+        file_relative_path = ruby_file[ruby_file.index(cookbook_path.split("/").last), ruby_file.length]
         Chef::Log.fatal("Cookbook file #{file_relative_path} has a ruby syntax error.")
         error_message.each_line { |l| Chef::Log.fatal(l.chomp) }
         false

--- a/spec/unit/cookbook/syntax_check_spec.rb
+++ b/spec/unit/cookbook/syntax_check_spec.rb
@@ -159,12 +159,15 @@ describe Chef::Cookbook::SyntaxCheck do
       end
 
       describe "and a file has a syntax error" do
+
         before do
           cookbook_path = File.join(CHEF_SPEC_DATA, "cookbooks", "borken")
           syntax_check.cookbook_path.replace(cookbook_path)
         end
 
         it "it indicates that a ruby file has a syntax error" do
+          expect(Chef::Log).to receive(:fatal).with("Cookbook file default.rb has a ruby syntax error.")
+          allow(Chef::Log).to receive(:fatal)
           expect(syntax_check.validate_ruby_files).to be_falsey
         end
 

--- a/spec/unit/cookbook/syntax_check_spec.rb
+++ b/spec/unit/cookbook/syntax_check_spec.rb
@@ -166,7 +166,7 @@ describe Chef::Cookbook::SyntaxCheck do
         end
 
         it "it indicates that a ruby file has a syntax error" do
-          expect(Chef::Log).to receive(:fatal).with("Cookbook file default.rb has a ruby syntax error.")
+          expect(Chef::Log).to receive(:fatal).with("Cookbook file borken/recipes/default.rb has a ruby syntax error.")
           allow(Chef::Log).to receive(:fatal)
           expect(syntax_check.validate_ruby_files).to be_falsey
         end


### PR DESCRIPTION
Signed-off-by: snehaldwivedi <sdwivedi@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
When uploading a file with a syntax error the error message was not specifying the file name where the issue exists. Fixed it by displaying the name of the file.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/9378

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
