### PR TITLE
Add --always-dump-stacktrace to integration tests that use chef-client

### DIFF
--- a/spec/functional/shell_spec.rb
+++ b/spec/functional/shell_spec.rb
@@ -81,7 +81,7 @@ describe Shell do
 
       require "pty"
       config = File.expand_path("shef-config.rb", CHEF_SPEC_DATA)
-      reader, writer, pid = PTY.spawn("bundle exec chef-shell --no-multiline --no-singleline --no-colorize -c #{config} #{options}")
+      reader, writer, pid = PTY.spawn("bundle exec #{ChefUtils::Dist::Infra::SHELL} --always-dump-stacktrace --no-multiline --no-singleline --no-colorize -c #{config} #{options}")
       read_until(reader, "chef (#{Chef::VERSION})>")
       yield reader, writer if block_given?
       writer.puts('"done"')

--- a/spec/functional/shell_spec.rb
+++ b/spec/functional/shell_spec.rb
@@ -81,7 +81,7 @@ describe Shell do
 
       require "pty"
       config = File.expand_path("shef-config.rb", CHEF_SPEC_DATA)
-      reader, writer, pid = PTY.spawn("bundle exec #{ChefUtils::Dist::Infra::SHELL} --always-dump-stacktrace --no-multiline --no-singleline --no-colorize -c #{config} #{options}")
+      reader, writer, pid = PTY.spawn("bundle exec #{ChefUtils::Dist::Infra::SHELL} --no-multiline --no-singleline --no-colorize -c #{config} #{options}")
       read_until(reader, "chef (#{Chef::VERSION})>")
       yield reader, writer if block_given?
       writer.puts('"done"')

--- a/spec/functional/version_spec.rb
+++ b/spec/functional/version_spec.rb
@@ -25,7 +25,7 @@ describe "Chef Versions", :executables do
   include Chef::Mixin::ShellOut
   let(:chef_dir) { File.join(__dir__, "..", "..") }
 
