### PR TITLE
Renamed private method as conflicting to inbuilt method and getting warning

### DIFF
--- a/lib/chef/secret_fetcher/azure_key_vault.rb
+++ b/lib/chef/secret_fetcher/azure_key_vault.rb
@@ -59,7 +59,7 @@ class Chef
       end
 
       def validate!
-        raise Chef::Exceptions::Secret::ConfigurationInvalid, "You may only specify one (these are mutually exclusive): :object_id, :client_id, or :mi_res_id" if [object_id, client_id, mi_res_id].count { |x| !x.nil? } > 1
+        raise Chef::Exceptions::Secret::ConfigurationInvalid, "You may only specify one (these are mutually exclusive): :object_id, :client_id, or :mi_res_id" if [config_object_id, client_id, mi_res_id].count { |x| !x.nil? } > 1
       end
 
       private
@@ -87,7 +87,7 @@ class Chef
         "https://vault.azure.net"
       end
 
-      def object_id
+      def config_object_id
         config[:object_id]
       end
 
@@ -104,7 +104,7 @@ class Chef
           p = {}
           p["api-version"] = api_version
           p["resource"] = resource
-          p["object_id"] = object_id if object_id
+          p["object_id"] = config_object_id if config_object_id
           p["client_id"] = client_id if client_id
           p["mi_res_id"] = mi_res_id if mi_res_id
           URI.encode_www_form(p)


### PR DESCRIPTION

Signed-off-by: sanga1794 <sausekar@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
There is a private method named as `object_id` due to which getting below warning:
```warning: redefining `object_id' may cause serious problems```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
