### PR TITLE
Updated ncurses and gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.592.0)
+    aws-partitions (1.594.0)
     aws-sdk-core (3.131.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -339,11 +339,11 @@ GEM
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
     public_suffix (4.0.7)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rainbow (3.1.1)
     rake (13.0.6)
     rb-readline (0.5.5)
-    regexp_parser (2.4.0)
+    regexp_parser (2.5.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -526,4 +526,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.14
+   2.3.12

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: a63bd71702f5bf350ca17ee0726ac36fc418d54e
+  revision: a9b13a09c2f89e4618225dd41b2fd08f2150a1ba
   branch: main
   specs:
     omnibus-software (4.0.0)
@@ -34,7 +34,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.592.0)
+    aws-partitions (1.594.0)
     aws-sdk-core (3.131.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -295,9 +295,9 @@ GEM
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     nori (2.6.0)
-    octokit (4.22.0)
-      faraday (>= 0.9)
-      sawyer (~> 0.8.0, >= 0.5.3)
+    octokit (4.23.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     ohai (17.9.0)
       chef-config (>= 14.12, < 18)
       chef-utils (>= 16.0, < 18)
@@ -327,7 +327,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.7)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rainbow (3.1.1)
     retryable (3.0.5)
     rexml (3.2.5)
@@ -351,9 +351,9 @@ GEM
     ruby2_keywords (0.0.5)
     rubyntlm (0.6.3)
     rubyzip (2.3.2)
-    sawyer (0.8.2)
+    sawyer (0.9.1)
       addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
+      faraday (>= 0.17.3, < 3)
     semverse (3.0.2)
     solve (4.0.4)
       molinillo (~> 0.6)
@@ -480,4 +480,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   2.3.14
+   2.3.12

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -16,7 +16,7 @@ override "libxslt", version: windows? ? "1.1.34" : "1.1.35"
 
 override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
-override "ncurses", version: "5.9"
+override "ncurses", version: "6.3"
 override "nokogiri", version: "1.13.1"
 override "openssl", version: mac_os_x? ? "1.1.1m" : "1.0.2zb"
 override "pkg-config-lite", version: "0.28-1"


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

Per https://buildkite.com/chef/chef-chef-main-omnibus-release/builds/1678#_
Updating ncurses gem to overcome freebsd build failures.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
