### PR TITLE
Simplify file reads

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
@@ -38,7 +38,7 @@ class Chef
 
           def read
             tmpfile = rest.streaming_request(file[:url])
-            File.open(tmpfile, "rb", &:read)
+            File.binread(tmpfile)
           rescue Timeout::Error => e
             raise Chef::ChefFS::FileSystem::OperationFailedError.new(:read, self, e, "Timeout reading #{file[:url]}: #{e}")
           rescue Net::HTTPClientException => e

--- a/lib/chef/chef_fs/file_system/repository/base_file.rb
+++ b/lib/chef/chef_fs/file_system/repository/base_file.rb
@@ -123,7 +123,7 @@ class Chef
             if is_ruby_file?
               data_handler.from_ruby(file_path).to_json
             else
-              File.open(file_path, "rb", &:read)
+              File.binread(file_path)
             end
           rescue Errno::ENOENT
             raise Chef::ChefFS::FileSystem::NotFoundError.new(self, $!)

--- a/lib/chef/chef_fs/file_system/repository/file_system_entry.rb
+++ b/lib/chef/chef_fs/file_system/repository/file_system_entry.rb
@@ -126,7 +126,7 @@ class Chef
           end
 
           def read
-            File.open(file_path, "rb", &:read)
+            File.binread(file_path)
           rescue Errno::ENOENT
             raise Chef::ChefFS::FileSystem::NotFoundError.new(self, $!)
           end

--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -119,7 +119,7 @@ class Chef
         # but we need the base64 encoding for the content-md5
         # header
         checksum64 = Base64.encode64([checksum].pack("H*")).strip
-        file_contents = File.open(file, "rb", &:read)
+        file_contents = File.binread(file)
 
         # Custom headers. 'content-type' disables JSON serialization of the request body.
         headers = { "content-type" => "application/x-binary", "content-md5" => checksum64, "accept" => "application/json" }

--- a/lib/chef/util/dsc/configuration_generator.rb
+++ b/lib/chef/util/dsc/configuration_generator.rb
@@ -175,7 +175,7 @@ class Chef::Util::DSC
     end
 
     def get_configuration_document(document_path)
-      ::File.open(document_path, "rb", &:read)
+      ::File.binread(document_path)
     end
   end
 end

--- a/spec/functional/resource/cookbook_file_spec.rb
+++ b/spec/functional/resource/cookbook_file_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::CookbookFile do
   let(:source) { "java.response" }
   let(:cookbook_name) { "java" }
   let(:expected_content) do
-    content = File.open(File.join(CHEF_SPEC_DATA, "cookbooks", "java", "files", "default", "java.response"), "rb", &:read)
+    content = File.binread(File.join(CHEF_SPEC_DATA, "cookbooks", "java", "files", "default", "java.response"))
     content.force_encoding(Encoding::BINARY) if content.respond_to?(:force_encoding)
     content
   end

--- a/spec/functional/resource/dsc_script_spec.rb
+++ b/spec/functional/resource/dsc_script_spec.rb
@@ -345,7 +345,7 @@ describe Chef::Resource::DscScript, :windows_powershell_dsc_only, :ruby64_only d
     let(:config_param_section) { config_params }
     let(:config_flags) { { "#{dsc_user_prefix_param_name}": (dsc_user_prefix).to_s, "#{dsc_user_suffix_param_name}": (dsc_user_suffix).to_s } }
     it "does not directly contain the user name" do
-      configuration_script_content = ::File.open(dsc_test_resource.command, &:read)
+      configuration_script_content = ::File.read(dsc_test_resource.command)
       expect(configuration_script_content.include?(dsc_user)).to be(false)
     end
     it_behaves_like "a dsc_script with configuration data"
@@ -355,7 +355,7 @@ describe Chef::Resource::DscScript, :windows_powershell_dsc_only, :ruby64_only d
     let(:dsc_user_code) { dsc_user_env_code }
 
     it "does not directly contain the user name" do
-      configuration_script_content = ::File.open(dsc_test_resource.command, &:read)
+      configuration_script_content = ::File.read(dsc_test_resource.command)
       expect(configuration_script_content.include?(dsc_user)).to be(false)
     end
     it_behaves_like "a dsc_script with configuration data"

--- a/spec/functional/resource/template_spec.rb
+++ b/spec/functional/resource/template_spec.rb
@@ -21,7 +21,7 @@ require "spec_helper"
 describe Chef::Resource::Template do
 
   def binread(file)
