### PR TITLE
apt: explicitly query apt-cache for a single package

### DIFF
--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -177,7 +177,7 @@ class Chef
           current_version = nil
           candidate_version = nil
           all_versions = []
-          run_noninteractive("apt-cache", default_release_options, "policy", pkg).stdout.each_line do |line|
+          run_noninteractive("apt-cache", default_release_options, "policy", "^#{pkg}$").stdout.each_line do |line|
             case line
             when /^\s{2}Installed: (.+)$/
               current_version = ( $1 != "(none)" ) ? $1 : nil
@@ -216,7 +216,7 @@ class Chef
         end
 
         def resolve_virtual_package_name(pkg)
-          showpkg = run_noninteractive("apt-cache", "showpkg", pkg).stdout
+          showpkg = run_noninteractive("apt-cache", "showpkg", "^#{pkg}$").stdout
           partitions = showpkg.rpartition(/Reverse Provides: ?#{$/}/)
           return nil if partitions[0] == "" && partitions[1] == "" # not found in output
 

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -67,7 +67,7 @@ describe Chef::Provider::Package::Apt do
 
     it "should create a current resource with the name of the new_resource" do
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "policy", @new_resource.package_name,
+        "apt-cache", "policy", "^#{@new_resource.package_name}$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(@shell_out)
@@ -107,7 +107,7 @@ describe Chef::Provider::Package::Apt do
       POLICY_STDOUT
       policy = double(stdout: policy_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "policy", "conic-smarms",
+        "apt-cache", "policy", "^conic-smarms$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(policy)
@@ -116,7 +116,7 @@ describe Chef::Provider::Package::Apt do
       SHOWPKG_STDOUT
       showpkg = double(stdout: showpkg_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "showpkg", "conic-smarms",
+        "apt-cache", "showpkg", "^conic-smarms$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(showpkg)
@@ -135,7 +135,7 @@ describe Chef::Provider::Package::Apt do
       VPKG_STDOUT
       virtual_package = double(stdout: virtual_package_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "policy", "libmysqlclient15-dev",
+        "apt-cache", "policy", "^libmysqlclient15-dev$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(virtual_package)
@@ -159,7 +159,7 @@ describe Chef::Provider::Package::Apt do
       SHOWPKG_STDOUT
       showpkg = double(stdout: showpkg_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "showpkg", "libmysqlclient15-dev",
+        "apt-cache", "showpkg", "^libmysqlclient15-dev$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(showpkg)
@@ -178,7 +178,7 @@ describe Chef::Provider::Package::Apt do
       RPKG_STDOUT
       real_package = double(stdout: real_package_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "policy", "libmysqlclient-dev",
+        "apt-cache", "policy", "^libmysqlclient-dev$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(real_package)
@@ -195,7 +195,7 @@ describe Chef::Provider::Package::Apt do
       VPKG_STDOUT
       virtual_package = double(stdout: virtual_package_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "policy", "mp3-decoder",
+        "apt-cache", "policy", "^mp3-decoder$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(virtual_package)
@@ -222,7 +222,7 @@ describe Chef::Provider::Package::Apt do
       SHOWPKG_STDOUT
       showpkg = double(stdout: showpkg_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "showpkg", "mp3-decoder",
+        "apt-cache", "showpkg", "^mp3-decoder$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(showpkg)
@@ -236,7 +236,7 @@ describe Chef::Provider::Package::Apt do
       @new_resource.default_release("lenny-backports")
       @new_resource.provider(nil)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "-o", "APT::Default-Release=lenny-backports", "policy", "irssi",
+        "apt-cache", "-o", "APT::Default-Release=lenny-backports", "policy", "^irssi$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(@shell_out)
@@ -246,7 +246,7 @@ describe Chef::Provider::Package::Apt do
     it "raises an exception if a source is specified (CHEF-5113)" do
       @new_resource.source "pluto"
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "policy", @new_resource.package_name,
+        "apt-cache", "policy", "^#{@new_resource.package_name}$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" } ,
         timeout: @timeout
       ).and_return(@shell_out)
@@ -277,7 +277,7 @@ describe Chef::Provider::Package::Apt do
       RPKG_STDOUT
       real_package = double(stdout: real_package_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "policy", "libmysqlclient-dev",
+        "apt-cache", "policy", "^libmysqlclient-dev$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" },
         timeout: @timeout
       ).and_return(real_package)
@@ -307,12 +307,12 @@ describe Chef::Provider::Package::Apt do
       RPKG_STDOUT
       real_package = double(stdout: real_package_out, exitstatus: 0)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "policy", @new_resource.package_name,
+        "apt-cache", "policy", "^#{@new_resource.package_name}$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" } ,
         timeout: @timeout
       ).and_return(real_package)
       expect(@provider).to receive(:shell_out_compacted!).with(
-        "apt-cache", "showpkg", @new_resource.package_name,
+        "apt-cache", "showpkg", "^#{@new_resource.package_name}$",
         env: { "DEBIAN_FRONTEND" => "noninteractive" } ,
         timeout: @timeout
       ).and_return(real_package)


### PR DESCRIPTION
## Description

`apt-cache` treats arguments which don't correspond to package names as
patterns: this means that Chef can end up attempting to install a
different set of packages to the ones requested if the request includes
an absent package with pattern-matching characters (e.g. `lua5.3` in
Ubuntu if universe is disabled will match `liblua5.3-dev` and others).

This commit modifies the `apt-cache` calls in the apt package provider
which pass a package name to wrap that package name in '^...$', ensuring
that `apt-cache` will attempt to select a single package regardless of
whether the package name contains pattern-matching characters.

An alternative would be to set `APT::Cmd::Pattern-Only` as `true` when
executing these commands: not all supported Ubuntu/Debian versions have
an apt which supports that configuration option, so this commit's
approach is more universal.

## Related Issue

Fixes: #12944

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).