### PR TITLE
fix invalid ffi type error after coerce in macos_userdefaults

### DIFF
--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -18,7 +18,6 @@
 require_relative "../resource"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 require "corefoundation" if RUBY_PLATFORM.match?(/darwin/)
-require "ffi" unless defined?(FFI)
 autoload :Plist, "plist"
 
 class Chef

--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -18,6 +18,7 @@
 require_relative "../resource"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 require "corefoundation" if RUBY_PLATFORM.match?(/darwin/)
+require "ffi" unless defined?(FFI)
 autoload :Plist, "plist"
 
 class Chef
@@ -81,8 +82,7 @@ class Chef
       property :host, [String, Symbol],
         description: "Set either :current, :all or a hostname to set the user default at the host level.",
         desired_state: false,
-        introduced: "16.3",
-        coerce: proc { |value| to_cf_host(value) }
+        introduced: "16.3"
 
       property :value, [Integer, Float, String, TrueClass, FalseClass, Hash, Array],
         description: "The value of the key. Note: With the `type` property set to `bool`, `String` forms of Boolean true/false values that Apple accepts in the defaults command will be coerced: 0/1, 'TRUE'/'FALSE,' 'true'/false', 'YES'/'NO', or 'yes'/'no'.",
@@ -96,8 +96,7 @@ class Chef
 
       property :user, [String, Symbol],
         description: "The system user that the default will be applied to. Set :current for current user, :all for all users or pass a valid username",
-        desired_state: false,
-        coerce: proc { |value| to_cf_user(value) }
+        desired_state: false
 
       property :sudo, [TrueClass, FalseClass],
         description: "Set to true if the setting you wish to modify requires privileged access. This requires passwordless sudo for the `/usr/bin/defaults` command to be setup for the user running #{ChefUtils::Dist::Infra::PRODUCT}.",
@@ -118,7 +117,7 @@ class Chef
       action :write, description: "Write the value to the specified domain/key." do
         converge_if_changed do
           Chef::Log.debug("Updating defaults value for #{new_resource.key} in #{new_resource.domain}")
-          CF::Preferences.set!(new_resource.key, new_resource.value, new_resource.domain, new_resource.user, new_resource.host)
+          CF::Preferences.set!(new_resource.key, new_resource.value, new_resource.domain, to_cf_user(new_resource.user), to_cf_host(new_resource.host))
         end
       end
 
@@ -128,12 +127,12 @@ class Chef
 
         converge_by("delete domain:#{new_resource.domain} key:#{new_resource.key}") do
           Chef::Log.debug("Removing defaults key: #{new_resource.key}")
-          CF::Preferences.set!(new_resource.key, nil, new_resource.domain, new_resource.user, new_resource.host)
+          CF::Preferences.set!(new_resource.key, nil, new_resource.domain, to_cf_user(new_resource.user), to_cf_host(new_resource.host))
         end
       end
 
       def get_preference(new_resource)
-        CF::Preferences.get(new_resource.key, new_resource.domain, new_resource.user, new_resource.host)
+        CF::Preferences.get(new_resource.key, new_resource.domain, to_cf_user(new_resource.user), to_cf_host(new_resource.host))
       end
 
       # Return valid hostname based on the input from host property

--- a/spec/functional/resource/macos_userdefaults_spec.rb
+++ b/spec/functional/resource/macos_userdefaults_spec.rb
@@ -116,4 +116,24 @@ describe Chef::Resource::MacosUserDefaults, :macos_only do
     resource.key "titlesize"
     expect { resource.run_action(:delete) }. to_not raise_error
   end
+
+  context "resource can process FFI::Pointer type" do
+    it "for host property" do
+      resource.domain "/Library/Preferences/ManagedInstalls"
+      resource.key "TestDictionaryValues"
+      resource.value "User": "/Library/Managed Installs/way_fake.log"
+      resource.host :current
+      resource.run_action(:write)
+      expect { resource.run_action(:write) }. to_not raise_error
+    end
+
+    it "for user property" do
+      resource.domain "/Library/Preferences/ManagedInstalls"
+      resource.key "TestDictionaryValues"
+      resource.value "User": "/Library/Managed Installs/way_fake.log"
+      resource.user :current
+      resource.run_action(:write)
+      expect { resource.run_action(:write) }. to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The input type is validated against the coerced values, which makes the userdefaults resource throw an error when using `:current` or `:all`. Removed coerce and uses the methods directly to transform values.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