-    File.open(file, "rb", &:read)
+    File.binread(file)
   end
 
   include_context Chef::Resource::File

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -22,7 +22,7 @@ describe "chef-client" do
     # just a normal file
     # (expected_content should be uncompressed)
     @api.get("/recipes.tgz", 200) do
-      File.open(recipes_filename, "rb", &:read)
+      File.binread(recipes_filename)
     end
   end
 

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -391,7 +391,7 @@ shared_examples_for "a configured file resource" do
   end
 
   def binread(file)
-    content = File.open(file, "rb", &:read)
+    content = File.binread(file)
     content.force_encoding(Encoding::BINARY) if "".respond_to?(:force_encoding)
     content
   end

--- a/spec/support/shared/functional/http.rb
+++ b/spec/support/shared/functional/http.rb
@@ -30,7 +30,7 @@ module ChefHTTPShared
   end
 
   def binread(file)
-    content = File.open(file, "rb", &:read)
+    content = File.binread(file)
     content.force_encoding(Encoding::BINARY) if "".respond_to?(:force_encoding)
     content
   end
@@ -51,19 +51,19 @@ module ChefHTTPShared
     # just a normal file
     # (expected_content should be uncompressed)
     @api.get("/nyan_cat.png", 200) do
-      File.open(nyan_uncompressed_filename, "rb", &:read)
+      File.binread(nyan_uncompressed_filename)
     end
 
     # this ends in .gz, we do not uncompress it and drop it on the filesystem as a .gz file (the internet often lies)
     # (expected_content should be compressed)
     @api.get("/nyan_cat.png.gz", 200, nil, { "Content-Type" => "application/gzip", "Content-Encoding" => "gzip" } ) do
-      File.open(nyan_compressed_filename, "rb", &:read)
+      File.binread(nyan_compressed_filename)
     end
 
     # this is an uncompressed file that was compressed by some mod_gzip-ish webserver thingy, so we will expand it
     # (expected_content should be uncompressed)
     @api.get("/nyan_cat_compressed.png", 200, nil, { "Content-Type" => "application/gzip", "Content-Encoding" => "gzip" } ) do
-      File.open(nyan_compressed_filename, "rb", &:read)
+      File.binread(nyan_compressed_filename)
     end
 
     #
@@ -75,7 +75,7 @@ module ChefHTTPShared
       {
         "Content-Length" => nyan_uncompressed_size.to_s,
       }) do
-        File.open(nyan_uncompressed_filename, "rb", &:read)
+        File.binread(nyan_uncompressed_filename)
       end
 
     # (expected_content should be uncompressed)
@@ -85,7 +85,7 @@ module ChefHTTPShared
         "Content-Type" => "application/gzip",
         "Content-Encoding" => "gzip",
       }) do
-        File.open(nyan_compressed_filename, "rb", &:read)
+        File.binread(nyan_compressed_filename)
       end
 
     #
@@ -97,7 +97,7 @@ module ChefHTTPShared
       {
         "Content-Length" => (nyan_uncompressed_size + 1).to_s,
       }) do
-        File.open(nyan_uncompressed_filename, "rb", &:read)
+        File.binread(nyan_uncompressed_filename)
       end
 
     # (expected_content should be uncompressed)
@@ -107,7 +107,7 @@ module ChefHTTPShared
         "Content-Type" => "application/gzip",
         "Content-Encoding" => "gzip",
       }) do
-        File.open(nyan_compressed_filename, "rb", &:read)
+        File.binread(nyan_compressed_filename)
       end
 
     #
@@ -120,7 +120,7 @@ module ChefHTTPShared
         "Content-Length" => (nyan_uncompressed_size + 1).to_s,
         "Transfer-Encoding" => "anything",
       }) do
-        File.open(nyan_uncompressed_filename, "rb", &:read)
+        File.binread(nyan_uncompressed_filename)
       end
 
     #

--- a/spec/unit/provider/user/solaris_spec.rb
+++ b/spec/unit/provider/user/solaris_spec.rb
@@ -74,7 +74,7 @@ describe Chef::Provider::User::Solaris do
       allow(Tempfile).to receive(:new).with("shadow", "/etc").and_return(temp_file)
       new_resource.password "verysecurepassword"
       provider.manage_user
-      expect(::File.open(password_file.path, "r").read).to match(/adam:verysecurepassword:/)
+      expect(::File.read(password_file.path)).to match(/adam:verysecurepassword:/)
       password_file.unlink
     end
   end


### PR DESCRIPTION
This is a new RuboCop cop that moves things to file.read an file.binread vs. an open and then a read.

Signed-off-by: Tim Smith <tsmith@chef.io>