### PR TITLE
CHEF16 - Windows2019 - Version ceiling lib/chef/win32/version.rb

### DIFF
--- a/lib/chef/win32/version.rb
+++ b/lib/chef/win32/version.rb
@@ -50,7 +50,7 @@ class Chef
 
       WIN_VERSIONS = {
         "Windows Server 2022" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type != VER_NT_WORKSTATION && build_number >= 20348 } },
-        "Windows Server 2019" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type != VER_NT_WORKSTATION && build_number >= 17763 } },
+        "Windows Server 2019" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type != VER_NT_WORKSTATION && build_number >= 17763 && build_number < 20348 } },
         "Windows 10" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type == VER_NT_WORKSTATION } },
         "Windows Server 2016" => { major: 10, minor: 0, callable: lambda { |product_type, suite_mask, build_number| product_type != VER_NT_WORKSTATION && build_number <= 14393 } },
         "Windows 8.1" => { major: 6, minor: 3, callable: lambda { |product_type, suite_mask, build_number| product_type == VER_NT_WORKSTATION } },


### PR DESCRIPTION
Update lib/chef/win32/version.rb - Add less than 2022 build number

This was an oversight

Follow up to: https://github.com/chef/chef/pull/12096

Signed-off-by: Wade Peacock <wade.peacock@alida.com>