### PR TITLE
Disable knife gem install in kitchen tests

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_gem.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_gem.rb
@@ -7,7 +7,9 @@
 
 # make sure customers can install knife back into the client for now
 # and also make sure chef_gem works in general
-gem_name = rhel6? ? "community_cookbook_releaser" : "knife"
+# ===== knife test has to be disabled until chef 17.10 is released ====
+# gem_name = rhel6? ? "community_cookbook_releaser" : "knife"
+gem_name = "community_cookbook_releaser"
 
 chef_gem gem_name do
   action :install


### PR DESCRIPTION
This causes horrible issues.

We are installing knife in a TK virt and can't really build it and
install it as a test (hacking up appbundler to do this would largely
invalidate the test since we wouldn't be testing customer behavior)
and as such it needs to be installed from rubygems.  That means
installing knife-17, which pulls down chef-17 which currently has
a dep on diff-lcs 1.3.x which conflicts with 1.5.x which throws
the errors around the binstubs conflicting (which may or may not be
a rubygems bug, I investigated that a bit and couldn't determine
why that is happening since the 3rd line has the magic rubygems
comment).  We can't just use "--force" as an option since that'll
ignore deps and stuff as well which is precisely the kinds of things
that we're trying to catch.  So for now this test is more pain
that it is worth.
