### PR TITLE
Fix error 'error validating X-Vault-AWS-IAM-Server-ID header: missing header X-Vault-AWS-IAM-Server-ID' in Hashi Vault secret manager for AWS IAM auth method

### DIFF
--- a/lib/chef/secret_fetcher/hashi_vault.rb
+++ b/lib/chef/secret_fetcher/hashi_vault.rb
@@ -112,7 +112,7 @@ class Chef
             raise Chef::Exceptions::Secret::ConfigurationInvalid.new("You must provide the authenticating Vault role name in the configuration as :role_name")
           end
 
-          Vault.auth.aws_iam(config[:role_name], Aws::InstanceProfileCredentials.new)
+          Vault.auth.aws_iam(config[:role_name], Aws::InstanceProfileCredentials.new, Vault.address)
         else
           raise Chef::Exceptions::Secret::ConfigurationInvalid.new("Invalid :auth_method provided.  You gave #{config[:auth_method]}, expected one of :#{SUPPORTED_AUTH_TYPES.join(", :")} ")
         end


### PR DESCRIPTION

Signed-off-by: Neha Pansare <neha.pansare@progress.com>

## Description
The implementation uses vault-ruby gem and its [Vault.auth.aws_iam](https://github.com/hashicorp/vault-ruby/blob/6f98a377218adff3bd180d6958426a130071306c/lib/vault/api/auth.rb#L207) method. (Refer chef/lib/chef/secret_fetcher/hashi_vault.rb for additional code details
Here the 3rd parameter iam_auth_header_value , which can be nil but if not passed, the gem throws the given error:
`error validating X-Vault-AWS-IAM-Server-ID header: missing header X-Vault-AWS-IAM-Server-ID' in Hashi Vault secret manager for AWS IAM auth method`

## Related Issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
