### PR TITLE
Update bundle config set path

### DIFF
--- a/.expeditor/scripts/bk_linux_exec.sh
+++ b/.expeditor/scripts/bk_linux_exec.sh
@@ -33,7 +33,8 @@ export CHEF_LICENSE="accept-silent"
 echo "--- Installing Gems"
 echo 'gem: --no-document' >> ~/.gemrc
 sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-bundle install --jobs=3 --retry=3 --path=../vendor/bundle
+bundle config set --local path 'vendor/bundle'
+bundle install --jobs=3 --retry=3
 
 echo "--- Config information"
 

--- a/.expeditor/scripts/bk_win_prep.ps1
+++ b/.expeditor/scripts/bk_win_prep.ps1
@@ -12,5 +12,6 @@ if (-not $?) { throw "Can't run Bundler. Is it installed?" }
 
 echo "--- bundle install"
 bundle config set --local without omnibus_package
-bundle install --jobs=3 --retry=3  --path=vendor/bundle
+bundle config set --local path 'vendor/bundle'
+bundle install --jobs=3 --retry=3
 if (-not $?) { throw "Unable to install gem dependencies" }

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -20,7 +20,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd chef-utils
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec
   expeditor:
     executor:
@@ -32,7 +33,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd chef-config
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec
   expeditor:
     executor:
@@ -47,7 +49,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -61,7 +64,8 @@ steps:
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -73,7 +77,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -85,7 +90,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -99,7 +105,8 @@ steps:
     - apt-get update -y
     - apt-get install -y cron locales # needed for functional tests to pass
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -111,7 +118,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -123,7 +131,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -136,7 +145,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - yum install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -148,7 +158,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -161,7 +172,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cron insserv-compat
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -174,7 +186,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cronie insserv-compat
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -187,7 +200,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - zypper install -y cron insserv-compat
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -199,7 +213,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -212,7 +227,8 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -227,7 +243,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -279,7 +296,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test chef/chef-zero main rake pedant
   expeditor:
     executor:
@@ -293,7 +311,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test chef/cheffish main rake spec
   expeditor:
     executor:
@@ -304,7 +323,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test chefspec/chefspec main rake
   expeditor:
     executor:
@@ -315,7 +335,8 @@ steps:
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test chef/knife-windows main rake spec
   expeditor:
     executor:
@@ -328,7 +349,8 @@ steps:
     - apt-get update -y
     - apt-get install -y graphviz
     - bundle config set --local without omnibus_package
-    - bundle install --jobs=3 --retry=3 --path=vendor/bundle
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test berkshelf/berkshelf main rake
   expeditor:
     executor:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -41,7 +41,8 @@ jobs:
         cd kitchen-tests
         $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
         bundle config set --local without 'omnibus_package'
-        bundle install --jobs=3 --retry=3 --path=vendor/bundle
+        bundle config set --local path 'vendor/bundle'
+        bundle install --jobs=3 --retry=3
         gem install berkshelf --no-doc
         # berks emits a ruby warning when it loads net/http due to a previously
         # defined constant. Even though it is just a warning, powershell immediately
@@ -83,7 +84,8 @@ jobs:
       run: |
         cd kitchen-tests
         sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
-        sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3 --path=vendor/bundle
+        sudo /opt/chef/embedded/bin/bundle config set --local path 'vendor/bundle'
+        sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3
         sudo /opt/chef/embedded/bin/gem install berkshelf --no-doc
         sudo /opt/chef/embedded/bin/berks vendor cookbooks
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist

--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -30,7 +30,8 @@ begin
         puts "--- Running #{gem} specs"
         Bundler.with_unbundled_env do
           puts "Executing tests in #{Dir.pwd}:"
-          sh("bundle install --jobs=3 --retry=3 --path=../vendor/bundle")
+          sh("bundle config set --local path 'vendor/bundle'")
+          sh("bundle install --jobs=3 --retry=3")
           sh("bundle exec rake spec")
         end
       end


### PR DESCRIPTION
## Description

[Bundler](https://bundler.io/) is/has deprecated the `--path` argument to `bundle install`. This updates all uses of `bundle install --path=vendor/bundle` to the new `bundle config set --local path 'vendor/bundle'`

## Related Issue

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
