### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/.expeditor/scripts/bk_win_prep.ps1
+++ b/.expeditor/scripts/bk_win_prep.ps1
@@ -11,6 +11,6 @@ bundle --version
 if (-not $?) { throw "Can't run Bundler. Is it installed?" }
 
 echo "--- bundle install"
-bundle config set without omnibus_package
+bundle config set --local without omnibus_package
 bundle install --jobs=3 --retry=3  --path=vendor/bundle
 if (-not $?) { throw "Unable to install gem dependencies" }

--- a/.expeditor/scripts/bk_win_prep.ps1
+++ b/.expeditor/scripts/bk_win_prep.ps1
@@ -11,5 +11,6 @@ bundle --version
 if (-not $?) { throw "Can't run Bundler. Is it installed?" }
 
 echo "--- bundle install"
-bundle install --jobs=3 --retry=3  --path=vendor/bundle --without omnibus_package
+bundle config set without omnibus_package
+bundle install --jobs=3 --retry=3  --path=vendor/bundle
 if (-not $?) { throw "Unable to install gem dependencies" }

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -19,7 +19,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd chef-utils
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec
   expeditor:
     executor:
@@ -30,7 +31,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd chef-config
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec
   expeditor:
     executor:
@@ -44,7 +46,8 @@ steps:
 - label: "Integration Ubuntu 18.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -57,7 +60,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -68,7 +72,8 @@ steps:
 - label: "Unit Ubuntu 18.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -79,7 +84,8 @@ steps:
 - label: "Integration Ubuntu 20.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -92,7 +98,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -103,7 +110,8 @@ steps:
 - label: "Unit Ubuntu 20.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -114,7 +122,8 @@ steps:
 - label: "Integration CentOS 7 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -126,7 +135,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - yum install -y crontabs e2fsprogs
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -137,7 +147,8 @@ steps:
 - label: "Unit CentOS 7 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -149,7 +160,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cron insserv-compat
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -161,7 +173,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cronie insserv-compat
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -173,7 +186,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cron insserv-compat
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -184,7 +198,8 @@ steps:
 - label: "Integration Fedora :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -196,7 +211,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
-    - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - cd /workdir; bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -210,7 +226,8 @@ steps:
 - label: "Unit Fedora :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -261,7 +278,8 @@ steps:
 - label: "chef-zero gem :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test chef/chef-zero master rake pedant
   expeditor:
     executor:
@@ -274,7 +292,8 @@ steps:
 - label: "cheffish gem :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test chef/cheffish master rake spec
   expeditor:
     executor:
@@ -284,7 +303,8 @@ steps:
 - label: "chefspec gem :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test chefspec/chefspec master rake
   expeditor:
     executor:
@@ -294,7 +314,8 @@ steps:
 - label: "knife-windows gem :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test chef/knife-windows master rake spec
   expeditor:
     executor:
@@ -306,7 +327,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y graphviz
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle --without omnibus_package
+    - bundle config set without omnibus_package
+    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test berkshelf/berkshelf master rake
   expeditor:
     executor:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -19,7 +19,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd chef-utils
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec
   expeditor:
@@ -31,7 +31,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd chef-config
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec
   expeditor:
@@ -46,7 +46,7 @@ steps:
 - label: "Integration Ubuntu 18.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
@@ -60,7 +60,7 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
@@ -72,7 +72,7 @@ steps:
 - label: "Unit Ubuntu 18.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
@@ -84,7 +84,7 @@ steps:
 - label: "Integration Ubuntu 20.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
@@ -98,7 +98,7 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
@@ -110,7 +110,7 @@ steps:
 - label: "Unit Ubuntu 20.04 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
@@ -122,7 +122,7 @@ steps:
 - label: "Integration CentOS 7 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
@@ -135,7 +135,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - yum install -y crontabs e2fsprogs
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
@@ -147,7 +147,7 @@ steps:
 - label: "Unit CentOS 7 :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
@@ -160,7 +160,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cron insserv-compat
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
@@ -173,7 +173,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cronie insserv-compat
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
@@ -186,7 +186,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cron insserv-compat
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
@@ -198,7 +198,7 @@ steps:
 - label: "Integration Fedora :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:integration
   expeditor:
@@ -211,7 +211,7 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
-    - cd /workdir; bundle config set without omnibus_package
+    - cd /workdir; bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:functional
   expeditor:
@@ -226,7 +226,7 @@ steps:
 - label: "Unit Fedora :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
@@ -278,7 +278,7 @@ steps:
 - label: "chef-zero gem :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test chef/chef-zero master rake pedant
   expeditor:
@@ -292,7 +292,7 @@ steps:
 - label: "cheffish gem :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test chef/cheffish master rake spec
   expeditor:
@@ -303,7 +303,7 @@ steps:
 - label: "chefspec gem :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test chefspec/chefspec master rake
   expeditor:
@@ -314,7 +314,7 @@ steps:
 - label: "knife-windows gem :ruby: 3.0"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test chef/knife-windows master rake spec
   expeditor:
@@ -327,7 +327,7 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - apt-get update -y
     - apt-get install -y graphviz
-    - bundle config set without omnibus_package
+    - bundle config set --local without omnibus_package
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - bundle exec tasks/bin/run_external_test berkshelf/berkshelf master rake
   expeditor:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         cd kitchen-tests
         $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
