### PR TITLE
Added source property support for apt package

### DIFF
--- a/knife/spec/integration/cookbook_download_spec.rb
+++ b/knife/spec/integration/cookbook_download_spec.rb
@@ -66,7 +66,7 @@ describe "knife cookbook download", :workstation do
         Downloading root_files
         Cookbook downloaded to #{tmpdir}/x-1.0.1
       EOM
-      )
+                                                                            )
     end
   end
 end

--- a/knife/spec/integration/cookbook_download_spec.rb
+++ b/knife/spec/integration/cookbook_download_spec.rb
@@ -66,7 +66,7 @@ describe "knife cookbook download", :workstation do
         Downloading root_files
         Cookbook downloaded to #{tmpdir}/x-1.0.1
       EOM
-                                                                            )
+      )
     end
   end
 end

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -100,7 +100,7 @@ class Chef
 
         def install_package(name, version)
           if source_files_exist?
-            sources = name.map { |n| "./{name_sources[n]}" }
+            sources = name.map { |n| name_sources[n] }
             logger.info("#{new_resource} installing package(s): #{name.join(" ")}")
             run_noninteractive("apt", "install", *options, *sources)
 

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -301,23 +301,8 @@ class Chef
 
         def read_current_version_of_package(package_name)
           logger.trace("#{new_resource} checking install state of #{package_name}")
-          status = shell_out!("dpkg", "-s", package_name, returns: [0, 1])
-          package_installed = false
-          status.stdout.each_line do |line|
-            case line
-            when /^Status: deinstall ok config-files/.freeze
-              # if we are 'purging' then we consider 'removed' to be 'installed'
-              package_installed = true if action == :purge
-            when /^Status: install ok installed/.freeze
-              package_installed = true
-            when /^Version: (.+)$/.freeze
-              if package_installed
-                logger.trace("#{new_resource} current version is #{$1}")
-                return $1
-              end
-            end
-          end
-          nil
+          status = shell_out!("apt", "show", package_name, returns: [0, 1])
+          check_status_of_installed_package(status)
         end
 
         def get_current_version_from(array)

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -100,9 +100,9 @@ class Chef
 
         def install_package(name, version)
           if source_files_exist?
-            sources = name.map { |n| name_sources[n] }
+            sources = name.map { |n| "./{name_sources[n]}" }
             logger.info("#{new_resource} installing package(s): #{name.join(" ")}")
-            run_noninteractive("dpkg", "-i", *options, *sources)
+            run_noninteractive("apt", "install", *options, *sources)
 
           else
             package_name = name.zip(version).map do |n, v|

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -244,16 +244,6 @@ describe Chef::Provider::Package::Apt do
       @provider.load_current_resource
     end
 
-    # it "raises an exception if a source is specified (CHEF-5113)" do
-    #   @new_resource.source "pluto"
-    #   expect(@provider).to receive(:shell_out_compacted!).with(
-    #     "apt-cache", "policy", @new_resource.package_name,
-    #     env: { "DEBIAN_FRONTEND" => "noninteractive" } ,
-    #     timeout: @timeout
-    #   ).and_return(@shell_out)
-    #   expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
-    # end
-
     it "downgrades when requested" do
       ubuntu1804downgrade_stubs
       so = instance_double(Mixlib::ShellOut, stdout: "apt 1.6~beta1 (amd64)\notherstuff\n")

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -399,7 +399,7 @@ describe Chef::Provider::Package::Apt do
           },
         })
         expect(@provider).to receive(:shell_out_compacted!).with(
-          "dpkg", "-i", "--force-yes", "/tmp/wget_1.11.4-1ubuntu1_amd64.deb",
+          "apt", "install", "--force-yes", "/tmp/wget_1.11.4-1ubuntu1_amd64.deb",
           { env: { "DEBIAN_FRONTEND" => "noninteractive" },
           timeout: @timeout }
         )


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We've added the functionality to apt package for supporting source property.

A sample recipe is mentioned below.
```
package 'nginx' do
  action :install
  source '/home/ubuntu/apacheds-2.0.0.AM26-amd64.deb'
end
```
This recipe will duely pick the package from the source path and install it. Before this change an error `apt package provider cannot handle source property. Use dpkg provider instead` was thrown instead.

## Related Issue
https://github.com/chef/chef/issues/11103

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
