### PR TITLE
Replace Ubuntu 21.10 testing with 22.04 testing

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -108,7 +108,7 @@ jobs:
           - 'oraclelinux-8'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
-          - 'ubuntu-2110'
+          - 'ubuntu-2204'
     runs-on: ubuntu-latest
     env:
       FORCE_FFI_YAJL: ext

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -135,9 +135,9 @@ platforms:
       - RUN /usr/bin/apt-get update -y
       - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
 
-- name: ubuntu-21.10
+- name: ubuntu-22.04
   driver:
-    image: dokken/ubuntu-21.10
+    image: dokken/ubuntu-22.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update -y


### PR DESCRIPTION
There's a docker container for the nightly builds of this version now.

Signed-off-by: Tim Smith <tsmith@chef.io>