### PR TITLE
Update windows gem name for chef

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,7 +63,7 @@ end
 task install: "pre_install:all"
 
 # make sure we build the correct gemspec on windows
-gemspec = Gem.win_platform? ? "chef-universal-mingw32" : "chef"
+gemspec = Gem.win_platform? ? "chef-universal-mingw-ucrt" : "chef"
 Bundler::GemHelper.install_tasks name: gemspec
 
 # this gets appended to the normal bundler install helper

--- a/chef-universal-mingw-ucrt.gemspec
+++ b/chef-universal-mingw-ucrt.gemspec
@@ -1,0 +1,22 @@
+gemspec = eval(IO.read(File.expand_path("chef.gemspec", __dir__)))
+
+gemspec.platform = Gem::Platform.new(%w{universal ucrt})
+
+gemspec.add_dependency "win32-api", "~> 1.5"
+gemspec.add_dependency "win32-event", "~> 0.6.1"
+# TODO: Relax this pin and make the necessary updaets. The issue originally
+# leading to this pin has been fixed in 0.6.5.
+gemspec.add_dependency "win32-eventlog", "0.6.3"
+gemspec.add_dependency "win32-mmap", "~> 0.4.1"
+gemspec.add_dependency "win32-mutex", "~> 0.4.2"
+gemspec.add_dependency "win32-process", "~> 0.9"
+gemspec.add_dependency "win32-service", ">= 2.1.5", "< 3.0"
+gemspec.add_dependency "wmi-lite", "~> 1.0"
+gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
+gemspec.add_dependency "iso8601", ">= 0.12.1", "< 0.14" # validate 0.14 when it comes out
+gemspec.add_dependency "win32-certstore", "~> 0.6.2" # 0.5+ required for specifying user vs. system store
+gemspec.add_dependency "chef-powershell", "~> 1.0.12" # The guts of the powershell_exec code have been moved to its own gem, chef-powershell. It's part of the chef-powershell-shim repo.
+gemspec.extensions << "ext/win32-eventlog/Rakefile"
+gemspec.files += Dir.glob("{distro,ext}/**/*")
+
+gemspec

--- a/post-bundle-install.rb
+++ b/post-bundle-install.rb
@@ -18,7 +18,7 @@ Dir["#{gem_home}/bundler/gems/*"].each do |gempath|
   next unless gem_name
 
   # FIXME: should omit the gem which is in the current directory and not hard code chef
-  next if %w{chef chef-universal-mingw32}.include?(gem_name)
+  next if %w{chef chef-universal-mingw32 chef-universal-mingw-ucrt}.include?(gem_name)
 
   puts "re-installing #{gem_name}..."
 


### PR DESCRIPTION
Under ruby 3.1, the platform name under windows has changed (mingw-win32 -> mingwucrt).
This is causing downstream dependencies under Windows to fail to load the correct gem
(universal-mingw-win32) because the platform does not match.

Updating the windows gem name to match (chef-universal-mingw-ucrt)

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
