### PR TITLE
Revert chef-zero back to 15.0.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       chef-config
       concurrent-ruby (~> 1.0)
     chef-vault (4.1.4)
-    chef-zero (15.0.11)
+    chef-zero (15.0.9)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 5.0)
       mixlib-log (>= 2.0, < 4.0)


### PR DESCRIPTION
15.0.11 adds new data to an API endpoint which breaks out specs.

Signed-off-by: Tim Smith <tsmith@chef.io>