### PR TITLE
Replace Ubuntu 21.04 kitchen tests with 21.10

### DIFF
--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -135,9 +135,9 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
 
-- name: ubuntu-21.04
+- name: ubuntu-21.10
   driver:
-    image: dokken/ubuntu-21.04
+    image: dokken/ubuntu-21.10
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update


### PR DESCRIPTION
Test with the very latest

Signed-off-by: Tim Smith <tsmith@chef.io>