### PR TITLE
Fix ruby cleanup breaking builds

### DIFF
--- a/chef-utils/lib/chef-utils/dist.rb
+++ b/chef-utils/lib/chef-utils/dist.rb
@@ -112,7 +112,7 @@ module ChefUtils
       SERVER_CTL = "chef-server-ctl"
 
       # OS user for server
-      SYSTEM_USER = "opscode" 
+      SYSTEM_USER = "opscode"
     end
 
     class Solo

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -20,7 +20,7 @@ group(:chefstyle) do
   gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "main"
 end
 
-gem "ohai", git: "https://github.com/chef/ohai.git", branch: "main"
+gem "ohai", git: "https://github.com/chef/ohai.git", branch: "17-stable"
 gem "chef", path: ".."
 gem "chef-utils", path: File.expand_path("../chef-utils", __dir__) if File.exist?(File.expand_path("../chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("../chef-config", __dir__) if File.exist?(File.expand_path("../chef-config", __dir__))

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -82,8 +82,8 @@ build do
   block "Removing VERSION files from installed gems" do
     # find the embedded ruby gems dir and clean it up for globbing
     Dir.glob("#{install_dir}/embedded/lib/ruby/gems/*/gems/*/VERSION".tr("\\", "/")).each do |f|
-      # we need to not delete the aws SDK VERSION file
-      next if File.basename(File.expand_path("..", f)).start_with?("aws")
+      # we need to not delete the aws SDK VERSION file or jmespath's VERSION file
+      next if File.basename(File.expand_path("..", f)).start_with?("aws", "jmespath")
 
       puts "Deleting #{f}"
       FileUtils.rm_rf(f)

--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -21,7 +21,7 @@ build_dir = Dir.pwd
 
 env = {
   "GEMFILE_MOD" => "gem 'chef', path: '#{build_dir}'; " \
-    "gem 'ohai', git: 'https://github.com/chef/ohai.git', branch: 'main'",
+    "gem 'ohai', git: 'https://github.com/chef/ohai.git', branch: '17-stable'",
   "CHEF_LICENSE" => "accept-no-persist",
 }
 


### PR DESCRIPTION
new jmespath gem uses the VERSION file.

Signed-off-by: Tim Smith <tsmith@chef.io>