### PR TITLE
windows_uac: fix registry settings for consent_behavior_users

### DIFF
--- a/lib/chef/resource/windows_uac.rb
+++ b/lib/chef/resource/windows_uac.rb
@@ -104,7 +104,9 @@ class Chef
         #
         # @return [Integer]
         def consent_behavior_users_symbol_to_reg(sym)
-          %i{auto_deny secure_prompt_for_creds prompt_for_creds}.index(sym)
+          # Since 2 isn't a valid value for ConsentPromptBehaviorUser, assign the value at index as nil.
+          # https://docs.microsoft.com/en-us/windows/security/identity-protection/user-account-control/user-account-control-group-policy-and-registry-key-settings#registry-key-settings
+          [:auto_deny, :secure_prompt_for_creds, nil, :prompt_for_creds].index(sym)
         end
       end
     end


### PR DESCRIPTION
…_users

Signed-off-by: rishichawda <rishichawda@users.noreply.github.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
`windows_uac` was trying to set `2` for `ConsentPromptBehaviorUser` key under `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System` which isn't valid. Updated it based on the documentation: https://docs.microsoft.com/en-us/windows/security/identity-protection/user-account-control/user-account-control-group-policy-and-registry-key-settings#registry-key-settings 

I couldn't think of any appropriate symbol name to put at index 2 without potentially creating mild confusion. Instead of adding checks, I have inserted `nil` at that index to imply that the index is unused as a registry value. Added a comment to go with it as well. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#11570 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
