### PR TITLE
Suppress deprecation warning for chef-client-updater cookbook

### DIFF
--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -54,7 +54,7 @@ class Chef
           resource_class.run_context = run_context
           resource_class.class_from_file(filename)
 
-          if !resource_class.unified_mode && !deprecated_class(resource_class) && !cookbook_name == "chef_client_updater"
+          if !resource_class.unified_mode && !deprecated_class(resource_class) && cookbook_name != "chef_client_updater"
             Chef.deprecated :unified_mode, "The #{resource_class.resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
           end
 

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -54,7 +54,7 @@ class Chef
           resource_class.run_context = run_context
           resource_class.class_from_file(filename)
 
-          if !resource_class.unified_mode && !deprecated_class(resource_class)
+          if !resource_class.unified_mode && !deprecated_class(resource_class) && !cookbook_name == "chef_client_updater"
             Chef.deprecated :unified_mode, "The #{resource_class.resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
           end
 

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -54,7 +54,7 @@ class Chef
           resource_class.run_context = run_context
           resource_class.class_from_file(filename)
 
-          if !resource_class.unified_mode && !deprecated_class(resource_class) && cookbook_name != "chef_client_updater"
+          if !resource_class.unified_mode && !deprecated_class(resource_class) && cookbook_name.to_s != "chef_client_updater"
             Chef.deprecated :unified_mode, "The #{resource_class.resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
           end
 


### PR DESCRIPTION
We need to support the chef_client_updater cookbook running on Chef 12 with the same code as runs on Chef 17/18 so we need to make one hardcoded exception in the universe for specifically this cookbook.