-  binaries = [ ChefUtils::Dist::Infra::CLIENT, "chef-shell", "chef-apply", ChefUtils::Dist::Solo::EXEC ]
+  binaries = [ ChefUtils::Dist::Infra::CLIENT, ChefUtils::Dist::Infra::SHELL, "chef-apply", ChefUtils::Dist::Solo::EXEC ]
 
   binaries.each do |binary|
     it "#{binary} version should be sane" do

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -89,8 +89,8 @@ describe "chef-client" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai" }
-  let(:chef_solo) { "bundle exec #{ChefUtils::Dist::Solo::EXEC} --legacy-mode --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
+  let(:chef_solo) { "bundle exec #{ChefUtils::Dist::Solo::EXEC} --legacy-mode --minimal-ohai --always-dump-stacktrace" }
   let(:client_name) { "chef-973334" }
 
   context "when validation.pem in current Directory" do

--- a/spec/integration/client/exit_code_spec.rb
+++ b/spec/integration/client/exit_code_spec.rb
@@ -23,7 +23,7 @@ describe "chef-client" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --no-fork --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --no-fork --minimal-ohai --always-dump-stacktrace" }
 
   let(:critical_env_vars) { %w{PATH RUBYOPT BUNDLE_GEMFILE GEM_PATH}.map { |o| "#{o}=#{ENV[o]}" } .join(" ") }
 

--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -76,7 +76,7 @@ describe "chef-client" do
 
   let(:chef_dir) { File.join(__dir__, "..", "..", "..") }
 
-  let(:chef_client_cmd) { %Q{bundle exec chef-client --minimal-ohai -c "#{path_to("config/client.rb")}" -lwarn} }
+  let(:chef_client_cmd) { %Q{bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai -c "#{path_to("config/client.rb")}" -lwarn --always-dump-stacktrace} }
 
   after do
     FileUtils.rm_rf(cache_path)

--- a/spec/integration/compliance/compliance_spec.rb
+++ b/spec/integration/compliance/compliance_spec.rb
@@ -20,7 +20,7 @@ describe "chef-client with compliance phase" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   when_the_repository "has a custom profile" do
     let(:report_file) { path_to("report_file.json") }

--- a/spec/integration/recipes/accumulator_spec.rb
+++ b/spec/integration/recipes/accumulator_spec.rb
@@ -17,7 +17,7 @@ describe "Accumulators" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   let(:aliases_temppath) do
     t = Tempfile.new("chef_accumulator_test")

--- a/spec/integration/recipes/lwrp_inline_resources_spec.rb
+++ b/spec/integration/recipes/lwrp_inline_resources_spec.rb
@@ -17,7 +17,7 @@ describe "LWRPs with inline resources" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   context "with a use_inline_resources provider with 'def action_a' instead of action :a" do
     class LwrpInlineResourcesTest < Chef::Resource

--- a/spec/integration/recipes/lwrp_spec.rb
+++ b/spec/integration/recipes/lwrp_spec.rb
@@ -17,7 +17,7 @@ describe "LWRPs" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   when_the_repository "has a cookbook named l-w-r-p" do
     before do

--- a/spec/integration/recipes/notifies_spec.rb
+++ b/spec/integration/recipes/notifies_spec.rb
@@ -23,7 +23,7 @@ describe "notifications" do
   include Chef::Mixin::ShellOut
 
   let(:chef_dir) { File.expand_path("../../..", __dir__) }
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   when_the_repository "notifies a nameless resource" do
     before do

--- a/spec/integration/recipes/notifying_block_spec.rb
+++ b/spec/integration/recipes/notifying_block_spec.rb
@@ -24,7 +24,7 @@ describe "notifying_block" do
   include Chef::Mixin::ShellOut
 
   let(:chef_dir) { File.expand_path("../../..", __dir__) }
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   when_the_repository "notifying_block test one" do
     before do

--- a/spec/integration/recipes/remote_directory.rb
+++ b/spec/integration/recipes/remote_directory.rb
@@ -16,7 +16,7 @@ describe Chef::Resource::RemoteDirectory do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   when_the_repository "has a cookbook with a source_dir with two subdirectories, each with one file and subdir in a different alphabetical order" do
     before do

--- a/spec/integration/recipes/unified_mode_spec.rb
+++ b/spec/integration/recipes/unified_mode_spec.rb
@@ -8,7 +8,7 @@ describe "Unified Mode" do
 
   let(:chef_dir) { File.expand_path("../../..", __dir__) }
 
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   when_the_repository "has a cookbook with a unified_mode resource with a delayed notification from the second block to the first block" do
     before do

--- a/spec/integration/recipes/use_partial_spec.rb
+++ b/spec/integration/recipes/use_partial_spec.rb
@@ -23,7 +23,7 @@ describe "notifying_block" do
   include Chef::Mixin::ShellOut
 
   let(:chef_dir) { File.expand_path("../../..", __dir__) }
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
 
   when_the_repository "has a cookbook with partial resources" do
     before do

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -18,7 +18,7 @@ describe ChefUtils::Dist::Solo::EXEC do
 
   let(:cookbook_ancient_100_metadata_rb) { cb_metadata("ancient", "1.0.0") }
 
-  let(:chef_solo) { "bundle exec #{ChefUtils::Dist::Solo::EXEC} --legacy-mode --minimal-ohai" }
+  let(:chef_solo) { "bundle exec #{ChefUtils::Dist::Solo::EXEC} --legacy-mode --minimal-ohai --always-dump-stacktrace" }
 
   when_the_repository "creates nodes" do
     let(:nodes_dir) { File.join(@repository_dir, "nodes") }
@@ -28,7 +28,7 @@ describe ChefUtils::Dist::Solo::EXEC do
       file "config/solo.rb", <<~EOM
         chef_repo_path "#{@repository_dir}"
       EOM
-      result = shell_out("bundle exec chef-solo -c \"#{path_to("config/solo.rb")}\" -l debug", cwd: chef_dir)
+      result = shell_out("#{chef_solo} -c \"#{path_to("config/solo.rb")}\" -l debug", cwd: chef_dir)
       result.error!
     end
 

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -28,7 +28,7 @@ describe ChefUtils::Dist::Solo::EXEC do
       file "config/solo.rb", <<~EOM
         chef_repo_path "#{@repository_dir}"
       EOM
-      result = shell_out("#{chef_solo} -c \"#{path_to("config/solo.rb")}\" -l debug", cwd: chef_dir)
+      result = shell_out("bundle exec #{ChefUtils::Dist::Solo::EXEC} --minimal-ohai --always-dump-stacktrace -c \"#{path_to("config/solo.rb")}\" -l debug", cwd: chef_dir)
       result.error!
     end
 


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

## Description
Currently when integration tests fail, they give no useful output other than to "check the stacktrace.out file" which is in a tempfile on the CI build server which we don't have easy access to and the tempdir probably gets wiped after the test anyway. So we will make use of --always-dump-stacktrace option which was introduced recently. 

Several of them also haven't been updated for the binary name change with cinc-client and need to use the ChefUtils::Dist::Infra::CLIENT constant instead of the literal string "chef-client".
Also "bundle exec chef-solo" and "bundle exec chef-shell" need to use ChefUtils::Dist::Solo::EXEC and ChefUtils::Dist::Infra::SHELL respectively.

## Related Issue
#12580 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
