### PR TITLE
Support '-' and '@' for homebrew cask name

### DIFF
--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -34,7 +34,7 @@ class Chef
 
       property :cask_name, String,
         description: "An optional property to set the cask name if it differs from the resource block's name.",
-        regex: %r{^[\w/-]+$},
+        regex: %r{^[\w/\-@]+$},
         validation_message: "The provided Homebrew cask name is not valid. Cask names can contain alphanumeric characters, _, -, or / only!",
         name_property: true
 

--- a/spec/unit/resource/homebrew_cask_spec.rb
+++ b/spec/unit/resource/homebrew_cask_spec.rb
@@ -43,42 +43,16 @@ describe Chef::Resource::HomebrewCask do
   context 'name with high fun' do
     let(:resource) { Chef::Resource::HomebrewCask.new("fakey-fakerton") }
 
-    it "has a resource name of :homebrew_cask" do
-      expect(resource.resource_name).to eql(:homebrew_cask)
-    end
-
     it "the cask_name property is the name_property" do
       expect(resource.cask_name).to eql("fakey-fakerton")
-    end
-
-    it "sets the default action as :install" do
-      expect(resource.action).to eql([:install])
-    end
-
-    it "supports :install, :remove actions" do
-      expect { resource.action :install }.not_to raise_error
-      expect { resource.action :remove }.not_to raise_error
     end
   end
 
   context 'name with at mark' do
     let(:resource) { Chef::Resource::HomebrewCask.new("fakey-fakerton@10") }
 
-    it "has a resource name of :homebrew_cask" do
-      expect(resource.resource_name).to eql(:homebrew_cask)
-    end
-
     it "the cask_name property is the name_property" do
       expect(resource.cask_name).to eql("fakey-fakerton@10")
-    end
-
-    it "sets the default action as :install" do
-      expect(resource.action).to eql([:install])
-    end
-
-    it "supports :install, :remove actions" do
-      expect { resource.action :install }.not_to raise_error
-      expect { resource.action :remove }.not_to raise_error
     end
   end
 end

--- a/spec/unit/resource/homebrew_cask_spec.rb
+++ b/spec/unit/resource/homebrew_cask_spec.rb
@@ -19,22 +19,66 @@ require "spec_helper"
 
 describe Chef::Resource::HomebrewCask do
 
-  let(:resource) { Chef::Resource::HomebrewCask.new("fakey_fakerton") }
+  context 'name with under bar' do
+    let(:resource) { Chef::Resource::HomebrewCask.new("fakey_fakerton") }
 
-  it "has a resource name of :homebrew_cask" do
-    expect(resource.resource_name).to eql(:homebrew_cask)
+    it "has a resource name of :homebrew_cask" do
+      expect(resource.resource_name).to eql(:homebrew_cask)
+    end
+
+    it "the cask_name property is the name_property" do
+      expect(resource.cask_name).to eql("fakey_fakerton")
+    end
+
+    it "sets the default action as :install" do
+      expect(resource.action).to eql([:install])
+    end
+
+    it "supports :install, :remove actions" do
+      expect { resource.action :install }.not_to raise_error
+      expect { resource.action :remove }.not_to raise_error
+    end
   end
 
-  it "the cask_name property is the name_property" do
-    expect(resource.cask_name).to eql("fakey_fakerton")
+  context 'name with high fun' do
+    let(:resource) { Chef::Resource::HomebrewCask.new("fakey-fakerton") }
+
+    it "has a resource name of :homebrew_cask" do
+      expect(resource.resource_name).to eql(:homebrew_cask)
+    end
+
+    it "the cask_name property is the name_property" do
+      expect(resource.cask_name).to eql("fakey-fakerton")
+    end
+
+    it "sets the default action as :install" do
+      expect(resource.action).to eql([:install])
+    end
+
+    it "supports :install, :remove actions" do
+      expect { resource.action :install }.not_to raise_error
+      expect { resource.action :remove }.not_to raise_error
+    end
   end
 
-  it "sets the default action as :install" do
-    expect(resource.action).to eql([:install])
-  end
+  context 'name with at mark' do
+    let(:resource) { Chef::Resource::HomebrewCask.new("fakey-fakerton@10") }
 
-  it "supports :install, :remove actions" do
-    expect { resource.action :install }.not_to raise_error
-    expect { resource.action :remove }.not_to raise_error
+    it "has a resource name of :homebrew_cask" do
+      expect(resource.resource_name).to eql(:homebrew_cask)
+    end
+
+    it "the cask_name property is the name_property" do
+      expect(resource.cask_name).to eql("fakey-fakerton@10")
+    end
+
+    it "sets the default action as :install" do
+      expect(resource.action).to eql([:install])
+    end
+
+    it "supports :install, :remove actions" do
+      expect { resource.action :install }.not_to raise_error
+      expect { resource.action :remove }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
Some cask name include '-' and '@' so I fix regular expressions for
cask name validation.

I change regular expression for cask name validation to support '-' and '@'

## Description
Some cask name like emacs-plus@28 include '-' and '@' but it can't accept by validation.

## Related Issue
No related issues found.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
