### PR TITLE
bugfix: remove duplicate ohai params

### DIFF
--- a/lib/chef/resource/support/client.erb
+++ b/lib/chef/resource/support/client.erb
@@ -13,8 +13,6 @@
       @minimal_ohai
       @named_run_list
       @no_proxy
-      @ohai_disabled_plugins
-      @ohai_optional_plugins
       @pid_file
       @policy_group
       @policy_name


### PR DESCRIPTION
## Description

This fixes the rendering of `ohai_disabled_plugins` and `ohai_optional_plugins` properties in the `client.rb` template.

## Related Issue

- https://github.com/chef/chef/issues/12816

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
