### PR TITLE
knife upload should warn if nothing was uploaded

### DIFF
--- a/knife/lib/chef/chef_fs/knife.rb
+++ b/knife/lib/chef/chef_fs/knife.rb
@@ -132,7 +132,7 @@ class Chef
           ui.error("Current working directory is '#{@chef_fs_config.cwd}'.")
           exit(1)
         elsif !Dir.exist?(arg)
-          ui.error("Cookbook does not exist in given path #{arg}")
+          ui.raise("Cookbook does not exist in given path #{arg}")
           exit(1)
         else
           inferred_path = Chef::ChefFS::PathUtils.join(@chef_fs_config.base_path, arg)

--- a/knife/lib/chef/chef_fs/knife.rb
+++ b/knife/lib/chef/chef_fs/knife.rb
@@ -131,6 +131,9 @@ class Chef
           ui.error("Attempt to use relative path '#{arg}' when current directory is outside the repository path.")
           ui.error("Current working directory is '#{@chef_fs_config.cwd}'.")
           exit(1)
+        elsif !Dir.exist?(arg)
+          ui.error("Cookbook does not exist in given path #{arg}")
+          exit(1)
         else
           inferred_path = Chef::ChefFS::PathUtils.join(@chef_fs_config.base_path, arg)
         end

--- a/knife/spec/integration/cookbook_download_spec.rb
+++ b/knife/spec/integration/cookbook_download_spec.rb
@@ -66,7 +66,7 @@ describe "knife cookbook download", :workstation do
         Downloading root_files
         Cookbook downloaded to #{tmpdir}/x-1.0.1
       EOM
-      )
+                                                                            )
     end
   end
 end

--- a/knife/spec/integration/cookbook_download_spec.rb
+++ b/knife/spec/integration/cookbook_download_spec.rb
@@ -66,7 +66,7 @@ describe "knife cookbook download", :workstation do
         Downloading root_files
         Cookbook downloaded to #{tmpdir}/x-1.0.1
       EOM
-                                                                            )
+      )
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: snehaldwivedi <sdwivedi@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
 `knife upload COOKBOOK_NAME` or `knife upload cookbooks/.../COOKBOOK_NAME`,  will raise a warning error if the cookbook does not exist in a given path.

## Related Issue
https://github.com/chef/chef/issues/8720

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
