### PR TITLE
Chef-18: Enable unifed_mode by default

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -994,7 +994,7 @@ module ChefConfig
     # applying in "compile" mode, with no "converge" mode. False is backwards compatible
     # setting for Chef 11-15 behavior.  This will break forward notifications.
     #
-    default :resource_unified_mode_default, false
+    default :resource_unified_mode_default, true
 
     # At the beginning of the Chef Client run, the cookbook manifests are downloaded which
     # contain URLs for every file in every relevant cookbook.  Most of the files

--- a/lib/chef/resource/alternatives.rb
+++ b/lib/chef/resource/alternatives.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Alternatives < Chef::Resource
-      unified_mode true
 
       provides(:alternatives) { true }
 

--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class AptPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :apt_package, target_mode: true
       provides :package, platform_family: "debian", target_mode: true

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class AptPreference < Chef::Resource
-      unified_mode true
 
       provides(:apt_preference) { true }
 

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -26,7 +26,6 @@ end
 class Chef
   class Resource
     class AptRepository < Chef::Resource
-      unified_mode true
 
       provides(:apt_repository) { true }
 

--- a/lib/chef/resource/apt_update.rb
+++ b/lib/chef/resource/apt_update.rb
@@ -22,7 +22,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class AptUpdate < Chef::Resource
-      unified_mode true
 
       provides(:apt_update) { true }
 

--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -30,7 +30,6 @@ end
 class Chef
   class Resource
     class ArchiveFile < Chef::Resource
-      unified_mode true
 
       provides :archive_file
       provides :libarchive_file # legacy cookbook name

--- a/lib/chef/resource/bash.rb
+++ b/lib/chef/resource/bash.rb
@@ -21,7 +21,6 @@ require_relative "script"
 class Chef
   class Resource
     class Bash < Chef::Resource::Script
-      unified_mode true
 
       provides :bash
 

--- a/lib/chef/resource/batch.rb
+++ b/lib/chef/resource/batch.rb
@@ -21,7 +21,6 @@ require_relative "windows_script"
 class Chef
   class Resource
     class Batch < Chef::Resource::WindowsScript
-      unified_mode true
 
       provides :batch
 

--- a/lib/chef/resource/bff_package.rb
+++ b/lib/chef/resource/bff_package.rb
@@ -22,7 +22,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class BffPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :bff_package
 

--- a/lib/chef/resource/breakpoint.rb
+++ b/lib/chef/resource/breakpoint.rb
@@ -22,7 +22,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class Breakpoint < Chef::Resource
-      unified_mode true
 
       provides :breakpoint, target_mode: true
 

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -19,7 +19,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class BuildEssential < Chef::Resource
-      unified_mode true
 
       provides(:build_essential) { true }
 

--- a/lib/chef/resource/cab_package.rb
+++ b/lib/chef/resource/cab_package.rb
@@ -23,7 +23,6 @@ class Chef
   class Resource
     class CabPackage < Chef::Resource::Package
       include Chef::Mixin::Uris
-      unified_mode true
 
       provides :cab_package
 

--- a/lib/chef/resource/chef_client_config.rb
+++ b/lib/chef/resource/chef_client_config.rb
@@ -20,7 +20,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class ChefClientConfig < Chef::Resource
-      unified_mode true
 
       provides :chef_client_config
 

--- a/lib/chef/resource/chef_client_cron.rb
+++ b/lib/chef/resource/chef_client_cron.rb
@@ -22,7 +22,6 @@ require "digest/md5" unless defined?(Digest::MD5)
 class Chef
   class Resource
     class ChefClientCron < Chef::Resource
-      unified_mode true
 
       provides :chef_client_cron
 

--- a/lib/chef/resource/chef_client_launchd.rb
+++ b/lib/chef/resource/chef_client_launchd.rb
@@ -19,7 +19,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class ChefClientLaunchd < Chef::Resource
-      unified_mode true
 
       provides :chef_client_launchd
 

--- a/lib/chef/resource/chef_client_scheduled_task.rb
+++ b/lib/chef/resource/chef_client_scheduled_task.rb
@@ -20,7 +20,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class ChefClientScheduledTask < Chef::Resource
-      unified_mode true
 
       provides :chef_client_scheduled_task
 

--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -20,7 +20,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class ChefClientSystemdTimer < Chef::Resource
-      unified_mode true
 
       provides :chef_client_systemd_timer
 

--- a/lib/chef/resource/chef_client_trusted_certificate.rb
+++ b/lib/chef/resource/chef_client_trusted_certificate.rb
@@ -20,7 +20,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class ChefClientTrustedCertificate < Chef::Resource
-      unified_mode true
 
       provides :chef_client_trusted_certificate
 

--- a/lib/chef/resource/chef_gem.rb
+++ b/lib/chef/resource/chef_gem.rb
@@ -23,7 +23,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class ChefGem < Chef::Resource::Package::GemPackage
-      unified_mode true
       provides :chef_gem
 
       description <<~DESC

--- a/lib/chef/resource/chef_handler.rb
+++ b/lib/chef/resource/chef_handler.rb
@@ -21,7 +21,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class ChefHandler < Chef::Resource
-      unified_mode true
 
       provides(:chef_handler) { true }
 

--- a/lib/chef/resource/chef_sleep.rb
+++ b/lib/chef/resource/chef_sleep.rb
@@ -22,8 +22,6 @@ class Chef
     class ChefSleep < Chef::Resource
       provides :chef_sleep
 
-      unified_mode true
-
       description "Use the **chef_sleep** resource to pause (sleep) for a number of seconds during a #{ChefUtils::Dist::Infra::PRODUCT} run. Only use this resource when a command or service exits successfully but is not ready for the next step in a recipe."
       introduced "15.5"
       examples <<~DOC

