### PR TITLE
Update Ohai to 17.2, InSpec to 4.37.20 and add back windows deps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 934109b9eb3d46da996eb4780719e0ebe11ccafc
+  revision: e1541bc6a90caa3686139524d9c1818b77ad721a
   branch: master
   specs:
-    ohai (17.1.0)
+    ohai (17.2.0)
       chef-config (>= 14.12, < 18)
       chef-utils (>= 16.0, < 18)
       ffi (~> 1.9)
@@ -194,7 +194,7 @@ GEM
     hashie (4.1.0)
     httpclient (2.8.3)
     iniparse (1.5.0)
-    inspec-core (4.37.25)
+    inspec-core (4.37.30)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -217,8 +217,8 @@ GEM
       train-core (~> 3.0)
       tty-prompt (~> 0.17)
       tty-table (~> 0.10)
-    inspec-core-bin (4.37.25)
-      inspec-core (= 4.37.25)
+    inspec-core-bin (4.37.30)
+      inspec-core (= 4.37.30)
     ipaddress (0.8.3)
     iso8601 (0.13.0)
     json (2.5.1)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 68f693d43977a30df7a3a25a705aa061205e91fd
+  revision: c626aa2a357f482461f59aa038581bf0ec809fcb
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.468.0)
+    aws-partitions (1.469.0)
     aws-sdk-core (3.114.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -101,6 +101,54 @@ GEM
       tty-screen (~> 0.6)
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
+    chef (16.13.16-universal-mingw32)
+      addressable
+      bcrypt_pbkdf (~> 1.1)
+      bundler (>= 1.10)
+      chef-config (= 16.13.16)
+      chef-utils (= 16.13.16)
+      chef-vault
+      chef-zero (>= 14.0.11)
+      diff-lcs (>= 1.2.4, < 1.4.0)
+      ed25519 (~> 1.2)
+      erubis (~> 2.7)
+      ffi (>= 1.9.25)
+      ffi-libarchive (~> 1.0, >= 1.0.3)
+      ffi-yajl (~> 2.2)
+      highline (>= 1.6.9, < 3)
+      iniparse (~> 1.4)
+      inspec-core (~> 4.23)
+      iso8601 (>= 0.12.1, < 0.14)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-authentication (>= 2.1, < 4)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      mixlib-log (>= 2.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
+      net-sftp (>= 2.1.2, < 4.0)
+      net-ssh (>= 5.1, < 7)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (~> 16.0)
+      pastel
+      plist (~> 3.2)
+      proxifier (~> 1.0)
+      syslog-logger (~> 1.6)
+      train-core (~> 3.2, >= 3.2.28)
+      train-winrm (>= 0.2.5)
+      tty-prompt (~> 0.21)
+      tty-screen (~> 0.6)
+      tty-table (~> 0.11)
+      uuidtools (>= 2.1.5, < 3.0)
+      win32-api (~> 1.5.3)
+      win32-certstore (~> 0.5.0)
+      win32-event (~> 0.6.1)
+      win32-eventlog (= 0.6.3)
+      win32-mmap (~> 0.4.1)
+      win32-mutex (~> 0.4.2)
+      win32-process (~> 0.9)
+      win32-service (>= 2.1.5, < 3.0)
+      win32-taskscheduler (~> 2.0)
+      wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
     chef-config (16.13.16)
       addressable
@@ -149,6 +197,8 @@ GEM
     ffi (1.15.3-x86-mingw32)
     ffi-libarchive (1.0.17)
       ffi (~> 1.0)
+    ffi-win32-extensions (1.0.4)
+      ffi
     ffi-yajl (2.4.0)
       libyajl2 (>= 1.2)
     fuzzyurl (0.9.0)
@@ -185,6 +235,7 @@ GEM
       tty-table (~> 0.10)
     iostruct (0.0.4)
     ipaddress (0.8.3)
+    iso8601 (0.13.0)
     jmespath (1.4.0)
     json (2.5.1)
     kitchen-vagrant (1.8.0)
@@ -220,6 +271,11 @@ GEM
     mixlib-log (3.0.9)
     mixlib-shellout (3.2.5)
       chef-utils
+    mixlib-shellout (3.2.5-universal-mingw32)
+      chef-utils
+      ffi-win32-extensions (~> 1.0.3)
+      win32-process (~> 0.9)
+      wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
     molinillo (0.7.0)
     multi_json (1.15.0)
@@ -303,8 +359,9 @@ GEM
       unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
+    structured_warnings (0.4.0)
     syslog-logger (1.6.8)
-    test-kitchen (2.11.2)
+    test-kitchen (2.12.0)
       bcrypt_pbkdf (~> 1.0)
       chef-utils (>= 16.4.35)
       ed25519 (~> 1.2)
@@ -355,6 +412,28 @@ GEM
     unicode_utils (1.4.0)
     uuidtools (2.2.0)
     webrick (1.7.0)
+    win32-api (1.5.3-universal-mingw32)
+    win32-certstore (0.5.3)
+      ffi
+      mixlib-shellout
+    win32-event (0.6.3)
+      win32-ipc (>= 0.6.0)
+    win32-eventlog (0.6.3)
+      ffi
+    win32-ipc (0.7.0)
+      ffi
+    win32-mmap (0.4.2)
+      ffi
+    win32-mutex (0.4.3)
+      win32-ipc (>= 0.6.0)
+    win32-process (0.9.0)
+      ffi (>= 1.0.0)
+    win32-service (2.2.0)
+      ffi
+      ffi-win32-extensions
+    win32-taskscheduler (2.0.4)
+      ffi
+      structured_warnings
     winrm (2.3.6)
       builder (>= 2.1.2)
       erubi (~> 1.8)


### PR DESCRIPTION
Bump everything but FFI

Signed-off-by: Tim Smith <tsmith@chef.io>