### PR TITLE
Support override run_lists in policyfiles

### DIFF
--- a/spec/unit/policy_builder/dynamic_spec.rb
+++ b/spec/unit/policy_builder/dynamic_spec.rb
@@ -55,11 +55,6 @@ describe Chef::PolicyBuilder::Dynamic do
         expect(policy_builder).to respond_to(:load_node)
       end
 
-      it "forwards #original_runlist" do
-        expect(implementation).to receive(:original_runlist)
-        policy_builder.original_runlist
-      end
-
       it "forwards #run_context" do
         expect(implementation).to receive(:run_context)
         policy_builder.run_context

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -146,10 +146,6 @@ describe Chef::PolicyBuilder::Policyfile do
       Chef::PolicyBuilder::Policyfile.new(node_name, ohai_data, json_attribs, override_runlist, events)
     end
 
-    it "always gives `false` for #temporary_policy?" do
-      expect(initialize_pb.temporary_policy?).to be_falsey
-    end
-
     context "chef-solo" do
       before { Chef::Config[:solo_legacy_mode] = true }
 
@@ -161,8 +157,8 @@ describe Chef::PolicyBuilder::Policyfile do
     context "when given an override run_list" do
       let(:override_runlist) { "recipe[foo],recipe[bar]" }
 
-      it "errors on create" do
-        expect { initialize_pb }.to raise_error(err_namespace::UnsupportedFeature)
+      it "does not error" do
+        expect { initialize_pb }.not_to raise_error
       end
     end
 
@@ -323,7 +319,7 @@ describe Chef::PolicyBuilder::Policyfile do
           "example2::server@4.2.0 (feab40e)",
         ]
 
-        expect(policy_builder.run_list_with_versions_for_display).to eq(expected)
+        expect(policy_builder.run_list_with_versions_for_display(policy_builder.run_list)).to eq(expected)
       end
 
       it "generates a RunListExpansion-alike object for feeding to the CookbookCompiler" do
@@ -577,11 +573,9 @@ describe Chef::PolicyBuilder::Policyfile do
               expect(node.automatic_attrs[:policy_name]).to eq("policy_name_from_node_json")
               expect(node.automatic_attrs[:policy_group]).to eq("policy_group_from_node_json")
               expect(node.automatic_attrs[:chef_environment]).to eq("policy_group_from_node_json")
-
             end
 
           end
-
         end
 
         it "resets default and override data" do
@@ -664,7 +658,7 @@ describe Chef::PolicyBuilder::Policyfile do
               expect(policy_builder.run_list).to eq([ "recipe[example1::default]" ])
               expected_expansion = Chef::PolicyBuilder::Policyfile::RunListExpansionIsh.new([ "example1::default" ], [])
               expect(policy_builder.run_list_expansion).to eq(expected_expansion)
-              expect(policy_builder.run_list_with_versions_for_display).to eq(["example1::default@2.3.5 (168d210)"])
+              expect(policy_builder.run_list_with_versions_for_display(policy_builder.run_list)).to eq(["example1::default@2.3.5 (168d210)"])
               expect(node.run_list).to eq([ Chef::RunList::RunListItem.new("recipe[example1::default]") ])
               expect(node[:roles]).to eq( [] )
               expect(node[:recipes]).to eq( ["example1::default"] )
@@ -675,7 +669,22 @@ describe Chef::PolicyBuilder::Policyfile do
             end
 
           end
+        end
 
+        context "when an override run_list is given" do
+          let(:override_runlist) { [ "recipe[example2::server]" ] }
+
+          before do
+            policy_builder.build_node
+          end
+
+          it "gives `true` for #temporary_policy?" do
+            expect(policy_builder.temporary_policy?).to be true
+          end
+
+          it "returns the override_runlist for the run_list" do
+            expect(policy_builder.run_list).to eql override_runlist
+          end
         end
 
         describe "hoisting attribute values" do
@@ -826,6 +835,7 @@ describe Chef::PolicyBuilder::Policyfile do
             end
 
             include_examples "fetching cookbooks when they exist"
+
           end
         end
 
@@ -863,10 +873,7 @@ describe Chef::PolicyBuilder::Policyfile do
           end
 
         end
-
       end
     end
-
   end
-
 end


### PR DESCRIPTION
Extends override run_lists to work within the policyfiles framework.

- No additional depsolving is done so the cookbook set does not change, and it will be impossible to run any recipe which isn't already being sychronized to the node.  This is a difference between how override run_lists work in a berks workflow where the chef-client redepsolves with the override run_list, prunes and resychronizes its cookbook set pulling in all the latest versions of any cookbook.  In a policyfile world the recipe(s) used in the override run_list must be already shipped to the node by the policyfile.  All that has to happen is any cookbook in the cookbook set must depend on the cookbook(s) providing the override run_lists.  It may be useful to have a set of utility override run_list in a cookbook which is dependend upon by a base cookbook to ensure those utility recipes are present in the shipped policy.

- The node is not saved when the override run list is run.

Effectively this acts like a named_run_list that isn't predeclared and which does not save the node.

The utility of named_run_lists is that they're guaranteed to be depsoolved and present on the server, with an override run list it is up to the user to make sure it is in the policy.

Enumerating all your override run_lists as named_run_lists would also ensure they are there.  Or alternatively invoking an already declared named run_list instead as an override run_list will bypass the node save.