--- a/lib/chef/resource/chef_vault_secret.rb
+++ b/lib/chef/resource/chef_vault_secret.rb
@@ -21,7 +21,6 @@ autoload :ChefVault, "chef-vault"
 class Chef
   class Resource
     class ChefVaultSecret < Chef::Resource
-      unified_mode true
 
       provides :chef_vault_secret
 

--- a/lib/chef/resource/chocolatey_config.rb
+++ b/lib/chef/resource/chocolatey_config.rb
@@ -17,7 +17,6 @@
 class Chef
   class Resource
     class ChocolateyConfig < Chef::Resource
-      unified_mode true
 
       provides :chocolatey_config
 

--- a/lib/chef/resource/chocolatey_feature.rb
+++ b/lib/chef/resource/chocolatey_feature.rb
@@ -17,7 +17,6 @@
 class Chef
   class Resource
     class ChocolateyFeature < Chef::Resource
-      unified_mode true
       provides :chocolatey_feature
 
       description "Use the **chocolatey_feature** resource to enable and disable Chocolatey features. Note: The Chocolatey package manager is not installed on Windows by default. You will need to install it prior to using this resource by adding the [Chocolatey cookbook](https://supermarket.chef.io/cookbooks/chocolatey/) to your node's run list."

--- a/lib/chef/resource/chocolatey_package.rb
+++ b/lib/chef/resource/chocolatey_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class ChocolateyPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :chocolatey_package
 

--- a/lib/chef/resource/chocolatey_source.rb
+++ b/lib/chef/resource/chocolatey_source.rb
@@ -17,7 +17,6 @@
 class Chef
   class Resource
     class ChocolateySource < Chef::Resource
-      unified_mode true
       provides :chocolatey_source
 
       description "Use the **chocolatey_source** resource to add, remove, enable, or disable Chocolatey sources. Note: The Chocolatey package manager is not installed on Windows by default. You will need to install it prior to using this resource by adding the [Chocolatey cookbook](https://supermarket.chef.io/cookbooks/chocolatey/) to your node's run list."

--- a/lib/chef/resource/cookbook_file.rb
+++ b/lib/chef/resource/cookbook_file.rb
@@ -27,7 +27,6 @@ class Chef
   class Resource
     class CookbookFile < Chef::Resource::File
       include Chef::Mixin::Securable
-      unified_mode true
 
       provides :cookbook_file
 

--- a/lib/chef/resource/cron/_cron_shared.rb
+++ b/lib/chef/resource/cron/_cron_shared.rb
@@ -1,4 +1,3 @@
-unified_mode true
 
 TIMEOUT_OPTS = %w{duration preserve-status foreground kill-after signal}.freeze
 TIMEOUT_REGEX = /\A\S+/.freeze

--- a/lib/chef/resource/cron/cron.rb
+++ b/lib/chef/resource/cron/cron.rb
@@ -25,7 +25,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class Cron < Chef::Resource
-      unified_mode true
 
       use "cron_shared"
 

--- a/lib/chef/resource/cron/cron_d.rb
+++ b/lib/chef/resource/cron/cron_d.rb
@@ -23,7 +23,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class CronD < Chef::Resource
-      unified_mode true
 
       use "cron_shared"
 

--- a/lib/chef/resource/cron_access.rb
+++ b/lib/chef/resource/cron_access.rb
@@ -23,7 +23,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class CronAccess < Chef::Resource
-      unified_mode true
       provides :cron_access
       provides(:cron_manage) # legacy name @todo in Chef 15 we should { true } this so it wins over the cookbook
 

--- a/lib/chef/resource/csh.rb
+++ b/lib/chef/resource/csh.rb
@@ -21,7 +21,6 @@ require_relative "script"
 class Chef
   class Resource
     class Csh < Chef::Resource::Script
-      unified_mode true
 
       provides :csh
 

--- a/lib/chef/resource/directory.rb
+++ b/lib/chef/resource/directory.rb
@@ -24,7 +24,6 @@ require_relative "../mixin/securable"
 class Chef
   class Resource
     class Directory < Chef::Resource
-      unified_mode true
 
       provides :directory
 

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class DmgPackage < Chef::Resource
-      unified_mode true
 
       provides(:dmg_package) { true }
 

--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -26,7 +26,6 @@ class Chef
       extend Chef::Mixin::Which
       extend Chef::Mixin::ShellOut
 
-      unified_mode true
       provides :dnf_package
 
       # all rhel variants >= 8 will use DNF

--- a/lib/chef/resource/dpkg_package.rb
+++ b/lib/chef/resource/dpkg_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class DpkgPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :dpkg_package
 

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -20,7 +20,6 @@ require_relative "../dsl/powershell"
 class Chef
   class Resource
     class DscResource < Chef::Resource
-      unified_mode true
 
       provides :dsc_resource
 

--- a/lib/chef/resource/dsc_script.rb
+++ b/lib/chef/resource/dsc_script.rb
@@ -26,7 +26,6 @@ class Chef
     class DscScript < Chef::Resource
       include Chef::DSL::Powershell
 
-      unified_mode true
       provides :dsc_script
 
       description <<~DESC

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -23,7 +23,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class Execute < Chef::Resource
-      unified_mode true
 
       provides :execute, target_mode: true
 

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -28,7 +28,6 @@ class Chef
   class Resource
     class File < Chef::Resource
       include Chef::Mixin::Securable
-      unified_mode true
 
       provides :file
 

--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -25,7 +25,6 @@ require_relative "../provider/package/freebsd/pkgng"
 class Chef
   class Resource
     class FreebsdPackage < Chef::Resource::Package
-      unified_mode true
       provides :freebsd_package
       provides :package, platform: "freebsd"
 

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -22,7 +22,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class GemPackage < Chef::Resource::Package
-      unified_mode true
       provides :gem_package
 
       description <<~DESC

--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -20,7 +20,6 @@
 class Chef
   class Resource
     class Group < Chef::Resource
