### PR TITLE
Add macos_ruby? helper and wire to the macos? helper

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -27,6 +27,7 @@ The Platform Family helpers provide an alternative to comparing values from `nod
 * `freebsd?`
 * `gentoo?`
 * `macos?`
+* `macos_ruby?` - this is always true if the ruby VM is running on a mac host and is not stubbed by ChefSpec
 * `netbsd?`
 * `openbsd?`
 * `rhel?` - includes redhat, centos, scientific, oracle, and clearos platforms

--- a/chef-utils/lib/chef-utils/dsl/platform_family.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform_family.rb
@@ -77,7 +77,7 @@ module ChefUtils
       # @return [Boolean]
       #
       def macos?(node = __getnode)
-        node["platform_family"] == "mac_os_x"
+        node ? node["platform_family"] == "mac_os_x" : macos_ruby?
       end
       # chef-sugar backcompat method
       alias_method :osx?, :macos?
@@ -85,6 +85,17 @@ module ChefUtils
       alias_method :mac?, :macos?
       # chef-sugar backcompat method
       alias_method :mac_os_x?, :macos?
+
+      # Determine if the Ruby VM is currently running on a Mac node (This is useful primarily for internal use
+      # by chef client before the node object exists).
+      #
+      # @since 17.3
+      #
+      # @return [Boolean]
+      #
+      def macos_ruby?
+        !!(RUBY_PLATFORM =~ /darwin/)
+      end
 
       # Determine if the current node is a member of the 'rhel' platform family (Red Hat, CentOS, Oracle or Scientific Linux, but NOT Amazon Linux or Fedora).
       #

--- a/chef-utils/lib/chef-utils/dsl/platform_family.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform_family.rb
@@ -87,7 +87,7 @@ module ChefUtils
       alias_method :mac_os_x?, :macos?
 
       # Determine if the Ruby VM is currently running on a Mac node (This is useful primarily for internal use
-      # by chef client before the node object exists).
+      # by Chef Infra Client before the node object exists).
       #
       # @since 17.3
       #

--- a/chef-utils/lib/chef-utils/parallel_map.rb
+++ b/chef-utils/lib/chef-utils/parallel_map.rb
@@ -45,7 +45,7 @@ module ChefUtils
         pool ||= ChefUtils::DefaultThreadPool.instance.pool
 
         futures = map do |item|
-          future = Concurrent::Future.execute(executor: pool) do
+          Concurrent::Future.execute(executor: pool) do
             yield item
           end
         end

--- a/chef-utils/spec/unit/dsl/platform_family_spec.rb
+++ b/chef-utils/spec/unit/dsl/platform_family_spec.rb
@@ -25,7 +25,7 @@ def pf_reports_true_for(*args)
       expect(described_class.send(method, node)).to be true
     end
   end
-  (PLATFORM_FAMILY_HELPERS - [ :windows_ruby? ] - args).each do |method|
+  (PLATFORM_FAMILY_HELPERS - %i{windows_ruby? macos_ruby?} - args).each do |method|
     it "reports false for #{method}" do
       expect(described_class.send(method, node)).to be false
     end
@@ -41,7 +41,7 @@ RSpec.describe ChefUtils::DSL::PlatformFamily do
     end
   end
 
-  ( PLATFORM_FAMILY_HELPERS - [ :windows_ruby? ]).each do |helper|
+  ( PLATFORM_FAMILY_HELPERS - %i{windows_ruby? macos_ruby?}).each do |helper|
     it "has the #{helper} in the ChefUtils module" do
       expect(ChefUtils).to respond_to(helper)
     end
@@ -217,6 +217,18 @@ RSpec.describe ChefUtils::DSL::PlatformFamily do
     else
       it "reports false for :windows_ruby?" do
         expect(described_class.windows_ruby?).to be false
+      end
+    end
+  end
+
+  context "node-independent mac APIs" do
+    if RUBY_PLATFORM.match?(/darwin/)
+      it "reports true for :macos_ruby?" do
+        expect(described_class.macos_ruby?).to be true
+      end
+    else
+      it "reports false for :macos_ruby?" do
+        expect(described_class.macos_ruby?).to be false
       end
     end
   end

--- a/chef-utils/spec/unit/parallel_map_spec.rb
+++ b/chef-utils/spec/unit/parallel_map_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe ChefUtils::ParallelMap do
     end
 
     it "recursive parallel_each will not deadlock" do
-      ans = Timeout.timeout(30) do
+      Timeout.timeout(30) do
         (1..2).parallel_each { |i| (1..2).parallel_each { |i| i } }
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe ChefUtils::ParallelMap do
     end
 
     it "parallel_each is lazy" do
-      ans = Timeout.timeout(30) do
+      Timeout.timeout(30) do
         (1..).lazy.parallel_each { |i| i }.first(5)
       end
     end


### PR DESCRIPTION
This is useful for internal use when we are in a class context or
whenever we are before load_node/build_node.

It might also be useful for users to gate requires that are
macos-specific for macos only gems, or something like that.