### PR TITLE
Loosen the win32-api dep to allow for the latest releases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ PATH
       train-winrm (>= 0.2.5)
       uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.16)
-      win32-api (~> 1.5.3)
+      win32-api (~> 1.5)
       win32-certstore (~> 0.6.2)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
@@ -411,7 +411,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    win32-api (1.5.3-universal-mingw32)
+    win32-api (1.10.1-universal-mingw32)
     win32-certstore (0.6.2)
       ffi
       mixlib-shellout

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -2,7 +2,7 @@ gemspec = eval(IO.read(File.expand_path("chef.gemspec", __dir__)))
 
 gemspec.platform = Gem::Platform.new(%w{universal mingw32})
 
-gemspec.add_dependency "win32-api", "~> 1.5.3"
+gemspec.add_dependency "win32-api", "~> 1.5"
 gemspec.add_dependency "win32-event", "~> 0.6.1"
 # TODO: Relax this pin and make the necessary updaets. The issue originally
 # leading to this pin has been fixed in 0.6.5.

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: d60226874b63a6076d6ed649e75be6e1d6972e44
+  revision: ab23925dd5d7c20c9bd66c8aef799bbc08c22c0a
   branch: main
   specs:
     omnibus-software (4.0.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: cf9ef0a34a441d0047bb3113c1a19cc4a376d7b3
+  revision: 124d5960ab2d3ed15b321d12d8da5b475631e16b
   branch: main
   specs:
     omnibus (8.3.2)
@@ -33,8 +33,8 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.554.0)
-    aws-sdk-core (3.126.1)
+    aws-partitions (1.555.0)
+    aws-sdk-core (3.126.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -68,12 +68,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (17.9.42)
+    chef (17.9.52)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
-      chef-config (= 17.9.42)
-      chef-utils (= 17.9.42)
+      chef-config (= 17.9.52)
+      chef-utils (= 17.9.52)
       chef-vault
       chef-zero (>= 14.0.11)
       corefoundation (~> 0.3.4)
@@ -99,12 +99,12 @@ GEM
       train-winrm (>= 0.2.5)
       uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.16)
-    chef (17.9.42-universal-mingw32)
+    chef (17.9.52-universal-mingw32)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
-      chef-config (= 17.9.42)
-      chef-utils (= 17.9.42)
+      chef-config (= 17.9.52)
+      chef-utils (= 17.9.52)
       chef-vault
       chef-zero (>= 14.0.11)
       corefoundation (~> 0.3.4)
@@ -142,9 +142,9 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.4)
-    chef-config (17.9.42)
+    chef-config (17.9.52)
       addressable
-      chef-utils (= 17.9.42)
+      chef-utils (= 17.9.52)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -152,7 +152,7 @@ GEM
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (17.9.42)
+    chef-utils (17.9.52)
       concurrent-ruby
     chef-vault (4.1.5)
     chef-zero (15.0.11)
@@ -167,7 +167,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     contracts (0.16.1)
-    corefoundation (0.3.10)
+    corefoundation (0.3.13)
       ffi (>= 1.15.0)
     diff-lcs (1.3)
     ed25519 (1.3.0)


### PR DESCRIPTION
We're using a version from 2015.

https://github.com/cosmo0920/win32-api/blob/master/CHANGES

Signed-off-by: Tim Smith <tsmith@chef.io>