-      unified_mode true
       state_attrs :members
 
       description "Use the **group** resource to manage a local group."

--- a/lib/chef/resource/habitat/habitat_package.rb
+++ b/lib/chef/resource/habitat/habitat_package.rb
@@ -21,7 +21,6 @@ require_relative "../package"
 class Chef
   class Resource
     class HabitatPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :habitat_package
       use "habitat_shared"

--- a/lib/chef/resource/habitat/habitat_sup.rb
+++ b/lib/chef/resource/habitat/habitat_sup.rb
@@ -20,7 +20,6 @@ require_relative "../../resource"
 class Chef
   class Resource
     class HabitatSup < Chef::Resource
-      unified_mode true
 
       provides :habitat_sup do |_node|
         false

--- a/lib/chef/resource/habitat_config.rb
+++ b/lib/chef/resource/habitat_config.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class HabitatConfig < Chef::Resource
-      unified_mode true
 
       provides :habitat_config
 

--- a/lib/chef/resource/habitat_install.rb
+++ b/lib/chef/resource/habitat_install.rb
@@ -19,7 +19,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class HabitatInstall < Chef::Resource
-      unified_mode true
       provides :habitat_install
 
       description "Use the **habitat_install** resource to install Chef Habitat."

--- a/lib/chef/resource/habitat_service.rb
+++ b/lib/chef/resource/habitat_service.rb
@@ -20,7 +20,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class HabitatService < Chef::Resource
-      unified_mode true
       provides :habitat_service
 
       description "Use the **habitat_service** resource to manage Chef Habitat services. This requires that `core/hab-sup` be running as a service. See the `habitat_sup` resource documentation for more information. Note: Applications may run as a specific user. Often with Habitat, the default is `hab`, or `root`. If the application requires another user, then it should be created with Chef's `user` resource."

--- a/lib/chef/resource/habitat_user_toml.rb
+++ b/lib/chef/resource/habitat_user_toml.rb
@@ -16,7 +16,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class HabitatUserToml < Chef::Resource
-      unified_mode true
       provides :habitat_user_toml
 
       description "Use the **habitat_user_toml** to template a `user.toml` for Chef Habitat services. Configurations set in the  `user.toml` override the `default.toml` for a given package, which makes it an alternative to applying service group level configuration."

--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -23,7 +23,6 @@ require_relative "../mixin/homebrew_user"
 class Chef
   class Resource
     class HomebrewCask < Chef::Resource
-      unified_mode true
 
       provides(:homebrew_cask) { true }
 

--- a/lib/chef/resource/homebrew_package.rb
+++ b/lib/chef/resource/homebrew_package.rb
@@ -24,7 +24,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class HomebrewPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :homebrew_package
       provides :package, os: "darwin"

--- a/lib/chef/resource/homebrew_tap.rb
+++ b/lib/chef/resource/homebrew_tap.rb
@@ -23,7 +23,6 @@ require_relative "../mixin/homebrew_user"
 class Chef
   class Resource
     class HomebrewTap < Chef::Resource
-      unified_mode true
 
       provides(:homebrew_tap) { true }
 

--- a/lib/chef/resource/homebrew_update.rb
+++ b/lib/chef/resource/homebrew_update.rb
@@ -27,8 +27,6 @@ class Chef
     class HomebrewUpdate < Chef::Resource
       include Chef::Mixin::HomebrewUser
 
-      unified_mode true
-
       provides(:homebrew_update) { true }
 
       description "Use the **homebrew_update** resource to manage Homebrew repository updates on macOS."

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -23,7 +23,6 @@ class Chef
     # Sets the hostname and updates /etc/hosts on *nix systems
     # @since 14.0.0
     class Hostname < Chef::Resource
-      unified_mode true
 
       provides :hostname
 

--- a/lib/chef/resource/http_request.rb
+++ b/lib/chef/resource/http_request.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class HttpRequest < Chef::Resource
-      unified_mode true
 
       provides :http_request
 

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Ifconfig < Chef::Resource
-      unified_mode true
 
       provides :ifconfig
 

--- a/lib/chef/resource/inspec_input.rb
+++ b/lib/chef/resource/inspec_input.rb
@@ -20,7 +20,6 @@ class Chef
   class Resource
     class InspecInput < Chef::Resource
       provides :inspec_input
-      unified_mode true
 
       description "Use the **inspec_input** resource to add an input to the Compliance Phase."
       introduced "17.5"

--- a/lib/chef/resource/inspec_waiver.rb
+++ b/lib/chef/resource/inspec_waiver.rb
@@ -20,7 +20,6 @@ class Chef
   class Resource
     class InspecWaiver < Chef::Resource
       provides :inspec_waiver
-      unified_mode true
 
       description "Use the **inspec_waiver** resource to add a waiver to the Compliance Phase."
       introduced "17.5"

--- a/lib/chef/resource/inspec_waiver_file_entry.rb
+++ b/lib/chef/resource/inspec_waiver_file_entry.rb
@@ -24,7 +24,6 @@ class Chef
   class Resource
     class InspecWaiverFileEntry < Chef::Resource
       provides :inspec_waiver_file_entry
-      unified_mode true
 
       description "Use the **inspec_waiver_file_entry** resource to add or remove entries from an InSpec waiver file. This can be used in conjunction with the Compliance Phase."
       introduced "17.1"

--- a/lib/chef/resource/ips_package.rb
+++ b/lib/chef/resource/ips_package.rb
@@ -22,7 +22,6 @@ require_relative "../provider/package/ips"
 class Chef
   class Resource
     class IpsPackage < ::Chef::Resource::Package
-      unified_mode true
 
       provides :ips_package
       provides :package, os: "solaris2"

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -11,7 +11,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class KernelModule < Chef::Resource
-      unified_mode true
 
       provides :kernel_module
 

