### PR TITLE
IPACK-136 Improve some verify pipeline windows tests

### DIFF
--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -9,12 +9,8 @@ $ErrorActionPreference = 'Stop'
 
 Write-Output "--- Enable Ruby 2.7"
 
-Write-Output "Add Uru to Environment PATH"
-$env:PATH = "C:\Program Files (x86)\Uru;" + $env:PATH
-[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
-
 Write-Output "Register Installed Ruby Version 2.7 With Uru"
-Start-Process "C:\Program Files (x86)\Uru\uru_rt.exe" -ArgumentList 'admin add C:\ruby27\bin' -Wait
+Start-Process "uru_rt.exe" -ArgumentList 'admin add C:\ruby27\bin' -Wait
 uru 271
 if (-not $?) { throw "Can't Activate Ruby. Did Uru Registration Succeed?" }
 ruby -v

--- a/.expeditor/scripts/bk_win_integration.ps1
+++ b/.expeditor/scripts/bk_win_integration.ps1
@@ -2,8 +2,7 @@ $CurrentDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $PrepScript = Join-Path $CurrentDirectory "bk_win_prep.ps1"
 Invoke-Expression $PrepScript
 
-# Set-Item -Path Env:Path -Value ($Env:Path + ";C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin")
-$Env:Path="C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\ruby27\bin;C:\ci-studio-common\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\Go\bin;C:\Users\ContainerAdministrator\go\bin"
+Set-Item -Path Env:Path -Value ("C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;" + $Env:Path)
 
 winrm quickconfig -q
 

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -260,7 +260,7 @@ steps:
       docker:
         image: rubydistros/fedora-latest:3.0
 
-- label: "Functional Windows :ruby: 3.0"
+- label: "Functional Windows :ruby: 2.7"
   commands:
     - .expeditor/scripts/bk_win_functional.ps1
   expeditor:


### PR DESCRIPTION
Update bk_win_integration.ps1 script to allow for different ruby versions

Update bk_win_functional.ps1 in verify pipeline. Remove some unnecessary things from the script and update the verify pipeline to show that the test is using ruby 2.7.