### PR TITLE
Fix edge condition in deprecation silence checker

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -79,10 +79,12 @@ class Chef
         return true if location =~ /^(.*?):(\d+):in/ && begin
           # Don't buffer the whole file in memory, so read it one line at a time.
           line_no = $2.to_i
-          location_file = ::File.open($1)
-          (line_no - 1).times { location_file.readline } # Read all the lines we don't care about.
-          relevant_line = location_file.readline
-          relevant_line.match?(/#.*chef:silence_deprecation($|[^:]|:#{self.class.deprecation_key})/)
+          if File.exist?($1) # some stacktraces come from `eval` and not a file
+            location_file = ::File.open($1)
+            (line_no - 1).times { location_file.readline } # Read all the lines we don't care about.
+            relevant_line = location_file.readline
+            relevant_line.match?(/#.*chef:silence_deprecation($|[^:]|:#{self.class.deprecation_key})/)
+          end
         end
 
         false


### PR DESCRIPTION
Catches a case where deprecations can be thrown against eval'd code.

```
/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/deprecated.rb:82:in `initialize'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/deprecated.rb:82:in `open'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/deprecated.rb:82:in `silenced?'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/formatters/doc.rb:369:in `deprecation'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/event_dispatch/dispatcher.rb:78:in `call'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/event_dispatch/dispatcher.rb:78:in `block in call_subscribers'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/event_dispatch/dispatcher.rb:68:in `each'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/event_dispatch/dispatcher.rb:68:in `call_subscribers'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/event_dispatch/dispatcher.rb:91:in `process_events_until_done'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/event_dispatch/dispatcher.rb:38:in `enqueue'
  (eval):2:in `run_completed'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/client.rb:291:in `run'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/application.rb:305:in `run_with_graceful_exit_option'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/application.rb:281:in `block in run_chef_client'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/local_mode.rb:42:in `with_server_connectivity'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/application.rb:264:in `run_chef_client'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/application/base.rb:352:in `run_application'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/application.rb:67:in `run'
  /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-bin-17.2.29/bin/chef-client:25:in `<top (required)>'
  /usr/local/bin/chef-client:143:in `load'
  /usr/local/bin/chef-client:143:in `<main>'
[2021-06-23T12:32:33-07:00] FATAL: Errno::ENOENT: No such file or directory @ rb_sysopen - (eval)
```

Unclear what triggers this, but its a bug.