### PR TITLE
Update the pid_one_command for opensuse tests

### DIFF
--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -146,7 +146,7 @@ platforms:
 - name: opensuse-leap-15
   driver:
     image: dokken/opensuse-leap-15
-    pid_one_command: /bin/systemd
+    pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN /usr/bin/zypper --non-interactive update
       - RUN /usr/bin/zypper --non-interactive install net-tools-deprecated # we need this for /etc/network/interfaces & ifconfig resource testing


### PR DESCRIPTION
Hopefully this gets us working opensuse tests again

Signed-off-by: Tim Smith <tsmith@chef.io>