### PR TITLE
backporting changes to pem storage in Certificate Store

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -580,6 +580,7 @@
     "keyivgen",
     "KEYNAME",
     "keyname",
+    "keypair",
     "keyscan",
     "KEYTAB",
     "keytab",

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -15,9 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+require "chef/mixin/powershell_exec"
 require_relative "auth_credentials"
 require_relative "../exceptions"
+require_relative "../win32/registry"
 autoload :OpenSSL, "openssl"
 
 class Chef
@@ -25,7 +26,9 @@ class Chef
     class Authenticator
 
       DEFAULT_SERVER_API_VERSION = "2".freeze
-
+      # cspell:disable-next-line
+      SOME_CHARS = "~!@#%^&*_-+=`|\\(){}[<]:;'>,.?/0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz".each_char.to_a
+      extend Chef::Mixin::PowershellExec
       attr_reader :signing_key_filename
       attr_reader :raw_key
       attr_reader :attr_names
@@ -83,13 +86,69 @@ class Chef
         @auth_credentials.client_name
       end
 
+      def detect_certificate_key(client_name)
+        self.class.detect_certificate_key(client_name)
+      end
+
+      def check_certstore_for_key(client_name)
+        self.class.check_certstore_for_key(client_name)
+      end
+
+      def retrieve_certificate_key(client_name)
+        self.class.retrieve_certificate_key(client_name)
+      end
+
+      def get_cert_password
+        self.class.get_cert_password
+      end
+
+      def encrypt_pfx_pass
+        self.class.encrypt_pfx_pass
+      end
+
+      def decrypt_pfx_pass
+        self.class.decrypt_pfx_pass
+      end
+
+      # Detects if a private key exists in a certificate repository like Keychain (macOS) or Certificate Store (Windows)
+      #
+      # @param client_name - we're using the node name to store and retrieve any keys
+      # Returns true if a key is found, false if not. False will trigger a registration event which will lead to a certificate based key being created
+      #
+      def self.detect_certificate_key(client_name)
+        if ChefUtils.windows?
+          check_certstore_for_key(client_name)
+        else # generic return for Mac and LInux clients
+          false
+        end
+      end
+
+      def self.check_certstore_for_key(client_name)
+        powershell_code = <<~CODE
+          $cert = Get-ChildItem -path cert:\\LocalMachine\\My -Recurse -Force  | Where-Object { $_.Subject -Match "chef-#{client_name}" } -ErrorAction Stop
+          if (($cert.HasPrivateKey -eq $true) -and ($cert.PrivateKey.Key.ExportPolicy -ne "NonExportable")) {
+            return $true
+          }
+          else{
+            return $false
+          }
+        CODE
+        powershell_exec!(powershell_code).result
+      end
+
       def load_signing_key(key_file, raw_key = nil)
-        if !!key_file
+        results = retrieve_certificate_key(Chef::Config[:node_name])
+
+        if !!results
+          @raw_key = results
+        elsif key_file == nil? && raw_key == nil?
+          puts "\nNo key detected\n"
+        elsif !!key_file
           @raw_key = IO.read(key_file).strip
         elsif !!raw_key
           @raw_key = raw_key.strip
         else
-          return nil
+          return
         end
         # Pass in '' as the passphrase to avoid OpenSSL prompting on the TTY if
         # given an encrypted key. This also helps if using a single file for
@@ -102,6 +161,111 @@ class Chef
         msg = "The file #{key_file} or :raw_key option does not contain a correctly formatted private key or the key is encrypted.\n"
         msg << "The key file should begin with '-----BEGIN RSA PRIVATE KEY-----' and end with '-----END RSA PRIVATE KEY-----'"
         raise Chef::Exceptions::InvalidPrivateKey, msg
