### PR TITLE
Fix zypper_package behavior when there is no candidate_version

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -113,6 +113,8 @@ class Chef
             end
           end
           nil
+        rescue
+          nil
         end
 
         def available_version(index)

--- a/spec/functional/resource/zypper_package_spec.rb
+++ b/spec/functional/resource/zypper_package_spec.rb
@@ -187,6 +187,13 @@ describe Chef::Resource::ZypperPackage, :requires_root, :suse_only do
         expect(zypper_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
       end
+
+      it "is idempotent when a package isn't installed" do
+        FileUtils.rm_f "/etc/zypp/repos.d/chef-zypp-localtesting.repo"
+        zypper_package.run_action(:remove)
+        expect(zypper_package.updated_by_last_action?).to be false
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
+      end
     end
   end
 


### PR DESCRIPTION
Specifically this fixes `:remove` when there's no candidate_version, but is more correct and may fix other behaviors as well.