### PR TITLE
Fixed issue for subscribes does not validate the resource spec

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -339,6 +339,7 @@ class Chef
     #   end
     #
     def subscribes(action, resources, timing = :delayed)
+      validate_resource_spec_sub!(resources)  
       resources = [resources].flatten
       resources.each do |resource|
         if resource.is_a?(String)
@@ -352,6 +353,10 @@ class Chef
       true
     end
 
+    # Helper for Subscribes
+    def validate_resource_spec_sub!(resources)
+      run_context.resource_collection.validate_lookup_spec!(resources)
+    end
     #
     # A command or block that indicates whether to actually run this resource.
     # The command or block is run just before the action actually executes, and

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -380,8 +380,8 @@ class Chef
     # @param opts [Hash] Options control the execution of the command
     # @param block [Proc] A ruby block to run. Ignored if a command is given.
     #
+
     def only_if(command = nil, opts = {}, &block)
-    
       if command || block_given?
         @only_if << Conditional.only_if(self, command, opts, &block)
       end

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -381,7 +381,7 @@ class Chef
     # @param block [Proc] A ruby block to run. Ignored if a command is given.
     #
     def only_if(command = nil, opts = {}, &block)
-        
+    
       if command || block_given?
         @only_if << Conditional.only_if(self, command, opts, &block)
       end

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -339,7 +339,7 @@ class Chef
     #   end
     #
     def subscribes(action, resources, timing = :delayed)
-      validate_resource_spec_sub!(resources)  
+      validate_resource_spec_sub!(resources)
       resources = [resources].flatten
       resources.each do |resource|
         if resource.is_a?(String)
@@ -381,6 +381,7 @@ class Chef
     # @param block [Proc] A ruby block to run. Ignored if a command is given.
     #
     def only_if(command = nil, opts = {}, &block)
+        
       if command || block_given?
         @only_if << Conditional.only_if(self, command, opts, &block)
       end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1044,7 +1044,7 @@ describe Chef::Resource do
 
         it "raises an exception immediately" do
           expect do
-            resource.notifies(:run, "typo[missing-closing-bracket")
+            resource.notifies(:run, "typo[missing-closing-bracket]", :immediately)
           end.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
         end
       end
@@ -1054,7 +1054,7 @@ describe Chef::Resource do
 
         it "raises an exception immediately" do
           expect do
-            resource.subscribes(:run, "typo[missing-closing-bracket")
+            resource.subscribes(:run, "typo[missing-closing-bracket]", :immediately)
         end.to raise_error(Chef::Exceptions::InvalidResourceSpecification) 
       end
     end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -315,6 +315,7 @@ describe Chef::Resource do
 
       run_context.resource_collection << Chef::Resource::ZenMaster.new("bean")
       zrb = run_context.resource_collection.find(zen_master: "bean")
+      zrb.run_context = run_context
       zrb.subscribes :reload, zr
       expect(zr.delayed_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil
     end
@@ -1046,6 +1047,15 @@ describe Chef::Resource do
             resource.notifies(:run, "typo[missing-closing-bracket")
           end.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
         end
+      end
+    end
+
+      describe "with a syntax error in the resource for subscribes" do
+
+        it "raises an exception immediately" do
+          expect do
+            resource.subscribes(:run, "typo[missing-closing-bracket")
+        end.to raise_error(Chef::Exceptions::InvalidResourceSpecification) 
       end
     end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1050,12 +1050,12 @@ describe Chef::Resource do
       end
     end
 
-      describe "with a syntax error in the resource for subscribes" do
+    describe "with a syntax error in the resource for subscribes" do
 
-        it  "raises an exception immediately" do
-          expect do
-            resource.subscribes(:run, "typo[missing-closing-bracket")
-        end.to raise_error(Chef::Exceptions::InvalidResourceSpecification) 
+      it "raises an exception immediately" do
+        expect do
+          resource.subscribes(:run, "typo[missing-closing-bracket")
+        end.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
       end
     end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1044,7 +1044,7 @@ describe Chef::Resource do
 
         it "raises an exception immediately" do
           expect do
-            resource.notifies(:run, "typo[missing-closing-bracket]", :immediately)
+            resource.notifies(:run, "typo[missing-closing-bracket")
           end.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
         end
       end
@@ -1052,9 +1052,9 @@ describe Chef::Resource do
 
       describe "with a syntax error in the resource for subscribes" do
 
-        it "raises an exception immediately" do
+        it  "raises an exception immediately" do
           expect do
-            resource.subscribes(:run, "typo[missing-closing-bracket]", :immediately)
+            resource.subscribes(:run, "typo[missing-closing-bracket")
         end.to raise_error(Chef::Exceptions::InvalidResourceSpecification) 
       end
     end


### PR DESCRIPTION
Signed-off-by: Saikrishna-msys <gmadhusudhan@msystechnologies.com>

**Description**
When missing a closing ] at a subscription, the subscription will be silently ignored. While notifies checks the syntax and raises an error. For this we added the validation(validate_resource_spec_sub!(resources)) in resource.rb and done code changes under the resource_spec.rb file to work subscription in proper flow functionality.

- lib/chef/resource.rb
- spec/unit/resource_spec.rb

 **Related Issue**
-  https://github.com/chef/chef/issues/8908

 **Types of changes**
[X]Bug fix (non-breaking change which fixes an issue)
[  ] New feature (non-breaking change which adds functionality)
[  ] Breaking change (fix or feature that would cause existing functionality to change)
[  ] Chore (non-breaking change that does not add functionality or fix an issue)

 **Checklist:**
[ x] I have read the **CONTRIBUTING** document.
[ x] I have run the pre-merge tests locally and they pass.
[ x] I have updated the documentation accordingly.
[ x] I have added tests to cover my changes.
[ x] All new and existing tests passed.
[   ] All commits have been signed-off for [the Developer Certificate of Origin]