### PR TITLE
Fix handling of ohai properties in chef_client_config

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_config.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_config.rb
@@ -1,6 +1,8 @@
 chef_client_config "Create chef-client's client.rb" do
   chef_server_url "https://localhost"
   chef_license "accept"
+  ohai_optional_plugins %i{Passwd Lspci Sysctl}
+  ohai_disabled_plugins %i{Sessions Interrupts}
   additional_config <<~CONFIG
     begin
       require 'aws-sdk'

--- a/lib/chef/resource/support/client.erb
+++ b/lib/chef/resource/support/client.erb
@@ -22,6 +22,12 @@
 <% next if instance_variable_get(prop).nil? || instance_variable_get(prop).empty? -%>
 <%=prop.delete_prefix("@") %> <%= instance_variable_get(prop).inspect %>
 <% end -%>
+<%# ohai_disabled_plugins and ohai_optional_plugins properties don't match the config value perfectly-%>
+<% %w(@ohai_disabled_plugins
+      @ohai_optional_plugins).each do |prop| -%>
+<% next if instance_variable_get(prop).nil? || instance_variable_get(prop).empty? -%>
+<%=prop.gsub("@ohai_", "ohai.") %> <%= instance_variable_get(prop).inspect %>
+<% end -%>
 <%# log_location is special due to STDOUT/STDERR from String -> IO Object -%>
 <% unless @log_location.nil? %>
   <% if @log_location.is_a?(String) && %w(STDOUT STDERR).include?(@log_location) -%>


### PR DESCRIPTION
These 2 properties don't match the config format so the existing logic didn't work.

Signed-off-by: Tim Smith <tsmith@chef.io>