### PR TITLE
Add data collector config items for infra config

### DIFF
--- a/lib/chef/resource/chef_client_config.rb
+++ b/lib/chef/resource/chef_client_config.rb
@@ -87,6 +87,17 @@ class Chef
         ]
       end
       ```
+
+      **Report directly to the [Chef Automate data collector endpoint](/automate/data_collection/#configure-chef-infra-client-to-use-the-data-collector-endpoint-in-chef-automate).**
+
+      ```ruby
+      chef_client_config 'Create client.rb' do
+        chef_server_url 'https://chef.example.dmz'
+        data_collector_server_url 'https://automate.example.dmz'
+        data_collector_token 'TEST_TOKEN_TEST'
+      end
+      ```
+
       DOC
 
       # @todo policy_file or policy_group being set requires the other to be set so enforce that.
@@ -231,6 +242,12 @@ class Chef
       property :additional_config, String,
         description: "Additional text to add at the bottom of the client.rb config. This can be used to run custom Ruby or to add less common config options"
 
+      property :data_collector_server_url, String,
+        description: "The data collector url (typically automate) to send node, converge and compliance data. Note: Data collection reporting to Automate should be performed directly by Chef Infra Server if possible, as this removes the need to distribute tokens to individual nodes."
+
+      property :data_collector_token, String,
+        description: "The data collector token to interact with the data collector server url (Automate). Note: Data collection reporting to Automate should be performed directly by Chef Infra Server if possible, as this removes the need to distribute tokens to individual nodes."
+
       action :create, description: "Create a client.rb config file for configuring #{ChefUtils::Dist::Infra::PRODUCT}." do
         unless ::Dir.exist?(new_resource.config_directory)
           directory new_resource.config_directory do
@@ -282,7 +299,9 @@ class Chef
             ssl_verify_mode: new_resource.ssl_verify_mode,
             start_handlers: format_handler(new_resource.start_handlers),
             additional_config: new_resource.additional_config,
-            policy_persist_run_list: new_resource.policy_persist_run_list
+            policy_persist_run_list: new_resource.policy_persist_run_list,
+            data_collector_server_url: new_resource.data_collector_server_url,
+            data_collector_token: new_resource.data_collector_token
           )
           mode "0640"
           action :create

--- a/lib/chef/resource/support/client.erb
+++ b/lib/chef/resource/support/client.erb
@@ -37,6 +37,13 @@ log_location <%= @log_location %>
 log_location <%= @log_location.inspect %>
   <% end -%>
 <% end -%>
+<%# These data_collector options are special as they have a '.' -%>
+<% unless @data_collector_server_url.nil? || @data_collector_server_url.empty? %>
+data_collector.server_url <%= @data_collector_server_url %>
+<% end %>
+<% unless @data_collector_token.nil? || @data_collector_token.empty? %>
+data_collector.token <%= @data_collector_token %>
+<% end %>
 <%# The code below is not DRY on purpose to improve readability -%>
 <% unless @start_handlers.empty? -%>
   # Do not crash if a start handler is missing / not installed yet


### PR DESCRIPTION
Add 2 config items to the chef infra client config generator

## Description
Not every chef infra server can talk to an automate instance or people running chef solo need a way to send their data to automate.
This is [documented](https://docs.chef.io/automate/data_collection/#configure-chef-infra-client-to-use-the-data-collector-endpoint-in-chef-automate) and this PR brings that functionality into the resource.

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