--- a/lib/chef/resource/ksh.rb
+++ b/lib/chef/resource/ksh.rb
@@ -21,7 +21,6 @@ require_relative "script"
 class Chef
   class Resource
     class Ksh < Chef::Resource::Script
-      unified_mode true
 
       provides :ksh
 

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Launchd < Chef::Resource
-      unified_mode true
       provides :launchd
 
       description "Use the **launchd** resource to manage system-wide services (daemons) and per-user services (agents) on the macOS platform."

--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -24,7 +24,6 @@ class Chef
   class Resource
     class Link < Chef::Resource
       include Chef::Mixin::Securable
-      unified_mode true
 
       provides :link
 

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -21,7 +21,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class Locale < Chef::Resource
-      unified_mode true
       provides :locale
 
       description "Use the **locale** resource to set the system's locale on Debian and Windows systems. Windows support was added in Chef Infra Client 16.0"

--- a/lib/chef/resource/log.rb
+++ b/lib/chef/resource/log.rb
@@ -29,7 +29,6 @@ class Chef
     #     level :debug
     #   end
     class Log < Chef::Resource
-      unified_mode true
 
       provides :log, target_mode: true
 

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -54,10 +54,6 @@ class Chef
           resource_class.run_context = run_context
           resource_class.class_from_file(filename)
 
-          if !resource_class.unified_mode && !deprecated_class(resource_class) && cookbook_name.to_s != "chef_client_updater"
-            Chef.deprecated :unified_mode, "The #{resource_class.resource_name} resource in the #{cookbook_name} cookbook should declare `unified_mode true`", filename
-          end
-
           # Make a useful string for the class (rather than <Class:312894723894>)
           resource_class.instance_eval do
             define_singleton_method(:to_s) do

--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -23,7 +23,6 @@ autoload :Plist, "plist"
 class Chef
   class Resource
     class MacosUserDefaults < Chef::Resource
-      unified_mode true
 
       # align with apple's marketing department
       provides(:macos_userdefaults) { true }

--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -21,7 +21,6 @@ require_relative "service"
 class Chef
   class Resource
     class MacosxService < Chef::Resource::Service
-      unified_mode true
 
       provides :macosx_service
       provides :service, os: "darwin"

--- a/lib/chef/resource/macports_package.rb
+++ b/lib/chef/resource/macports_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class MacportsPackage < Chef::Resource::Package
-      unified_mode true
       provides :macports_package
 
       description "Use the **macports_package** resource to manage packages for the macOS platform using the MacPorts package management system."

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Mdadm < Chef::Resource
-      unified_mode true
 
       provides :mdadm
 

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -23,7 +23,6 @@ class Chef
   class Resource
     class Mount < Chef::Resource
       description "Use the **mount** resource to manage a mounted file system."
-      unified_mode true
 
       provides :mount
 

--- a/lib/chef/resource/msu_package.rb
+++ b/lib/chef/resource/msu_package.rb
@@ -23,7 +23,6 @@ class Chef
   class Resource
     class MsuPackage < Chef::Resource::Package
       include Chef::Mixin::Uris
-      unified_mode true
 
       provides :msu_package
 

--- a/lib/chef/resource/notify_group.rb
+++ b/lib/chef/resource/notify_group.rb
@@ -21,8 +21,6 @@ class Chef
     class NotifyGroup < Chef::Resource
       provides :notify_group
 
-      unified_mode true
-
       description "The notify_group resource does nothing, and always fires notifications which are set on it.  Use it to DRY blocks of notifications that are common to multiple resources, and provide a single target for other resources to notify.  Unlike most resources, its default action is :nothing."
       introduced "15.8"
       examples <<~DOC

--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -25,7 +25,6 @@ require "ohai" unless defined?(Ohai::System)
 class Chef
   class Resource
     class Ohai < Chef::Resource
-      unified_mode true
 
       provides :ohai
 

--- a/lib/chef/resource/ohai_hint.rb
+++ b/lib/chef/resource/ohai_hint.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class OhaiHint < Chef::Resource
-      unified_mode true
 
       provides(:ohai_hint) { true }
 

--- a/lib/chef/resource/openbsd_package.rb
+++ b/lib/chef/resource/openbsd_package.rb
@@ -25,7 +25,6 @@ require_relative "../provider/package/openbsd"
 class Chef
   class Resource
     class OpenbsdPackage < Chef::Resource::Package
-      unified_mode true
       provides :openbsd_package
       provides :package, os: "openbsd"
 

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -23,8 +23,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      unified_mode true
-
       provides(:openssl_dhparam) { true }
 
       description "Use the **openssl_dhparam** resource to generate `dhparam.pem` files. If a valid `dhparam.pem` file is found at the specified location, no new file will be created. If a file is found at the specified location but it is not a valid `dhparam.pem` file, it will be overwritten."

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -24,8 +24,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      unified_mode true
-
       provides :openssl_ec_private_key
 
       description "Use the **openssl_ec_private_key** resource to generate an elliptic curve (EC) private key file. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, then it will be overwritten."

--- a/lib/chef/resource/openssl_ec_public_key.rb
+++ b/lib/chef/resource/openssl_ec_public_key.rb
@@ -24,8 +24,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      unified_mode true
-
       provides :openssl_ec_public_key
 
       description "Use the **openssl_ec_public_key** resource to generate elliptic curve (EC) public key files from a given EC private key."

--- a/lib/chef/resource/openssl_rsa_private_key.rb
+++ b/lib/chef/resource/openssl_rsa_private_key.rb
@@ -23,8 +23,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      unified_mode true
-
       provides(:openssl_rsa_private_key) { true }
       provides(:openssl_rsa_key) { true } # legacy cookbook resource name
 

--- a/lib/chef/resource/openssl_rsa_public_key.rb
+++ b/lib/chef/resource/openssl_rsa_public_key.rb
@@ -23,8 +23,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      unified_mode true
-
       provides(:openssl_rsa_public_key) { true }
 
       examples <<~DOC

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -24,8 +24,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      unified_mode true
-
       provides :openssl_x509_certificate
       provides(:openssl_x509) { true } # legacy cookbook name.
 

