### PR TITLE
IPACK-126 add platforms to chef-16

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -40,8 +40,7 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
-  freebsd-11-amd64:
-    - freebsd-11-amd64
+  freebsd-12-amd64:
     - freebsd-12-amd64
   mac_os_x-10.15-x86_64:
     - mac_os_x-10.15-x86_64

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: ff4c90223f63bf0cda91e2c723a81c0183d86995
+  revision: 8a0e391d4232ab3fc5fb7a03b15932335a0214c4
   branch: main
   specs:
     omnibus-software (4.0.0)
-      omnibus (>= 8.0.0)
+      omnibus (>= 9.0.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 27c37fc4a27533deda445bd0b44dcec1c674c329
+  revision: 63be4f1663fe28c35e762697500dab7dd88c4dbf
   branch: main
   specs:
-    omnibus (8.3.3)
+    omnibus (9.0.0)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)


### PR DESCRIPTION
Build on FreeBSD 12 and remove FreeBSD 11 since it is EOL.

Update omnibus and omnibus-software so Windows builds use new omnibus Windows images and build logic.