### PR TITLE
Remove EOL FreeBSD 11 builds

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -36,10 +36,8 @@ builder-to-testers-map:
     - amazon-2-x86_64
   el-8-x86_64:
     - el-8-x86_64
-  freebsd-11-amd64:
-    - freebsd-11-amd64
+  freebsd-12-amd64:
     - freebsd-12-amd64
-#    - freebsd-13-amd64
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -38,8 +38,7 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
-  freebsd-11-amd64:
-    - freebsd-11-amd64
+  freebsd-12-amd64:
     - freebsd-12-amd64
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64


### PR DESCRIPTION
FreeBSD 11 goes EOL at the end of Sept 2021.

Signed-off-by: Tim Smith <tsmith@chef.io>