### PR TITLE
replace wget with curl in 'rake spellcheck'

### DIFF
--- a/tasks/spellcheck.rb
+++ b/tasks/spellcheck.rb
@@ -44,7 +44,7 @@ namespace :spellcheck do
     chef_dictionary = "chef_dictionary.txt"
 
     unless File.readable?(chef_dictionary)
-      abort "Dictionary file '#{config_file}' not found, skipping spellcheck"
+      abort "Dictionary file '#{chef_dictionary}' not found, skipping spellcheck"
     end
 
     config_file = "cspell.json"


### PR DESCRIPTION
## Description

`rake spellcheck` requires wget, but macOS does not install `wget` by default. Swap in curl, which is more-widely available by default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
