### PR TITLE
Exclude running libarchive tests on platforms where loading libarchive is broken

### DIFF
--- a/spec/functional/resource/archive_file_spec.rb
+++ b/spec/functional/resource/archive_file_spec.rb
@@ -18,7 +18,8 @@
 require "spec_helper"
 require "tmpdir"
 
-describe Chef::Resource::ArchiveFile do
+# Exclude this test on platforms where ffi-libarchive loading is broken
+describe Chef::Resource::ArchiveFile, :libarchive_loading_broken do
   include RecipeDSLHelper
 
   let(:tmp_path) { Dir.mktmpdir }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -187,6 +187,8 @@ RSpec.configure do |config|
   config.filter_run_excluding not_rhel7: true if rhel7?
   config.filter_run_excluding not_intel_64bit: true if intel_64bit?
 
+  config.filter_run_excluding libarchive_loading_broken: true if aix? || amazon_linux? || rhel7?
+
   # these let us use chef: ">= 13" or ruby: "~> 2.0.0" or any other Gem::Dependency-style constraint
   config.filter_run_excluding chef: DependencyProc.with(Chef::VERSION)
   config.filter_run_excluding ruby: DependencyProc.with(RUBY_VERSION)

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -163,6 +163,10 @@ def aix?
   RUBY_PLATFORM.include?("aix")
 end
 
+def amazon_linux?
+  ohai[:platform_family] == "amazon"
+end
+
 def wpar?
   !((ohai[:virtualization] || {})[:wpar_no].nil?)
 end

--- a/spec/unit/resource/archive_file_spec.rb
+++ b/spec/unit/resource/archive_file_spec.rb
@@ -16,10 +16,21 @@
 #
 
 require "spec_helper"
-require "ffi-libarchive"
 
-# Excluding this test on Windows until CI issues can be addressed.
-describe Chef::Resource::ArchiveFile do
+begin
+  require "ffi-libarchive"
+rescue LoadError
+  module Archive
+    class Reader
+      def close; end
+      def each_entry; end
+      def extract(entry, flags = 0, destination: nil); end
+    end
+  end
+end
+
+# Exclude this test on platforms where ffi-libarchive loading is broken
+describe Chef::Resource::ArchiveFile, :libarchive_loading_broken do
   let(:node) { Chef::Node.new }
   let(:events) { Chef::EventDispatch::Dispatcher.new }
   let(:run_context) { Chef::RunContext.new(node, {}, events) }


### PR DESCRIPTION
## Description

This aims to exclude testing archive_file in CI environments where libarchive loading is broken. This is intended to be temporary while working through issues in various CI pipelines.

## Related Issue

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