-        bundle config set without 'omnibus_package'
+        bundle config set --local without 'omnibus_package'
         bundle install --jobs=3 --retry=3 --path=vendor/bundle
         gem install berkshelf --no-doc
         # berks emits a ruby warning when it loads net/http due to a previously
@@ -82,7 +82,7 @@ jobs:
       id: run
       run: |
         cd kitchen-tests
-        sudo /opt/chef/embedded/bin/bundle config set without 'omnibus_package'
+        sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
         sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3 --path=vendor/bundle
         sudo /opt/chef/embedded/bin/gem install berkshelf --no-doc
         sudo /opt/chef/embedded/bin/berks vendor cookbooks

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -9,7 +9,7 @@ gem "pedump"
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
 # the Test Kitchen-based build lab. You can skip these unnecessary dependencies
-# by running `bundle install --without development` to speed up build times.
+# by running `bundle config set without development && bundle install` to speed up build times.
 group :development do
   # Use Berkshelf for resolving cookbook dependencies
   gem "berkshelf", ">= 7.0"

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -9,7 +9,7 @@ gem "pedump"
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
 # the Test Kitchen-based build lab. You can skip these unnecessary dependencies
-# by running `bundle config set without development && bundle install` to speed up build times.
+# by running `bundle config set --local without development && bundle install` to speed up build times.
 group :development do
   # Use Berkshelf for resolving cookbook dependencies
   gem "berkshelf", ">= 7.0"

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -10,7 +10,7 @@ This project creates full-stack platform-specific packages for the following pro
 You must have a sane Ruby environment with Bundler installed. Ensure all the required gems are installed:
 
 ```shell
-bundle config set without development
+bundle config set --local without development
 bundle install
 ```
 
@@ -81,7 +81,7 @@ Then login to the instance and build the project as described in the Usage secti
 ```shell
 $ bundle exec kitchen login <PROJECT>-ubuntu-1204
 [vagrant@ubuntu...] $ cd chef/omnibus
-[vagrant@ubuntu...] $ bundle config set without development # Don't install dev tools!
+[vagrant@ubuntu...] $ bundle config set --local without development # Don't install dev tools!
 [vagrant@ubuntu...] $ bundle install
 [vagrant@ubuntu...] $ ...
 [vagrant@ubuntu...] $ bundle exec omnibus build <PROJECT> -l internal
@@ -91,7 +91,7 @@ $ bundle exec kitchen login <PROJECT>-ubuntu-1204
 $ kitchen login chef-ubuntu-1604
 [vagrant@ubuntu...] $ source load-omnibus-toolchain.sh
 [vagrant@ubuntu...] $ cd chef/omnibus
-[vagrant@ubuntu...] $ bundle config set without development # Don't install dev tools!
+[vagrant@ubuntu...] $ bundle config set --local without development # Don't install dev tools!
 [vagrant@ubuntu...] $ bundle install
 [vagrant@ubuntu...] $ ...
 [vagrant@ubuntu...] $ bundle exec omnibus build chef -l internal
@@ -109,7 +109,7 @@ C:\>C:\vagrant\load-omnibus-toolchain.ps1
 
 C:\>cd C:\vagrant\chef\omnibus
 
-C:\vagrant\chef\omnibus>bundle config set without development
+C:\vagrant\chef\omnibus>bundle config set --local without development
 
 C:\vagrant\chef\omnibus>bundle install
 

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -10,7 +10,8 @@ This project creates full-stack platform-specific packages for the following pro
 You must have a sane Ruby environment with Bundler installed. Ensure all the required gems are installed:
 
 ```shell
-bundle install --without development
+bundle config set without development
+bundle install
 ```
 
 ## Usage
@@ -80,7 +81,8 @@ Then login to the instance and build the project as described in the Usage secti
 ```shell
 $ bundle exec kitchen login <PROJECT>-ubuntu-1204
 [vagrant@ubuntu...] $ cd chef/omnibus
-[vagrant@ubuntu...] $ bundle install --without development # Don't install dev tools!
+[vagrant@ubuntu...] $ bundle config set without development # Don't install dev tools!
+[vagrant@ubuntu...] $ bundle install
 [vagrant@ubuntu...] $ ...
 [vagrant@ubuntu...] $ bundle exec omnibus build <PROJECT> -l internal
 ```
@@ -89,7 +91,8 @@ $ bundle exec kitchen login <PROJECT>-ubuntu-1204
 $ kitchen login chef-ubuntu-1604
 [vagrant@ubuntu...] $ source load-omnibus-toolchain.sh
 [vagrant@ubuntu...] $ cd chef/omnibus
-[vagrant@ubuntu...] $ bundle install --without development # Don't install dev tools!
+[vagrant@ubuntu...] $ bundle config set without development # Don't install dev tools!
+[vagrant@ubuntu...] $ bundle install
 [vagrant@ubuntu...] $ ...
 [vagrant@ubuntu...] $ bundle exec omnibus build chef -l internal
 ```
@@ -106,7 +109,9 @@ C:\>C:\vagrant\load-omnibus-toolchain.ps1
 
 C:\>cd C:\vagrant\chef\omnibus
 
-C:\vagrant\chef\omnibus>bundle install --without development
+C:\vagrant\chef\omnibus>bundle config set without development
+
+C:\vagrant\chef\omnibus>bundle install
 
 C:\vagrant\chef\omnibus>bundle exec omnibus build chef -l internal
 ```


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
