### PR TITLE
Add cookbook_artifacts as valid knife acl object type

### DIFF
--- a/knife/lib/chef/knife/acl_base.rb
+++ b/knife/lib/chef/knife/acl_base.rb
@@ -25,7 +25,7 @@ class Chef
 
       PERM_TYPES = %w{create read update delete grant}.freeze unless defined? PERM_TYPES
       MEMBER_TYPES = %w{client group user}.freeze unless defined? MEMBER_TYPES
-      OBJECT_TYPES = %w{clients containers cookbooks data environments groups nodes roles policies policy_groups}.freeze unless defined? OBJECT_TYPES
+      OBJECT_TYPES = %w{clients containers cookbook_artifacts cookbooks data environments groups nodes roles policies policy_groups}.freeze unless defined? OBJECT_TYPES
       OBJECT_NAME_SPEC = /^[\-[:alnum:]_\.]+$/.freeze unless defined? OBJECT_NAME_SPEC
 
       def validate_object_type!(type)


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Adds __cookbook_artifacts__ as a valid object type for `knife acl` so that in-place acls can be updated with `knife acl bulk` commands.

Currently the following commands work as expected via `knife` for updating the acl permissions of in-place objects, such as when wanting to add read access:

```sh
knife acl bulk add group readonly cookbooks '.*' read -y
knife acl bulk add group readonly policies '.*' read -y
knife acl bulk add group readonly policy_groups '.*' read -y
```

The command to update `cookbook_artifacts` fails with the following message:

```sh
$ knife acl bulk add group readonly cookbook_artifacts '.*' read -y

FATAL: Unknown object type "cookbook_artifacts".  The following types are permitted: clients, containers, cookbooks, data, environments, groups, nodes, roles, policies, policy_groups
```

This change will allow acls of existing cookbook_artifacts objects to be updated in the same way that other objects are.  Testing confirms that with this line update to prevent an error, objects under __cookbook_artifacts__ are updated as expected.

Command output after updating:

```sh
$ knife acl bulk add group readonly cookbook_artifacts '.*' read -y
The ACL of the following cookbook_artifacts will be modified:

client_credentials_secure  nodejs                     vim                      
elasticsearch              ssh-hardening            
mongodb                    test_cookbook            

Adding 'readonly' to 'read' ACE of 'client_credentials_secure'
Adding 'readonly' to 'read' ACE of 'elasticsearch'
Adding 'readonly' to 'read' ACE of 'mongodb'
Adding 'readonly' to 'read' ACE of 'nodejs'
Adding 'readonly' to 'read' ACE of 'ssh-hardening'
Adding 'readonly' to 'read' ACE of 'test_cookbook'
Adding 'readonly' to 'read' ACE of 'vim'
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

https://github.com/chef/chef-server/issues/2836

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
