### PR TITLE
Allow specifying transport protocol in RFC099 credential files

### DIFF
--- a/chef-config/lib/chef-config/mixin/train_transport.rb
+++ b/chef-config/lib/chef-config/mixin/train_transport.rb
@@ -112,7 +112,7 @@ module ChefConfig
         # Load the credentials file, and place any valid settings into the train configuration
         credentials = load_credentials(tm_config.host)
 
-        protocol = credentials[:train_protocol] || tm_config.protocol
+        protocol = credentials[:transport_protocol] || tm_config.protocol
         train_config = tm_config.to_hash.select { |k| Train.options(protocol).key?(k) }
         logger.trace("Using target mode options from #{ChefUtils::Dist::Infra::PRODUCT} config file: #{train_config.keys.join(", ")}") if train_config
 


### PR DESCRIPTION
## Description

For using Target Mode with non-standard transports like `ssh` or `winrm`, specification of the needed protocol is currently done in `client.rb` under `target_mode.protocol`.

This PR proposes a new key `train_protocol` in RFC099 credentials to avoid splitting target configurations across two files. 

```toml
['remote-target']
train_protocol = "serial"

device = "/dev/ttyUSB0"
# ... and other Transport-specific settings
```

## Related Issue

none, usability-related

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
