### PR TITLE
user: handle nil home dirs on macOS

### DIFF
--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -48,7 +48,7 @@ class Chef
           if user_plist
             current_resource.uid(user_plist[:uid][0])
             current_resource.gid(user_plist[:gid][0])
-            current_resource.home(user_plist[:home][0])
+            current_resource.home(user_plist[:home]&.first) # use &.first since home can be nil
             current_resource.shell(user_plist[:shell]&.first) # use &.first since shell can be nil
             current_resource.comment(user_plist[:comment][0])
 


### PR DESCRIPTION
Don't fail with a NoMethodError error if home is not defined. We're seeing this failure in our specs right now.

Signed-off-by: Tim Smith <tsmith@chef.io>