### PR TITLE
POC: Core Foundation based macos_userdefaults rewrite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "master"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 
+gem "corefoundation", git: "https://github.com/chef/corefoundation.git"
+
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout
   gem "chef-bin", path: File.expand_path("chef-bin", __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,13 @@ GIT
       rubocop (= 1.17.0)
 
 GIT
+  remote: https://github.com/chef/corefoundation.git
+  revision: 7df25155153ca6b5a14a494e63cfb2b8f7548f8b
+  specs:
+    corefoundation (0.2.0)
+      ffi
+
+GIT
   remote: https://github.com/chef/ohai.git
   revision: faf25314310a9ce27a7ba3e73ffb8301633dec83
   branch: master
@@ -41,6 +48,7 @@ PATH
       chef-utils (= 17.3.16)
       chef-vault
       chef-zero (>= 14.0.11)
+      corefoundation
       diff-lcs (>= 1.2.4, < 1.4.0)
       erubis (~> 2.7)
       ffi (>= 1.5.0)
@@ -68,6 +76,7 @@ PATH
       chef-utils (= 17.3.16)
       chef-vault
       chef-zero (>= 14.0.11)
+      corefoundation
       diff-lcs (>= 1.2.4, < 1.4.0)
       erubis (~> 2.7)
       ffi (>= 1.5.0)
@@ -419,6 +428,7 @@ DEPENDENCIES
   chef-vault
   cheffish (>= 17)
   chefstyle!
+  corefoundation!
   fauxhai-ng
   inspec-core-bin (~> 4.24)
   ohai!
@@ -432,4 +442,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.19
+   2.2.20

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -55,6 +55,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "proxifier", "~> 1.0"
 
+  s.add_dependency "corefoundation"
+
   s.bindir       = "bin"
   s.executables  = %w{ }
 

--- a/spec/unit/resource/macos_user_defaults_spec.rb
+++ b/spec/unit/resource/macos_user_defaults_spec.rb
@@ -35,8 +35,8 @@ describe Chef::Resource::MacosUserDefaults do
     expect(resource.value).to eq({ "User" => "/Library/Managed Installs/way_fake.log" })
   end
 
-  it "the host property defaults to nil" do
-    expect(resource.host).to be_nil
+  it "the host property defaults to be all_hosts" do
+    expect(resource.host).to eq :all_hosts
   end
 
   it "the sudo property defaults to false" do
@@ -73,7 +73,7 @@ describe Chef::Resource::MacosUserDefaults do
     end
 
     it "maps `all_users` to corresponding constant" do
-      resource.user = :all_users
+      resource.user = 'all_users'
       expect(provider.mapped_user).to eq CF::Preferences::ALL_USERS
     end
   end


### PR DESCRIPTION
Core Foundation based `macos_userdefaults` rewrite.
**Note: This is a POC**

Signed-off-by: Amulya <atomer@progress.com>

Uses https://github.com/chef/corefoundation to interact with MacOS Core Foundation APIs, and uses [preferences utils](https://developer.apple.com/documentation/corefoundation/preferences_utilities) to implement a backward compatible `macos_userdefaults` resource.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
