### PR TITLE
Fix habitat builds by using `rake install:local`

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -97,7 +97,7 @@ do_build() {
     build_line "Installing gems from git repos properly ..."
     ruby ./post-bundle-install.rb
     build_line "Installing this project's gems ..."
-    bundle exec rake install
+    bundle exec rake install:local
   )
 }
 


### PR DESCRIPTION
No idea why I had to do this last year for omnibus builds and
now this year for everything else.
