### PR TITLE
Fix typo in subscribes method documentation

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -311,7 +311,7 @@ class Chef
     #   file '/foo.txt' do
     #     content 'hi'
     #     action :nothing
-    #     subscribes :create, '/bar.txt'
+    #     subscribes :create, bar
     #   end
     # @example Multiple resources by string
     #   file '/foo.txt' do


### PR DESCRIPTION
In the direct resource example, the intention is to show that you can subscribe to the resource using a reference to the resource, instead of a string. The subscribes line should therefore reference `bar`. This is similar to the multiple string vs direct resource examples that follow just below.

<!--- Provide a short summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
