### PR TITLE
(doc) Add note about requirement for Chocolatey

### DIFF
--- a/lib/chef/resource/chocolatey_config.rb
+++ b/lib/chef/resource/chocolatey_config.rb
@@ -21,7 +21,7 @@ class Chef
 
       provides :chocolatey_config
 
-      description "Use the **chocolatey_config** resource to add or remove Chocolatey configuration keys."
+      description "Use the **chocolatey_config** resource to add or remove Chocolatey configuration keys. Note: The Chocolatey package manager is not installed on Windows by default. You will need to install it prior to using this resource by adding the [Chocolatey cookbook](https://supermarket.chef.io/cookbooks/chocolatey/) to your node's run list."
       introduced "14.3"
       examples <<~DOC
       **Set the Chocolatey cacheLocation config**:

--- a/lib/chef/resource/chocolatey_feature.rb
+++ b/lib/chef/resource/chocolatey_feature.rb
@@ -20,7 +20,7 @@ class Chef
       unified_mode true
       provides :chocolatey_feature
 
-      description "Use the **chocolatey_feature** resource to enable and disable Chocolatey features."
+      description "Use the **chocolatey_feature** resource to enable and disable Chocolatey features. Note: The Chocolatey package manager is not installed on Windows by default. You will need to install it prior to using this resource by adding the [Chocolatey cookbook](https://supermarket.chef.io/cookbooks/chocolatey/) to your node's run list."
       introduced "15.1"
       examples <<~DOC
         **Enable the checksumFiles Chocolatey feature**

--- a/lib/chef/resource/chocolatey_source.rb
+++ b/lib/chef/resource/chocolatey_source.rb
@@ -20,7 +20,7 @@ class Chef
       unified_mode true
       provides :chocolatey_source
 
-      description "Use the **chocolatey_source** resource to add, remove, enable, or disable Chocolatey sources."
+      description "Use the **chocolatey_source** resource to add, remove, enable, or disable Chocolatey sources. Note: The Chocolatey package manager is not installed on Windows by default. You will need to install it prior to using this resource by adding the [Chocolatey cookbook](https://supermarket.chef.io/cookbooks/chocolatey/) to your node's run list."
       introduced "14.3"
       examples <<~DOC
         **Add a Chocolatey source**


### PR DESCRIPTION
## Description

Add a note to each Chocolatey Resource page, so that it is clear that the Chocolatey Cookbook needs to be used in order to install Chocolatey before using the Chocolatey Resources.

This note exists on the `chocolatey_package` resource - https://docs.chef.io/resources/chocolatey_package/

![2021-10-11_09-54-18](https://user-images.githubusercontent.com/1271146/136762269-cac73145-b97f-4b5c-ac72-f1208ee16aca.png)

But not on:

* https://docs.chef.io/resources/chocolatey_config/
* https://docs.chef.io/resources/chocolatey_feature/
* https://docs.chef.io/resources/chocolatey_source/


## Related Issue

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
