### PR TITLE
Ruby 3.1 fixes

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -113,7 +113,7 @@ class Chef
       dirname = ::File.dirname(partial)
       basename = ::File.basename(partial, ".rb")
       basename = basename[1..] if basename.start_with?("_")
-      class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.absolute_path)))
+      class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.path)))
     end
 
     # delegate to the resource

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1501,7 +1501,7 @@ class Chef
       dirname = ::File.dirname(partial)
       basename = ::File.basename(partial, ".rb")
       basename = basename[1..] if basename.start_with?("_")
-      class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.absolute_path)))
+      class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.path)))
     end
 
     # The cookbook in which this Resource was defined (if any).


### PR DESCRIPTION
caller_location.first.absolute_path returns nil sometimes on ruby 3.1

switch to .path which is going to always be an absolute path anyway, but
which ruby 3.1 doesn't return nil for.

i have no idea why.  smells like a ruby language bug.
