### PR TITLE
Skip tests on FreeBSD >= 12.3

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -41,6 +41,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
+    - freebsd-13-amd64
   mac_os_x-10.15-x86_64:
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -41,6 +41,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
+    - freebsd-13-amd64
   mac_os_x-10.15-x86_64:
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64

--- a/knife/spec/support/platform_helpers.rb
+++ b/knife/spec/support/platform_helpers.rb
@@ -127,6 +127,10 @@ def freebsd?
   RUBY_PLATFORM.include?("freebsd")
 end
 
+def freebsd_gte_12_3?
+  RUBY_PLATFORM.include?("freebsd") && !!(ohai[:platform_version].to_f >= 12.3)
+end
+
 def intel_64bit?
   !!(ohai[:kernel][:machine] == "x86_64")
 end

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -425,7 +425,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       end
     end
 
-    describe "when there is a group" do
+    describe "when there is a group", :not_supported_on_freebsd_gte_12_3 do
       it_behaves_like "correct group management"
     end
 
@@ -463,7 +463,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       end
     end
 
-    describe "when there is a group" do
+    describe "when there is a group", :not_supported_on_freebsd_gte_12_3 do
       it_behaves_like "correct group management"
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,6 +144,7 @@ RSpec.configure do |config|
   config.filter_run_excluding macos_only: true unless macos?
   config.filter_run_excluding not_macos_gte_11: true if macos_gte_11?
   config.filter_run_excluding not_supported_on_aix: true if aix?
+  config.filter_run_excluding not_supported_on_freebsd_gte_12_3: true if freebsd_gte_12_3?
   config.filter_run_excluding not_supported_on_solaris: true if solaris?
   config.filter_run_excluding not_supported_on_gce: true if gce?
   config.filter_run_excluding win2012r2_only: true unless windows_2012r2?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -127,6 +127,10 @@ def freebsd?
   RUBY_PLATFORM.include?("freebsd")
 end
 
+def freebsd_gte_12_3?
+  RUBY_PLATFORM.include?("freebsd") && !!(ohai[:platform_version].to_f >= 12.3)
+end
+
 def intel_64bit?
   !!(ohai[:kernel][:machine] == "x86_64")
 end


### PR DESCRIPTION
Skip tests on FreeBSD >= 12.3

Somehow [these shared examples](https://github.com/chef/chef/blob/v17.9.19/spec/support/shared/functional/securable_resource_with_reporting.rb#L115-L142) puts rspec into a state that causes 12 group_spec.rb tests to fail on FreeBSD >= 12.3.
These tests were not failing on FreeBSD <= 12.2.
We have not been able to find a way to fix the tests.

This PR also adds FreeBSD 13 to the omnibus build matrix.