### PR TITLE
fix mac_user create_user for running without full disk access

### DIFF
--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -143,27 +143,29 @@ class Chef
         #
 
         def create_user
-          cmd = [-"-addUser", new_resource.username]
-          cmd += ["-fullName", new_resource.comment] if prop_is_set?(:comment)
-          cmd += ["-UID", prop_is_set?(:uid) ? new_resource.uid : get_free_uid]
-          cmd += ["-shell", new_resource.shell]
-          cmd += ["-home", new_resource.home]
-          cmd += ["-admin"] if new_resource.admin
-
-          # We can technically create a new user without the admin credentials
-          # but without them the user cannot enable SecureToken, thus they cannot
-          # create other secure users or enable FileVault full disk encryption.
-          if prop_is_set?(:admin_username) && prop_is_set?(:admin_password)
-            cmd += ["-adminUser", new_resource.admin_username]
-            cmd += ["-adminPassword", new_resource.admin_password]
+          uid = prop_is_set?(:uid) ? new_resource.uid : get_free_uid
+          # 'sysadminctl' cannot create user with specified UID
+          # on Mac where Chef does not have full disk access
+          # But 'dscl' can
+          run_dscl('create', "/Users/#{new_resource.username}",
+                   'UniqueID', uid)
+          if prop_is_set?(:comment)
+            run_dscl('create', "/Users/#{new_resource.username}",
+                     'RealName', new_resource.comment)
+          else
+            # 'comment' field is optional for mac_user
+            # but 'load_current_resource' above needs it
+            # otherwise it will fail
+            run_dscl('create', "/Users/#{new_resource.username}",
+                     'RealName', new_resource.username)
           end
-
-          # sysadminctl doesn't exit with a non-zero exit code if it encounters
-          # a problem. We'll check stderr and make sure we see that it finished
-          # correctly.
-          res = run_sysadminctl(cmd)
-          unless /creating user/.match?(res.downcase)
-            raise Chef::Exceptions::User, "error when creating user: #{res}"
+          run_dscl('create', "/Users/#{new_resource.username}",
+                   'UserShell', new_resource.shell)
+          run_dscl('create', "/Users/#{new_resource.username}",
+                   'NFSHomeDirectory', new_resource.home)
+          if new_resource.admin
+            run_dscl('append', '/Groups/admin', 'GroupMembership',
+                     new_resource.username)
           end
 
           # Wait for the user to show up in the ds cache
@@ -179,18 +181,6 @@ class Chef
 
           if prop_is_set?(:password)
             converge_by("set password") { set_password }
-          end
-
-          if new_resource.manage_home
-            # "sysadminctl -addUser" will create the home directory if it's
-            # the default /Users/<username>, otherwise it sets it in plist
-            # but does not create it. Here we'll ensure that it gets created
-            # if we've been given a directory that is not the default.
-            unless ::File.directory?(new_resource.home) && ::File.exist?(new_resource.home)
-              converge_by("create home directory") do
-                shell_out!("createhomedir -c -u #{new_resource.username}")
-              end
-            end
           end
 
           if prop_is_set?(:gid)
@@ -209,6 +199,16 @@ class Chef
 
             converge_by("create primary group ID") do
               run_dscl("create", "/Users/#{new_resource.username}", "PrimaryGroupID", group_id)
+            end
+          end
+
+          # createhomedir needs user GID set first
+          # otherwise createhomedir will do nothing
+          # Always create homedir for all users
+          # because 'sysadminctl' does but 'dscl' does not
+          unless ::File.directory?(new_resource.home) && ::File.exist?(new_resource.home)
+            converge_by('create home directory') do
+              shell_out!("createhomedir -c -u #{new_resource.username}")
             end
           end
 

--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -144,27 +144,27 @@ class Chef
 
         def create_user
           uid = prop_is_set?(:uid) ? new_resource.uid : get_free_uid
-          # 'sysadminctl' cannot create user with specified UID
+          # "sysadminctl" cannot create user with specified UID
           # on Mac where Chef does not have full disk access
-          # But 'dscl' can
-          run_dscl('create', "/Users/#{new_resource.username}",
-                   'UniqueID', uid)
+          # But "dscl" can
+          run_dscl("create", "/Users/#{new_resource.username}",
+                   "UniqueID", uid)
           if prop_is_set?(:comment)
