### PR TITLE
Use ** when passing options in subversion provider

### DIFF
--- a/lib/chef/provider/subversion.rb
+++ b/lib/chef/provider/subversion.rb
@@ -58,7 +58,7 @@ class Chef
       action :checkout, description: "Clone or check out the source. When a checkout is available, this provider does nothing." do
         if target_dir_non_existent_or_empty?
           converge_by("perform checkout of #{new_resource.repository} into #{new_resource.destination}") do
-            shell_out!(checkout_command, run_options)
+            shell_out!(checkout_command, **run_options)
           end
         else
           logger.debug "#{new_resource} checkout destination #{new_resource.destination} already exists or is a non-empty directory - nothing to do"
@@ -75,7 +75,7 @@ class Chef
 
       action :force_export, description: "Export the source, excluding or removing any version control artifacts and force an export of the source that is overwriting the existing copy (if it exists)." do
         converge_by("export #{new_resource.repository} into #{new_resource.destination}") do
-          shell_out!(export_command, run_options)
+          shell_out!(export_command, **run_options)
         end
       end
 
@@ -86,7 +86,7 @@ class Chef
           logger.trace "#{new_resource} current revision: #{current_rev} target revision: #{revision_int}"
           unless current_revision_matches_target_revision?
             converge_by("sync #{new_resource.destination} from #{new_resource.repository}") do
-              shell_out!(sync_command, run_options)
+              shell_out!(sync_command, **run_options)
               logger.info "#{new_resource} updated to revision: #{revision_int}"
             end
           end
@@ -125,7 +125,7 @@ class Chef
                             new_resource.revision
                           else
                             command = scm(:info, new_resource.repository, new_resource.svn_info_args, authentication, "-r#{new_resource.revision}")
-                            svn_info = shell_out!(command, run_options(cwd: cwd, returns: [0, 1])).stdout
+                            svn_info = shell_out!(command, **run_options(cwd: cwd, returns: [0, 1])).stdout
 
                             extract_revision_info(svn_info)
                           end
@@ -137,7 +137,7 @@ class Chef
         return nil unless ::File.exist?(::File.join(new_resource.destination, ".svn"))
 
         command = scm(:info)
-        svn_info = shell_out!(command, run_options(cwd: cwd, returns: [0, 1])).stdout
+        svn_info = shell_out!(command, **run_options(cwd: cwd, returns: [0, 1])).stdout
 
         extract_revision_info(svn_info)
       end

--- a/spec/unit/provider/subversion_spec.rb
+++ b/spec/unit/provider/subversion_spec.rb
@@ -190,7 +190,7 @@ describe Chef::Provider::Subversion do
   it "runs an export with the --force option" do
     allow(::File).to receive(:directory?).with("/my/deploy").and_return(true)
     expected_cmd = "svn export --force -q   -r12345 http://svn.example.org/trunk/ /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd, {})
+    expect(@provider).to receive(:shell_out!).with(expected_cmd)
     @provider.run_action(:force_export)
     expect(@resource).to be_updated
   end
@@ -198,7 +198,7 @@ describe Chef::Provider::Subversion do
   it "runs the checkout command for action_checkout" do
     allow(::File).to receive(:directory?).with("/my/deploy").and_return(true)
     expected_cmd = "svn checkout -q   -r12345 http://svn.example.org/trunk/ /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd, {})
+    expect(@provider).to receive(:shell_out!).with(expected_cmd)
     @provider.run_action(:checkout)
     expect(@resource).to be_updated
   end
@@ -248,7 +248,7 @@ describe Chef::Provider::Subversion do
     allow(@provider).to receive(:find_current_revision).and_return("11410")
     allow(@provider).to receive(:current_revision_matches_target_revision?).and_return(false)
     expected_cmd = "svn update -q   -r12345 /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd, {})
+    expect(@provider).to receive(:shell_out!).with(expected_cmd)
     @provider.run_action(:sync)
     expect(@resource).to be_updated
   end
@@ -265,7 +265,7 @@ describe Chef::Provider::Subversion do
   it "runs the export_command on action_export" do
     allow(::File).to receive(:directory?).with("/my/deploy").and_return(true)
     expected_cmd = "svn export --force -q   -r12345 http://svn.example.org/trunk/ /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd, {})
+    expect(@provider).to receive(:shell_out!).with(expected_cmd)
     @provider.run_action(:export)
     expect(@resource).to be_updated
   end


### PR DESCRIPTION
## Description

Ruby 3 as used in chef 17 requires that the options be dereferenced with `**` or they will be interpreted as an extra argument.

Without this change the subversion provider is totally broken in chef 17 and unable to do anything useful.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