+      end
+
+      def self.get_cert_password
+        @win32registry = Chef::Win32::Registry.new
+        path = "HKEY_LOCAL_MACHINE\\Software\\Progress\\Authentication"
+        # does the registry key even exist?
+        present = @win32registry.get_values(path)
+        if present.nil? || present.empty?
+          raise Chef::Exceptions::Win32RegKeyMissing
+        end
+        present.each do |secret|
+          if secret[:name] == "PfxPass"
+            password = decrypt_pfx_pass(secret[:data])
+            return password
+          end
+        end
+        raise Chef::Exceptions::Win32RegKeyMissing
+      rescue Chef::Exceptions::Win32RegKeyMissing
+        # if we don't have a password, log that and generate one
+        Chef::Log.warn "Authentication Hive and values not present in registry, creating them now"
+        new_path = "HKEY_LOCAL_MACHINE\\Software\\Progress\\Authentication"
+        unless @win32registry.key_exists?(new_path)
+          @win32registry.create_key(new_path, true)
+        end
+        size = 14
+        password = (0...size).map { SOME_CHARS[rand(SOME_CHARS.size)] }.join
+        encrypted_pass = encrypt_pfx_pass(password)
+        values = { name: "PfxPass", type: :string, data: encrypted_pass }
+        @win32registry.set_value(new_path, values)
+        password
+      end
+
+      def self.encrypt_pfx_pass(password)
+        powershell_code = <<~CODE
+          $encrypted_string = ConvertTo-SecureString "#{password}" -AsPlainText -Force
+          $secure_string = ConvertFrom-SecureString $encrypted_string
+          return $secure_string
+        CODE
+        powershell_exec!(powershell_code).result
+      end
+
+      def self.decrypt_pfx_pass(password)
+        powershell_code = <<~CODE
+          $secure_string = "#{password}" | ConvertTo-SecureString
+          $string = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR((($secure_string))))
+          return $string
+        CODE
+        powershell_exec!(powershell_code).result
+      end
+
+      def self.retrieve_certificate_key(client_name)
+        require "openssl" unless defined?(OpenSSL)
+
+        if ChefUtils.windows?
+          password = get_cert_password
+          return false unless password
+
+          if check_certstore_for_key(client_name)
+            ps_blob = powershell_exec!(get_the_key_ps(client_name, password)).result
+            file_path = ps_blob["PSPath"].split("::")[1]
+            pkcs = OpenSSL::PKCS12.new(File.binread(file_path), password)
+
+            # We test the pfx we just extracted the private key from
+            # We check the pfx we just extracted the private key from
+            # if that cert is expiring in 7 days or less we generate a new pfx/p12 object
+            # then we post the new public key from that to the client endpoint on
+            # chef server.
+            # is_certificate_expiring(pkcs)
+            File.delete(file_path)
+            key_expiring = is_certificate_expiring?(pkcs)
+            if key_expiring
+              powershell_exec!(delete_old_key_ps(client_name))
+              ::Chef::Client.update_key_and_register(Chef::Config[:client_name], pkcs)
+            end
+
+            return pkcs.key.private_to_pem
+          end
+        end
+        false
+      end
+
+      def self.is_certificate_expiring?(pkcs)
+        today = Date.parse(Time.now.utc.iso8601)
+        future = Date.parse(pkcs.certificate.not_after.iso8601)
+        future.mjd - today.mjd <= 7
+      end
+
+      def self.get_the_key_ps(client_name, password)
+        powershell_code = <<~CODE
+            Try {
+              $my_pwd = ConvertTo-SecureString -String "#{password}" -Force -AsPlainText;
+              $cert = Get-ChildItem -path cert:\\LocalMachine\\My -Recurse | Where-Object { $_.Subject -match "chef-#{client_name}$" } -ErrorAction Stop;
+              $tempfile = [System.IO.Path]::GetTempPath() + "export_pfx.pfx";
+              Export-PfxCertificate -Cert $cert -Password $my_pwd -FilePath $tempfile;
+            }
+            Catch {
+              return $false
+            }
+        CODE
+      end
+
+      def self.delete_old_key_ps(client_name)
+        powershell_code = <<~CODE
+          Get-ChildItem -path cert:\\LocalMachine\\My -Recurse | Where-Object { $_.Subject -match "chef-#{client_name}$" } | Remove-Item -ErrorAction Stop;
+        CODE
       end
 
       def authentication_headers(method, url, json_body = nil, headers = nil)

