### PR TITLE
Add http_options property to remote_file

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1046,6 +1046,7 @@
     "netbw",
     "NETCARD",
     "netdom",
+    "nethttp",
     "NETLOGON",
     "netmsg",
     "NETNAME",

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -468,12 +468,12 @@ class Chef
 
     # @api private
     def http_retry_delay
-      config[:http_retry_delay]
+      options[:http_retry_delay] || config[:http_retry_delay]
     end
 
     # @api private
     def http_retry_count
-      config[:http_retry_count]
+      options[:http_retry_count] || config[:http_retry_count]
     end
 
     # @api private

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -82,6 +82,9 @@ class Chef
     # [Boolean] if we're doing keepalives or not
     attr_reader :keepalives
 
+    # @returns [Hash] options for Net::HTTP to be sent to setters on the object
+    attr_reader :nethttp_opts
+
     # Create a HTTP client object. The supplied +url+ is used as the base for
     # all subsequent requests. For example, when initialized with a base url
     # http://localhost:4000, a call to +get+ with 'nodes' will make an
@@ -94,6 +97,7 @@ class Chef
       @redirect_limit = 10
       @keepalives = options[:keepalives] || false
       @options = options
+      @nethttp_opts = options[:nethttp] || {}
 
       @middlewares = []
       self.class.middlewares.each do |middleware_class|
@@ -311,7 +315,7 @@ class Chef
 
         SocketlessChefZeroClient.new(base_url)
       else
-        BasicClient.new(base_url, ssl_policy: ssl_policy, keepalives: keepalives)
+        BasicClient.new(base_url, ssl_policy: ssl_policy, keepalives: keepalives, nethttp_opts: nethttp_opts)
       end
     end
 

--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -137,7 +137,7 @@ class Chef
           if new_resource.ssl_verify_mode
             opts[:ssl_verify_mode] = new_resource.ssl_verify_mode
           end
-          opts
+          opts.merge(new_resource.http_options)
         end
 
       end

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -34,6 +34,36 @@ class Chef
 
       description "Use the **remote_file** resource to transfer a file from a remote location using file specificity. This resource is similar to the **file** resource. Note: Fetching files from the `files/` directory in a cookbook should be done with the **cookbook_file** resource."
 
+      examples <<~DOC
+      **Download a file from an http server**:
+
+      ```ruby
+        remote_file '/tmp/remote.txt' do
+          source 'https://example.org/remote.txt'
+        end
+      ```
+
+      **Set Chef::HTTP options and configure the Net::HTTP object**
+
+      ```ruby
+        remote_file '/tmp/remote.txt' do
+          source 'https://example.org/remote.txt'
+          http_options({
+            http_retry_delay: 0,
+            http_retry_count: 0,
+            keepalives: false,
+            nethttp: {
+              continue_timeout: 5,
+              max_retries: 5,
+              read_timeout: 5,
+              write_timeout: 5,
+              ssl_timeout: 5,
+            },
+          })
+        end
+      ```
+      DOC
+
       def initialize(name, run_context = nil)
         super
         @source = []

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -118,6 +118,9 @@ class Chef
 
       property :authentication, Symbol, equal_to: %i{remote local}, default: :remote
 
+      property :http_options, Hash, default: {},
+        description: "A Hash of custom HTTP options. For example: `http_options({ http_retry_count: 0, http_retry_delay: 2 })`"
+
       def after_created
         validate_identity_platform(remote_user, remote_password, remote_domain)
         identity = qualify_user(remote_user, remote_password, remote_domain)

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -119,6 +119,7 @@ class Chef
       property :authentication, Symbol, equal_to: %i{remote local}, default: :remote
 
       property :http_options, Hash, default: {},
+        introduced: "17.5",
         description: "A Hash of custom HTTP options. For example: `http_options({ http_retry_count: 0, http_retry_delay: 2 })`"
 
       def after_created

--- a/spec/unit/http/basic_client_spec.rb
+++ b/spec/unit/http/basic_client_spec.rb
@@ -47,6 +47,36 @@ describe "HTTP Connection" do
       expect(Net::HTTP).to receive(:new).and_return(net_http_mock)
       expect(basic_client.http_client).to eql(net_http_mock)
     end