--- a/lib/chef/resource/openssl_x509_crl.rb
+++ b/lib/chef/resource/openssl_x509_crl.rb
@@ -24,8 +24,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      unified_mode true
-
       provides :openssl_x509_crl
 
       description "Use the **openssl_x509_crl** resource to generate PEM-formatted x509 certificate revocation list (CRL) files."

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -24,8 +24,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      unified_mode true
-
       provides :openssl_x509_request
 
       description "Use the **openssl_x509_request** resource to generate PEM-formatted x509 certificates requests. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate."

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -25,7 +25,6 @@ autoload :Plist, "plist"
 class Chef
   class Resource
     class OsxProfile < Chef::Resource
-      unified_mode true
 
       provides :osx_profile
       provides :osx_config_profile

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Package < Chef::Resource
-      unified_mode true
       provides :package
 
       description "Use the **package** resource to manage packages. When the package is"\

--- a/lib/chef/resource/pacman_package.rb
+++ b/lib/chef/resource/pacman_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class PacmanPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :pacman_package
 

--- a/lib/chef/resource/paludis_package.rb
+++ b/lib/chef/resource/paludis_package.rb
@@ -22,7 +22,6 @@ require_relative "../provider/package/paludis"
 class Chef
   class Resource
     class PaludisPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :paludis_package
 

--- a/lib/chef/resource/perl.rb
+++ b/lib/chef/resource/perl.rb
@@ -21,7 +21,6 @@ require_relative "script"
 class Chef
   class Resource
     class Perl < Chef::Resource::Script
-      unified_mode true
 
       provides :perl
 

--- a/lib/chef/resource/plist.rb
+++ b/lib/chef/resource/plist.rb
@@ -22,7 +22,6 @@ class Chef
   class Resource
 
     class PlistResource < Chef::Resource # we name this PlistResource to avoid confusion with Plist from the plist gem
-      unified_mode true
 
       provides :plist
 

--- a/lib/chef/resource/portage_package.rb
+++ b/lib/chef/resource/portage_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class PortagePackage < Chef::Resource::Package
-      unified_mode true
 
       provides :portage_package
 

--- a/lib/chef/resource/powershell_package.rb
+++ b/lib/chef/resource/powershell_package.rb
@@ -20,7 +20,6 @@ require_relative "package"
 class Chef
   class Resource
     class PowershellPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :powershell_package
 

--- a/lib/chef/resource/powershell_package_source.rb
+++ b/lib/chef/resource/powershell_package_source.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class PowershellPackageSource < Chef::Resource
-      unified_mode true
 
       provides :powershell_package_source
 

--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -20,7 +20,6 @@ require_relative "windows_script"
 class Chef
   class Resource
     class PowershellScript < Chef::Resource::WindowsScript
-      unified_mode true
 
       set_guard_inherited_attributes(:interpreter)
 

--- a/lib/chef/resource/python.rb
+++ b/lib/chef/resource/python.rb
@@ -20,7 +20,6 @@ require_relative "script"
 class Chef
   class Resource
     class Python < Chef::Resource::Script
-      unified_mode true
 
       provides :python
 

--- a/lib/chef/resource/reboot.rb
+++ b/lib/chef/resource/reboot.rb
@@ -22,7 +22,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class Reboot < Chef::Resource
-      unified_mode true
 
       provides :reboot
 

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -23,7 +23,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class RegistryKey < Chef::Resource
-      unified_mode true
 
       provides(:registry_key) { true }
 

--- a/lib/chef/resource/remote_directory.rb
+++ b/lib/chef/resource/remote_directory.rb
@@ -25,7 +25,6 @@ class Chef
   class Resource
     class RemoteDirectory < Chef::Resource::Directory
       include Chef::Mixin::Securable
-      unified_mode true
 
       provides :remote_directory
 

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -28,7 +28,6 @@ class Chef
   class Resource
     class RemoteFile < Chef::Resource::File
       include Chef::Mixin::Securable
-      unified_mode true
 
       provides :remote_file
 

--- a/lib/chef/resource/rhsm_errata.rb
+++ b/lib/chef/resource/rhsm_errata.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class RhsmErrata < Chef::Resource
-      unified_mode true
       provides(:rhsm_errata) { true }
 
       description "Use the **rhsm_errata** resource to install packages associated with a given Red Hat Subscription Manager Errata ID. This is helpful if packages to mitigate a single vulnerability must be installed on your hosts."

--- a/lib/chef/resource/rhsm_errata_level.rb
+++ b/lib/chef/resource/rhsm_errata_level.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class RhsmErrataLevel < Chef::Resource
-      unified_mode true
       provides(:rhsm_errata_level) { true }
 
       description "Use the **rhsm_errata_level** resource to install all packages of a specified errata level from the Red Hat Subscription Manager. For example, you can ensure that all packages associated with errata marked at a 'Critical' security level are installed."

--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -22,7 +22,6 @@ require "shellwords" unless defined?(Shellwords)
 class Chef
   class Resource
     class RhsmRegister < Chef::Resource
-      unified_mode true
       provides(:rhsm_register) { true }
 
       description "Use the **rhsm_register** resource to register a node with the Red Hat Subscription Manager or a local Red Hat Satellite server."

--- a/lib/chef/resource/rhsm_repo.rb
+++ b/lib/chef/resource/rhsm_repo.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class RhsmRepo < Chef::Resource
-      unified_mode true
 
       provides(:rhsm_repo) { true }
 

--- a/lib/chef/resource/rhsm_subscription.rb
+++ b/lib/chef/resource/rhsm_subscription.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class RhsmSubscription < Chef::Resource
-      unified_mode true
 
       provides(:rhsm_subscription) { true }
 

