### PR TITLE
Enable chef-client scheduled task to behave like chef_client_cron, with consistent delay calculated once from splay

### DIFF
--- a/lib/chef/resource/chef_client_scheduled_task.rb
+++ b/lib/chef/resource/chef_client_scheduled_task.rb
@@ -58,6 +58,15 @@ class Chef
         daemon_options ['-n audit_only']
       end
       ```
+
+      **Run #{ChefUtils::Dist::Infra::PRODUCT} with a persistent delay on every run calculated once, similar to how chef_client_cron resource works**:
+
+      ```ruby
+      chef_client_scheduled_task 'Run chef-client with persistent splay' do
+        use_consistent_splay true
+      end
+      ```
+
       DOC
 
       resource_name :chef_client_scheduled_task
@@ -103,6 +112,9 @@ class Chef
         callbacks: { "should be a positive number" => proc { |v| v > 0 } },
         description: "A random number of seconds between 0 and X to add to interval so that all #{ChefUtils::Dist::Infra::CLIENT} commands don't execute at the same time.",
         default: 300
+
+      property :use_consistent_splay, [true, false],
+        default: false
 
       property :run_on_battery, [true, false],
         description: "Run the #{ChefUtils::Dist::Infra::PRODUCT} task when the system is on batteries.",
@@ -151,7 +163,7 @@ class Chef
           frequency_modifier             new_resource.frequency_modifier if frequency_supports_frequency_modifier?
           start_time                     new_resource.start_time
           start_day                      new_resource.start_date unless new_resource.start_date.nil?
-          random_delay                   new_resource.splay if frequency_supports_random_delay?
+          random_delay                   new_resource.splay if frequency_supports_random_delay? && !new_resource.use_consistent_splay
           disallow_start_if_on_batteries new_resource.splay unless new_resource.run_on_battery
           action                         %i{create enable}
         end
@@ -173,7 +185,31 @@ class Chef
           # Fetch path of cmd.exe through environment variable comspec
           cmd_path = ENV["COMSPEC"]
 
-          "#{cmd_path} /c \"#{client_cmd}\""
+          "#{cmd_path} /c \"#{consistent_splay_command}#{client_cmd}\""
+        end
+
+        #
+        # Generate a uniformly distributed unique number to sleep from 0 to the splay time
+        #
+        # @param [Integer] splay The number of seconds to splay
+        #
+        # @return [Integer]
+        #
+        def splay_sleep_time(splay)
+          seed = node["shard_seed"] || Digest::MD5.hexdigest(node.name).to_s.hex
+          random = Random.new(seed.to_i)
+          random.rand(splay)
+        end
+
+        #
+        # The consistent splay sleep time when use_consistent_splay is true.
+        #
+        # @return [NilClass,String] The prepended sleep command to run prior to executing the full command.
+        #
+        def consistent_splay_command
+          return unless new_resource.use_consistent_splay
+
+          "C:/windows/system32/windowspowershell/v1.0/powershell.exe Start-Sleep -s #{splay_sleep_time(new_resource.splay)} && "
         end
 
         #

--- a/spec/unit/resource/chef_client_scheduled_task_spec.rb
+++ b/spec/unit/resource/chef_client_scheduled_task_spec.rb
@@ -25,6 +25,11 @@ describe Chef::Resource::ChefClientScheduledTask do
   let(:resource) { Chef::Resource::ChefClientScheduledTask.new("fakey_fakerton", run_context) }
   let(:provider) { resource.provider_for_action(:add) }
 
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("COMSPEC").and_return("C:\\Windows\\System32\\cmd.exe")
+  end
+  
   it "sets the default action as :add" do
     expect(resource.action).to eql([:add])
   end
@@ -76,6 +81,56 @@ describe Chef::Resource::ChefClientScheduledTask do
   it "supports :add and :remove actions" do
     expect { resource.action :add }.not_to raise_error
     expect { resource.action :remove }.not_to raise_error
+  end
+
+  it "expects use_consistent_splay to be true when set" do
+    resource.use_consistent_splay = true
+    expect(resource.use_consistent_splay).to eql(true)
+  end
+
+  context "when configured to use a consistent splay" do
+    before do
+      node.automatic_attrs[:shard_seed] = nil
+      allow(node).to receive(:name).and_return("test_node")
+      resource.config_directory = "C:/chef" # Allows local unit testing on nix flavors
+      resource.use_consistent_splay = true
+    end
+
+    it "sleeps the same amount each time based on splay before running the task" do
+      expect(provider.full_command).to eql("C:\\Windows\\System32\\cmd.exe /c \"C:/windows/system32/windowspowershell/v1.0/powershell.exe Start-Sleep -s 272 && C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb\"")
+    end
+  end
+
+  describe "#consistent_splay_command" do
+    context "when use_consistent_splay is false" do
+      it "returns nil" do
+        expect(provider.consistent_splay_command).to eql(nil)
+      end
+    end
+
+    context "when use_consistent_splay is true" do
+      before do
+        resource.use_consistent_splay true
+        allow(provider).to receive(:splay_sleep_time).and_return(222)
+      end
+
+      it "returns a powershell sleep command to be appended to the chef client run command" do
+        expect(provider.consistent_splay_command).to eql("C:/windows/system32/windowspowershell/v1.0/powershell.exe Start-Sleep -s 222 && ")
+      end
+    end
+  end
+
+  describe "#splay_sleep_time" do
+    it "uses shard_seed attribute if present" do
+      node.automatic_attrs[:shard_seed] = "73399073"
+      expect(provider.splay_sleep_time(300)).to satisfy { |v| v >= 0 && v <= 300 }
+    end
+
+    it "uses a hex conversion of a md5 hash of the splay if present" do
+      node.automatic_attrs[:shard_seed] = nil
+      allow(node).to receive(:name).and_return("test_node")
+      expect(provider.splay_sleep_time(300)).to satisfy { |v| v >= 0 && v <= 300 }
+    end
   end
 
   describe "#client_cmd" do


### PR DESCRIPTION
…t splay and snapped start time for predictable actual start times

Signed-off-by: George Holt <George.Holt@bwater.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
