### PR TITLE
Turn on chef_node_attribute_enabled for compliance phase by default

### DIFF
--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -88,7 +88,7 @@ class Chef
 
       # If enabled, a hash representation of the Chef Infra node object will be sent to Chef InSpec in an input
       # named `chef_node`.
-      "chef_node_attribute_enabled" => false,
+      "chef_node_attribute_enabled" => true,
 
       # Should the built-in compliance phase run. True and false force the behavior. Nil does magic based on if you have
       # profiles defined but do not have the audit cookbook enabled.

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -221,7 +221,7 @@ describe Chef::Compliance::Runner do
       inputs = runner.inspec_opts[:inputs]
 
       expect(inputs["tacos"]).to eq("lunch")
-      expect(inputs.key?("chef_node")).to eq(false)
+      expect(inputs.key?("chef_node")).to eq(true)
     end
 
     it "includes chef_node in inputs with chef_node_attribute_enabled set" do


### PR DESCRIPTION
Getting Chef Infra attributes into Chef Inspec inputs is a FAQ and this
seems like an obviously better default.

We are unaware of any breaking change this would cause.