### PR TITLE
Allow az vault name to be included in secret name

### DIFF
--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -308,8 +308,6 @@ class Chef
           super("No secret service provided. Supported services are: :#{fetcher_service_names.join(" :")}")
         end
       end
-
-      class MissingVaultName < RuntimeError; end
     end
 
     # Exception class for collecting multiple failures. Used when running

--- a/spec/unit/secret_fetcher/azure_key_vault_spec.rb
+++ b/spec/unit/secret_fetcher/azure_key_vault_spec.rb
@@ -22,20 +22,11 @@ require "chef/secret_fetcher"
 require "chef/secret_fetcher/azure_key_vault"
 
 describe Chef::SecretFetcher::AzureKeyVault do
-  let(:config) { { vault: "myvault" } }
+  let(:config) { { vault: "my_vault" } }
   let(:fetcher) { Chef::SecretFetcher::AzureKeyVault.new(config, nil) }
 
-  context "when validating configuration and configuration is missing :vault" do
-    context "and configuration does not have a 'vault'" do
-      let(:config) { {} }
-      it "raises a MissingVaultError error on validate!" do
-        expect { fetcher.validate! }.to raise_error(Chef::Exceptions::Secret::MissingVaultName)
-      end
-    end
-  end
-
   context "when performing a fetch" do
-    let(:body) { "" }
+    let(:body) { '{ "value" : "my secret value" }' }
     let(:response_mock) { double("response", body: body) }
     let(:http_mock) { double("http", :get => response_mock, :use_ssl= => nil) }
 
@@ -44,20 +35,36 @@ describe Chef::SecretFetcher::AzureKeyVault do
       allow(Net::HTTP).to receive(:new).and_return(http_mock)
     end
 
-    context "and a valid response is received" do
+    context "and vault name is only provided in the secret name" do
       let(:body) { '{ "value" : "my secret value" }' }
-      it "returns the expected response" do
-        expect(fetcher.fetch("value")).to eq "my secret value"
+      let(:config) { {} }
+      it "fetches the value" do
+        expect(fetcher.fetch("my_vault/value")).to eq "my secret value"
       end
     end
 
+    context "and vault name is not provided in the secret name" do
+      context "and vault name is not provided in config" do
+        let(:config) { {} }
+        it "raises a ConfigurationInvalid exception" do
+          expect { fetcher.fetch("value") }.to raise_error(Chef::Exceptions::Secret::ConfigurationInvalid)
+        end
+      end
+
+      context "and vault name is provided in config" do
+        let(:config) { { vault: "my_vault" } }
+        it "fetches the value" do
+          expect(fetcher.fetch("value")).to eq "my secret value"
+        end
+      end
+    end
     context "and an error response is received in the body" do
+      let(:config) { { vault: "my_vault" } }
       let(:body) { '{ "error" : { "code" : 404, "message" : "secret not found" } }' }
       it "raises FetchFailed" do
         expect { fetcher.fetch("value") }.to raise_error(Chef::Exceptions::Secret::FetchFailed)
       end
     end
-
   end
 end
 


### PR DESCRIPTION
This modifies the `:azure_key_vault` fetcher so that it's possible
to fetch a secret by embedding the vault name in the secret name
instead of providing it in configuration. This continues down the path
of making secrets accessible with less typing and sane default
expectations.

Example:

```
file "/home/ubuntu/test2" do
  content secret(name: "test-chef-infra-secrets/test-secret-1", service: :azure_key_vault)
end
```

Specifying vault name via configuration is still supported, but if it is
specified in the secret name as well that will take precedence.

Fixes: #11852 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

