### PR TITLE
ZD 28188 - remote_file resource not correctly setting HTTP timeout/retries fixes

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -450,7 +450,7 @@ class Chef
       rescue Timeout::Error
         if @http_retry_count - http_attempts >= 0
           Chef::Log.warn("Timeout connecting to #{url}, retry #{http_attempts}/#{@http_retry_count}") # Updated from error to warn
-          sleep(@http_retry_delay).
+          sleep(@http_retry_delay)
           retry
         end
         raise Timeout::Error, "Timeout connecting to #{url}, giving up"

--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -137,7 +137,7 @@ class Chef
           if new_resource.ssl_verify_mode
             opts[:ssl_verify_mode] = new_resource.ssl_verify_mode
           end
-          opts
+          opts.merge(new_resource.http_options)
         end
 
       end

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -118,6 +118,9 @@ class Chef
 
       property :authentication, Symbol, equal_to: %i{remote local}, default: :remote
 
+      property :http_options, Hash, default: {},
+        description: "A Hash of custom HTTP options. For example: `http_options({ http_retry_count: 0, http_retry_delay: 2 })`"
+
       def after_created
         validate_identity_platform(remote_user, remote_password, remote_domain)
         identity = qualify_user(remote_user, remote_password, remote_domain)

--- a/spec/unit/provider/remote_file/http_spec.rb
+++ b/spec/unit/provider/remote_file/http_spec.rb
@@ -321,4 +321,14 @@ describe Chef::Provider::RemoteFile::HTTP do
 
   end
 
+  describe "#http_client_opts" do
+    before do
+      new_resource.http_options({ retries: 2, retry_delay: 3 })
+    end
+
+    it "should set http client options" do
+      expect(fetcher.send(:http_client_opts)).to eq({ retries: 2, retry_delay: 3 })
+    end
+  end
+
 end


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
- Fixed http retry and delay settings.
- Added test cases for the changes.


## Related Issue
#11870
[#422](https://github.com/chef/customer-bugs/issues/422)
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
