### PR TITLE
Remove the full option from homebrew_tap

### DIFF
--- a/lib/chef/resource/homebrew_tap.rb
+++ b/lib/chef/resource/homebrew_tap.rb
@@ -41,10 +41,6 @@ class Chef
       property :url, String,
         description: "The URL of the tap."
 
-      property :full, [TrueClass, FalseClass],
-        description: "Perform a full clone on the tap, as opposed to a shallow clone.",
-        default: false
-
       property :homebrew_path, String,
         description: "The path to the Homebrew binary.",
         default: "/usr/local/bin/brew"


### PR DESCRIPTION
## Description

brew tap --full is no longer supported and there is no replacement.

## Related Issue

Fixes #12345 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
