### PR TITLE
Fix documentation for chef_client_scheduled_task

### DIFF
--- a/knife/lib/chef/knife/core/ui.rb
+++ b/knife/lib/chef/knife/core/ui.rb
@@ -233,7 +233,7 @@ class Chef
             tf.sync = true
             tf.puts output
             tf.close
-            raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_setup/ for details." unless system("#{config[:editor]} #{tf.path}")
+            raise "Please set EDITOR environment variable. See https://docs.chef.io/workstation/knife_setup/#setting-your-text-editor for details." unless system("#{config[:editor]} #{tf.path}")
 
             output = IO.read(tf.path)
           end

--- a/knife/lib/chef/knife/edit.rb
+++ b/knife/lib/chef/knife/edit.rb
@@ -74,7 +74,7 @@ class Chef
 
             # Let the user edit the temporary file
             unless system("#{config[:editor]} #{file.path}")
-              raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_setup/ for details."
+              raise "Please set EDITOR environment variable. See https://docs.chef.io/workstation/knife_setup/#setting-your-text-editor for details."
             end
 
             result_text = IO.read(file.path)

--- a/knife/lib/chef/knife/user_edit.rb
+++ b/knife/lib/chef/knife/user_edit.rb
@@ -81,7 +81,7 @@ class Chef
             f.sync = true
             f.puts output
             f.close
-            raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_setup/ for details." unless system("#{config[:editor]} #{f.path}")
+            raise "Please set EDITOR environment variable. See https://docs.chef.io/workstation/knife_setup/#setting-your-text-editor for details." unless system("#{config[:editor]} #{f.path}")
 
             edited_user = JSON.parse(IO.read(f.path))
           end

--- a/lib/chef/resource/chef_client_scheduled_task.rb
+++ b/lib/chef/resource/chef_client_scheduled_task.rb
@@ -122,7 +122,8 @@ class Chef
 
       property :config_directory, String,
         description: "The path of the config directory.",
-        default: ChefConfig::Config.etc_chef_dir
+        default: ChefConfig::Config.etc_chef_dir,
+        default_description: "`C:\\chef\\`"
 
       property :log_directory, String,
         description: "The path of the directory to create the log file in.",

--- a/lib/chef/resource/chef_client_scheduled_task.rb
+++ b/lib/chef/resource/chef_client_scheduled_task.rb
@@ -123,7 +123,7 @@ class Chef
       property :config_directory, String,
         description: "The path of the config directory.",
         default: ChefConfig::Config.etc_chef_dir,
-        default_description: "`C:\\chef\\`"
+        default_description: ChefConfig::Config.c_chef_dir
 
       property :log_directory, String,
         description: "The path of the directory to create the log file in.",


### PR DESCRIPTION
Obvious fix.

Current documentation says "/etc/" for a Windows-only resource.

```ruby
chef_client_scheduled_task 'name' do
...
  config_directory          String # default value: "/etc/chef"
...
end
```