--- a/lib/chef/resource/route.rb
+++ b/lib/chef/resource/route.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Route < Chef::Resource
-      unified_mode true
 
       provides :route
 

--- a/lib/chef/resource/rpm_package.rb
+++ b/lib/chef/resource/rpm_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class RpmPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :rpm_package
 

--- a/lib/chef/resource/ruby.rb
+++ b/lib/chef/resource/ruby.rb
@@ -21,7 +21,6 @@ require_relative "script"
 class Chef
   class Resource
     class Ruby < Chef::Resource::Script
-      unified_mode true
 
       provides :ruby
 

--- a/lib/chef/resource/ruby_block.rb
+++ b/lib/chef/resource/ruby_block.rb
@@ -24,7 +24,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class RubyBlock < Chef::Resource
-      unified_mode true
 
       provides :ruby_block, target_mode: true
 

--- a/lib/chef/resource/scm/_scm.rb
+++ b/lib/chef/resource/scm/_scm.rb
@@ -16,8 +16,6 @@
 # limitations under the License.
 #
 
-unified_mode true
-
 default_action :sync
 allowed_actions :checkout, :export, :sync, :diff, :log
 

--- a/lib/chef/resource/scm/git.rb
+++ b/lib/chef/resource/scm/git.rb
@@ -23,8 +23,6 @@ class Chef
     class Git < Chef::Resource
       use "scm"
 
-      unified_mode true
-
       provides :git
 
       description "Use the **git** resource to manage source control resources that exist in a git repository. git version 1.6.5 (or higher) is required to use all of the functionality in the git resource."

--- a/lib/chef/resource/scm/subversion.rb
+++ b/lib/chef/resource/scm/subversion.rb
@@ -24,8 +24,6 @@ class Chef
     class Subversion < Chef::Resource
       use "scm"
 
-      unified_mode true
-
       provides :subversion
 
       description "Use the **subversion** resource to manage source control resources that exist in a Subversion repository. Warning: The subversion resource has known bugs and may not work as expected. For more information see Chef GitHub issues, particularly [#4050](https://github.com/chef/chef/issues/4050) and [#4257](https://github.com/chef/chef/issues/4257)."

--- a/lib/chef/resource/script.rb
+++ b/lib/chef/resource/script.rb
@@ -22,7 +22,6 @@ require_relative "execute"
 class Chef
   class Resource
     class Script < Chef::Resource::Execute
-      unified_mode true
 
       provides :script
 

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -27,7 +27,6 @@ class Chef
     class Service < Chef::Resource
       include Chef::Platform::ServiceHelpers
       extend Chef::Platform::ServiceHelpers
-      unified_mode true
 
       provides :service, target_mode: true
 

--- a/lib/chef/resource/smartos_package.rb
+++ b/lib/chef/resource/smartos_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class SmartosPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :smartos_package
       provides :package, platform_family: "smartos"

--- a/lib/chef/resource/snap_package.rb
+++ b/lib/chef/resource/snap_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class SnapPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :snap_package
 

--- a/lib/chef/resource/solaris_package.rb
+++ b/lib/chef/resource/solaris_package.rb
@@ -22,7 +22,6 @@ require_relative "package"
 class Chef
   class Resource
     class SolarisPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :solaris_package
 

--- a/lib/chef/resource/ssh_known_hosts_entry.rb
+++ b/lib/chef/resource/ssh_known_hosts_entry.rb
@@ -23,7 +23,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class SshKnownHostsEntry < Chef::Resource
-      unified_mode true
 
       provides :ssh_known_hosts_entry
 

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -24,7 +24,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Sudo < Chef::Resource
-      unified_mode true
 
       provides(:sudo) { true }
 

--- a/lib/chef/resource/swap_file.rb
+++ b/lib/chef/resource/swap_file.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class SwapFile < Chef::Resource
-      unified_mode true
 
       provides(:swap_file) { true }
 

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Sysctl < Chef::Resource
-      unified_mode true
 
       provides(:sysctl) { true }
       provides(:sysctl_param) { true }

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -23,7 +23,6 @@ require "iniparse"
 class Chef
   class Resource
     class SystemdUnit < Chef::Resource
-      unified_mode true
 
       provides(:systemd_unit) { true }
 

--- a/lib/chef/resource/template.rb
+++ b/lib/chef/resource/template.rb
@@ -34,7 +34,6 @@ class Chef
     # chef-client. This resource includes actions and properties from the file resource. Template files managed by the
     # template resource follow the same file specificity rules as the remote_file and file resources.
     class Template < Chef::Resource::File
-      unified_mode true
 
       provides :template
 

--- a/lib/chef/resource/timezone.rb
+++ b/lib/chef/resource/timezone.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Timezone < Chef::Resource
-      unified_mode true
 
       provides :timezone
 

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class User < Chef::Resource
-      unified_mode true
 
       description "Use the **user** resource to add users, update existing users, remove users, and to lock/unlock user passwords."
 

--- a/lib/chef/resource/user/aix_user.rb
+++ b/lib/chef/resource/user/aix_user.rb
@@ -21,7 +21,6 @@ class Chef
   class Resource
     class User
       class AixUser < Chef::Resource::User
-        unified_mode true
 
         provides :aix_user
         provides :user, os: "aix"

--- a/lib/chef/resource/user/linux_user.rb
+++ b/lib/chef/resource/user/linux_user.rb
@@ -21,7 +21,6 @@ class Chef
   class Resource
     class User
       class LinuxUser < Chef::Resource::User
-        unified_mode true
 
         provides :linux_user
         provides :user, os: "linux"

--- a/lib/chef/resource/user/mac_user.rb
+++ b/lib/chef/resource/user/mac_user.rb
@@ -58,7 +58,6 @@ class Chef
       #   the 'password' property corresponds to a plaintext password and will
       #   attempt to use it in place of secure_token_password if it not set.
       class MacUser < Chef::Resource::User
