### PR TITLE
Avoid calculating etc_chef_dir multiple times on startup

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -84,8 +84,11 @@ module ChefConfig
     # @return [String] the platform-specific path
     #
     def self.etc_chef_dir(windows: ChefUtils.windows?)
-      path = windows ? c_chef_dir : PathHelper.join("/etc", ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
-      PathHelper.cleanpath(path, windows: windows)
+      @etc_chef_dir ||= {}
+      @etc_chef_dir[windows] ||= begin
+        path = windows ? c_chef_dir : PathHelper.join("/etc", ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
+        PathHelper.cleanpath(path, windows: windows)
+      end
     end
 
     # On *nix, /var/chef, on Windows C:\chef

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -282,6 +282,14 @@ RSpec.describe ChefConfig::Config do
         expect(ChefConfig::Config.etc_chef_dir(windows: true)).to eql("C:\\#{dirname}")
       end
     end
+
+    context "when calling etc_chef_dir multiple times" do
+      it "should not recalculate path for every call" do
+        expect(ChefConfig::Config.etc_chef_dir(windows: false)).to eql("/etc/#{dirname}")
+        expect(ChefConfig::PathHelper).not_to receive(:cleanpath)
+        expect(ChefConfig::Config.etc_chef_dir(windows: false)).to eql("/etc/#{dirname}")
+      end
+    end
   end
 
   [ false, true ].each do |is_windows|


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

## Description
Running chef-apply we calculated this value 5 times. We also have several other resources that use this method which would again have to be calculated. Each of those calculations run the PathHelper.join which involves a whole series of terrible string manipulations. Just calculate this once and be done with it.

## Related Issue
Duplicates PR #10562 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
