### PR TITLE
Update omnibus/Gemfile.lock for compatibility with omnibus-toolchain 3.0.0

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -44,6 +44,10 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
+  el-9-aarch64:
+    - el-9-aarch64
+  el-9-x86_64:
+    - el-9-x86_64
   freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -44,6 +44,10 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
+  el-9-aarch64:
+    - el-9-aarch64
+  el-9-x86_64:
+    - el-9-x86_64
   freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 29ebd6cc3f9c3e4e96b9cfbdc426514d60c10aaf
+  revision: a63bd71702f5bf350ca17ee0726ac36fc418d54e
   branch: main
   specs:
     omnibus-software (4.0.0)
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 78ad41dcb79f0153c7f8efb963ea4d80fe055340
+  revision: 83d8428abde4cb289a161f736822ba02563a884c
   branch: main
   specs:
-    omnibus (9.0.2)
+    omnibus (9.0.3)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)
@@ -20,9 +20,9 @@ GIT
       license_scout (~> 1.0)
       mixlib-shellout (>= 2.0, < 4.0)
       mixlib-versioning
-      nokogiri (~> 1)
       ohai (>= 15, < 18)
       pedump
+      rexml (~> 3.2)
       ruby-progressbar (~> 1.7)
       thor (>= 0.18, < 2.0)
 
@@ -194,6 +194,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
     ffi (1.15.5-x64-mingw32)
     ffi (1.15.5-x86-mingw32)
     ffi-libarchive (1.1.3)
@@ -247,7 +248,7 @@ GEM
       tomlrb (>= 1.2, < 3.0)
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
-    license_scout (1.3.0)
+    license_scout (1.3.1)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)
@@ -256,7 +257,6 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
     method_source (1.0.0)
-    mini_portile2 (2.8.0)
     minitar (0.9)
     mixlib-archive (1.1.7)
       mixlib-log
@@ -278,6 +278,11 @@ GEM
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
+    mixlib-shellout (3.2.7-x64-mingw-ucrt)
+      chef-utils
+      ffi-win32-extensions (~> 1.0.3)
+      win32-process (~> 0.9)
+      wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -289,13 +294,6 @@ GEM
     net-ssh (6.1.0)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
-    nokogiri (1.13.6)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x64-mingw32)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86-mingw32)
-      racc (~> 1.4)
     nori (2.6.0)
     octokit (4.22.0)
       faraday (>= 0.9)
@@ -329,7 +327,6 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.7)
-    racc (1.6.0)
     rack (2.2.3)
     rainbow (3.1.1)
     retryable (3.0.5)
@@ -468,6 +465,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw
   x64-mingw32
   x86-mingw32
 


### PR DESCRIPTION
Update omnibus/Gemfile.lock for compatibility with omnibus-toolchain 3.0.0

Add RHEL 9 to build matrix
