### PR TITLE
backport-17: Fix error 'error validating X-Vault-AWS-IAM-Server-ID header: missing header X-Vault-AWS-IAM-Server-ID' in Hashi Vault secret manager for AWS IAM auth method 

### DIFF
--- a/lib/chef/dsl/secret.rb
+++ b/lib/chef/dsl/secret.rb
@@ -162,10 +162,6 @@ class Chef
       #   value = secret(name: "test1", service: :aws_secrets_manager, version: "v1", config: { region: "us-west-1" })
       #   log "My secret is #{value}"
       def secret(name: nil, version: nil, service: default_secret_service, config: default_secret_config)
-        Chef::Log.warn <<~EOM.gsub("\n", " ")
-          The secrets Chef Infra language helper is currently in beta. If you have feedback or you would
-          like to be part of the future design of this helper e-mail us at secrets_management_beta@progress.com"
-        EOM
         sensitive(true) if is_a?(Chef::Resource)
         Chef::SecretFetcher.for_service(service, config, run_context).fetch(name, version)
       end

--- a/lib/chef/secret_fetcher/hashi_vault.rb
+++ b/lib/chef/secret_fetcher/hashi_vault.rb
@@ -112,7 +112,7 @@ class Chef
             raise Chef::Exceptions::Secret::ConfigurationInvalid.new("You must provide the authenticating Vault role name in the configuration as :role_name")
           end
 
-          Vault.auth.aws_iam(config[:role_name], Aws::InstanceProfileCredentials.new)
+          Vault.auth.aws_iam(config[:role_name], Aws::InstanceProfileCredentials.new, Vault.address)
         else
           raise Chef::Exceptions::Secret::ConfigurationInvalid.new("Invalid :auth_method provided.  You gave #{config[:auth_method]}, expected one of :#{SUPPORTED_AUTH_TYPES.join(", :")} ")
         end


### PR DESCRIPTION
backport https://github.com/chef/chef/pull/12956

Also remove the beta feature warning which shows up when using Secret Manager