### PR TITLE
Remove the beta feature warning which shows up when using Secret Manager

### DIFF
--- a/lib/chef/dsl/secret.rb
+++ b/lib/chef/dsl/secret.rb
@@ -162,10 +162,6 @@ class Chef
       #   value = secret(name: "test1", service: :aws_secrets_manager, version: "v1", config: { region: "us-west-1" })
       #   log "My secret is #{value}"
       def secret(name: nil, version: nil, service: default_secret_service, config: default_secret_config)
-        Chef::Log.warn <<~EOM.gsub("\n", " ")
-          The secrets Chef Infra language helper is currently in beta. If you have feedback or you would
-          like to be part of the future design of this helper e-mail us at secrets_management_beta@progress.com"
-        EOM
         sensitive(true) if is_a?(Chef::Resource)
         Chef::SecretFetcher.for_service(service, config, run_context).fetch(name, version)
       end


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

## Description
As we have tested all the Secret Manager in recipe, we will remove the beta warning that shows up when using it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
