### PR TITLE
Fix chef15 perf regression in docker? helper

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/introspection.rb
+++ b/chef-utils/lib/chef-utils/dsl/introspection.rb
@@ -48,9 +48,7 @@ module ChefUtils
       # @return [Boolean]
       #
       def docker?(node = __getnode)
-        # Using "File.exist?('/.dockerinit') || File.exist?('/.dockerenv')" makes Travis sad,
-        # and that makes us sad too.
-        !!(node && node.read("virtualization", "systems", "docker") == "guest")
+        File.exist?("/.dockerinit") || File.exist?("/.dockerenv")
       end
 
       # Determine if the node uses the systemd init system.

--- a/chef-utils/spec/unit/dsl/introspection_spec.rb
+++ b/chef-utils/spec/unit/dsl/introspection_spec.rb
@@ -45,18 +45,20 @@ RSpec.describe ChefUtils::DSL::Introspection do
   end
 
   context "#docker?" do
-    # FIXME: use a real VividMash for these tests instead of stubbing
     it "is false by default" do
-      expect(node).to receive(:read).with("virtualization", "systems", "docker").and_return(nil)
+      allow(File).to receive(:exist?).with("/.dockerinit").and_return(false)
+      allow(File).to receive(:exist?).with("/.dockerenv").and_return(false)
       expect(ChefUtils.docker?(node)).to be false
     end
-    it "is true when ohai reports a docker guest" do
-      expect(node).to receive(:read).with("virtualization", "systems", "docker").and_return("guest")
+    it "is true when /.dockerinit exists" do
+      allow(File).to receive(:exist?).with("/.dockerinit").and_return(true)
+      allow(File).to receive(:exist?).with("/.dockerenv").and_return(false)
       expect(ChefUtils.docker?(node)).to be true
     end
-    it "is false for any other value other than guest" do
-      expect(node).to receive(:read).with("virtualization", "systems", "docker").and_return("some nonsense")
-      expect(ChefUtils.docker?(node)).to be false
+    it "is true when /.dockerenv exists" do
+      allow(File).to receive(:exist?).with("/.dockerinit").and_return(false)
+      allow(File).to receive(:exist?).with("/.dockerenv").and_return(true)
+      expect(ChefUtils.docker?(node)).to be true
     end
   end
 

--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -133,6 +133,7 @@ shared_examples_for Chef::Provider::File do
   before(:each) do
     allow(content).to receive(:tempfile).and_return(tempfile)
     allow(File).to receive(:exist?).with(tempfile.path).and_call_original
+    allow(resource).to receive(:docker?).and_return(false)
   end
 
   after do

--- a/spec/unit/provider/apt_update_spec.rb
+++ b/spec/unit/provider/apt_update_spec.rb
@@ -84,6 +84,7 @@ describe "Chef::Provider::AptUpdate" do
 
     it "should run if the time stamp is old" do
       expect(File).to receive(:mtime).with("#{stamp_dir}/update-success-stamp").and_return(Time.now - 86_500)
+      allow_any_instance_of(Chef::Resource::File).to receive(:docker?).and_return(false)
       expect_any_instance_of(Chef::Provider::Execute).to receive(:shell_out_compacted!).with(*apt_update_cmd, anything)
       provider.run_action(:periodic)
       expect(new_resource).to be_updated_by_last_action
@@ -103,6 +104,7 @@ describe "Chef::Provider::AptUpdate" do
 
       it "should run if the time stamp is old" do
         expect(File).to receive(:mtime).with("#{stamp_dir}/update-success-stamp").and_return(Time.now - 500)
+        allow_any_instance_of(Chef::Resource::File).to receive(:docker?).and_return(false)
         expect_any_instance_of(Chef::Provider::Execute).to receive(:shell_out_compacted!).with(*apt_update_cmd, anything)
         provider.run_action(:periodic)
         expect(new_resource).to be_updated_by_last_action

--- a/spec/unit/provider/template_spec.rb
+++ b/spec/unit/provider/template_spec.rb
@@ -57,6 +57,9 @@ describe Chef::Provider::Template do
   it_behaves_like Chef::Provider::File
 
   context "when creating the template" do
+    before(:each) do
+      allow(resource).to receive(:docker?).and_return(false)
+    end
 
     let(:enclosing_directory) do
       canonicalize_path(File.expand_path(File.join(CHEF_SPEC_DATA, "templates")))


### PR DESCRIPTION
This closes #12710.

Reverting back to the `File.exist?` checks and bypassing node access seems to completely fix the perf regression.  Going from `node.read` to the manual nil checking in the 15.4.x code for `docker?` actually fixed the bulk of the perf regression.  While this should fix the regression, none of it actually makes any sense and there's pretty clearly some underlying node attribute performance bug that this change tickled and which is not being fixed at all in this PR.  I have no explanation for why `node.read` should perform so badly over doing things manually--that makes absolutely no sense at all.