### PR TITLE
Rename inspec attributes to inputs in compliance phase

### DIFF
--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -47,8 +47,10 @@ class Chef
       "profiles" => {},
 
       # Extra inputs passed to Chef InSpec to allow finer-grained control over behavior.
-      # These are mapped to Chef InSpec's inputs, but are named attributes here for legacy reasons.
       # See Chef Inspec's documentation for more information: https://docs.chef.io/inspec/inputs/
+      "inputs" => {},
+
+      # Legacy alias for inputs
       "attributes" => {},
 
       # A string path or an array of paths to Chef InSpec waiver files.

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -113,8 +113,17 @@ class Chef
         logger.info "Chef Infra Compliance Phase Complete"
       end
 
+      def inputs_from_attributes
+        if !node["audit"]["inputs"].empty?
+          node["audit"]["inputs"].to_h
+        else
+          node["audit"]["attributes"].to_h
+        end
+      end
+
       def inspec_opts
-        inputs = node["audit"]["attributes"].to_h
+        inputs = inputs_from_attributes
+
         if node["audit"]["chef_node_attribute_enabled"]
           inputs["chef_node"] = node.to_h
           inputs["chef_node"]["chef_environment"] = node.chef_environment
@@ -300,6 +309,11 @@ class Chef
             raise "CMPL002: Unrecognized Compliance Phase fetcher (node['audit']['fetcher'] = #{fetcher}). Supported fetchers are: #{SUPPORTED_FETCHERS.join(", ")}, or nil. For more information, see the documentation at https://docs.chef.io/chef_compliance_phase#fetch-profiles"
           end
         end
+
+        if !node["audit"]["attributes"].empty? && !node["audit"]["inputs"].empty?
+          raise "CMPL004: both node['audit']['inputs'] and node['audit']['attributes'] are set.  The node['audit']['attributes'] setting is deprecated and should not be used."
+        end
+
         @validation_passed = true
       end
     end

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -311,7 +311,7 @@ class Chef
         end
 
         if !node["audit"]["attributes"].empty? && !node["audit"]["inputs"].empty?
-          raise "CMPL004: both node['audit']['inputs'] and node['audit']['attributes'] are set.  The node['audit']['attributes'] setting is deprecated and should not be used."
+          raise "CMPL011: both node['audit']['inputs'] and node['audit']['attributes'] are set.  The node['audit']['attributes'] setting is deprecated and should not be used."
         end
 
         @validation_passed = true

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -202,6 +202,16 @@ describe Chef::Compliance::Runner do
       expect { runner.load_and_validate! }.to raise_error(/^CMPL002:/)
     end
 
+    it "raises CMPL004 if both the inputs and attributes node attributes are set" do
+      node.normal["audit"]["attributes"] = {
+        "tacos" => "lunch",
+      }
+      node.normal["audit"]["inputs"] = {
+        "tacos" => "lunch",
+      }
+      expect { runner.load_and_validate! }.to raise_error(/^CMPL004:/)
+    end
+
     it "validates configured reporters" do
       node.normal["audit"]["reporter"] = [ "chef-automate" ]
       reporter_double = double("reporter", validate_config!: nil)
@@ -212,6 +222,40 @@ describe Chef::Compliance::Runner do
   end
 
   describe "#inspec_opts" do
+    it "pulls inputs from the attributes setting" do
+      node.normal["audit"]["attributes"] = {
+        "tacos" => "lunch",
+      }
+
+      inputs = runner.inspec_opts[:inputs]
+
+      expect(inputs["tacos"]).to eq("lunch")
+    end
+
+    it "pulls inputs from the inputs setting" do
+      node.normal["audit"]["inputs"] = {
+        "tacos" => "lunch",
+      }
+
+      inputs = runner.inspec_opts[:inputs]
+
+      expect(inputs["tacos"]).to eq("lunch")
+    end
+
+    it "favors inputs over attributes" do
+      node.normal["audit"]["attributes"] = {
+        "tacos" => "dinner",
+      }
+
+      node.normal["audit"]["inputs"] = {
+        "tacos" => "lunch",
+      }
+
+      inputs = runner.inspec_opts[:inputs]
+
+      expect(inputs["tacos"]).to eq("lunch")
+    end
+
     it "does not include chef_node in inputs by default" do
       node.normal["audit"]["attributes"] = {
         "tacos" => "lunch",

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -209,7 +209,7 @@ describe Chef::Compliance::Runner do
       node.normal["audit"]["inputs"] = {
         "tacos" => "lunch",
       }
-      expect { runner.load_and_validate! }.to raise_error(/^CMPL004:/)
+      expect { runner.load_and_validate! }.to raise_error(/^CMPL011:/)
     end
 
     it "validates configured reporters" do


### PR DESCRIPTION
Supports attributes as a fallback.

Blows up if you set both.

Closes #11572
