### PR TITLE
Added waring if databag and databag_item name consist of period

### DIFF
--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -42,6 +42,9 @@ class Chef
       if RESERVED_NAMES.match?(name)
         raise Exceptions::InvalidDataBagName, "DataBags may not have a name matching #{RESERVED_NAMES.inspect}, you gave #{name.inspect}"
       end
+      if name.include? "."
+        Chef::Log.warn(" Databags should not contain ' . ' period in name, you gave: #{name.inspect}")
+      end
     end
 
     # Create a new Chef::DataBag

--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -42,6 +42,9 @@ class Chef
       if id_str.nil? || ( id_str !~ VALID_ID )
         raise Exceptions::InvalidDataBagItemID, "Data Bag items must have an id matching #{VALID_ID.inspect}, you gave: #{id_str.inspect}"
       end
+      if id_str.include?(".")
+        Chef::Log.warn(" Data bag items should not contain ' . ' period in ID, you gave: #{id_str.inspect}")
+      end
     end
 
     # delegate missing methods to the @raw_data Hash


### PR DESCRIPTION
Signed-off-by: sanga17 <sausekar@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Databag item ID can not contain period " . " when created through knife databag commands or via chef manage UI.
As period is being used in existing databags, Adding warning instead of raising an exception OR restricting.

## Related Issue
https://github.com/chef/chef/issues/3697
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
