### PR TITLE
Workaround binstub conflicts with diff-lcs gem 

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -89,6 +89,7 @@ jobs:
         sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
         sudo /opt/chef/embedded/bin/bundle config set --local path 'vendor/bundle'
         sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3
+        sudo rm -f /opt/chef/embedded/bin/{htmldiff,ldiff}
         sudo /opt/chef/embedded/bin/gem install berkshelf --no-doc
         sudo /opt/chef/embedded/bin/berks vendor cookbooks
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist


### PR DESCRIPTION
Just delete the binstubs that already exist and let the gem install replace them.

This is likely caused by diff-lcs version thrashing and conflicts over htmldiff which may be rubygems bugs ultimately (don't have a good repro case though to cut a bug there, and I while there's relevantish bugs there nothing made any sense to me, and I looked at it long enough to figure out that our binstubs do have the magic 3rd line on them, so AFAIK that error should never be happening, yet it does...)