### PR TITLE
Fix small documentation typo in execute.rb

### DIFF
--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -346,7 +346,7 @@ class Chef
 
         By default, notifications are `:delayed`, that is they are queued up as they are
         triggered, and then executed at the very end of a Chef Infra Client run. To run
-        kan action immediately, use `:immediately`:
+        an action immediately, use `:immediately`:
 
         ```ruby
         template '/etc/nagios3/configures-nagios.conf' do


### PR DESCRIPTION
## Description
Fix a small typo

## Related Issue
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [N/A] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [N/A] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
