### PR TITLE
set default values for user and host on userdefaults

### DIFF
--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -40,4 +40,4 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: false
     - run: bundle install
-    - run: bundle exec rspec spec/functional/resource/macos_userdefaults_spec.rb
+    - run: sudo bundle exec rspec spec/functional/resource/macos_userdefaults_spec.rb

--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -79,6 +79,7 @@ class Chef
 
       property :host, [String, Symbol],
         description: "Set either :current, :all or a hostname to set the user default at the host level.",
+        default: :all,
         desired_state: false,
         introduced: "16.3"
 
@@ -94,6 +95,7 @@ class Chef
 
       property :user, [String, Symbol],
         description: "The system user that the default will be applied to. Set :current for current user, :all for all users or pass a valid username",
+        default: :current,
         desired_state: false
 
       property :sudo, [TrueClass, FalseClass],

--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -50,15 +50,17 @@ class Chef
         end
         ```
 
-        **Specifying the type of a key to skip automatic type detection**
+        **Setting a value for specific user and hosts**
 
         ```ruby
-        macos_userdefaults 'Finder expanded save dialogs' do
-          key 'NSNavPanelExpandedStateForSaveMode'
-          value 'TRUE'
-          type 'bool'
+        macos_userdefaults 'Enable macOS firewall' do
+          key 'globalstate'
+          value 1
+          user 'jane'
+          host :current
         end
         ```
+
       DOC
 
       property :domain, String,

--- a/spec/functional/resource/macos_userdefaults_spec.rb
+++ b/spec/functional/resource/macos_userdefaults_spec.rb
@@ -38,12 +38,12 @@ describe Chef::Resource::MacosUserDefaults, :macos_only do
       expect(resource.domain).to eq("NSGlobalDomain")
     end
 
-    it "nil for the host property" do
-      expect(resource.host).to be_nil
+    it ":all for the host property" do
+      expect(resource.host).to :all
     end
 
-    it "nil for the user property" do
-      expect(resource.user).to be_nil
+    it ":current for the user property" do
+      expect(resource.user).to :current
     end
 
     it ":write for resource action" do

--- a/spec/functional/resource/macos_userdefaults_spec.rb
+++ b/spec/functional/resource/macos_userdefaults_spec.rb
@@ -39,11 +39,11 @@ describe Chef::Resource::MacosUserDefaults, :macos_only do
     end
 
     it ":all for the host property" do
-      expect(resource.host).to :all
+      expect(resource.host).to eq(:all)
     end
 
     it ":current for the user property" do
-      expect(resource.user).to :current
+      expect(resource.user).to eq(:current)
     end
 
     it ":write for resource action" do

--- a/spec/unit/resource/macos_user_defaults_spec.rb
+++ b/spec/unit/resource/macos_user_defaults_spec.rb
@@ -40,11 +40,11 @@ describe Chef::Resource::MacosUserDefaults, :macos_only do
     end
 
     it ":all for the host property" do
-      expect(resource.host).to :all
+      expect(resource.host).to eq(:all)
     end
 
     it ":current for the user property" do
-      expect(resource.user).to :current
+      expect(resource.user).to eq(:current)
     end
 
     it ":write for resource action" do

--- a/spec/unit/resource/macos_user_defaults_spec.rb
+++ b/spec/unit/resource/macos_user_defaults_spec.rb
@@ -39,12 +39,12 @@ describe Chef::Resource::MacosUserDefaults, :macos_only do
       expect(resource.domain).to eq("NSGlobalDomain")
     end
 
-    it "nil for the host property" do
-      expect(resource.host).to be_nil
+    it ":all for the host property" do
+      expect(resource.host).to :all
     end
 
-    it "nil for the user property" do
-      expect(resource.user).to be_nil
+    it ":current for the user property" do
+      expect(resource.user).to :current
     end
 
     it ":write for resource action" do


### PR DESCRIPTION
Signed-off-by: rishichawda <rishichawda@users.noreply.github.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

`user` property was not being used when `host` isn't passed. This is because how the native corefoundation APIs work where we can either pass both to `CFPreferencesSetValue` or pass none to `CFPreferencesSetAppValue`. This PR sets default values for user and host as current user and any host. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

https://github.com/chef/customer-bugs/issues/657

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
