### PR TITLE
zypper_package is not idempotent on SUSE

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -97,7 +97,11 @@ class Chef
 
         def resolve_available_version(package_name, new_version)
           search_string = new_version.nil? ? package_name : "#{package_name}=#{new_version}"
-          so = shell_out!("zypper", "--non-interactive", "search", "-s", "--provides", "--match-exact", "--type=package", search_string)
+          so = begin
+                shell_out!("zypper", "--non-interactive", "search", "-s", "--provides", "--match-exact", "--type=package", search_string)
+              rescue Exception => e
+                Mixlib::ShellOut.new
+              end
           so.stdout.each_line do |line|
             if md = line.match(/^(\S*)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(.*)$/)
               (status, name, type, version, arch, repo) = [ md[1], md[2], md[3], md[4], md[5], md[6] ]

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -248,6 +248,13 @@ describe Chef::Provider::Package::Zypper do
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
+     
+      it "should run zypper remove for non existing package" do
+        shell_out_expectation!(
+          "zypper", "--non-interactive", "remove", "noname=1.0"
+        )
+        provider.remove_package(["noname"], ["1.0"])
+      end
     end
   end
 


### PR DESCRIPTION
- Fixed the issue by handling the exception which raises if SUSE system is not able to search a particular package.

Signed-off-by: Ashwin <ashvinvarma2@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
