### PR TITLE
Clean up some more File.exists? uses

### DIFF
--- a/lib/chef/provider/link.rb
+++ b/lib/chef/provider/link.rb
@@ -43,8 +43,8 @@ class Chef
           )
         else
           current_resource.link_type(:hard)
-          if ::File.exists?(current_resource.target_file)
-            if ::File.exists?(new_resource.to) &&
+          if ::File.exist?(current_resource.target_file)
+            if ::File.exist?(new_resource.to) &&
                 file_class.stat(current_resource.target_file).ino ==
                     file_class.stat(new_resource.to).ino
               current_resource.to(canonicalize(new_resource.to))

--- a/lib/chef/provider/template.rb
+++ b/lib/chef/provider/template.rb
@@ -39,7 +39,7 @@ class Chef
         super
 
         requirements.assert(:create, :create_if_missing) do |a|
-          a.assertion { ::File.exists?(content.template_location) }
+          a.assertion { ::File.exist?(content.template_location) }
           a.failure_message "Template source #{content.template_location} could not be found."
           a.whyrun "Template source #{content.template_location} does not exist. Assuming it would have been created."
           a.block_action!

--- a/spec/unit/provider/link_spec.rb
+++ b/spec/unit/provider/link_spec.rb
@@ -125,7 +125,7 @@ describe Chef::Resource::Link do
 
   describe "when the target doesn't exist" do
     before do
-      allow(File).to receive(:exists?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(false)
+      allow(File).to receive(:exist?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(false)
       allow(provider.file_class).to receive(:symlink?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(false)
       provider.load_current_resource
     end
@@ -152,13 +152,16 @@ describe Chef::Resource::Link do
       allow(stat).to receive(:mode).and_return(0755)
       allow(provider.file_class).to receive(:stat).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(stat)
 
-      allow(File).to receive(:exists?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(true)
+      # XXX: this might be broken?  it preserves prior behavior in the specs caused by File.exist?/exists? interactions
+      allow(Chef::ScanAccessControl).to receive(:new).and_return(instance_double(Chef::ScanAccessControl, set_all!: nil))
+
+      allow(File).to receive(:exist?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(true)
       allow(provider.file_class).to receive(:symlink?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(false)
     end
 
     describe "and the source does not exist" do
       before do
-        allow(File).to receive(:exists?).with("#{CHEF_SPEC_DATA}/fofile").and_return(false)
+        expect(File).to receive(:exist?).with("#{CHEF_SPEC_DATA}/fofile").and_return(false)
         provider.load_current_resource
       end
 
@@ -185,7 +188,7 @@ describe Chef::Resource::Link do
 
         allow(provider.file_class).to receive(:stat).with("#{CHEF_SPEC_DATA}/fofile").and_return(stat)
 
-        allow(File).to receive(:exists?).with("#{CHEF_SPEC_DATA}/fofile").and_return(true)
+        allow(File).to receive(:exist?).with("#{CHEF_SPEC_DATA}/fofile").and_return(true)
         provider.load_current_resource
       end
 
@@ -212,7 +215,7 @@ describe Chef::Resource::Link do
 
         allow(provider.file_class).to receive(:stat).with("#{CHEF_SPEC_DATA}/fofile").and_return(stat)
 
-        allow(File).to receive(:exists?).with("#{CHEF_SPEC_DATA}/fofile").and_return(true)
+        allow(File).to receive(:exist?).with("#{CHEF_SPEC_DATA}/fofile").and_return(true)
         provider.load_current_resource
       end
 
@@ -261,6 +264,9 @@ describe Chef::Resource::Link do
       allow(provider.file_class).to receive(:stat).with(
         "#{CHEF_SPEC_DATA}/fofile-link"
       ).and_return(stat)
+
+      # XXX: this might be broken?  it preserves prior behavior in the specs caused by File.exist?/exists? interactions
+      allow(Chef::ScanAccessControl).to receive(:new).and_return(instance_double(Chef::ScanAccessControl, set_all!: nil))
 
       provider.load_current_resource
     end
@@ -336,10 +342,10 @@ describe Chef::Resource::Link do
           "#{CHEF_SPEC_DATA}/fofile-link"
         ).and_return(false)
 
-        allow(File).to receive(:exists?).with(
+        allow(File).to receive(:exist?).with(
           "#{CHEF_SPEC_DATA}/fofile-link"
         ).and_return(true)
-        allow(File).to receive(:exists?).with(
+        allow(File).to receive(:exist?).with(
           "#{CHEF_SPEC_DATA}/fofile"
         ).and_return(true)
 

--- a/spec/unit/provider/template_spec.rb
+++ b/spec/unit/provider/template_spec.rb
@@ -50,7 +50,7 @@ describe Chef::Provider::Template do
 
   let(:content) do
     content = double("Chef::Provider::File::Content::Template", template_location: "/foo/bar/baz")
-    allow(File).to receive(:exists?).with("/foo/bar/baz").and_return(true)
+    allow(File).to receive(:exist?).with("/foo/bar/baz").and_return(true)
     content
   end
 
@@ -76,7 +76,7 @@ describe Chef::Provider::Template do
     it "stops executing when the local template source can't be found" do
       setup_normal_file
       allow(content).to receive(:template_location).and_return("/baz/bar/foo")
-      allow(File).to receive(:exists?).with("/baz/bar/foo").and_return(false)
+      allow(File).to receive(:exist?).with("/baz/bar/foo").and_return(false)
       expect { provider.run_action(:create) }.to raise_error Chef::Mixin::WhyRun::ResourceRequirements::Assertion::AssertionFailure
     end
 


### PR DESCRIPTION
For the link provider around line 155 it was stubbing `File.exists?("#{CHEF_SPEC_DATA}/fofile-link")` to true for the provider, while `File.exist?("#{CHEF_SPEC_DATA}/fofile-link")` was false because it didn't exist inside of ScanAccessControl which would effectively NOP the evaluation of ScanAccessControl in load_current_resource.  By setting up the expectation on `File.exist?` to true now that means that ScanAccessControl would run which would blow up.  The whole thing made my head kind of hurt a bit and I'm not certain that the expectations in the specs are even correct.  But I've hit my hard timebox for this so I just preserved the original behavior the way I found it.

The best thing to do would probably be to junk all the link provider specs entirely and start over clean, with no stubbing at all and really have the provider manage real links in a spec-constructed tmpdir.  All the stubbing is just creating confusion and pain.