### PR TITLE
Fix issue in returning masked? status of a resource when using systemd_unit resource

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -236,7 +236,8 @@ class Chef
       def masked?
         # Note: masked-runtime is excluded, because runtime is volatile, and
         # because masked-runtime is not masked.
-        systemd_unit_status["UnitFileState"] == "masked"
+        # Unit status of a masked resource is "bad"
+        %w{masked bad}.include?(systemd_unit_status["UnitFileState"])
       end
 
       def static?


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

## Description
When a process is masked using `systemd`, its `UnitFileState` becomes `bad`. 
The method `masked?` on resource `systemd_unit` is updated to consider this since it would result in resource not being converged when run multiple times.

## Related Issue
https://github.com/chef/chef/issues/11735

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
