### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/omnibus"
+  schedule:
+    interval: daily
+    time: "06:00"
+    timezone: America/Los_Angeles
+  open-pull-requests-limit: 10
+  labels:
+  - "Type: Chore"


### PR DESCRIPTION
They fixed their bundler issue by upgrading

Signed-off-by: Tim Smith <tsmith@chef.io>