### PR TITLE
Add AKeyless Vault support

### DIFF
--- a/lib/chef/secret_fetcher.rb
+++ b/lib/chef/secret_fetcher.rb
@@ -21,7 +21,7 @@ require_relative "exceptions"
 class Chef
   class SecretFetcher
 
-    SECRET_FETCHERS = %i{example aws_secrets_manager azure_key_vault hashi_vault}.freeze
+    SECRET_FETCHERS = %i{example aws_secrets_manager azure_key_vault hashi_vault akeyless_vault}.freeze
 
     # Returns a configured and validated instance
     # of a [Chef::SecretFetcher::Base]  for the given
@@ -45,10 +45,13 @@ class Chef
                 when :hashi_vault
                   require_relative "secret_fetcher/hashi_vault"
                   Chef::SecretFetcher::HashiVault.new(config, run_context)
+                when :akeyless_vault
+                  require_relative "secret_fetcher/akeyless_vault"
+                  Chef::SecretFetcher::AKeylessVault.new(config, run_context)
                 when nil, ""
                   raise Chef::Exceptions::Secret::MissingFetcher.new(SECRET_FETCHERS)
                 else
-                  raise Chef::Exceptions::Secret::InvalidFetcherService.new("Unsupported secret service: #{service}", SECRET_FETCHERS)
+                  raise Chef::Exceptions::Secret::InvalidFetcherService.new("Unsupported secret service: '#{service}'", SECRET_FETCHERS)
                 end
       fetcher.validate!
       fetcher

--- a/lib/chef/secret_fetcher/akeyless_vault.rb
+++ b/lib/chef/secret_fetcher/akeyless_vault.rb
@@ -1,0 +1,34 @@
+#
+# Author:: Marc Paradise (<marc@chef.io>)
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "base"
+require "aws-sdk-core" # Support for aws instance profile auth
+require_relative "hashi_vault"
+
+class Chef
+  class SecretFetcher
+    # == Chef::SecretFetcher::AKeylessVault
+    # A fetcher that fetches a secret from AKeyless Vault.  Initial implementation is
+    # based on HashiVault , because AKeyless provides a compatibility layer that makes this possible.
+    # Future revisions will use native akeyless authentication.
+    class AKeylessVault < HashiVault
+
+    end
+  end
+end
+

--- a/lib/chef/secret_fetcher/hashi_vault.rb
+++ b/lib/chef/secret_fetcher/hashi_vault.rb
@@ -57,7 +57,7 @@ class Chef
     SUPPORTED_AUTH_TYPES = %i{iam_role token}.freeze
     class HashiVault < Base
 
-      # Validate and authenticate the current session using the configurated auth strategy and parameters
+      # Validate and authenticate the current session using the configured auth strategy and parameters
       def validate!
         if config[:vault_addr].nil?
           raise Chef::Exceptions::Secret::ConfigurationInvalid.new("You must provide the Vault address in the configuration as :vault_addr")

--- a/spec/unit/secret_fetcher/akeyless_vault_spec.rb
+++ b/spec/unit/secret_fetcher/akeyless_vault_spec.rb
@@ -1,0 +1,37 @@
+#
+# Author:: Marc Paradise <marc@chef.io>
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../../spec_helper"
+require "chef/secret_fetcher/akeyless_vault"
+
+describe Chef::SecretFetcher::AKeylessVault do
+  let(:node) { {} }
+  let(:run_context) { double("run_context", node: node) }
+
+  context "when validating provided AKeyless Vault configuration" do
+    it "raises ConfigurationInvalid when :secret_access_key is not provided" do
+      fetcher = Chef::SecretFetcher::AKeylessVault.new( { access_id: "provided" }, run_context)
+      expect { fetcher.validate! }.to raise_error(Chef::Exceptions::Secret::ConfigurationInvalid, /:secret_access_key/)
+    end
+
+    it "raises ConfigurationInvalid when :access_key_id is not provided" do
+      fetcher = Chef::SecretFetcher::AKeylessVault.new( { access_key: "provided" }, run_context)
+      expect { fetcher.validate! }.to raise_error(Chef::Exceptions::Secret::ConfigurationInvalid, /:access_key_id/)
+    end
+  end
+end


### PR DESCRIPTION
This iteration uses AKeyless's Hashi Vault compatibility proxy.  To use it, ensure that  `hvp.akeyless.io` is accessible from the nodes being converged. 

Example usage: 

```
file "/home/user/test1" do
  content secret(name: "/secret/data/MySecret",
                 service: :akeyless_vault,
                 config: {
                   access_key: "....api access key here...",
                   access_id: "...api access id here...", 
                 }).to_s
end

```
Fixes #11825 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>