### PR TITLE
Coerce mount_point only when it is not root directory

### DIFF
--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -42,7 +42,7 @@ class Chef
         sensitive: true
 
       property :mount_point, String, name_property: true,
-               coerce: proc { |arg| arg.chomp("/") }, # Removed "/" from the end of str, because it was causing idempotency issue.
+               coerce: proc { |arg| (arg == "/" || arg.match?(":/$"))? arg : arg.chomp("/") }, # Removed "/" from the end of str, because it was causing idempotency issue.
                description: "The directory (or path) in which the device is to be mounted. Defaults to the name of the resource block if not provided."
 
       property :device, String, identity: true,

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -42,7 +42,7 @@ class Chef
         sensitive: true
 
       property :mount_point, String, name_property: true,
-               coerce: proc { |arg| (arg == "/" || arg.match?(":/$"))? arg : arg.chomp("/") }, # Removed "/" from the end of str, because it was causing idempotency issue.
+               coerce: proc { |arg| (arg == "/" || arg.match?(":/$")) ? arg : arg.chomp("/") }, # Removed "/" from the end of str, because it was causing idempotency issue.
                description: "The directory (or path) in which the device is to be mounted. Defaults to the name of the resource block if not provided."
 
       property :device, String, identity: true,

--- a/spec/unit/resource/mount_spec.rb
+++ b/spec/unit/resource/mount_spec.rb
@@ -59,6 +59,16 @@ describe Chef::Resource::Mount do
     expect(resource.mount_point).to eql("//192.168.11.102/Share/backup")
   end
 
+  it "does not strip slash when mount_point is root directory" do
+    resource.mount_point "/"
+    expect(resource.mount_point).to eql("/")
+  end
+
+  it "does not strip slash when mount_point is root of network mount" do
+    resource.mount_point "127.0.0.1:/"
+    expect(resource.mount_point).to eql("127.0.0.1:/")
+  end
+
   it "raises error when mount_point property is not set" do
     expect { resource.mount_point nil }.to raise_error(Chef::Exceptions::ValidationFailed, "Property mount_point must be one of: String!  You passed nil.")
   end


### PR DESCRIPTION
Signed-off-by: JiSoo Kim <jskim910118@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Since #10614, mount resource is updated to have coerce in mount_point attribute. root directory
There were several issues around for root of the network mount, but the same change is also affecting the plain root directory. After the coercion, it is simply going to be nil. This PR is trying to address the issue by not applying the coercion when mount_point is either root directory or root of network mount.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/12021

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
