### PR TITLE
Fix cron_d job name character set

### DIFF
--- a/lib/chef/resource/cron/cron_d.rb
+++ b/lib/chef/resource/cron/cron_d.rb
@@ -92,6 +92,7 @@ class Chef
 
       property :cron_name, String,
         description: "An optional property to set the cron name if it differs from the resource block's name.",
+        regex: /^[a-zA-Z0-9_-]+$/,
         name_property: true
 
       property :cookbook, String, desired_state: false, skip_docs: true

--- a/spec/unit/resource/cron_d_spec.rb
+++ b/spec/unit/resource/cron_d_spec.rb
@@ -34,6 +34,14 @@ describe Chef::Resource::CronD do
     expect(resource.cron_name).to eql("cronify")
   end
 
+  it "the cron_name property is valid" do
+    expect { resource.cron_name "cron-job" }.not_to raise_error
+    expect { resource.cron_name "cron_job_0" }.not_to raise_error
+    expect { resource.cron_name "CronJob" }.not_to raise_error
+    expect { resource.cron_name "cron!" }.to raise_error(ArgumentError)
+    expect { resource.cron_name "cron job" }.to raise_error(ArgumentError)
+  end
+
   it "the mode property defaults to '0600'" do
     expect(resource.mode).to eql("0600")
   end

--- a/spec/unit/resource/cron_d_spec.rb
+++ b/spec/unit/resource/cron_d_spec.rb
@@ -18,7 +18,11 @@
 require "spec_helper"
 
 describe Chef::Resource::CronD do
-  let(:resource) { Chef::Resource::CronD.new("cronify") }
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::CronD.new("cronify", run_context) }
+  let(:provider) { resource.provider_for_action(:create) }
 
   it "has a default action of [:create]" do
     expect(resource.action).to eql([:create])
@@ -34,12 +38,36 @@ describe Chef::Resource::CronD do
     expect(resource.cron_name).to eql("cronify")
   end
 
-  it "the cron_name property is valid" do
-    expect { resource.cron_name "cron-job" }.not_to raise_error
-    expect { resource.cron_name "cron_job_0" }.not_to raise_error
-    expect { resource.cron_name "CronJob" }.not_to raise_error
-    expect { resource.cron_name "cron!" }.to raise_error(ArgumentError)
-    expect { resource.cron_name "cron job" }.to raise_error(ArgumentError)
+  context "on linux" do
+    before(:each) do
+      node.automatic_attrs[:os] = "linux"
+    end
+
+    it "the cron_name property is valid" do
+      provider.define_resource_requirements
+
+      expect { resource.cron_name "cron-job";   provider.process_resource_requirements }.not_to raise_error
+      expect { resource.cron_name "cron_job_0"; provider.process_resource_requirements }.not_to raise_error
+      expect { resource.cron_name "CronJob";    provider.process_resource_requirements }.not_to raise_error
+      expect { resource.cron_name "cron!";      provider.process_resource_requirements }.to raise_error "The cron job name should contain letters, numbers, hyphens and underscores only."
+      expect { resource.cron_name "cron job";   provider.process_resource_requirements }.to raise_error "The cron job name should contain letters, numbers, hyphens and underscores only."
+    end
+  end
+
+  context "not on linux" do
+    before(:each) do
+      node.automatic_attrs[:os] = "aix"
+    end
+
+    it "all cron names are valid" do
+      provider.define_resource_requirements
+
+      expect { resource.cron_name "cron-job";   provider.process_resource_requirements }.not_to raise_error
+      expect { resource.cron_name "cron_job_0"; provider.process_resource_requirements }.not_to raise_error
+      expect { resource.cron_name "CronJob";    provider.process_resource_requirements }.not_to raise_error
+      expect { resource.cron_name "cron!";      provider.process_resource_requirements }.not_to raise_error
+      expect { resource.cron_name "cron job";   provider.process_resource_requirements }.not_to raise_error
+    end
   end
 
   it "the mode property defaults to '0600'" do


### PR DESCRIPTION
This commit restrict the `cron_d` job name property to the character set
according to the cron specification:

> Additionally, cron reads the files in /etc/cron.d [...] Files must
> conform to the same naming convention as used by run-parts(8): they
> must consist solely of upper- and lower-case letters, digits,
> underscores, and hyphens.

closes #12165

Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>

## Description

The `cron_d` resource allows some special characters which aren't allowed.
This lets cron ignore the cron jobs silenty.

## Related Issue

- #12165 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
