### PR TITLE
Handling compliance phase error

### DIFF
--- a/lib/chef/compliance/input_collection.rb
+++ b/lib/chef/compliance/input_collection.rb
@@ -40,7 +40,7 @@ class Chef
       def from_file(filename, cookbook_name)
         new_input = Input.from_file(events, filename, cookbook_name)
         self << new_input
-        events.compliance_input_loaded(new_input)
+        events&.compliance_input_loaded(new_input)
       end
 
       # Add a input from a raw hash.  This input will be enabled by default.

--- a/lib/chef/compliance/profile_collection.rb
+++ b/lib/chef/compliance/profile_collection.rb
@@ -41,7 +41,7 @@ class Chef
       def from_file(path, cookbook_name)
         new_profile = Profile.from_file(events, path, cookbook_name)
         self << new_profile
-        events.compliance_profile_loaded(new_profile)
+        events&.compliance_profile_loaded(new_profile)
       end
 
       # @return [Boolean] if any of the profiles are enabled

--- a/lib/chef/compliance/waiver_collection.rb
+++ b/lib/chef/compliance/waiver_collection.rb
@@ -40,7 +40,7 @@ class Chef
       def from_file(filename, cookbook_name)
         new_waiver = Waiver.from_file(events, filename, cookbook_name)
         self << new_waiver
-        events.compliance_waiver_loaded(new_waiver)
+        events&.compliance_waiver_loaded(new_waiver)
       end
 
       # Add a waiver from a raw hash.  This waiver will be enabled by default.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
adding exception to bypass nil class error in the compliance phase

## Related Issue
When utilizing the Compliance phase, and more specifically when an Inspec profile exists within the cookbook structure, Chef Spec does not appear to be able to handle at least one of the new methods in Chef to load the Compliance Profiles.

Chef Spec returns undefined method 'compliance_profile_loaded' for nil:NilClass.

I have validated this behavior on several versions of Chef workstation including the latest we have installed which is 22.2.807

To Reproduce

Within the cookbook tree structure, create an Inspec profile complete with controls and inspec.yml and place it in /compliance/profiles.
Define any type of unit test in a spec.rb file within /spec/unit/recipes
Run chef exec rspec
Any test should fail referencing the error with relation to not recognizing the compliance_profile_method not being recognized

Expected behavior

Successful tests that don't throw NoMethodErrors

Actual behavior
```
docker_config_cb::default When additional attributes are specified for repos, on redhat 7 converges successfully
Failure/Error: expect { chef_run }.to_not raise_error

   expected no Exception, got #<NoMethodError: undefined method `compliance_profile_loaded' for nil:NilClass> with backtrace:       
     # ./spec/unit/recipes/default_spec.rb:32:in `block (3 levels) in <top (required)>'
     # ./spec/unit/recipes/default_spec.rb:42:in `block (4 levels) in <top (required)>'
     # ./spec/unit/recipes/default_spec.rb:42:in `block (3 levels) in <top (required)>'
 # ./spec/unit/recipes/default_spec.rb:42:in `block (3 levels) in <top (required)>'
```
https://github.com/chef/customer-bugs/issues/671

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