--- a/spec/unit/http/authenticator_spec.rb
+++ b/spec/unit/http/authenticator_spec.rb
@@ -15,9 +15,70 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 require "spec_helper"
 require "chef/http/authenticator"
+
+describe Chef::HTTP::Authenticator, :windows_only do
+  let(:class_instance) { Chef::HTTP::Authenticator.new(client_name: "test") }
+  let(:method) { "GET" }
+  let(:url) { URI("https://chef.example.com/organizations/test") }
+  let(:headers) { {} }
+  let(:data) { "" }
+  let(:node_name) { "test" }
+  let(:passwrd) { "some_insecure_password" }
+
+  before do
+    Chef::Config[:node_name] = node_name
+    cert_name = "chef-#{node_name}"
+    d = Time.now
+    end_date = Time.new + (3600 * 24 * 90)
+    end_date = end_date.utc.iso8601
+
+    my_client = Chef::Client.new
+    pfx = my_client.generate_pfx_package(cert_name, end_date)
+    my_client.import_pfx_to_store(pfx)
+  end
+
+  after(:each) do
+    require "chef/mixin/powershell_exec"
+    extend Chef::Mixin::PowershellExec
+    cert_name = "chef-#{node_name}"
+    delete_certificate(cert_name)
+  end
+
+  context "when retrieving a certificate from the certificate store" do
+    it "retrieves a certificate password from the registry when the hive does not already exist" do
+      delete_registry_hive
+      expect { class_instance.get_cert_password }.not_to raise_error
+    end
+    it "should return a password of at least 14 characters in length" do
+      password = class_instance.get_cert_password
+      expect(password.length).to eql(14)
+    end
+    it "correctly retrieves a valid certificate in pem format from the certstore" do
+      require "openssl"
+      certificate = class_instance.retrieve_certificate_key(node_name)
+      cert_object = OpenSSL::PKey::RSA.new(certificate)
+      expect(cert_object.to_s).to match(/BEGIN RSA PRIVATE KEY/)
+    end
+  end
+
+  def delete_certificate(cert_name)
+    powershell_code = <<~CODE
+      Get-ChildItem -path cert:\\LocalMachine\\My -Recurse -Force  | Where-Object { $_.Subject -Match "#{cert_name}" } | Remove-item
+    CODE
+    powershell_exec!(powershell_code)
+  end
+
+  def delete_registry_hive
+    @win32registry = Chef::Win32::Registry.new
+    path = "HKEY_LOCAL_MACHINE\\Software\\Progress\\Authentication"
+    present = @win32registry.get_values(path)
+    unless present.nil? || present.empty?
+      @win32registry.delete_key(path, true)
+    end
+  end
+end
 
 describe Chef::HTTP::Authenticator do
   let(:class_instance) { Chef::HTTP::Authenticator.new(client_name: "test") }
@@ -25,6 +86,10 @@ describe Chef::HTTP::Authenticator do
   let(:url) { URI("https://chef.example.com/organizations/test") }
   let(:headers) { {} }
   let(:data) { "" }
+
+  before do
+    ::Chef::Config[:node_name] = "foo"
+  end
 
   context "when handle_request is called" do
     shared_examples_for "merging the server API version into the headers" do


### PR DESCRIPTION
Signed-off-by: John McCrae <jmccrae@chf.io>

This code is a completion of some previously started work on moving certificates to the Windows Certificate Store. The work in this PR solves 2 problems. The first is that if the chef-client is already running on a given node and the admin wants to move keys to the certstore, what do they do? They set the flag migrate_key_to_keystore true in the client.rb and then the code creates a pfx object, extracts the public key from it, sends that to the chef-server and then stores the pfx in the \LocalMachine\My store. The second problem that this updates is certificate lifetimes. We put a 90 day lifespan on certificates to increase security. The code in this PR checks to see if the given keys are expiring and then creates a new pfx on the fly and updates the chef server with the new public key and stores the updated pfx in the \LocalMachine\My store. It finally checks if there are only 2 keys on the chef-server for that client and deletes the old key in that case - we assume more than 2 keys means that the client has some special designation and we leave those alone.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
