### PR TITLE
Downgraded the Log level to warn as per AHA idea I-25

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -423,7 +423,7 @@ class Chef
           if response.is_a?(Net::HTTPServerError) && !Chef::Config.local_mode
             if http_retry_count - http_attempts >= 0
               sleep_time = 1 + (2**http_attempts) + rand(2**http_attempts)
-              Chef::Log.error("Server returned error #{response.code} for #{url}, retrying #{http_attempts}/#{http_retry_count} in #{sleep_time}s")
+              Chef::Log.warn("Server returned error #{response.code} for #{url}, retrying #{http_attempts}/#{http_retry_count} in #{sleep_time}s")
               sleep(sleep_time)
               redo
             end
@@ -432,7 +432,7 @@ class Chef
         end
       rescue SocketError, Errno::ETIMEDOUT, Errno::ECONNRESET => e
         if http_retry_count - http_attempts >= 0
-          Chef::Log.error("Error connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
+          Chef::Log.warn("Error connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
           sleep(http_retry_delay)
           retry
         end
@@ -440,21 +440,21 @@ class Chef
         raise e
       rescue Errno::ECONNREFUSED
         if http_retry_count - http_attempts >= 0
-          Chef::Log.error("Connection refused connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
+          Chef::Log.warn("Connection refused connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
           sleep(http_retry_delay)
           retry
         end
         raise Errno::ECONNREFUSED, "Connection refused connecting to #{url}, giving up"
       rescue Timeout::Error
         if http_retry_count - http_attempts >= 0
-          Chef::Log.error("Timeout connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
+          Chef::Log.warn("Timeout connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
           sleep(http_retry_delay)
           retry
         end
         raise Timeout::Error, "Timeout connecting to #{url}, giving up"
       rescue OpenSSL::SSL::SSLError => e
         if (http_retry_count - http_attempts >= 0) && !e.message.include?("certificate verify failed")
-          Chef::Log.error("SSL Error connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
+          Chef::Log.warn("SSL Error connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
           sleep(http_retry_delay)
           retry
         end


### PR DESCRIPTION
I have updated the code to fix the issue mentioned in the INFRA AHA Idea 25: https://chef-software.ideas.aha.io/ideas/INFRA-I-25.

The code fixes the issue mentioned in the description:
------------------------------------------------------------------------------------------------------------
When running Chef Infra Client and communicating with external resources on the Chef Infra Server, such as data-collector, the client will report an ERROR if connection cannot be established and retry up to 5 times.



Could this ERROR that is happening during the retries be downgraded to a WARN level event and only report as an ERROR if 5/5 attempts fail? There are times in networks due to connectivity, server load or other outside factors which could cause initial attempts to fail but it is not truly a fault event until the 5/5 threshold is reached:



Example:

[2021-06-22T15:34:49+00:00] ERROR: Connection refused connecting to https://chef-local.local/organizations/localorg/nodes/mynode.local, retry 1/5
[2021-06-22T15:34:54+00:00] ERROR: Connection refused connecting to https://chef-local.local/organizations/localorg/nodes/mynode.local, retry 2/5
[2021-06-22T15:34:59+00:00] ERROR: Server returned error 502 for https://chef-local.local/organizations/localorg/nodes/mynode.local, retrying 3/5 in 15s

In this example, the Chef Infra Server was not able to respond to the first three attempts, but successfully completed on the 4th attempt. This could be potentially downgraded to a WARN level event until all of the attempts have been exhausted and communication failed.
------------------------------------------------------------------------------------------------------
