### PR TITLE
Fix cron resource commented job handling

### DIFF
--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -100,7 +100,10 @@ class Chef
         newcron = get_crontab_entry
 
         if @cron_exists
-          unless cron_different?
+          # Only compare the crontab if the current resource has a set command.
+          # This may not be set in cases where the Chef comment exists but the
+          # crontab command was commented out.
+          if current_resource.property_is_set?(:command) && !cron_different?
             logger.debug("#{new_resource}: Skipping existing cron entry")
             return
           end


### PR DESCRIPTION
## Description
This change fixes an edge case failure that may occur when processing a
cron resource where the following conditions are true:

* A `# Chef Name` comment exists for the job
* The following line is commented out
* The new cron resource uses default values for the minute, hour, day,
month, weekday, and time properties

This causes the following error to be raised within the
`Chef::Provider::Cron#cron_different?` method:

```
  Chef::Exceptions::ValidationFailed
  ----------------------------------
  command is a required property
```

The new guard prevents `cron_different?` from being called when the
current resource does not have a set command property. Since the new
resource requires the command property to be set to be valid, we can
assume it is different from the current cron resource if the command is
unset.


## Related Issue
#11030

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
