### PR TITLE
Handle source_line being nil gracefully

### DIFF
--- a/lib/chef/handler/slow_report.rb
+++ b/lib/chef/handler/slow_report.rb
@@ -59,7 +59,7 @@ class Chef
 
       def stripped_source_line(resource)
         # strip the leading path off of the source line
-        resource.source_line.gsub(%r{.*/cookbooks/}, "").gsub(%r{.*/chef-[0-9\.]+/}, "")
+        resource.source_line&.gsub(%r{.*/cookbooks/}, "")&.gsub(%r{.*/chef-[0-9\.]+/}, "")
       end
     end
   end


### PR DESCRIPTION
When a resource is marked sensitive, the source_line is nil and you can't gsub on it. So if a sensitive resource is slow, it should not crash the SlowReport because it has no source_line.

Fixes chef/chef#11690

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
