### PR TITLE
Updated files to account for pem storage in the Certificate Store

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -589,6 +589,7 @@
     "keyivgen",
     "KEYNAME",
     "keyname",
+    "keypair",
     "keyscan",
     "keysign",
     "KEYTAB",

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -228,18 +228,29 @@ class Chef
             file_path = ps_blob["PSPath"].split("::")[1]
             pkcs = OpenSSL::PKCS12.new(File.binread(file_path), password)
 
-            # We test the pfx we just extracted the private key from
+            # We check the pfx we just extracted the private key from
             # if that cert is expiring in 7 days or less we generate a new pfx/p12 object
             # then we post the new public key from that to the client endpoint on
             # chef server.
-            # is_certificate_expiring(pkcs)
             File.delete(file_path)
+            key_expiring = is_certificate_expiring?(pkcs)
+            if key_expiring
+              powershell_exec!(delete_old_key_ps(client_name))
+              ::Chef::Client.update_key_and_register(Chef::Config[:client_name], pkcs)
+            end
 
+            File.delete(file_path)
             return pkcs.key.private_to_pem
           end
         end
 
         false
+      end
+
+      def self.is_certificate_expiring?(pkcs)
+        today = Date.parse(Time.now.utc.iso8601)
+        future = Date.parse(pkcs.certificate.not_after.iso8601)
+        future.mjd - today.mjd <= 7
       end
 
       def self.get_the_key_ps(client_name, password)
@@ -253,6 +264,12 @@ class Chef
             Catch {
               return $false
             }
+        CODE
+      end
+
+      def self.delete_old_key_ps(client_name)
+        powershell_code = <<~CODE
+          Get-ChildItem -path cert:\\LocalMachine\\My -Recurse | Where-Object { $_.Subject -match "chef-#{client_name}$" } | Remove-Item -ErrorAction Stop;
         CODE
       end
 

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -191,7 +191,7 @@ class Chef
           @win32registry.create_key(new_path, true)
         end
         size = 14
-        password = (0...size).map { SOME_CHARS.sample(1) }.join
+        password = (0...size).map{ SOME_CHARS[rand(SOME_CHARS.size)] }.join
         encrypted_pass = encrypt_pfx_pass(password)
         values = { name: "PfxPass", type: :string, data: encrypted_pass }
         @win32registry.set_value(new_path, values)

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -191,7 +191,7 @@ class Chef
           @win32registry.create_key(new_path, true)
         end
         size = 14
-        password = (0...size).map{ SOME_CHARS[rand(SOME_CHARS.size)] }.join
+        password = (0...size).map { SOME_CHARS[rand(SOME_CHARS.size)] }.join
         encrypted_pass = encrypt_pfx_pass(password)
         values = { name: "PfxPass", type: :string, data: encrypted_pass }
         @win32registry.set_value(new_path, values)

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -239,7 +239,6 @@ class Chef
               ::Chef::Client.update_key_and_register(Chef::Config[:client_name], pkcs)
             end
 
-            File.delete(file_path)
             return pkcs.key.private_to_pem
           end
         end

--- a/spec/unit/http/authenticator_spec.rb
+++ b/spec/unit/http/authenticator_spec.rb
@@ -83,112 +83,112 @@ describe Chef::HTTP::Authenticator, :windows_only do
   end
 end
 
-# describe Chef::HTTP::Authenticator do
-#   let(:class_instance) { Chef::HTTP::Authenticator.new(client_name: "test") }
-#   let(:method) { "GET" }
-#   let(:url) { URI("https://chef.example.com/organizations/test") }
-#   let(:headers) { {} }
-#   let(:data) { "" }
+describe Chef::HTTP::Authenticator do
+  let(:class_instance) { Chef::HTTP::Authenticator.new(client_name: "test") }
+  let(:method) { "GET" }
+  let(:url) { URI("https://chef.example.com/organizations/test") }
+  let(:headers) { {} }
+  let(:data) { "" }
 
-#   before do
-#     ::Chef::Config[:node_name] = "foo"
-#   end
+  before do
+    ::Chef::Config[:node_name] = "foo"
+  end
 
-#   context "when handle_request is called" do
-#     shared_examples_for "merging the server API version into the headers" do
-#       before do
-#         allow(class_instance).to receive(:authentication_headers).and_return({})
-#       end
+  context "when handle_request is called" do
+    shared_examples_for "merging the server API version into the headers" do
+      before do
+        allow(class_instance).to receive(:authentication_headers).and_return({})
+      end
 
