### PR TITLE
Add support for `sensitive` in `chef_client_trusted_certificate`

### DIFF
--- a/lib/chef/resource/chef_client_trusted_certificate.rb
+++ b/lib/chef/resource/chef_client_trusted_certificate.rb
@@ -75,6 +75,7 @@ class Chef
         file cert_path do
           content new_resource.certificate
           mode "0640"
+          sensitive new_resource.sensitive
         end
       end
 

--- a/spec/unit/resource/chef_client_trusted_certificate_spec.rb
+++ b/spec/unit/resource/chef_client_trusted_certificate_spec.rb
@@ -51,4 +51,18 @@ describe Chef::Resource::ChefClientTrustedCertificate do
       expect(provider.cert_path).to match(%r{trusted_certs/something.pem$})
     end
   end
+
+  describe "sensitive attribute" do
+    context "should be insensitive by default" do
+      it { expect(resource.sensitive).to(be_falsey) }
+    end
+
+    context "when set" do
+      before { resource.sensitive(true) }
+
+      it "should be set on the resource" do
+        expect(resource.sensitive).to(be_truthy)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Signed-off-by: Jared Kauppila <Jared.Kauppila@sentry.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Currently `sensitive` on `chef_client_trusted_certificate` is not being passed to the `file` resource.

While these values are not sensitive, you may want to hide the output from the logs.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
