### PR TITLE
Setup auto issue labeler for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
 *            @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners
-.expeditor/  @chef/jex-team
+.expeditor/  @chef/releng-ops
 *.md         @chef/docs-team

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+documentation:
+  - 'README.md'
+  - 'CODE_OF_CONDUCT.md'
+  - 'CONTRIBUTING.md'
+  - 'lib/chef/resource/**/*'
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@main
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Make sure that things the docs team should review are auto labeled so it shows up on their zenhub board. This will create false positives, but that's better than missing stuff.

Signed-off-by: Tim Smith <tsmith@chef.io>