### PR TITLE
updating gemfile.locks to pull in ohai 18.0.14

### DIFF
--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -26,8 +26,6 @@ class Chef
   class HTTP
     class Authenticator
       DEFAULT_SERVER_API_VERSION = "2".freeze
-      # cspell:disable-next-line
-      SOME_CHARS = "~!@#%^&*_-+=`|\\(){}[<]:;'>,.?/0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz".each_char.to_a
 
       extend Chef::Mixin::PowershellExec
 
@@ -190,8 +188,9 @@ class Chef
         unless @win32registry.key_exists?(new_path)
           @win32registry.create_key(new_path, true)
         end
+        require "securerandom"
         size = 14
-        password = (0...size).map { SOME_CHARS[rand(SOME_CHARS.size)] }.join
+        password = SecureRandom.alphanumeric(size)
         encrypted_pass = encrypt_pfx_pass(password)
         values = { name: "PfxPass", type: :string, data: encrypted_pass }
         @win32registry.set_value(new_path, values)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Existing code in the password generator was creating password that would sometimes not meet length requirements. Investigation concluded there were probably characters in the string that was being sampled that were unsuitable for a password and thus Ruby was escaping them and that in turn caused an invalid password. This code replacement is much better. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
Signed-off-by: John McCrae <john.mccrae@progress.com>