### PR TITLE
Add #recipe_name to Chef::Provider

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -35,7 +35,6 @@ class Chef
     attr_accessor :after_resource
     attr_accessor :run_context
 
-    attr_reader :recipe_name
     attr_reader :logger
 
     include Chef::Mixin::WhyRun
@@ -172,6 +171,10 @@ class Chef
 
     def cookbook_name
       new_resource.cookbook_name
+    end
+
+    def recipe_name
+      new_resource.recipe_name
     end
 
     # hook that subclasses can use to do lazy validation for where properties aren't flexible enough


### PR DESCRIPTION
## Description

Problem: Currently when using [#build_resource](https://github.com/chef/chef/blob/main/lib/chef/dsl/declare_resource.rb#L309-L310) it references both the recipe name and cookbook name. Because the `Chef::Provider` class doesn't redirect this onto `new_resource` it gets missed and ends up building a resource with a `cookbook_name` defined, but *not* a `recipe_name`.

This ensures that child resource(s) actually get the correct recipe name for where they were built.

## Related Issue

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
