### PR TITLE
Pin `pry` to 0.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,10 @@ group(:omnibus_package) do
 end
 
 group(:omnibus_package, :pry) do
-  gem "pry"
+  gem "pry", "= 0.13.0" # Locked because pry-byebug is broken with 13+
+                        # some work is ongoing? https://github.com/deivid-rodriguez/pry-byebug/issues/343
   # byebug does not install on freebsd on ruby 3.0
-  # gem "pry-byebug"
+  gem "pry-byebug" unless RUBY_PLATFORM =~ /freebsd/i
   gem "pry-stack_explorer"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: 507e9f69d57b99da1d5adc64e668cf19d31f1f2d
+  revision: 662529d2ea179b9faf6d1c0bed497a37ce62cf9a
   branch: master
   specs:
     chefstyle (2.0.5)
@@ -136,6 +136,7 @@ GEM
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
+    byebug (11.1.3)
     chef-telemetry (1.0.29)
       chef-config
       concurrent-ruby (~> 1.0)
@@ -159,7 +160,7 @@ GEM
     diff-lcs (1.3)
     erubi (1.10.0)
     erubis (2.7.0)
-    faraday (1.4.2)
+    faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -265,9 +266,12 @@ GEM
       tty-color (~> 0.5)
     plist (3.6.0)
     proxifier (1.0.3)
-    pry (0.14.1)
+    pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
@@ -404,6 +408,7 @@ PLATFORMS
   ruby
   x64-mingw32
   x86-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   appbundler
@@ -417,7 +422,8 @@ DEPENDENCIES
   fauxhai-ng
   inspec-core-bin (~> 4.24)
   ohai!
-  pry
+  pry (= 0.13.0)
+  pry-byebug
   pry-stack_explorer
   rake
   rb-readline


### PR DESCRIPTION
This permits `pry-byebug` to continue working with it, until
either https://github.com/pry/pry/pull/2177 is merged,
or  https://github.com/deivid-rodriguez/pry-byebug/issues/343 is
otherwise resolved.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>