-        unified_mode true
 
         provides :mac_user
         provides :user, platform: "mac_os_x"

--- a/lib/chef/resource/user/pw_user.rb
+++ b/lib/chef/resource/user/pw_user.rb
@@ -21,7 +21,6 @@ class Chef
   class Resource
     class User
       class PwUser < Chef::Resource::User
-        unified_mode true
 
         provides :pw_user
         provides :user, os: "freebsd"

--- a/lib/chef/resource/user/solaris_user.rb
+++ b/lib/chef/resource/user/solaris_user.rb
@@ -21,7 +21,6 @@ class Chef
   class Resource
     class User
       class SolarisUser < Chef::Resource::User
-        unified_mode true
 
         provides :solaris_user
         provides :user, os: %w{omnios solaris2}

--- a/lib/chef/resource/user/windows_user.rb
+++ b/lib/chef/resource/user/windows_user.rb
@@ -21,7 +21,6 @@ class Chef
   class Resource
     class User
       class WindowsUser < Chef::Resource::User
-        unified_mode true
 
         provides :windows_user
         provides :user, os: "windows"

--- a/lib/chef/resource/user_ulimit.rb
+++ b/lib/chef/resource/user_ulimit.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class UserUlimit < Chef::Resource
-      unified_mode true
 
       provides :user_ulimit
 

--- a/lib/chef/resource/whyrun_safe_ruby_block.rb
+++ b/lib/chef/resource/whyrun_safe_ruby_block.rb
@@ -20,7 +20,6 @@ class Chef
   class Resource
     class WhyrunSafeRubyBlock < Chef::Resource::RubyBlock
       provides :whyrun_safe_ruby_block
-      unified_mode true
     end
   end
 end

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -23,8 +23,6 @@ class Chef
     class WindowsAdJoin < Chef::Resource
       provides :windows_ad_join
 
-      unified_mode true
-
       description "Use the **windows_ad_join** resource to join a Windows Active Directory domain."
       introduced "14.0"
       examples <<~DOC

--- a/lib/chef/resource/windows_audit_policy.rb
+++ b/lib/chef/resource/windows_audit_policy.rb
@@ -83,8 +83,6 @@ class Chef
                                  "User Account Management",
                                 ].freeze
 
-      unified_mode true
-
       provides :windows_audit_policy
 
       description "Use the **windows_audit_policy** resource to configure system level and per-user Windows advanced audit policy settings."

--- a/lib/chef/resource/windows_auto_run.rb
+++ b/lib/chef/resource/windows_auto_run.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsAutorun < Chef::Resource
-      unified_mode true
 
       provides(:windows_auto_run) { true }
 

--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -29,7 +29,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class WindowsCertificate < Chef::Resource
-      unified_mode true
 
       provides :windows_certificate
 

--- a/lib/chef/resource/windows_defender.rb
+++ b/lib/chef/resource/windows_defender.rb
@@ -19,7 +19,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDefender < Chef::Resource
-      unified_mode true
       provides :windows_defender
 
       description "Use the **windows_defender** resource to enable or disable the Microsoft Windows Defender service."

--- a/lib/chef/resource/windows_defender_exclusion.rb
+++ b/lib/chef/resource/windows_defender_exclusion.rb
@@ -45,7 +45,6 @@ class Chef
       end
       ```
       DOC
-      unified_mode true
 
       property :paths, [String, Array], default: [],
         coerce: proc { |x| to_consistent_path_array(x) },

--- a/lib/chef/resource/windows_dfs_folder.rb
+++ b/lib/chef/resource/windows_dfs_folder.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDfsFolder < Chef::Resource
-      unified_mode true
 
       provides :windows_dfs_folder
 

--- a/lib/chef/resource/windows_dfs_namespace.rb
+++ b/lib/chef/resource/windows_dfs_namespace.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDfsNamespace < Chef::Resource
-      unified_mode true
 
       provides :windows_dfs_namespace
 

--- a/lib/chef/resource/windows_dfs_server.rb
+++ b/lib/chef/resource/windows_dfs_server.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDfsServer < Chef::Resource
-      unified_mode true
 
       provides :windows_dfs_server
 

--- a/lib/chef/resource/windows_dns_record.rb
+++ b/lib/chef/resource/windows_dns_record.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDnsRecord < Chef::Resource
-      unified_mode true
 
       provides :windows_dns_record
 

--- a/lib/chef/resource/windows_dns_zone.rb
+++ b/lib/chef/resource/windows_dns_zone.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDnsZone < Chef::Resource
-      unified_mode true
 
       provides :windows_dns_zone
 

--- a/lib/chef/resource/windows_env.rb
+++ b/lib/chef/resource/windows_env.rb
@@ -24,7 +24,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class WindowsEnv < Chef::Resource
-      unified_mode true
 
       provides :windows_env
       provides :env # backwards compat with the pre-Chef 14 resource name

--- a/lib/chef/resource/windows_feature.rb
+++ b/lib/chef/resource/windows_feature.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsFeature < Chef::Resource
-      unified_mode true
 
       provides(:windows_feature) { true }
 

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -22,7 +22,6 @@ require_relative "../platform/query_helpers"
 class Chef
   class Resource
     class WindowsFeatureDism < Chef::Resource
-      unified_mode true
 
       provides(:windows_feature_dism) { true }
 

--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -23,7 +23,6 @@ require_relative "../platform/query_helpers"
 class Chef
   class Resource
     class WindowsFeaturePowershell < Chef::Resource
-      unified_mode true
 
       provides(:windows_feature_powershell) { true }
 

--- a/lib/chef/resource/windows_firewall_profile.rb
+++ b/lib/chef/resource/windows_firewall_profile.rb
@@ -58,8 +58,6 @@ class Chef
       ```
       DOC
 
