### PR TITLE
fix knife bootstrap issue when max wait is specified ref#12281

### DIFF
--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -930,7 +930,7 @@ class Chef
           opts[:logger] = Chef::Log
           opts[:password] = config[:connection_password] if config.key?(:connection_password)
           opts[:user] = user if user
-          opts[:max_wait_until_ready] = config[:max_wait].to_f unless config[:max_wait].nil?
+          opts[:max_wait_until_ready] = config[:max_wait].to_i unless config[:max_wait].nil?
           # TODO - when would we need to provide rdp_port vs port?  Or are they not mutually exclusive?
           opts[:port] = port if port
         end

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -817,7 +817,7 @@ describe Chef::Knife::Bootstrap do
             # Set everything to easily identifiable and obviously fake values
             # to verify that Chef::Config is being sourced instead of knife.config
             knife.config = {}
-            Chef::Config[:knife][:max_wait] = 9999
+            Chef::Config[:knife][:max_wait] = 9999.0
             Chef::Config[:knife][:winrm_user] = "winbob"
             Chef::Config[:knife][:winrm_port] = 9999
             Chef::Config[:knife][:ca_trust_file] = "trust.me"
@@ -836,7 +836,7 @@ describe Chef::Knife::Bootstrap do
               {
                 logger: Chef::Log, # not configurable
                 ca_trust_path: "trust.me",
-                max_wait_until_ready: 9999,
+                max_wait_until_ready: 9999, # converted to int
                 operation_timeout: 9999,
                 ssl_peer_fingerprint: "ABCDEF",
                 winrm_transport: "kerberos",
@@ -899,7 +899,7 @@ describe Chef::Knife::Bootstrap do
               # pull in the Chef::Config value
               Chef::Config[:knife][:winrm_auth_method] = "negotiate"
               knife.config[:connection_password] = "blue"
-              knife.config[:max_wait] = 1000
+              knife.config[:max_wait] = 1000.0
               knife.config[:connection_user] = "clippy"
               knife.config[:connection_port] = 1000
               knife.config[:winrm_port] = 1001 # We should not see this value get used
@@ -918,7 +918,7 @@ describe Chef::Knife::Bootstrap do
               {
                 logger: Chef::Log, # not configurable
                 ca_trust_path: "trust.the.internet",
-                max_wait_until_ready: 1000,
+                max_wait_until_ready: 1000, # converted to int
                 operation_timeout: 1000,
                 ssl_peer_fingerprint: "FEDCBA",
                 winrm_transport: "kerberos",
@@ -971,7 +971,7 @@ describe Chef::Knife::Bootstrap do
             # Set everything to easily identifiable and obviously fake values
             # to verify that Chef::Config is being sourced instead of knife.config
             knife.config = {}
-            Chef::Config[:knife][:max_wait] = 9999
+            Chef::Config[:knife][:max_wait] = 9999.0
             Chef::Config[:knife][:session_timeout] = 9999
             Chef::Config[:knife][:ssh_user] = "sshbob"
             Chef::Config[:knife][:ssh_port] = 9999
@@ -986,7 +986,7 @@ describe Chef::Knife::Bootstrap do
             let(:expected_result) do
               {
                 logger: Chef::Log, # not configurable
-                max_wait_until_ready: 9999.0,
+                max_wait_until_ready: 9999, # converted to int
                 connection_timeout: 9999,
                 user: "sshbob",
                 bastion_host: "mygateway.local",
@@ -1032,7 +1032,7 @@ describe Chef::Knife::Bootstrap do
               knife.config[:connection_port] = 12
               knife.config[:ssh_port] = "13" # canary to indirectly verify we're not looking for the wrong CLI flag
               knife.config[:connection_password] = "feta cheese"
-              knife.config[:max_wait] = 150
+              knife.config[:max_wait] = 150.0
               knife.config[:session_timeout] = 120
               knife.config[:use_sudo] = true
               knife.config[:use_sudo_pasword] = true
@@ -1042,7 +1042,7 @@ describe Chef::Knife::Bootstrap do
             let(:expected_result) do
               {
                 logger: Chef::Log, # not configurable
-                max_wait_until_ready: 150.0, # cli
+                max_wait_until_ready: 150, # cli (converted to int)
                 connection_timeout: 120, # cli
                 user: "sshalice", # cli
                 password: "feta cheese", # cli
@@ -1068,7 +1068,7 @@ describe Chef::Knife::Bootstrap do
           context "and all CLI options have been given" do
             before do
               knife.config = {}
-              knife.config[:max_wait] = 150
+              knife.config[:max_wait] = 150.0
               knife.config[:session_timeout] = 120
               knife.config[:connection_user] = "sshroot"
               knife.config[:connection_port] = 1000
@@ -1093,7 +1093,7 @@ describe Chef::Knife::Bootstrap do
             let(:expected_result) do
               {
                 logger: Chef::Log, # not configurable
-                max_wait_until_ready: 150,
+                max_wait_until_ready: 150, # converted to int
                 connection_timeout: 120,
                 user: "sshroot",
                 password: "blah",


### PR DESCRIPTION
Signed-off-by: kasif <kadnan@progress.com>

## Description
Knife bootstrap was not working with winrm, when max wait was specified.
This PR fixes the problem.


## Related Issue
#12281 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
