### PR TITLE
Add platforms

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -8,10 +8,16 @@ fips-platforms:
   - el-*-ppc64*
   - ubuntu-*-x86_64
   - windows-*
+skip-artifactory-platforms:
+  - freebsd-13-amd64
 builder-to-testers-map:
   # aix-7.1-powerpc:
   #   - aix-7.1-powerpc
   #   - aix-7.2-powerpc
+  amazon-2022-aarch64:
+    - amazon-2022-aarch64
+  amazon-2022-x86_64:
+    - amazon-2022-x86_64
   debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
@@ -38,9 +44,9 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
-  freebsd-11-amd64:
-    - freebsd-11-amd64
+  freebsd-12-amd64:
     - freebsd-12-amd64
+    - freebsd-13-amd64
   mac_os_x-10.15-x86_64:
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64
@@ -63,10 +69,12 @@ builder-to-testers-map:
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
+    - ubuntu-22.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
+    - ubuntu-22.04-x86_64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -8,10 +8,14 @@ fips-platforms:
   - el-*-ppc64*
   - ubuntu-*-x86_64
   - windows-*
+skip-artifactory-platforms:
+  - freebsd-13-amd64
 builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc
     - aix-7.2-powerpc
+  amazon-2022-aarch64:
+    - amazon-2022-aarch64
   amazon-2022-x86_64:
     - amazon-2022-x86_64
   debian-9-x86_64:
@@ -40,9 +44,9 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
-  freebsd-11-amd64:
-    - freebsd-11-amd64
+  freebsd-12-amd64:
     - freebsd-12-amd64
+    - freebsd-13-amd64
   mac_os_x-10.15-x86_64:
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64
@@ -65,10 +69,12 @@ builder-to-testers-map:
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
+    - ubuntu-22.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
+    - ubuntu-22.04-x86_64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 6c95d0c3073cd6bc2d2d9ac2b4091ebe6bbf8825
+  revision: 8a0e391d4232ab3fc5fb7a03b15932335a0214c4
   branch: main
   specs:
     omnibus-software (4.0.0)
-      omnibus (>= 8.0.0)
+      omnibus (>= 9.0.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 27c37fc4a27533deda445bd0b44dcec1c674c329
+  revision: 63be4f1663fe28c35e762697500dab7dd88c4dbf
   branch: main
   specs:
-    omnibus (8.3.3)
+    omnibus (9.0.0)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)


### PR DESCRIPTION
Add Amazon Linux 2022 arm64, FreeBSD 13 amd64, Ubuntu 22.04 arm64 and amd64.

Update omnibus and omnibus-software so Windows builds use new omnibus Windows images and build logic.