### PR TITLE
Fix PEM file generation when user is created

### DIFF
--- a/knife/lib/chef/knife/user_create.rb
+++ b/knife/lib/chef/knife/user_create.rb
@@ -128,6 +128,7 @@ class Chef
             display_name: "#{user.first_name} #{user.last_name}",
             email: user.email,
             password: password,
+            create_key: user.create_key,
           }
         else
           user_hash = {
@@ -137,6 +138,7 @@ class Chef
             display_name: user.display_name,
             email: user.email,
             password: password,
+            create_key: user.create_key,
           }
         end
 
@@ -159,13 +161,13 @@ class Chef
         end
 
         ui.info("Created #{user.username}")
-        if final_user["private_key"]
+        if final_user["chef_key"] && final_user["chef_key"]["private_key"]
           if config[:file]
             File.open(config[:file], "w") do |f|
-              f.print(final_user["private_key"])
+              f.print(final_user["chef_key"]["private_key"])
             end
           else
-            ui.msg final_user["private_key"]
+            ui.msg final_user["chef_key"]["private_key"]
           end
         end
       end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Fix PEM file generation when user created via knife. 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This issue arises because of ~~changes in infra API response~~ create_key is missing from body params. And not accessing the `private_key` in the correct way

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
- https://github.com/chef/chef-workstation/issues/2505

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