-#       it "merges the default version of X-Ops-Server-API-Version into the headers" do
-#         # headers returned
-#         expect(class_instance.handle_request(method, url, headers, data)[2])
-#           .to include({ "X-Ops-Server-API-Version" => Chef::HTTP::Authenticator::DEFAULT_SERVER_API_VERSION })
-#       end
+      it "merges the default version of X-Ops-Server-API-Version into the headers" do
+        # headers returned
+        expect(class_instance.handle_request(method, url, headers, data)[2])
+          .to include({ "X-Ops-Server-API-Version" => Chef::HTTP::Authenticator::DEFAULT_SERVER_API_VERSION })
+      end
 
-#       context "when version_class is provided" do
-#         class V0Class; extend Chef::Mixin::VersionedAPI; minimum_api_version 0; end
-#         class V2Class; extend Chef::Mixin::VersionedAPI; minimum_api_version 2; end
+      context "when version_class is provided" do
+        class V0Class; extend Chef::Mixin::VersionedAPI; minimum_api_version 0; end
+        class V2Class; extend Chef::Mixin::VersionedAPI; minimum_api_version 2; end
 
-#         class AuthFactoryClass
-#           extend Chef::Mixin::VersionedAPIFactory
-#           add_versioned_api_class V0Class
-#           add_versioned_api_class V2Class
-#         end
+        class AuthFactoryClass
+          extend Chef::Mixin::VersionedAPIFactory
+          add_versioned_api_class V0Class
+          add_versioned_api_class V2Class
+        end
 
-#         let(:class_instance) { Chef::HTTP::Authenticator.new({ version_class: AuthFactoryClass }) }
+        let(:class_instance) { Chef::HTTP::Authenticator.new({ version_class: AuthFactoryClass }) }
 
-#         it "uses it to select the correct http version" do
-#           Chef::ServerAPIVersions.instance.reset!
-#           expect(AuthFactoryClass).to receive(:best_request_version).and_call_original
-#           expect(class_instance.handle_request(method, url, headers, data)[2])
-#             .to include({ "X-Ops-Server-API-Version" => "2" })
-#         end
-#       end
+        it "uses it to select the correct http version" do
+          Chef::ServerAPIVersions.instance.reset!
+          expect(AuthFactoryClass).to receive(:best_request_version).and_call_original
+          expect(class_instance.handle_request(method, url, headers, data)[2])
+            .to include({ "X-Ops-Server-API-Version" => "2" })
+        end
+      end
 
-#       context "when api_version is set to something other than the default" do
-#         let(:class_instance) { Chef::HTTP::Authenticator.new({ api_version: "-10" }) }
+      context "when api_version is set to something other than the default" do
+        let(:class_instance) { Chef::HTTP::Authenticator.new({ api_version: "-10" }) }
 
-#         it "merges the requested version of X-Ops-Server-API-Version into the headers" do
-#           expect(class_instance.handle_request(method, url, headers, data)[2])
-#             .to include({ "X-Ops-Server-API-Version" => "-10" })
-#         end
-#       end
-#     end
+        it "merges the requested version of X-Ops-Server-API-Version into the headers" do
+          expect(class_instance.handle_request(method, url, headers, data)[2])
+            .to include({ "X-Ops-Server-API-Version" => "-10" })
+        end
+      end
+    end
 
-#     context "when !sign_requests?" do
-#       before do
-#         allow(class_instance).to receive(:sign_requests?).and_return(false)
-#       end
+    context "when !sign_requests?" do
+      before do
+        allow(class_instance).to receive(:sign_requests?).and_return(false)
+      end
 
-#       it_behaves_like "merging the server API version into the headers"
+      it_behaves_like "merging the server API version into the headers"
 
-#       it "authentication_headers is not called" do
-#         expect(class_instance).to_not receive(:authentication_headers)
-#         class_instance.handle_request(method, url, headers, data)
-#       end
+      it "authentication_headers is not called" do
+        expect(class_instance).to_not receive(:authentication_headers)
+        class_instance.handle_request(method, url, headers, data)
+      end
 
-#     end
+    end
 
-#     context "when sign_requests?" do
-#       before do
-#         allow(class_instance).to receive(:sign_requests?).and_return(true)
-#       end
+    context "when sign_requests?" do
+      before do
+        allow(class_instance).to receive(:sign_requests?).and_return(true)
+      end
 
-#       it_behaves_like "merging the server API version into the headers"
+      it_behaves_like "merging the server API version into the headers"
 
