### PR TITLE
Clarify recursive delete

### DIFF
--- a/lib/chef/resource/directory.rb
+++ b/lib/chef/resource/directory.rb
@@ -46,7 +46,7 @@ class Chef
                description: "The path to the directory. Using a fully qualified path is recommended, but is not always required."
 
       property :recursive, [ TrueClass, FalseClass ],
-        description: "Create or delete parent directories recursively. For the owner, group, and mode properties, the value of this property applies only to the leaf directory.",
+        description: "Create parent directories recursively, or delete direcory and all children recursively. For the owner, group, and mode properties, the value of this property applies only to the leaf directory.",
         default: false
     end
   end


### PR DESCRIPTION
## Description
Clarify that `recursive true` with `action :delete` will delete _children_, not parents. As it reads now, the docs sound like parent directories will be deleted

Signed-off-by: Josh Gitlin <jgitlin@pinnacle21.com>

## Related Issue
None, obvious fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
