### PR TITLE
Remove oraclelinux from kitchen testing

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -108,8 +108,6 @@ jobs:
           - 'debian-11'
           - 'fedora-latest'
           - 'opensuse-leap-15'
-          - 'oraclelinux-7'
-          - 'oraclelinux-8'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
           - 'ubuntu-2204'


### PR DESCRIPTION
We get good enough coverage from centos-6/7 and alma-8
