### PR TITLE
Add rubygems_url property to chef_client_config resource

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_config.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_config.rb
@@ -4,6 +4,7 @@ chef_client_config "Create chef-client's client.rb" do
   chef_license "accept"
   ohai_optional_plugins %i{Passwd Lspci Sysctl}
   ohai_disabled_plugins %i{Sessions Interrupts}
+  rubygems_url "https://rubygems.org/"
   additional_config <<~CONFIG
     begin
       require 'aws-sdk'

--- a/kitchen-tests/test/integration/end-to-end/_chef_client_config.rb
+++ b/kitchen-tests/test/integration/end-to-end/_chef_client_config.rb
@@ -7,5 +7,6 @@ client_rb = if os.windows?
 describe file(client_rb) do
   its("content") { should match(%r{chef_server_url "https://localhost"}) }
   its("content") { should match(/chef_license "accept"/) }
+  its("content") { should match(%r{rubygems_url "https://rubygems.org/"}) }
   its("content") { should match(/require 'aws-sdk'/) }
 end

--- a/lib/chef/resource/chef_client_config.rb
+++ b/lib/chef/resource/chef_client_config.rb
@@ -208,6 +208,10 @@ class Chef
         description: %q(An array of hashes that contain a report handler class and the arguments to pass to that class on initialization. The hash should include `class` and `argument` keys where `class` is a String and `argument` is an array of quoted String values. For example: `[{'class' => 'MyHandler', %w('"argument1"', '"argument2"')}]`),
         default: []
 
+      property :rubygems_url, [String, Array],
+        description: "The location to source rubygems. It can be set to a string or array of strings for URIs to set as rubygems sources. This allows individuals to setup an internal mirror of rubygems for “airgapped” environments.",
+        introduced: "17.11"
+
       property :exception_handlers, Array,
         description: %q(An array of hashes that contain a exception handler class and the arguments to pass to that class on initialization. The hash should include `class` and `argument` keys where `class` is a String and `argument` is an array of quoted String values. For example: `[{'class' => 'MyHandler', %w('"argument1"', '"argument2"')}]`),
         default: []
@@ -295,6 +299,7 @@ class Chef
             policy_group: new_resource.policy_group,
             policy_name: new_resource.policy_name,
             report_handlers: format_handler(new_resource.report_handlers),
+            rubygems_url: new_resource.rubygems_url,
             ssl_verify_mode: new_resource.ssl_verify_mode,
             start_handlers: format_handler(new_resource.start_handlers),
             additional_config: new_resource.additional_config,

--- a/lib/chef/resource/support/client.erb
+++ b/lib/chef/resource/support/client.erb
@@ -18,6 +18,7 @@
       @pid_file
       @policy_group
       @policy_name
+      @rubygems_url
       @ssl_verify_mode
       @policy_persist_run_list).each do |prop| -%>
 <% next if instance_variable_get(prop).nil? || instance_variable_get(prop).empty? -%>

--- a/spec/unit/resource/chef_client_config_spec.rb
+++ b/spec/unit/resource/chef_client_config_spec.rb
@@ -134,4 +134,12 @@ describe Chef::Resource::ChefClientConfig do
       expect(provider.format_handler([{ "class" => "Foo", "arguments" => ["'one'", "two", "three"] }])).to eql(["Foo.new('one',two,three)"])
     end
   end
+
+  describe "rubygems_url property" do
+    it "accepts nil, a single URL, or an array of URLs" do
+      expect { resource.rubygems_url(nil) }.not_to raise_error
+      expect { resource.rubygems_url("https://rubygems.internal.example.com") }.not_to raise_error
+      expect { resource.rubygems_url(["https://rubygems.east.example.com", "https://rubygems.west.example.com"]) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Adds a `rubygems_url` property to the `chef_client_config` resource to configure the same such property in `client.rb`

## Related Issue
Fixes #12711 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
