### PR TITLE
WIP Delete node and client ALCs on --purge option

### DIFF
--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -288,6 +288,8 @@ class Chef
                   else
                     begin
                       dest_entry.delete(true)
+                      # if this is a node or client, delete associated ACLs (user ACLs handled elsewhere)
+                      ::File.delete "#{dest_entry.parent.file_path}/../acls#{dest_path}" if ['/nodes', '/clients'].include? Pathname.new(dest_path).parent.to_s
                       ui.output "Deleted extra entry #{dest_path} (purge is on)" if ui
                     rescue Chef::ChefFS::FileSystem::NotFoundError
                       ui.output "Entry #{dest_path} does not exist. Nothing to do. (purge is on)" if ui


### PR DESCRIPTION
Delete node and client ALCs on `knife ec backup` when `--purge` option is given (currently this does not happen).

Addresses:
https://github.com/chef/chef-server/issues/2842

**This may be the correct change, and may supersede this one:**
https://github.com/chef/knife-ec-backup/pull/171

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
