### PR TITLE
Changes for Disabling openssl initialize on host OS while running kni…

### DIFF
--- a/knife/lib/chef/knife.rb
+++ b/knife/lib/chef/knife.rb
@@ -660,7 +660,6 @@ class Chef
       unless config[:fips].nil?
         Chef::Config[:fips] = config[:fips]
       end
-      Chef::Config.init_openssl
     end
 
     def root_rest

--- a/knife/spec/unit/application/knife_spec.rb
+++ b/knife/spec/unit/application/knife_spec.rb
@@ -114,7 +114,6 @@ describe Chef::Application::Knife do
       it "overwrites the Chef::Config value when passed --fips" do
         with_argv(*%w{noop knife command --fips}) do
           expect(@knife).to receive(:exit).with(0)
-          expect(Chef::Config).to receive(:enable_fips_mode)
           @knife.run
           expect(Chef::Config[:fips]).to eq(true)
         end
@@ -129,7 +128,6 @@ describe Chef::Application::Knife do
       it "initializes fips mode when passed --fips" do
         with_argv(*%w{noop knife command --fips}) do
           expect(@knife).to receive(:exit).with(0)
-          expect(Chef::Config).to receive(:enable_fips_mode)
           @knife.run
           expect(Chef::Config[:fips]).to eq(true)
         end


### PR DESCRIPTION
knife bootstrap --fips does not work if the host OS is not FIPS enabled

Signed-off-by: smriti <sgarg@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Disabled execution of `initopenssl` on host OS while running knife bootstrap command with --fips option. When the feature was implemented last here 

https://github.com/chef/chef/commit/ed44d58632c02744ce02bcc6af504e4e3c802f1f

The assumption was the  `fips mode you run knife with is the fips mode the node will get.` But this limits the host OS which are not FIPS enabled to execute knife bootstrap for OS with --fips option. 

## Related Issue
https://github.com/chef/chef/issues/11758

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
