### PR TITLE
Do not run assertions for actions that are not being executed

### DIFF
--- a/lib/chef/mixin/why_run.rb
+++ b/lib/chef/mixin/why_run.rb
@@ -242,8 +242,12 @@ class Chef
           end
         end
 
-        def initialize(resource, run_context)
-          @resource, @run_context = resource, run_context
+        attr_accessor :action
+
+        def initialize(resource, run_context, action)
+          @resource = resource
+          @run_context = run_context
+          @action = action
           @assertions = Hash.new { |h, k| h[k] = [] }
           @blocked_actions = []
         end
@@ -305,6 +309,8 @@ class Chef
         #                       "You don't have sufficient privileges to delete #{@new_resource.path}")
         #   end
         def assert(*actions)
+          return unless actions.include?(action.to_sym)
+
           assertion = Assertion.new
           yield assertion
           actions.each { |action| @assertions[action] << assertion }

--- a/lib/chef/mixin/why_run.rb
+++ b/lib/chef/mixin/why_run.rb
@@ -309,7 +309,7 @@ class Chef
         #                       "You don't have sufficient privileges to delete #{@new_resource.path}")
         #   end
         def assert(*actions)
-          return unless actions.include?(action.to_sym)
+          return unless actions.include?(action.to_sym) || actions.include?(:all_actions)
 
           assertion = Assertion.new
           yield assertion

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -269,7 +269,7 @@ class Chef
     end
 
     def requirements
-      @requirements ||= ResourceRequirements.new(@new_resource, run_context)
+      @requirements ||= ResourceRequirements.new(@new_resource, run_context, action)
     end
 
     def description(description = "NOT_PASSED")

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -269,7 +269,7 @@ class Chef
     end
 
     def requirements
-      @requirements ||= ResourceRequirements.new(@new_resource, run_context, action)
+      @requirements ||= ResourceRequirements.new(@new_resource, run_context, action || new_resource.action)
     end
 
     def description(description = "NOT_PASSED")

--- a/spec/unit/file_access_control_spec.rb
+++ b/spec/unit/file_access_control_spec.rb
@@ -35,7 +35,7 @@ describe Chef::FileAccessControl do
         @events = Chef::EventDispatch::Dispatcher.new
         @run_context = Chef::RunContext.new(@node, {}, @events)
         @current_resource = Chef::Resource::File.new("/tmp/different_file.txt")
-        @provider_requirements = Chef::Provider::ResourceRequirements.new(@resource, @run_context)
+        @provider_requirements = Chef::Provider::ResourceRequirements.new(@resource, @run_context, :create)
         @provider = double("File provider", requirements: @provider_requirements, manage_symlink_access?: false)
 
         @fac = Chef::FileAccessControl.new(@current_resource, @resource, @provider)

--- a/spec/unit/mixin/why_run_spec.rb
+++ b/spec/unit/mixin/why_run_spec.rb
@@ -1,0 +1,53 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Mixin::WhyRun::ResourceRequirements do
+  class TestResource < Chef::Resource
+    action_class do
+      def define_resource_requirements
+        requirements.assert(:boom) do |a|
+          a.assertion { raise "boom1" }
+          a.failure_message("#{raise "boom2"}")
+          a.whyrun("#{raise "boom3"}")
+        end
+      end
+    end
+
+    action :boom do
+      # nothing
+    end
+
+    action :noboom do
+      # nothing
+    end
+  end
+
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { TestResource.new("name", run_context) }
+
+  it "raises an exception for an action where the assertions raise exceptions" do
+    expect { resource.run_action(:boom) }.to raise_error(StandardError)
+  end
+
+  it "does not raise an exception for an action which has no assertions" do
+    resource.run_action(:noboom)
+  end
+end

--- a/spec/unit/mixin/why_run_spec.rb
+++ b/spec/unit/mixin/why_run_spec.rb
@@ -44,7 +44,7 @@ describe Chef::Mixin::WhyRun::ResourceRequirements do
   let(:resource) { TestResource.new("name", run_context) }
 
   it "raises an exception for an action where the assertions raise exceptions" do
-    expect { resource.run_action(:boom) }.to raise_error(StandardError)
+    expect { resource.run_action(:boom) }.to raise_error(StandardError, /boom2/)
   end
 
   it "does not raise an exception for an action which has no assertions" do

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -169,6 +169,7 @@ describe Chef::Provider::Group::Groupadd do
 
     before do
       allow(File).to receive(:exist?).and_return(false)
+      provider.action = :modify
       provider.define_resource_requirements
     end
 

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -58,18 +58,18 @@ describe Chef::Provider::Group::Usermod do
       end
 
       it "should raise an error when setting the entire group directly" do
