### PR TITLE
systemd_unit generates invalid units when passing a hash issue fix

### DIFF
--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -113,7 +113,7 @@ class Chef
         when Hash
           IniParse.gen do |doc|
             content.each_pair do |sect, opts|
-              doc.section(sect) do |section|
+              doc.section(sect, { :option_sep => "=" }) do |section|
                 opts.each_pair do |opt, val|
                   [val].flatten.each do |v|
                     section.option(opt, v)

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -113,7 +113,7 @@ class Chef
         when Hash
           IniParse.gen do |doc|
             content.each_pair do |sect, opts|
-              doc.section(sect, { :option_sep => "=" }) do |section|
+              doc.section(sect, { option_sep: "=" }) do |section|
                 opts.each_pair do |opt, val|
                   [val].flatten.each do |v|
                     section.option(opt, v)

--- a/spec/unit/resource/systemd_unit_spec.rb
+++ b/spec/unit/resource/systemd_unit_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 
 describe Chef::Resource::SystemdUnit do
   let(:resource) { Chef::Resource::SystemdUnit.new("sysstat-collect.timer") }
-  let(:unit_content_string) { "[Unit]\nDescription = Run system activity accounting tool every 10 minutes\nDocumentation = foo\nDocumentation = bar\n\n[Timer]\nOnCalendar = *:00/10\n\n[Install]\nWantedBy = sysstat.service\n" }
+  let(:unit_content_string) { "[Unit]\nDescription=Run system activity accounting tool every 10 minutes\nDocumentation=foo\nDocumentation=bar\n\n[Timer]\nOnCalendar=*:00/10\n\n[Install]\nWantedBy=sysstat.service\n" }
   let(:unit_content_hash) do
     {
       "Unit" => {


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

- Fixed generates systemd service should not have spaces around the equal signs.
- Fixed testcase failure.

## Related Issue
#9259 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
