### PR TITLE
Fix cron resource commented job handling

### DIFF
--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -100,8 +100,11 @@ class Chef
         newcron = get_crontab_entry
 
         if @cron_exists
-          unless cron_different?
-            logger.trace("Skipping existing cron entry '#{new_resource.name}'")
+          # Only compare the crontab if the current resource has a set command.
+          # This may not be set in cases where the Chef comment exists but the
+          # crontab command was commented out.
+          if current_resource.property_is_set?(:command) && !cron_different?
+            logger.debug("#{new_resource}: Skipping existing cron entry")
             return
           end
           read_crontab.each_line do |line|


### PR DESCRIPTION
This change fixes an edge case failure that may occur when processing a
cron resource where the following conditions are true:

* A `# Chef Name` comment exists for the job
* The following line is commented out
* The new cron resource uses default values for the minute, hour, day,
month, weekday, and time properties

This causes the following error to be raised within the
`Chef::Provider::Cron#cron_different?` method:

```
  Chef::Exceptions::ValidationFailed
  ----------------------------------
  command is a required property
```

The new guard prevents `cron_different?` from being called when the
current resource does not have a set command property. Since the new
resource requires the command property to be set to be valid, we can
assume it is different from the current cron resource if the command is
unset.

Signed-off-by: Matthew Newell <18470637+wheatevo@users.noreply.github.com>