+
+    it "allows setting net-http accessor options" do
+      basic_client = Chef::HTTP::BasicClient.new(uri, nethttp_opts: {
+        "continue_timeout" => 5,
+        "max_retries" => 5,
+        "read_timeout" => 5,
+        "write_timeout" => 5,
+        "ssl_timeout" => 5,
+      })
+      expect(basic_client.http_client.continue_timeout).to eql(5)
+      expect(basic_client.http_client.max_retries).to eql(5)
+      expect(basic_client.http_client.read_timeout).to eql(5)
+      expect(basic_client.http_client.write_timeout).to eql(5)
+      expect(basic_client.http_client.ssl_timeout).to eql(5)
+    end
+
+    it "allows setting net-http accssor options as symbols" do
+      basic_client = Chef::HTTP::BasicClient.new(uri, nethttp_opts: {
+        continue_timeout: 5,
+        max_retries: 5,
+        read_timeout: 5,
+        write_timeout: 5,
+        ssl_timeout: 5,
+      })
+      expect(basic_client.http_client.continue_timeout).to eql(5)
+      expect(basic_client.http_client.max_retries).to eql(5)
+      expect(basic_client.http_client.read_timeout).to eql(5)
+      expect(basic_client.http_client.write_timeout).to eql(5)
+      expect(basic_client.http_client.ssl_timeout).to eql(5)
+    end
   end
 
   describe "#build_http_client" do

--- a/spec/unit/http_spec.rb
+++ b/spec/unit/http_spec.rb
@@ -46,13 +46,19 @@ describe Chef::HTTP do
   describe "#initialize" do
     it "accepts a keepalive option and passes it to the http_client" do
       http = Chef::HTTP.new(uri, keepalives: true)
-      expect(Chef::HTTP::BasicClient).to receive(:new).with(uri, ssl_policy: Chef::HTTP::APISSLPolicy, keepalives: true).and_call_original
+      expect(Chef::HTTP::BasicClient).to receive(:new).with(uri, ssl_policy: Chef::HTTP::APISSLPolicy, nethttp_opts: {}, keepalives: true).and_call_original
       expect(http.http_client).to be_a_kind_of(Chef::HTTP::BasicClient)
     end
 
     it "the default is not to use keepalives" do
       http = Chef::HTTP.new(uri)
-      expect(Chef::HTTP::BasicClient).to receive(:new).with(uri, ssl_policy: Chef::HTTP::APISSLPolicy, keepalives: false).and_call_original
+      expect(Chef::HTTP::BasicClient).to receive(:new).with(uri, ssl_policy: Chef::HTTP::APISSLPolicy, nethttp_opts: {}, keepalives: false).and_call_original
+      expect(http.http_client).to be_a_kind_of(Chef::HTTP::BasicClient)
+    end
+
+    it "allows setting the nethttp options hash" do
+      http = Chef::HTTP.new(uri, { nethttp: { "continue_timeout" => 5 } })
+      expect(Chef::HTTP::BasicClient).to receive(:new).with(uri, ssl_policy: Chef::HTTP::APISSLPolicy, nethttp_opts: { "continue_timeout" => 5 }, keepalives: false).and_call_original
       expect(http.http_client).to be_a_kind_of(Chef::HTTP::BasicClient)
     end
   end

--- a/spec/unit/provider/remote_file/http_spec.rb
+++ b/spec/unit/provider/remote_file/http_spec.rb
@@ -321,4 +321,14 @@ describe Chef::Provider::RemoteFile::HTTP do
 
   end
 
+  describe "#http_client_opts" do
+    before do
+      new_resource.http_options({ retries: 2, retry_delay: 3 })
+    end
+
+    it "should set http client options" do
+      expect(fetcher.send(:http_client_opts)).to eq({ retries: 2, retry_delay: 3 })
+    end
+  end
+
 end


### PR DESCRIPTION
This lets the remote_file resource set any of the Chef::HTTP options.

It also exposes the Net::HTTP settings like "ssl_timeout" through a "nethttp" sub-hash.

Note that "rest_timeout" can set be set at the higher level which is the Chef::HTTP/Chef::Config option that winds up setting both the read_timeout and open_timeout to the same value at the lower nethttp setting.  Setting the nethttp settings explicitly will override those completely.

The defaults on the read_timeout and open_timeout are 300 seconds (due to needing to work around crushed chef-servers caused by thundering herd starts of hundreds of chef-clients at the same time).  Since that may also happen with thundering herds of chef-clients hammering on some expensive remote_file resource at the same time that default is deliberately kept to avoid a breaking change.

```
remote_file "/tmp/remote_file.out" do
  source "https://www.chef.io"
  http_options({ 
    http_retry_delay: 0,
    http_retry_count: 0,
    keepalives: false,
    nethttp: { 
      continue_timeout: 5,
      max_retries: 5,
      read_timeout: 5,
      write_timeout: 5,
      ssl_timeout: 5,
    },
  })
end
```

replaces #11905