### PR TITLE
adding a sleep to ensure groups are created properly during testing o…

### DIFF
--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -48,7 +48,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       # Adding a 2 second delay for this platform is enough to get correct results.
       # We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617
       sleep 2 if aix? && (ohai[:platform_version] == "7.2")
-     # freebsd 13 is throwing similar "what group?" errors. Adding a delay here for the same purpose
+      # freebsd 13 is throwing similar "what group?" errors. Adding a delay here for the same purpose
       sleep 2 if freebsd?
       Etc.getgrnam(group_name).mem.include?(user)
     end

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -48,6 +48,8 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       # Adding a 2 second delay for this platform is enough to get correct results.
       # We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617
       sleep 2 if aix? && (ohai[:platform_version] == "7.2")
+     # freebsd 13 is throwing similar "what group?" errors. Adding a delay here for the same purpose
+      sleep 2 if freebsd?
       Etc.getgrnam(group_name).mem.include?(user)
     end
   end


### PR DESCRIPTION
…n Freebsd

Signed-off-by: John McCrae <john.mccrae@progress.com>

Freebsd is consistently throwing errors during group/user creation in testing. I added a delay identical to the one used on AIX to ensure that groups are created properly - the error says that the group doesn't exist. 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
