### PR TITLE
Adds approle support for Chef::SecretFetcher::HashiVault

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -46,6 +46,7 @@
     "anonymized",
     "APISSL",
     "applewood",
+    "approle",
     "Appscript",
     "appscript",
     "ARCHITEW",

--- a/spec/unit/secret_fetcher/hashi_vault_spec.rb
+++ b/spec/unit/secret_fetcher/hashi_vault_spec.rb
@@ -70,7 +70,6 @@ describe Chef::SecretFetcher::HashiVault do
       it "raises ConfigurationInvalid message when :approle_name or :approle_id are not specified" do
         fetcher = Chef::SecretFetcher::HashiVault.new( { auth_method: :approle, vault_addr: "https://vault.example.com:8200" }, run_context)
         expect { fetcher.validate! }.to raise_error(Chef::Exceptions::Secret::ConfigurationInvalid)
-        expect { fetcher.validate! }.to raise_error("You must provide the :approle_name or :approle_id in the configuration with :auth_method set to :approle")
       end
 
       it "authenticates using the approle_id and approle_secret_id during validation when all configuration is correct" do

--- a/spec/unit/secret_fetcher/hashi_vault_spec.rb
+++ b/spec/unit/secret_fetcher/hashi_vault_spec.rb
@@ -65,6 +65,53 @@ describe Chef::SecretFetcher::HashiVault do
         fetcher.validate!
       end
     end
+
+    context "and using auth_method: :approle" do
+      it "raises ConfigurationInvalid message when :approle_name or :approle_id are not specified" do
+        fetcher = Chef::SecretFetcher::HashiVault.new( { auth_method: :approle, vault_addr: "https://vault.example.com:8200" }, run_context)
+        expect { fetcher.validate! }.to raise_error(Chef::Exceptions::Secret::ConfigurationInvalid)
+        expect { fetcher.validate! }.to raise_error("You must provide the :approle_name or :approle_id in the configuration with :auth_method set to :approle")
+      end
+
+      it "authenticates using the approle_id and approle_secret_id during validation when all configuration is correct" do
+        fetcher = Chef::SecretFetcher::HashiVault.new({
+          auth_method: :approle,
+          approle_id: "idguid",
+          approle_secret_id: "secretguid",
+          vault_addr: "https://vault.example.com:8200" },
+          run_context)
+        auth = instance_double(Vault::Authenticate)
+        allow(auth).to receive(:approle)
+        allow(Vault).to receive(:auth).and_return(auth)
+        expect(auth).to receive(:approle).with("idguid", "secretguid")
+        fetcher.validate!
+      end
+
+      it "looks up the :role_id and :secret_id when all configuration is correct" do
+        fetcher = Chef::SecretFetcher::HashiVault.new({
+          auth_method: :approle,
+          approle_name: "myapprole",
+          token: "t.1234abcd",
+          vault_addr: "https://vault.example.com:8200" },
+          run_context)
+        approle = instance_double(Vault::AppRole)
+        auth = instance_double(Vault::Authenticate)
+        allow(Vault).to receive(:approle).and_return(approle)
+        allow(approle).to receive(:role_id).with("myapprole").and_return("idguid")
+        allow(approle).to receive(:create_secret_id).with("myapprole").and_return(Vault::Secret.new({
+          data: {
+            secret_id: "secretguid",
+            secret_id_accessor: "accessor_guid",
+            secret_id_ttl: 0,
+          },
+          lease_duration: 0,
+          lease_id: "",
+        }))
+        allow(Vault).to receive(:auth).and_return(auth)
+        expect(auth).to receive(:approle).with("idguid", "secretguid")
+        fetcher.validate!
+      end
+    end
   end
 
   context "when fetching a secret from Hashi Vault" do


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Adds _approle_ support for `secret` helper `Chef::SecretFetcher::HashiVault` 

Supports the following approle auth types:

- Explicitly providing the `approle_id` and `approle_secret_id`.  This provides all the required information to connect to a Vault instance with an approle
- Providing the `approle_secret_id` along with an `approle_name`.  This allows for a known `secret_id` to be used and the associated `approle_id` will be fetched via lookup from the Vault instance.  A `token` may be supplied or omitted with this option depending on deployment requirements.
- Providing an `approle_name` (and optionally a `token`).  This type will use the `create_secret_id` method from Vault::Approle and dynamically generate an approle `secret_id`.  A `token` may be supplied or omitted with this option depending on deployment requirements.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#11966 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
