### PR TITLE
Check for ca_key_file before loading ca key

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
     "ADMINI",
     "adminonly",
     "advapi",
+    "Afile",
     "Afonov",
     "agrs",
     "airgapped",

--- a/kitchen-tests/test/integration/end-to-end/_openssl.rb
+++ b/kitchen-tests/test/integration/end-to-end/_openssl.rb
@@ -1,0 +1,6 @@
+# Reference recipes/_openssl.rb test to 'generate and sign a certificate with the CA'
+# This ensures that the generated certificate is valid.
+describe command("/opt/chef/embedded/bin/openssl verify -CAfile /etc/ssl_test/my_ca.crt /etc/ssl_test/my_signed_cert.crt") do
+  its("stdout") { should match /my_signed_cert.*OK/ }
+  its("stderr") { should be_empty }
+end

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -226,7 +226,7 @@ class Chef
         end
 
         def ca_private_key
-          if new_resource.csr_file.nil?
+          if new_resource.ca_key_file.nil?
             key
           else
             OpenSSL::PKey.read ::File.read(new_resource.ca_key_file), new_resource.ca_key_pass


### PR DESCRIPTION
Checking for csr_file wasn't correct, because that's not what we're
using to load the ca key.

This also adds an inspec verification to ensure that the generated
`openssl_x509_certificate` in the _openssl.rb test is valid. It fails
without the supporting change.

Fixes #12091 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