-            run_dscl('create', "/Users/#{new_resource.username}",
-                     'RealName', new_resource.comment)
+            run_dscl("create", "/Users/#{new_resource.username}",
+                     "RealName", new_resource.comment)
           else
-            # 'comment' field is optional for mac_user
-            # but 'load_current_resource' above needs it
+            # "comment" field is optional for mac_user
+            # but "load_current_resource" above needs it
             # otherwise it will fail
-            run_dscl('create', "/Users/#{new_resource.username}",
-                     'RealName', new_resource.username)
+            run_dscl("create", "/Users/#{new_resource.username}",
+                     "RealName", new_resource.username)
           end
-          run_dscl('create', "/Users/#{new_resource.username}",
-                   'UserShell', new_resource.shell)
-          run_dscl('create', "/Users/#{new_resource.username}",
-                   'NFSHomeDirectory', new_resource.home)
+          run_dscl("create", "/Users/#{new_resource.username}",
+                   "UserShell", new_resource.shell)
+          run_dscl("create", "/Users/#{new_resource.username}",
+                   "NFSHomeDirectory", new_resource.home)
           if new_resource.admin
-            run_dscl('append', '/Groups/admin', 'GroupMembership',
+            run_dscl("append", "/Groups/admin", "GroupMembership",
                      new_resource.username)
           end
 
@@ -205,9 +205,9 @@ class Chef
           # createhomedir needs user GID set first
           # otherwise createhomedir will do nothing
           # Always create homedir for all users
-          # because 'sysadminctl' does but 'dscl' does not
+          # because "sysadminctl" does but "dscl" does not
           unless ::File.directory?(new_resource.home) && ::File.exist?(new_resource.home)
-            converge_by('create home directory') do
+            converge_by("create home directory") do
               shell_out!("createhomedir -c -u #{new_resource.username}")
             end
           end


### PR DESCRIPTION
Signed-off-by: Gilbert Liu <zpak@fb.com>

Moving mac_user `create_user` to use `dscl` to create user when running without full disk access

## Description

The UID is different than what Chef specifies in the `sysadminctl` command, and this causes later Chef run to fail.
Running `sysadminctl` command on M1 Mac mini, both macOS 11.4 and 12.0, SIP on, default security level.
```
# sysadminctl -addUser svc -UID 30023 -shell /sbin/nologin -home /var/svc
2021-06-15 18:29:41.702 sysadminctl[64046:1889653] ----------------------------
2021-06-15 18:29:41.702 sysadminctl[64046:1889653] No clear text password or interactive option was specified (adduser, change/reset password will not allow user to use FDE) !
2021-06-15 18:29:41.702 sysadminctl[64046:1889653] ----------------------------
2021-06-15 18:29:41.748 sysadminctl[64046:1889653] Creating user record…
2021-06-15 18:29:41.796 sysadminctl[64046:1889653] Assigning UID: 30023 GID: 20
2021-06-15 18:29:41.813 sysadminctl[64046:1889653] ### Error:-14120 File:/System/Volumes/Data/SWE/macOS/BuildRoots/e90674e518/Library/Caches/com.apple.xbs/Sources/Admin/Admin-876/DSRecord.m Line:418
2021-06-15 18:29:41.841 sysadminctl[64046:1889653] Home directory is assigned (not created!) at /var/svc

# dscl . -read /Users/svc
...
NFSHomeDirectory: /var/svc
Password: ********
Picture:
/Library/User Pictures/Flowers/Lotus.tif
PrimaryGroupID: 20
RealName: svc
RecordName: svc
RecordType: dsRecTypeStandard:Users
UniqueID: 501
UserShell: /sbin/nologin
```

`dscl . -create /Users/username UniqueID <UID>` can create the user with specified UID. But because `dscl` does not create user homedir like `sysadminctl`, `createhomedir` will always run now.

Another caveat is `createhomdir` only works when the homedir path does not exist, and after setting GID for the user, or it will create nothing. Thus the block is moved to after setting user GID.

`dscl` cannot set secure token for user. The `toggle_secure_token` can handle this and is unchanged.

## Related Issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

