### PR TITLE
Add warning to secret DSL usage

### DIFF
--- a/lib/chef/dsl/secret.rb
+++ b/lib/chef/dsl/secret.rb
@@ -50,6 +50,12 @@ class Chef
       #   value = secret(name: "test1", service: :aws_secrets_manager, version: "v1", config: { region: "us-west-1" })
       #   log "My secret is #{value}"
       def secret(name: nil, version: nil, service: nil, config: nil)
+        Chef::Log.warn <<~EOM.gsub("\n", "")
+          The secrets Chef Infra language helper is currently in beta.
+          This helper will most likely change over time in potentially breaking ways.
+          If you have feedback or you'd like to be part of the future design of this
+          helper e-mail us at secrets_management_beta@progress.com"
+        EOM
         sensitive(true) if is_a?(Chef::Resource)
         Chef::SecretFetcher.for_service(service, config).fetch(name, version)
       end


### PR DESCRIPTION
Ensure that people know the secret DSL is subject to change, and should
be used with caution.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

Fixes #11835 