### PR TITLE
Do not omit `removed` features if `source` is not explicitly defined on `windows_feature_powershell`

### DIFF
--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -146,7 +146,7 @@ class Chef
           # the intersection of the features to install & disabled/removed features are what needs installing
           @features_to_install ||= begin
             features = node["powershell_features_cache"]["disabled"]
-            features |= node["powershell_features_cache"]["removed"] if new_resource.source
+            features |= node["powershell_features_cache"]["removed"]
             new_resource.feature_name & features
           end
         end


### PR DESCRIPTION
## Description
Do not omit `removed` Windows features if `source` is not explicitly defined.

This mirrors the current behavior of `windows_feature_dism`  that was not omitting removed features. https://github.com/chef/chef/blob/main/lib/chef/resource/windows_feature_dism.rb#L133

The resource already checks to see if `source` is explicitly defined on the resource or if the appropriate registry key is set as part of `fail_if_removed` so an error would already be raised if there are any removed featured attempting to be installed. https://github.com/chef/chef/blob/main/lib/chef/resource/windows_feature_powershell.rb#L231

## Related Issue
#12397

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


closes #12397
