### PR TITLE
windows_user_privilege.rb : fixed exception: privilege is a required property, even when it was set

### DIFF
--- a/lib/chef/resource/windows_user_privilege.rb
+++ b/lib/chef/resource/windows_user_privilege.rb
@@ -139,7 +139,7 @@ class Chef
         coerce: proc { |v| Array(v) },
         callbacks: {
           "Privilege property restricted to the following values: #{PRIVILEGE_OPTS}" => lambda { |n| (n - PRIVILEGE_OPTS).empty? },
-        }
+        }, identity: true
 
       load_current_value do |new_resource|
         if new_resource.principal && (new_resource.action.include?(:add) || new_resource.action.include?(:remove))


### PR DESCRIPTION
Signed-off-by: snehaldwivedi <sdwivedi@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
`Windows_user_privilege` resource throws the error `privilege is required` even when it was set. As the value for `privilege` was not getting copied. As privilege is part of the identity that should get copied to the current resource rather than loaded in load_current_value so added `identity: true` for it.

## Related Issue
https://github.com/chef/customer-bugs/issues/413
https://github.com/chef/chef/issues/11744

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
