### PR TITLE
Add Ubuntu 16.04 back to the builds

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -64,7 +64,8 @@ builder-to-testers-map:
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
-  ubuntu-18.04-x86_64:
+  ubuntu-16.04-x86_64:
+    - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
   windows-2012r2-i386:


### PR DESCRIPTION
Ubuntu 16.04 had its support lifecycle extended to a full 10 years so it goes EOL April 2026 now.

Signed-off-by: Tim Smith <tsmith@chef.io>