### PR TITLE
flush package cache after registering via rhsm_register

### DIFF
--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -117,12 +117,17 @@ class Chef
           end
         end
 
+        package flush_package_cache_name do
+          action :nothing
+        end
+
         execute "Register to RHSM" do
           sensitive new_resource.sensitive
           command register_command
           default_env true
           action :run
           not_if { registered_with_rhsm? } unless new_resource.force
+          notifies :flush_cache, "package[#{flush_package_cache_name}]", :immediately
         end
 
         if new_resource.install_katello_agent && !new_resource.satellite_host.nil?
@@ -131,11 +136,16 @@ class Chef
       end
 
       action :unregister, description: "Unregister the node from RHSM." do
+        package flush_package_cache_name do
+          action :nothing
+        end
+
         execute "Unregister from RHSM" do
           command "subscription-manager unregister"
           default_env true
           action :run
           only_if { registered_with_rhsm? }
+          notifies :flush_cache, "package[#{flush_package_cache_name}]", :immediately
           notifies :run, "execute[Clean RHSM Config]", :immediately
         end
 
@@ -147,6 +157,13 @@ class Chef
       end
 
       action_class do
+        #
+        # @return [String]
+        #
+        def flush_package_cache_name
+          "rhsm_register-#{new_resource.name}-flush_cache"
+        end
+
         #
         # @return [Symbol] dnf_package or yum_package depending on OS release
         #


### PR DESCRIPTION
## Description

This ensures that the Chef Infra Client internal package cache gets flushed after registering with Red Hat Satellite and newer packages are available. I also went ahead and added the inverse situation as well which is unsubscribing and losing access to content that may have previously been cached by the Chef Infra Client.

## Related Issue

- Closes https://github.com/chef/chef/issues/12829
- https://github.com/chef/chef/pull/11534

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