-      unified_mode true
-
       property :profile, String,
         name_property: true,
         equal_to: %w{ Domain Public Private },

--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -22,7 +22,6 @@
 class Chef
   class Resource
     class WindowsFirewallRule < Chef::Resource
-      unified_mode true
 
       provides :windows_firewall_rule
 

--- a/lib/chef/resource/windows_font.rb
+++ b/lib/chef/resource/windows_font.rb
@@ -21,7 +21,6 @@ class Chef
   class Resource
     class WindowsFont < Chef::Resource
       require_relative "../util/path_helper"
-      unified_mode true
 
       provides(:windows_font) { true }
 

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -26,7 +26,6 @@ class Chef
   class Resource
     class WindowsPackage < Chef::Resource::Package
       include Chef::Mixin::Uris
-      unified_mode true
 
       provides(:windows_package) { true }
       provides :package, os: "windows"

--- a/lib/chef/resource/windows_pagefile.rb
+++ b/lib/chef/resource/windows_pagefile.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsPagefile < Chef::Resource
-      unified_mode true
 
       provides(:windows_pagefile) { true }
 

--- a/lib/chef/resource/windows_path.rb
+++ b/lib/chef/resource/windows_path.rb
@@ -23,7 +23,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsPath < Chef::Resource
-      unified_mode true
 
       provides(:windows_path) { true }
 

--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -27,7 +27,6 @@ class Chef
     # 2. Fail with a warning if the port can't be found and create_port is false
     # 3. Fail with helpful messaging if the printer driver can't be installed
     class WindowsPrinter < Chef::Resource
-      unified_mode true
 
       autoload :Resolv, "resolv"
 

--- a/lib/chef/resource/windows_printer_port.rb
+++ b/lib/chef/resource/windows_printer_port.rb
@@ -23,7 +23,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsPrinterPort < Chef::Resource
-      unified_mode true
 
       autoload :Resolv, "resolv"
 

--- a/lib/chef/resource/windows_script.rb
+++ b/lib/chef/resource/windows_script.rb
@@ -24,8 +24,6 @@ class Chef
     class WindowsScript < Chef::Resource::Script
       include Chef::Mixin::WindowsArchitectureHelper
 
-      unified_mode true
-
       # This is an abstract resource meant to be subclasses; thus no 'provides'
 
       set_guard_inherited_attributes(:architecture)

--- a/lib/chef/resource/windows_security_policy.rb
+++ b/lib/chef/resource/windows_security_policy.rb
@@ -22,7 +22,6 @@ require "tempfile" unless defined?(Tempfile)
 class Chef
   class Resource
     class WindowsSecurityPolicy < Chef::Resource
-      unified_mode true
 
       provides :windows_security_policy
 

--- a/lib/chef/resource/windows_service.rb
+++ b/lib/chef/resource/windows_service.rb
@@ -23,7 +23,6 @@ class Chef
   class Resource
     class WindowsService < Chef::Resource::Service
       include Chef::Win32ServiceConstants
-      unified_mode true
 
       ALLOWED_START_TYPES = {
         automatic: SERVICE_AUTO_START,

--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -25,7 +25,6 @@ require_relative "../util/path_helper"
 class Chef
   class Resource
     class WindowsShare < Chef::Resource
-      unified_mode true
 
       provides :windows_share
 

--- a/lib/chef/resource/windows_shortcut.rb
+++ b/lib/chef/resource/windows_shortcut.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsShortcut < Chef::Resource
-      unified_mode true
 
       provides(:windows_shortcut) { true }
 

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -27,7 +27,6 @@ require "win32/taskscheduler" if ChefUtils.windows_ruby?
 class Chef
   class Resource
     class WindowsTask < Chef::Resource
-      unified_mode true
 
       provides(:windows_task) { true }
 

--- a/lib/chef/resource/windows_uac.rb
+++ b/lib/chef/resource/windows_uac.rb
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsUac < Chef::Resource
-      unified_mode true
 
       provides :windows_uac
 

--- a/lib/chef/resource/windows_update_settings.rb
+++ b/lib/chef/resource/windows_update_settings.rb
@@ -23,7 +23,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsUpdateSettings < Chef::Resource
-      unified_mode true
 
       provides :windows_update_settings
 

--- a/lib/chef/resource/windows_user_privilege.rb
+++ b/lib/chef/resource/windows_user_privilege.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsUserPrivilege < Chef::Resource
-      unified_mode true
 
       provides :windows_user_privilege
       description "The windows_user_privilege resource allows to add and set principal (User/Group) to the specified privilege.\n Ref: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/user-rights-assignment"

--- a/lib/chef/resource/windows_workgroup.rb
+++ b/lib/chef/resource/windows_workgroup.rb
@@ -21,7 +21,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class WindowsWorkgroup < Chef::Resource
-      unified_mode true
 
       provides :windows_workgroup
 

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -22,7 +22,6 @@ require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 class Chef
   class Resource
     class YumPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :yum_package
       provides :package, platform_family: "fedora_derived"

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class YumRepository < Chef::Resource
-      unified_mode true
 
       provides(:yum_repository) { true }
 

--- a/lib/chef/resource/zypper_package.rb
+++ b/lib/chef/resource/zypper_package.rb
@@ -21,7 +21,6 @@ require_relative "package"
 class Chef
   class Resource
     class ZypperPackage < Chef::Resource::Package
-      unified_mode true
 
       provides :zypper_package
       provides :package, platform_family: "suse"

--- a/lib/chef/resource/zypper_repository.rb
+++ b/lib/chef/resource/zypper_repository.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class ZypperRepository < Chef::Resource
-      unified_mode true
 
       provides(:zypper_repository) { true }
       provides(:zypper_repo) { true } # legacy cookbook compatibility


### PR DESCRIPTION
This is the breaking change for Chef 18, which was announced
throughout the Chef-17 cycle.

This should never be backported to Chef 17 or before
