### PR TITLE
Adds 'makecache_fast' property to `yum_repository` minimise cached repodata

### DIFF
--- a/lib/chef/provider/yum_repository.rb
+++ b/lib/chef/provider/yum_repository.rb
@@ -44,7 +44,7 @@ class Chef
           mode new_resource.mode
           if new_resource.make_cache
             notifies :run, "execute[yum clean metadata #{new_resource.repositoryid}]", :immediately if new_resource.clean_metadata || new_resource.clean_headers
-            if new_resource.makecache_fast 
+            if new_resource.makecache_fast
               notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
             else
               notifies :run, "execute[yum-makecache-fast-#{new_resource.repositoryid}]", :immediately
@@ -73,7 +73,6 @@ class Chef
             action :nothing
             only_if { new_resource.enabled }
           end
-
 
           package "package-cache-reload-#{new_resource.repositoryid}" do
             action :nothing

--- a/lib/chef/provider/yum_repository.rb
+++ b/lib/chef/provider/yum_repository.rb
@@ -44,10 +44,11 @@ class Chef
           mode new_resource.mode
           if new_resource.make_cache
             notifies :run, "execute[yum clean metadata #{new_resource.repositoryid}]", :immediately if new_resource.clean_metadata || new_resource.clean_headers
-            if new_resource.makecache_fast
-              notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
-            else
+            # makecache fast only works on non-dnf systems.
+            if !which "dnf" && new_resource.makecache_fast
               notifies :run, "execute[yum-makecache-fast-#{new_resource.repositoryid}]", :immediately
+            else
+              notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
             end
             notifies :flush_cache, "package[package-cache-reload-#{new_resource.repositoryid}]", :immediately
           end

--- a/lib/chef/provider/yum_repository.rb
+++ b/lib/chef/provider/yum_repository.rb
@@ -44,7 +44,11 @@ class Chef
           mode new_resource.mode
           if new_resource.make_cache
             notifies :run, "execute[yum clean metadata #{new_resource.repositoryid}]", :immediately if new_resource.clean_metadata || new_resource.clean_headers
-            notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
+            if new_resource.makecache_fast 
+              notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately
+            else
+              notifies :run, "execute[yum-makecache-fast-#{new_resource.repositoryid}]", :immediately
+            end
             notifies :flush_cache, "package[package-cache-reload-#{new_resource.repositoryid}]", :immediately
           end
         end
@@ -62,6 +66,14 @@ class Chef
             action :nothing
             only_if { new_resource.enabled }
           end
+
+          # download only the minimum required metadata
+          execute "yum-makecache-fast-#{new_resource.repositoryid}" do
+            command "yum -q -y makecache fast --disablerepo=* --enablerepo=#{new_resource.repositoryid}"
+            action :nothing
+            only_if { new_resource.enabled }
+          end
+
 
           package "package-cache-reload-#{new_resource.repositoryid}" do
             action :nothing

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -114,6 +114,10 @@ class Chef
         description: "Determines whether package files downloaded by Yum stay in cache directories. By using cached data, you can carry out certain operations without a network connection.",
         default: true
 
+      property :makecache_fast, [TrueClass, FalseClass],
+        description: "if make_cache is true, uses `yum makecache fast`, which downloads only the minimum amount of data required. Useful over slower connections and when diskspace is at a premium.",
+        default: false
+
       property :max_retries, [String, Integer],
         description: "Number of times any attempt to retrieve a file should retry before returning an error. Setting this to `0` makes Yum try forever."
 

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -115,7 +115,7 @@ class Chef
         default: true
 
       property :makecache_fast, [TrueClass, FalseClass],
-        description: "if make_cache is true, uses `yum makecache fast`, which downloads only the minimum amount of data required. Useful over slower connections and when diskspace is at a premium.",
+        description: "if make_cache is true, uses `yum makecache fast`, which downloads only the minimum amount of data required. Useful over slower connections and when disk space is at a premium.",
         default: false
 
       property :max_retries, [String, Integer],

--- a/spec/unit/resource/yum_repository_spec.rb
+++ b/spec/unit/resource/yum_repository_spec.rb
@@ -69,7 +69,7 @@ describe Chef::Resource::YumRepository do
   end
 
   it "makecache_fast property defaults to false" do
-    expect(resource.make_cache).to eql(false)
+    expect(resource.makecache_fast).to eql(false)
   end
 
   it "mode property defaults to '0644'" do

--- a/spec/unit/resource/yum_repository_spec.rb
+++ b/spec/unit/resource/yum_repository_spec.rb
@@ -68,6 +68,10 @@ describe Chef::Resource::YumRepository do
     expect(resource.make_cache).to eql(true)
   end
 
+  it "makecache_fast property defaults to false" do
+    expect(resource.make_cache).to eql(false)
+  end
+
   it "mode property defaults to '0644'" do
     expect(resource.mode).to eql("0644")
   end


### PR DESCRIPTION
## Description
adds a `makecache_fast` property to the `yum_repository` resource/provider, to enable downloading only the minimum require metadata when refreshing the cache

in recent RHEL releases (and possibly other related distros like CentOS etc) additional multi-Gb metadata is downloaded by the standard `yum makecache` command, which is fairly wasteful of both disk space and bandwidth, for example:

```
total 8.9G
-rw-rw-r-- 1 root root 629M Aug 23  2021 filelists.xml
-rw-r--r-- 1 root root 330M May 24 04:30 filelists.xml.sqlite
-rw-rw-r-- 1 root root 3.6G Aug 23  2021 other.xml
-rw-r--r-- 1 root root 3.7G May 24 04:32 other.xml.sqlite
-rw-r--r-- 1 root root 374M Aug 23  2021 primary.xml
-rw-r--r-- 1 root root 454M May 23 05:01 primary.xml.sqlite
-rw-r--r-- 1 root root  23M Aug 23  2021 updateinfo.xml
```

the only way to avoid this appears to be to use `yum makecache fast`, which does not fetch the larger files listed above.  An example from the same system as above:

```
total 850M
-rw-rw-r-- 1 root root 374M Aug 23  2021 primary.xml
-rw-r--r-- 1 root root 454M May 24 04:38 primary.xml.sqlite
-rw-rw-r-- 1 root root  23M Aug 23  2021 updateinfo.xml
```

This PR adds the `makecache_fast` boolean to the `yum_repository` resource, defaulting to false, which allows makecache fast to be used on a per-repository basis if required

## Related Issue
None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
