### PR TITLE
Add helpers to detect VMware desktop vs server platforms

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/virtualization.rb
+++ b/chef-utils/lib/chef-utils/dsl/virtualization.rb
@@ -140,6 +140,26 @@ module ChefUtils
         node.dig("virtualization", "system") == "vmware" && node.dig("virtualization", "role") == "host"
       end
 
+      # Determine if the current node is virtualized on VMware Desktop (Fusion/Player/Workstation).
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def vmware_desktop?(node = __getnode)
+        node.dig("virtualization", "system") == "vmware" && node.dig("vmware", "host", "type") == "vmware_desktop"
+      end
+
+      # Determine if the current node is virtualized on VMware vSphere (ESX).
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def vmware_vsphere?(node = __getnode)
+        node.dig("virtualization", "system") == "vmware" && node.dig("vmware", "host", "type") == "vmware_vsphere"
+      end
+
       # Determine if the current node is an openvz guest.
       #
       # @param [Chef::Node] node

--- a/chef-utils/lib/chef-utils/dsl/virtualization.rb
+++ b/chef-utils/lib/chef-utils/dsl/virtualization.rb
@@ -143,6 +143,7 @@ module ChefUtils
       # Determine if the current node is virtualized on VMware Desktop (Fusion/Player/Workstation).
       #
       # @param [Chef::Node] node
+      # @since 17.9
       #
       # @return [Boolean]
       #
@@ -153,6 +154,7 @@ module ChefUtils
       # Determine if the current node is virtualized on VMware vSphere (ESX).
       #
       # @param [Chef::Node] node
+      # @since 17.9
       #
       # @return [Boolean]
       #


### PR DESCRIPTION
## Description

Adds `vmware_desktop?` and `vmware_vsphere?` helpers. Depends on [Ohai PR #1720](https://github.com/chef/ohai/pull/1720) to work.

## Related Issue

Minor flexibility update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
