### PR TITLE
Windows Server 2022 - version / build information ADD

### DIFF
--- a/lib/chef/win32/version.rb
+++ b/lib/chef/win32/version.rb
@@ -49,6 +49,7 @@ class Chef
       private_class_method :method_name_from_marketing_name
 
       WIN_VERSIONS = {
+        "Windows Server 2022" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type != VER_NT_WORKSTATION && build_number >= 20348 } },
         "Windows Server 2019" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type != VER_NT_WORKSTATION && build_number >= 17763 } },
         "Windows 10" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type == VER_NT_WORKSTATION } },
         "Windows Server 2016" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type != VER_NT_WORKSTATION && build_number <= 14393 } },


### PR DESCRIPTION
Add windows server 2022 version info to lib/chef/win32/version.rb

Signed-off-by: Wade Peacock wade.peacock@alida.com