### PR TITLE
clean up scripts and docker login to auth to chef docker org

### DIFF
--- a/.expeditor/build-docker-images.sh
+++ b/.expeditor/build-docker-images.sh
@@ -2,12 +2,14 @@
 set -eu -o pipefail
 
 arch=$1
+channel="${EXPEDITOR_CHANNEL:-unstable}"
+version="${EXPEDITOR_VERSION:?You must manually set the EXPEDITOR_VERSION environment variable to an existing semantic version.}"
 
-echo "--- Building chef/chef:${EXPEDITOR_VERSION} docker image for ${arch}"
+echo "--- Building chef/chef:${version} docker image for ${arch}"
 docker build \
-  --build-arg "CHANNEL=${EXPEDITOR_CHANNEL}" \
-  --build-arg "VERSION=${EXPEDITOR_VERSION}" \
-  -t "chef/chef:${EXPEDITOR_VERSION}-${arch}" .
+  --build-arg "CHANNEL=${channel}" \
+  --build-arg "VERSION=${version}" \
+  -t "chef/chef:${version}-${arch}" .
 
-echo "--- Pushing chef/chef:${EXPEDITOR_VERSION} docker image for ${arch} to dockerhub"
-docker push "chef/chef:${EXPEDITOR_VERSION}-${arch}"
+echo "--- Pushing chef/chef:${version} docker image for ${arch} to dockerhub"
+docker push "chef/chef:${version}-${arch}"

--- a/.expeditor/docker-manifest-create.sh
+++ b/.expeditor/docker-manifest-create.sh
@@ -3,18 +3,21 @@ set -eu -o pipefail
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
+channel="${EXPEDITOR_CHANNEL:-unstable}"
+version="${EXPEDITOR_VERSION:?You must manually set the EXPEDITOR_VERSION environment variable to an existing semantic version.}"
+
 function create_and_push_manifest() {
   manifest_tag="${1}"
 
   echo "--- Creating manifest for ${manifest_tag}"
   docker manifest create "chef/chef:${manifest_tag}" \
-    --amend "chef/chef:${EXPEDITOR_VERSION}-arm64" \
-    --amend "chef/chef:${EXPEDITOR_VERSION}-amd64"
+    --amend "chef/chef:${version}-arm64" \
+    --amend "chef/chef:${version}-amd64"
 
   echo "--- Pushing manifest for ${manifest_tag}"
   docker manifest push "chef/chef:${manifest_tag}"
 }
 
 # create the initial version and initial channel docker images
-create_and_push_manifest "${EXPEDITOR_VERSION}"
-create_and_push_manifest "${EXPEDITOR_CHANNEL}"
+create_and_push_manifest "${version}"
+create_and_push_manifest "${channel}"

--- a/.expeditor/promote-docker-images.sh
+++ b/.expeditor/promote-docker-images.sh
@@ -3,30 +3,40 @@ set -eu -o pipefail
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
+channel="${EXPEDITOR_CHANNEL:-unstable}"
+version="${EXPEDITOR_VERSION:?You must manually set the EXPEDITOR_VERSION environment variable to an existing semantic version.}"
+
+docker_login_user="expeditor"
+docker_login_password="$(vault read -field=expeditor-full-access secret/docker/expeditor)"
+
+# login to docker
+echo "--- Docker login so we can push to chef org"
+docker login -u "${docker_login_user}" -p "${docker_login_password}"
+
 function create_and_push_manifest() {
   manifest_tag="${1}"
 
   echo "--- Creating manifest for ${manifest_tag}"
   docker manifest create "chef/chef:${manifest_tag}" \
-    --amend "chef/chef:${EXPEDITOR_VERSION}-arm64" \
-    --amend "chef/chef:${EXPEDITOR_VERSION}-amd64"
+    --amend "chef/chef:${version}-arm64" \
+    --amend "chef/chef:${version}-amd64"
 
   echo "--- Pushing manifest for ${manifest_tag}"
   docker manifest push "chef/chef:${manifest_tag}"
 }
 
 # create the promoted channel docker image
-create_and_push_manifest "${EXPEDITOR_CHANNEL}"
+create_and_push_manifest "${channel}"
 
-if [[ ${EXPEDITOR_CHANNEL} == "stable" ]]; then
+if [[ ${channel} == "stable" ]]; then
   create_and_push_manifest "latest"
 
   # split the version and add the tags for major and major.minor
-  version=(${EXPEDITOR_VERSION//./ })
+  IFS="."; read -ra split_version <<< "${version}"
 
   # major version
-  create_and_push_manifest "${version[0]}"
+  create_and_push_manifest "${split_version[0]}"
 
   # major.minor version
-  create_and_push_manifest "${version[0]}.${version[1]}"
+  create_and_push_manifest "${split_version[0]}.${split_version[1]}"
 fi


### PR DESCRIPTION
Make scripts have sane defaults for ENV VARS and login to docker when running the bash action to authenticate to the chef docker organization.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
