### PR TITLE
Updated Rspec to add verbose logging 

### DIFF
--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -77,7 +77,7 @@ begin
       RSpec::Core::RakeTask.new(sub) do |t|
         puts "--- Running chef #{sub} specs"
         t.verbose = false
-        t.rspec_opts = %w{--profile}
+        t.rspec_opts = %w{--profile --format doc}
         t.pattern = FileList["spec/#{sub}/**/*_spec.rb"]
       end
     end


### PR DESCRIPTION

Signed-off-by: John McCrae <jmccrae@chf.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Updated Rspec to add verbose logging  for the purposes of tracking down intermittent failures in Integration and Unit testing on Windows. When these happen we get weird, random output regarding Libyajl that don't make sense. 

(https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
