### PR TITLE
fix typo in chef-sleep resource documentation example block

### DIFF
--- a/lib/chef/resource/chef_sleep.rb
+++ b/lib/chef/resource/chef_sleep.rb
@@ -47,7 +47,7 @@ class Chef
         service 'Service that is slow to start and reports as started' do
           service_name 'my_database'
           action :start
-          notifies :sleep, chef_sleep['wait for service start']
+          notifies :sleep, 'chef_sleep[wait for service start]'
         end
 
         chef_sleep 'wait for service start' do


### PR DESCRIPTION
Signed-off-by: Jose Hernandez <jhboricua@gmail.com>

Quick fix to example in chef-sleep resource documentation

## Description
The quotes are not placed correctly in the documentation example.

## Related Issue
#12385 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
