### PR TITLE
Validate resource spec passed to subscribes

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -341,6 +341,7 @@ class Chef
     def subscribes(action, resources, timing = :delayed)
       resources = [resources].flatten
       resources.each do |resource|
+        validate_resource_spec!(resource)
         if resource.is_a?(String)
           resource = UnresolvedSubscribes.new(resource, run_context)
         end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -300,6 +300,14 @@ describe Chef::Resource do
   end
 
   describe "subscribes" do
+    context "with syntax error in resources parameter" do
+      it "raises an exception immediately" do
+        expect do
+          resource.subscribes(:run, "typo[missing-closing-bracket")
+        end.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
+      end
+    end
+
     it "should make resources appear in the actions hash of subscribed nodes" do
       run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee")
       zr = run_context.resource_collection.find(zen_master: "coffee")

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -312,7 +312,7 @@ describe Chef::Resource do
       run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee")
       zr = run_context.resource_collection.find(zen_master: "coffee")
       resource.subscribes :reload, zr
-      expect(zr.delayed_notifications.detect { |e| e.resource.name == "funk" && e.action == :reload }).not_to be_nil
+      expect(zr.delayed_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil
     end
 
     it "should make resources appear in the actions hash of subscribed nodes" do
@@ -323,8 +323,8 @@ describe Chef::Resource do
 
       run_context.resource_collection << Chef::Resource::ZenMaster.new("bean")
       zrb = run_context.resource_collection.find(zen_master: "bean")
-      zrb.subscribes :reload, zr
-      expect(zr.delayed_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil
+      resource.subscribes :reload, zrb
+      expect(zrb.delayed_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil
     end
 
     it "should make subscribed resources be capable of acting immediately" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -309,26 +309,26 @@ describe Chef::Resource do
     end
 
     it "should make resources appear in the actions hash of subscribed nodes" do
-      run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee")
+      run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee", run_context)
       zr = run_context.resource_collection.find(zen_master: "coffee")
       resource.subscribes :reload, zr
-      expect(zr.delayed_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil
+      expect(zr.delayed_notifications.detect { |e| e.resource.name == "funk" && e.action == :reload }).not_to be_nil
     end
 
     it "should make resources appear in the actions hash of subscribed nodes" do
-      run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee")
+      run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee", run_context)
       zr = run_context.resource_collection.find(zen_master: "coffee")
       resource.subscribes :reload, zr
       expect(zr.delayed_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil
 
-      run_context.resource_collection << Chef::Resource::ZenMaster.new("bean")
+      run_context.resource_collection << Chef::Resource::ZenMaster.new("bean", run_context)
       zrb = run_context.resource_collection.find(zen_master: "bean")
-      resource.subscribes :reload, zrb
-      expect(zrb.delayed_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil
+      zrb.subscribes :reload, zr
+      expect(zr.delayed_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil
     end
 
     it "should make subscribed resources be capable of acting immediately" do
-      run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee")
+      run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee", run_context)
       zr = run_context.resource_collection.find(zen_master: "coffee")
       resource.subscribes :reload, zr, :immediately
       expect(zr.immediate_notifications.detect { |e| e.resource.name == resource.name && e.action == :reload }).not_to be_nil


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

## Description
When missing a closing ] in the resources passed to subscribes, it will be silently ignored whereas notifies checks the syntax and raises an error. To fix this we are validating the resources passed to subscribes and raising an exception when it is invalid.

- lib/chef/resource.rb

- spec/unit/resource_spec.rb

## Related Issue
#8908 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
