### PR TITLE
Backport: group: fix gid in use error on macOS

### DIFF
--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -158,7 +158,7 @@ class Chef
           if new_resource.group_name && (current_resource.group_name != new_resource.group_name)
             dscl_create_group
           end
-          if new_resource.gid && (current_resource.gid != new_resource.gid)
+          if new_resource.gid && (current_resource.gid != new_resource.gid.to_s)
             set_gid
           end
           if new_resource.members || new_resource.excluded_members


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Backporting the following change made in https://github.com/chef/chef/pull/11927 to `chef-16`.

> When executing `:create` action for a group that already exists and passing the `gid` as `Integer`, the resource ends up in `set_gid` block and raise the error on this line https://github.com/chef/chef/blob/eb34e97386cb393c5558e4814adbc3174f532620/lib/chef/provider/group/dscl.rb#L103
> 
> This PR fixes the issue by making sure the comparison between `current_resource.gid` and `new_resource.gid` is correctly performed by using `to_s` on `new_resource.gid` since `current_resource.gid` is always a string.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

#11624 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