-#       it "calls authentication_headers with the proper input" do
-#         expect(class_instance).to receive(:authentication_headers).with(
-#           method, url, data,
-#           { "X-Ops-Server-API-Version" => Chef::HTTP::Authenticator::DEFAULT_SERVER_API_VERSION }
-#         ).and_return({})
-#         class_instance.handle_request(method, url, headers, data)
-#       end
-#     end
+      it "calls authentication_headers with the proper input" do
+        expect(class_instance).to receive(:authentication_headers).with(
+          method, url, data,
+          { "X-Ops-Server-API-Version" => Chef::HTTP::Authenticator::DEFAULT_SERVER_API_VERSION }
+        ).and_return({})
+        class_instance.handle_request(method, url, headers, data)
+      end
+    end
 
-#     context "when ssh_agent_signing" do
-#       let(:public_key) { <<~EOH }
-#         -----BEGIN PUBLIC KEY-----
-#         MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA49TA0y81ps0zxkOpmf5V
-#         4/c4IeR5yVyQFpX3JpxO4TquwnRh8VSUhrw8kkTLmB3cS39Db+3HadvhoqCEbqPE
-#         6915kXSuk/cWIcNozujLK7tkuPEyYVsyTioQAddSdfe+8EhQVf3oHxaKmUd6waXr
-#         WqYCnhxgOjxocenREYNhZ/OETIeiPbOku47vB4nJK/0GhKBytL2XnsRgfKgDxf42
-#         BqAi1jglIdeq8lAWZNF9TbNBU21AO1iuT7Pm6LyQujhggPznR5FJhXKRUARXBJZa
-#         wxpGV4dGtdcahwXNE4601aXPra+xPcRd2puCNoEDBzgVuTSsLYeKBDMSfs173W1Q
-#         YwIDAQAB
-#         -----END PUBLIC KEY-----
-#       EOH
+    context "when ssh_agent_signing" do
+      let(:public_key) { <<~EOH }
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA49TA0y81ps0zxkOpmf5V
+        4/c4IeR5yVyQFpX3JpxO4TquwnRh8VSUhrw8kkTLmB3cS39Db+3HadvhoqCEbqPE
+        6915kXSuk/cWIcNozujLK7tkuPEyYVsyTioQAddSdfe+8EhQVf3oHxaKmUd6waXr
+        WqYCnhxgOjxocenREYNhZ/OETIeiPbOku47vB4nJK/0GhKBytL2XnsRgfKgDxf42
+        BqAi1jglIdeq8lAWZNF9TbNBU21AO1iuT7Pm6LyQujhggPznR5FJhXKRUARXBJZa
+        wxpGV4dGtdcahwXNE4601aXPra+xPcRd2puCNoEDBzgVuTSsLYeKBDMSfs173W1Q
+        YwIDAQAB
+        -----END PUBLIC KEY-----
+      EOH
 
-#       let(:class_instance) { Chef::HTTP::Authenticator.new(client_name: "test", raw_key: public_key, ssh_agent_signing: true) }
+      let(:class_instance) { Chef::HTTP::Authenticator.new(client_name: "test", raw_key: public_key, ssh_agent_signing: true) }
 
-#       it "sets use_ssh_agent if needed" do
-#         expect(Mixlib::Authentication::SignedHeaderAuth).to receive(:signing_object).and_wrap_original { |m, *args|
-#           m.call(*args).tap do |signing_obj|
-#             expect(signing_obj).to receive(:sign).with(instance_of(OpenSSL::PKey::RSA), use_ssh_agent: true).and_return({})
-#           end
-#         }
-#         class_instance.handle_request(method, url, headers, data)
-#       end
-#     end
-#   end
-# end
+      it "sets use_ssh_agent if needed" do
+        expect(Mixlib::Authentication::SignedHeaderAuth).to receive(:signing_object).and_wrap_original { |m, *args|
+          m.call(*args).tap do |signing_obj|
+            expect(signing_obj).to receive(:sign).with(instance_of(OpenSSL::PKey::RSA), use_ssh_agent: true).and_return({})
+          end
+        }
+        class_instance.handle_request(method, url, headers, data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: John McCrae <jmccrae@chf.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
This code is a completion of some previously started work on moving certificates to the Windows Certificate Store. The work in this PR solves 2 problems. The first is that if the chef-client is already running on a given node and the admin wants to move keys to the certstore, what do they do? They set the flag `migrate_key_to_keystore true` in the client.rb and then the code creates a pfx object, extracts the public key from it, sends that to the chef-server and then stores the pfx in the \\LocalMachine\My store. The second problem that this updates is certificate lifetimes. We put a 90 day lifespan on certificates to increase security. The code in this PR checks to see if the given keys are expiring and then creates a new pfx on the fly and updates the chef server with the new public key and stores the updated pfx in the \\LocalMachine\My store. It finally checks if there are only 2 keys on the chef-server for that client and deletes the old key in that case - we assume more than 2 keys means that the client has some special designation and we leave those alone. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
