### PR TITLE
Build RHEL 8 packages on RHEL 8

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -23,8 +23,9 @@ builder-to-testers-map:
     - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
-    - el-8-aarch64
     - amazon-2-aarch64
+  el-8-aarch64:
+    - el-8-aarch64
   el-7-ppc64:
     - el-7-ppc64
   el-7-ppc64le:
@@ -34,8 +35,9 @@ builder-to-testers-map:
     - el-8-s390x
   el-7-x86_64:
     - el-7-x86_64
-    - el-8-x86_64
     - amazon-2-x86_64
+  el-8-x86_64:
+    - el-8-x86_64
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64


### PR DESCRIPTION
This ensures they have el8 in their name

Signed-off-by: Tim Smith <tsmith@chef.io>