### PR TITLE
Reduce 213 requires from each knife call

### DIFF
--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -20,6 +20,7 @@ require_relative "../knife"
 require_relative "data_bag_secret_options"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 require "license_acceptance/cli_flags/mixlib_cli"
+require "chef/json_compat" unless defined?(Chef::JSONCompat) # can't be lazy loaded since it's used in options
 
 module LicenseAcceptance
   autoload :Acceptor, "license_acceptance/acceptor"
@@ -416,9 +417,6 @@ class Chef
       attr_reader :connection
 
       deps do
-        require "erubis" unless defined?(Erubis)
-        require "net/ssh" unless defined?(Net::SSH)
-        require "chef/json_compat" unless defined?(Chef::JSONCompat)
         require "chef-config/path_helper" unless defined?(ChefConfig::PathHelper)
         require_relative "bootstrap/chef_vault_handler"
         require_relative "bootstrap/client_builder"
@@ -544,6 +542,7 @@ class Chef
       end
 
       def render_template
+        require "erubis" unless defined?(Erubis)
         @config[:first_boot_attributes] = first_boot_attributes
         template_file = find_template
         template = IO.read(template_file).chomp


### PR DESCRIPTION
Right now for terrible reasons knife bootstrap gets initialized during every knife command due to sadness in knife-cloud. That wouldn't be nearly as bad if we were a bit more lazy in the bootstrap plugin.

1. JSON compat is actually used in the options so it needs to be required outside deps method. This works right now because we're not lazy all over the place and this thing gets loaded in 20 places
2. Net::SSH doesn't even appear to be used here. This plugin is all train now so we shouldn't have to require that.
3. Erubis should only get called when we're rendering out the template

Before:

```
There were 642 requires
The total time spend requiring was: 1.167499999748543
```

After

```
There were 429 requires
The total time spend requiring was: 0.6953230001963675
```

Signed-off-by: Tim Smith <tsmith@chef.io>