### PR TITLE
Remove support for macOS 10.14

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -41,8 +41,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
-  mac_os_x-10.14-x86_64:
-    - mac_os_x-10.14-x86_64
+  mac_os_x-10.15-x86_64:
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64


### PR DESCRIPTION
We support N-2 which is 12, 11, 10.15 now.

Signed-off-by: Tim Smith <tsmith@chef.io>