+        @provider.action = :modify
         @provider.define_resource_requirements
         @provider.load_current_resource
         @provider.instance_variable_set("@group_exists", true)
-        @provider.action = :modify
         expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "setting group members directly is not supported by #{@provider}, must set append true in group")
       end
 
       it "should raise an error when excluded_members are set" do
+        @provider.action = :modify
         @provider.define_resource_requirements
         @provider.load_current_resource
         @provider.instance_variable_set("@group_exists", true)
-        @provider.action = :modify
         @new_resource.append(true)
         @new_resource.excluded_members(["someone"])
         expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "excluded_members is not supported by #{@provider}")

--- a/spec/unit/provider/ifconfig_spec.rb
+++ b/spec/unit/provider/ifconfig_spec.rb
@@ -61,6 +61,7 @@ describe Chef::Provider::Ifconfig do
         expect(@provider.instance_variable_get("@status").exitstatus).not_to eq(0)
       end
       it "should thrown an exception when ifconfig fails" do
+        @provider.action = :add
         @provider.define_resource_requirements
         expect { @provider.process_resource_requirements }.to raise_error Chef::Exceptions::Ifconfig
       end
@@ -81,6 +82,7 @@ describe Chef::Provider::Ifconfig do
         expect(@provider.instance_variable_get("@status").exitstatus).not_to eq(0)
       end
       it "should thrown an exception when ifconfig fails" do
+        @provider.action = :add
         @provider.define_resource_requirements
         expect { @provider.process_resource_requirements }.to raise_error Chef::Exceptions::Ifconfig
       end

--- a/spec/unit/provider/package/bff_spec.rb
+++ b/spec/unit/provider/package/bff_spec.rb
@@ -61,6 +61,7 @@ describe Chef::Provider::Package::Bff do
       allow(@provider).to receive(:shell_out_compacted).and_return(@empty_status)
       allow(::File).to receive(:exist?).with(@new_resource.source).and_return(false)
       @provider.load_current_resource
+      @provider.action = :install
       @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Package)
     end

--- a/spec/unit/provider/package/solaris_spec.rb
+++ b/spec/unit/provider/package/solaris_spec.rb
@@ -65,6 +65,7 @@ describe Chef::Provider::Package::Solaris do
       allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       allow(::File).to receive(:exist?).and_return(false)
       @provider.load_current_resource
+      @provider.action = :install
       @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Package)
     end

--- a/spec/unit/provider/service/arch_service_spec.rb
+++ b/spec/unit/provider/service/arch_service_spec.rb
@@ -95,15 +95,15 @@ describe Chef::Provider::Service::Arch, "load_current_resource" do
 
   it "should raise error if the node has a nil ps property and no other means to get status" do
     @node.automatic_attrs[:command] = { ps: nil }
-    @provider.define_resource_requirements
     @provider.action = :start
+    @provider.define_resource_requirements
     expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
   end
 
   it "should raise error if the node has an empty ps property and no other means to get status" do
     @node.automatic_attrs[:command] = { ps: "" }
-    @provider.define_resource_requirements
     @provider.action = :start
+    @provider.define_resource_requirements
     expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
   end
 

--- a/spec/unit/provider/service/debian_service_spec.rb
+++ b/spec/unit/provider/service/debian_service_spec.rb
@@ -50,6 +50,7 @@ describe Chef::Provider::Service::Debian do
     it "ensures /usr/sbin/update-rc.d is available" do
       expect(File).to receive(:exist?).with("/usr/sbin/update-rc.d").and_return(false)
 
+      @provider.action = :start
       @provider.define_resource_requirements
       expect do
         @provider.process_resource_requirements

--- a/spec/unit/provider/service/gentoo_service_spec.rb
+++ b/spec/unit/provider/service/gentoo_service_spec.rb
@@ -42,6 +42,7 @@ describe Chef::Provider::Service::Gentoo do
   describe "load_current_resource" do
     it "should raise Chef::Exceptions::Service if /sbin/rc-update does not exist" do
       expect(File).to receive(:exist?).with("/sbin/rc-update").and_return(false)
+      @provider.action = :start
       @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
     end

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -237,6 +237,7 @@ describe Chef::Provider::Service::Macosx do
                   allow(Dir).to receive(:glob).and_return([(plist).to_s,
                                               "/Users/wtf/something.plist"])
                   provider.load_current_resource
