### PR TITLE
Updating Gemfile.lock to update mixlib-shellout to 3.2.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,9 +278,9 @@ GEM
     mixlib-config (3.0.9)
       tomlrb
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.5)
+    mixlib-shellout (3.2.6)
       chef-utils
-    mixlib-shellout (3.2.5-universal-mingw32)
+    mixlib-shellout (3.2.6-universal-mingw32)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

