### PR TITLE
Fix tests for new omnibus test systems

### DIFF
--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -181,7 +181,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
 
     describe "when the users exist" do
       before do
-        high_uid = 30000
+        high_uid = 40000
         (spec_members).each do |member|
           remove_user(member)
           create_user(member, high_uid)

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -44,6 +44,10 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       members.shift # Get rid of GroupMembership: string
       members.include?(user)
     else
+      # TODO For some reason our temporary AIX 7.2 system does not correctly report group membership immediately after changes have been made.
+      # Adding a 2 second delay for this platform is enough to get correct results.
+      # We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617
+      sleep 2 if aix? && (ohai[:platform_version] == "7.2")
       Etc.getgrnam(group_name).mem.include?(user)
     end
   end

--- a/spec/functional/resource/link_spec.rb
+++ b/spec/functional/resource/link_spec.rb
@@ -345,9 +345,17 @@ describe Chef::Resource::Link do
             let(:test_user) { "test-link-user" }
             before do
               user(test_user).run_action(:create)
+              # TODO For some reason our temporary AIX 7.2 system does not correctly report user existence immediately after changes have been made.
+              # Adding a 2 second delay for this platform is enough to get correct results.
+              # We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617
+              sleep 2 if aix? && (ohai[:platform_version] == "7.2")
             end
             after do
               user(test_user).run_action(:remove)
+              # TODO For some reason our temporary AIX 7.2 system does not correctly report user existence immediately after changes have been made.
+              # Adding a 2 second delay for this platform is enough to get correct results.
+              # We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617
+              sleep 2 if aix? && (ohai[:platform_version] == "7.2")
             end
             before(:each) do
               resource.owner(test_user)


### PR DESCRIPTION
For some reason our temporary AIX 7.2 system does not correctly report group membership immediately after changes have been made. Adding a 2 second delay for this platform is enough to get correct results. We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617

Use a higher starting uid for tests. Some of our new test infrastructure has uids that are colliding with the 30000 starting point.