### PR TITLE
Fix reporting/data_collector for @recipe_files

### DIFF
--- a/lib/chef/data_collector/run_end_message.rb
+++ b/lib/chef/data_collector/run_end_message.rb
@@ -128,7 +128,7 @@ class Chef
 
           if new_resource.cookbook_name
             hash["cookbook_name"]    = new_resource.cookbook_name
-            hash["cookbook_version"] = new_resource.cookbook_version.version
+            hash["cookbook_version"] = new_resource.cookbook_version&.version
             hash["recipe_name"]      = new_resource.recipe_name
           end
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1508,7 +1508,7 @@ class Chef
     # @return Chef::CookbookVersion The cookbook in which this Resource was defined.
     #
     def cookbook_version
-      if cookbook_name
+      if cookbook_name && cookbook_name != "@recipe_files"
         run_context.cookbook_collection[cookbook_name]
       end
     end

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -41,7 +41,7 @@ class Chef
       as_hash["result"] = action_record.action.to_s
       if new_resource.cookbook_name
         as_hash["cookbook_name"] = new_resource.cookbook_name
-        as_hash["cookbook_version"] = new_resource.cookbook_version.version
+        as_hash["cookbook_version"] = new_resource.cookbook_version&.version
       end
 
       as_hash

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -348,6 +348,11 @@ describe Chef::Resource do
     it "should recognize dynamically defined resources" do
       expect(resource.defined_at).to eq("dynamically defined")
     end
+
+    it "should return nil for the cookbook_version when the cookbook_name is @recipe_files" do
+      resource.cookbook_name = "@recipe_files"
+      expect(resource.cookbook_version).to be nil
+    end
   end
 
   describe "to_s" do


### PR DESCRIPTION
When individual recipes are invoked like 'chef-client ./whatever.rb'
those files get a cookbook_name of `@recipe_files` which is a magic
value that nees to be handled specially to avoid the reporting
classes from blowing up.
