### PR TITLE
Adjusting cert creation for older Windows platforms

### DIFF
--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -37,7 +37,14 @@ describe "chef-client" do
 
   def install_certificate_in_store(client_name)
     if ChefUtils.windows?
-      powershell_exec!("New-SelfSignedCertificate -certstorelocation cert:\\localmachine\\my -Subject #{client_name} -FriendlyName #{client_name} -KeyExportPolicy Exportable")
+      powershell_exec! <<~EOH
+        if ($PSVersionTable.PSVersion -match 3) {
+          New-SelfSignedCertificate -CertStoreLocation Cert:\\LocalMachine\\My -DnsName #{client_name}
+        }
+        else {
+          New-SelfSignedCertificate -certstorelocation cert:\\localmachine\\my -Subject #{client_name} -FriendlyName #{client_name} -KeyExportPolicy Exportable
+        }
+      EOH
     end
   end
 


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

Adhoc and Release pipelines fail on Windows Server 2012 in part because we try to install a self-signed certificate using PowerShell 5.x syntax and the version of PowerShell installed on that OS is 3.0. I added a flag to capture that difference and create the certificate correctly based on that. 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
