### PR TITLE
Remove the default json logger from the compliance API

### DIFF
--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -28,7 +28,7 @@ class Chef
       # Controls what is done with the resulting report after the Chef InSpec run.
       # Accepts a single string value or an array of multiple values.
       # Accepted values: 'chef-server-automate', 'chef-automate', 'json-file', 'audit-enforcer', 'cli'
-      "reporter" => %w{json-file cli},
+      "reporter" => "cli",
 
       # Controls if Chef InSpec profiles should be fetched from Chef Automate or Chef Infra Server
       # in addition to the default fetch locations provided by Chef Inspec.

--- a/spec/integration/compliance/compliance_spec.rb
+++ b/spec/integration/compliance/compliance_spec.rb
@@ -47,6 +47,7 @@ describe "chef-client with compliance phase" do
         {
           "audit": {
             "compliance_phase": true,
+            "reporter": "json-file",
             "json_file": {
               "location": "#{report_file}"
             },

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -278,7 +278,7 @@ describe Chef::Compliance::Runner do
       inputs = runner.inspec_opts[:inputs]
 
       expect(inputs["tacos"]).to eq("lunch")
-      expect(inputs["chef_node"]["audit"]["reporter"]).to eq(%w{json-file cli})
+      expect(inputs["chef_node"]["audit"]["reporter"]).to eq("cli")
       expect(inputs["chef_node"]["chef_environment"]).to eq("_default")
     end
   end


### PR DESCRIPTION
This indirectly fixes #11585 and avoids the json logger silently
consuming disk space.  By reverting back to a single value we also
avoid the attributes array merging issues.

This might conceivably change behavior to people who were reliant
on the additive array-merge behavior, but the compliance phase
has been considered experimental.
