### PR TITLE
avoid coercion to block for new plist file content, fix adding a new dictionary 

### DIFF
--- a/lib/chef/resource/plist.rb
+++ b/lib/chef/resource/plist.rb
@@ -189,7 +189,12 @@ class Chef
         sep = " "
         arg = case subcommand.to_s
               when "add"
-                type_to_commandline_string(value)
+                if value.is_a?(Hash)
+                  sep = ":"
+                  value.map { |k, v| "#{k} #{type_to_commandline_string(v)}" }.join(sep)
+                else
+                  type_to_commandline_string(value)
+                end
               when "set"
                 if value.is_a?(Hash)
                   sep = ":"

--- a/lib/chef/resource/plist.rb
+++ b/lib/chef/resource/plist.rb
@@ -191,7 +191,7 @@ class Chef
               when "add"
                 if value.is_a?(Hash)
                   sep = ":"
-                  value.map { |k, v| "#{k} #{type_to_commandline_string(v)}" }.join(sep)
+                  value.map { |k, v| "#{k} #{type_to_commandline_string(v)}" }
                 else
                   type_to_commandline_string(value)
                 end

--- a/lib/chef/resource/plist.rb
+++ b/lib/chef/resource/plist.rb
@@ -85,8 +85,7 @@ class Chef
         converge_if_changed :path do
           converge_by "create new plist: '#{new_resource.path}'" do
             file new_resource.path do
-              empty_plist = {}.to_plist
-              content empty_plist
+              content({}.to_plist)
               owner new_resource.owner
               group new_resource.group
               mode new_resource.mode if property_is_set?(:mode)

--- a/lib/chef/resource/plist.rb
+++ b/lib/chef/resource/plist.rb
@@ -85,7 +85,8 @@ class Chef
         converge_if_changed :path do
           converge_by "create new plist: '#{new_resource.path}'" do
             file new_resource.path do
-              content {}.to_plist
+              empty_plist = {}.to_plist
+              content empty_plist
               owner new_resource.owner
               group new_resource.group
               mode new_resource.mode if property_is_set?(:mode)

--- a/spec/functional/resource/plist_spec.rb
+++ b/spec/functional/resource/plist_spec.rb
@@ -19,7 +19,7 @@ describe Chef::Resource::PlistResource, :macos_only, requires_root: true do
         value(gregorian: 4)
       end
       expect(File.exist?(global_prefs))
-      expect(shell_out!("/usr/libexec/PlistBuddy -c 'Print :\"AppleFirstWeekday\":gregorian' \"#{global_prefs}\"").stdout.strip.to_i).to eq(4)
+      expect(shell_out!("/usr/libexec/PlistBuddy -c 'Print :\"AppleFirstWeekday\":gregorian' \"#{global_prefs}\"").stdout.to_i).to eq(4)
     end
   end
 end

--- a/spec/functional/resource/plist_spec.rb
+++ b/spec/functional/resource/plist_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'plist'
+
+describe Chef::Resource::PlistResource, :macos_only, requires_root: true do
+  include RecipeDSLHelper
+  
+  let(:global_prefs) do
+    File.join(Dir.mktmpdir, '.GlobalPreferences.plist')
+  end
+
+  before(:each) do
+    FileUtils.rm_f global_prefs
+  end
+
+  context "make Monday the first DOW" do
+    it "creates a new plist with a hash value" do
+      plist global_prefs do
+        entry 'AppleFirstWeekday'
+        value(gregorian: 4)
+      end
+      expect(File.exist?(global_prefs))
+      expect(shell_out!("/usr/libexec/PlistBuddy -c 'Print :\"AppleFirstWeekday\":gregorian' \"#{global_prefs}\"").stdout.strip.to_i).to eq(4)
+    end
+  end
+end

--- a/spec/functional/resource/plist_spec.rb
+++ b/spec/functional/resource/plist_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
-require 'plist'
+require "spec_helper"
+require "plist"
 
 describe Chef::Resource::PlistResource, :macos_only, requires_root: true do
   include RecipeDSLHelper
-  
+
   let(:global_prefs) do
-    File.join(Dir.mktmpdir, '.GlobalPreferences.plist')
+    File.join(Dir.mktmpdir, ".GlobalPreferences.plist")
   end
 
   before(:each) do
@@ -15,7 +15,7 @@ describe Chef::Resource::PlistResource, :macos_only, requires_root: true do
   context "make Monday the first DOW" do
     it "creates a new plist with a hash value" do
       plist global_prefs do
-        entry 'AppleFirstWeekday'
+        entry "AppleFirstWeekday"
         value(gregorian: 4)
       end
       expect(File.exist?(global_prefs))


### PR DESCRIPTION
Signed-off-by: Jacob Zaval <jazava@microsoft.com>

## Description
When creating a new plist, the `plist` resource passes an empty hash with the `to_plist` method (`{}.to_plist`) to the `content` property of `file` resource. However, the `file` resource interprets this first as a block, as demonstrated in #12678. This PR assigns the empty plist to a variable first, so it can be properly evaluated before being passed to `file`.

Also, during the addition of a functional spec test with a `Hash` for `value`, I discovered a bug with the "add" case for a new dictionary and updated accordingly (similar solution to the `Hash` "set" case).

## Related Issue
#12678 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
