### PR TITLE
Fix reference to chef/chef_dictionary main branch

### DIFF
--- a/tasks/spellcheck.rb
+++ b/tasks/spellcheck.rb
@@ -35,7 +35,7 @@ namespace :spellcheck do
   end
 
   task :fetch_common do
-    sh "curl -s https://raw.githubusercontent.com/chef/chef_dictionary/master/chef.txt -o chef_dictionary.txt"
+    sh "curl -s https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt -o chef_dictionary.txt"
   end
 
   task :config_check do


### PR DESCRIPTION
## Description

Fixes the reference to the main branch for chef/chef_dictionary.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