+                  provider.action = :enable
                   provider.define_resource_requirements
                   expect { provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
                 end

--- a/spec/unit/provider/service/simple_service_spec.rb
+++ b/spec/unit/provider/service/simple_service_spec.rb
@@ -52,12 +52,14 @@ describe Chef::Provider::Service::Simple, "load_current_resource" do
 
   it "should raise error if the node has a nil ps property and no other means to get status" do
     @node.automatic_attrs[:command] = { ps: nil }
+    @provider.action = :start
     @provider.define_resource_requirements
     expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
   end
 
   it "should raise error if the node has an empty ps property and no other means to get status" do
     @node.automatic_attrs[:command] = { ps: "" }
+    @provider.action = :start
     @provider.define_resource_requirements
     expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
   end
@@ -112,8 +114,8 @@ describe Chef::Provider::Service::Simple, "load_current_resource" do
     end
 
     it "should raise an exception if no start command is specified" do
-      @provider.define_resource_requirements
       @provider.action = :start
+      @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
     end
   end
@@ -126,8 +128,8 @@ describe Chef::Provider::Service::Simple, "load_current_resource" do
     end
 
     it "should raise an exception if no stop command is specified" do
-      @provider.define_resource_requirements
       @provider.action = :stop
+      @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
     end
   end
@@ -140,8 +142,8 @@ describe Chef::Provider::Service::Simple, "load_current_resource" do
     end
 
     it "should raise an exception if the resource doesn't support restart, no restart command is provided, and no stop command is provided" do
-      @provider.define_resource_requirements
       @provider.action = :restart
+      @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
     end
 
@@ -155,8 +157,8 @@ describe Chef::Provider::Service::Simple, "load_current_resource" do
 
   describe Chef::Provider::Service::Simple, "reload_service" do
     it "should raise an exception if reload is requested but no command is specified" do
-      @provider.define_resource_requirements
       @provider.action = :reload
+      @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::UnsupportedAction)
     end
 

--- a/spec/unit/provider/user_spec.rb
+++ b/spec/unit/provider/user_spec.rb
@@ -170,6 +170,7 @@ describe Chef::Provider::User do
                                                     sp_warn: 7, sp_inact: -1, sp_expire: -1, sp_flag: -1)
               expect(Shadow::Passwd).to receive(:getspnam).with("notarealuser").and_return(passwd_info)
               @provider.load_current_resource
+              @provider.action = :create
               @provider.define_resource_requirements
               @provider.process_resource_requirements
             end
@@ -180,6 +181,7 @@ describe Chef::Provider::User do
       it "should fail assertions when ruby-shadow cannot be loaded" do
         expect(@provider).to receive(:require).with("shadow") { raise LoadError }
         @provider.load_current_resource
+        @provider.action = :create
         @provider.define_resource_requirements
         expect { @provider.process_resource_requirements }.to raise_error Chef::Exceptions::MissingLibrary
       end


### PR DESCRIPTION
define_resource_requirements should not parse assertions for actions
which are not being run.

This came up in the context of this code in the Chef::Provider::Package superclass:

```
      def define_resource_requirements
        # XXX: upgrade with a specific version doesn't make a whole lot of sense, but why don't we throw this anyway if it happens?
        # if not, shouldn't we raise to tell the user to use install instead of upgrade if they want to pin a version?
        requirements.assert(:install) do |a|
          a.assertion { candidates_exist_for_all_forced_changes? }
          a.failure_message(Chef::Exceptions::Package, "No version specified, and no candidate version available for #{forced_packages_missing_candidates.join(", ")}")
          a.whyrun("Assuming a repository that offers #{forced_packages_missing_candidates.join(", ")} would have been configured")
        end

        ....
     end
```

During an `:remove` that isn't relevant at all, but DRR is still parsed and prior to this change the assertion for the :install action was being built.  This doesn't cause an issue for the actual `assertion` since that takes a block and is lazy, but the `failure_message` and `whyrun` message are string arguments so are parsed when the block is applied, which causes string interpolation to get resolved, which was causing `forced_packages_missing_candidates` to be evaluated, even if it was useless.  In the case of the zypper_package provider this was throwing (arguably buggy behavior since it should have just returned nil which was fixed in #12279) and was causing the operation to fail.  This behavior probably causes the evaluation of the candidate_version in cases where the candidate_version is not requirement (and it is somewhat confusing as to why this has not been reported as a perf issue, although maybe it has?).

So the change is to only build the assertions which are going to actually be used by the action being run.

We still have the situation where both the failure_message and the whyrun message are parsed and interpolated prior to the assertion being checked, which might cause some kind of confusion.  That could be fixed by passing a block argument instead of a string and lazily evaluating it, but since we haven't hit that problem in the past ~10 years it seems of less priority, and it is sort of easier to logically sort out what is going on there.