### PR TITLE
Remove chef-bin from berkshelf Gemfile to fix dep solving

### DIFF
--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -32,6 +32,7 @@ Dir.mktmpdir("chef-external-test") do |dir|
   Dir.chdir(dir) do
     shell_out!("git checkout #{git_thing}", live_stream: STDOUT)
     Bundler.with_unbundled_env do
+      shell_out!("sed -i '/chef-bin/d' Gemfile", live_stream: STDOUT, env: env, timeout: 3600)
       shell_out!("bundle install --jobs=3 --retry=3", live_stream: STDOUT, env: env, timeout: 3600)
       shell_out!("bundle exec #{ARGV.join(" ")}", live_stream: STDOUT, env: env)
     end


### PR DESCRIPTION
## Description

This should fix the berkshelf tests in this project.

## Related Issue

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
