### PR TITLE
AdHoc Pipeline Windows PageFile Test errors

### DIFF
--- a/lib/chef/resource/windows_pagefile.rb
+++ b/lib/chef/resource/windows_pagefile.rb
@@ -148,10 +148,12 @@ class Chef
         def exists?(pagefile)
           @exists ||= begin
             logger.trace("Checking if #{pagefile} exists by running: Get-CimInstance Win32_PagefileSetting | Where-Object { $_.name -eq $($pagefile)} ")
-            cmd =  "$page_file_name = '#{pagefile}';"
-            cmd << "$pagefile = Get-CimInstance Win32_PagefileSetting | Where-Object { $_.name -eq $($page_file_name)};"
-            cmd << "if ([string]::IsNullOrEmpty($pagefile)) { return $false } else { return $true }"
-            powershell_exec!(cmd).result
+            powershell_code = <<~CODE
+              $page_file_name = '#{pagefile}';
+              $pagefile = Get-CimInstance Win32_PagefileSetting | Where-Object { $_.name -eq $($page_file_name)}
+              if ([string]::IsNullOrEmpty($pagefile)) { return $false } else { return $true }
+            CODE
+            powershell_exec!(powershell_code).result
           end
         end
 

--- a/lib/chef/resource/windows_pagefile.rb
+++ b/lib/chef/resource/windows_pagefile.rb
@@ -246,14 +246,13 @@ class Chef
         # @param [String] min the minimum size of the pagefile
         # @param [String] max the minimum size of the pagefile
         def set_custom_size(pagefile, min, max)
+          unset_automatic_managed
           converge_by("set #{pagefile} to InitialSize=#{min} & MaximumSize=#{max}") do
             logger.trace("Set-CimInstance -Property @{InitialSize = #{min} MaximumSize = #{max}")
             powershell_exec! <<~EOD
               $page_file = "#{pagefile}"
               $driveLetter = $page_file.split(':')[0]
-              Get-CimInstance -ClassName Win32_PageFileSetting -Filter "SettingID='pagefile.sys @ $($driveLetter):'" -ErrorAction Stop | Set-CimInstance -Property @{
-              InitialSize = #{min}
-              MaximumSize = #{max}}
+              Get-CimInstance -ClassName Win32_PageFileSetting -Filter "SettingID='pagefile.sys @ $($driveLetter):'" -ErrorAction Stop | Set-CimInstance -Property @{InitialSize = #{min}; MaximumSize = #{max};}
             EOD
           end
         end

--- a/spec/functional/resource/windows_pagefile_spec.rb
+++ b/spec/functional/resource/windows_pagefile_spec.rb
@@ -49,6 +49,15 @@ describe Chef::Resource::WindowsPagefile, :windows_only do
     powershell_exec!(powershell_code)
   end
 
+   def set_automatic_managed_to_true
+    powershell_code = <<~EOH
+      $computersys = Get-WmiObject Win32_ComputerSystem -EnableAllPrivileges;
+      $computersys.AutomaticManagedPagefile = $True;
+      $computersys.Put();
+    EOH
+    powershell_exec!(powershell_code)
+  end
+
   describe "Setting Up Pagefile Management" do
     context "Disable Automatic Management" do
       it "Verifies Automatic Management is Disabled" do
@@ -62,6 +71,14 @@ describe Chef::Resource::WindowsPagefile, :windows_only do
       it "Enable Automatic Management " do
         subject.path c_path
         subject.automatic_managed true
+        subject.run_action(:set)
+        expect(subject).to be_updated_by_last_action
+      end
+
+      it "Disables Automatic Management" do
+        set_automatic_managed_to_true
+        subject.path c_path
+        subject.automatic_managed false
         subject.run_action(:set)
         expect(subject).to be_updated_by_last_action
       end
@@ -79,8 +96,8 @@ describe Chef::Resource::WindowsPagefile, :windows_only do
     context "Update a pagefile" do
       it "Changes a pagefile to use custom sizes" do
         subject.path c_path
-        subject.initial_size 20000
-        subject.maximum_size 80000
+        subject.initial_size 128
+        subject.maximum_size 512
         subject.run_action(:set)
         expect(subject).to be_updated_by_last_action
       end

--- a/spec/functional/resource/windows_pagefile_spec.rb
+++ b/spec/functional/resource/windows_pagefile_spec.rb
@@ -42,11 +42,11 @@ describe Chef::Resource::WindowsPagefile, :windows_only do
 
   describe "Setting Up Pagefile Management" do
     context "Disable Automatic Management" do
-      it "Disables Automatic Management" do
+      it "Verifies Automatic Management is Disabled" do
         subject.path c_path
         subject.automatic_managed false
         subject.run_action(:set)
-        expect(subject).to be_updated_by_last_action
+        expect(subject).not_to be_updated_by_last_action
       end
 
       it "Enable Automatic Management " do

--- a/spec/functional/resource/windows_pagefile_spec.rb
+++ b/spec/functional/resource/windows_pagefile_spec.rb
@@ -40,9 +40,19 @@ describe Chef::Resource::WindowsPagefile, :windows_only do
     new_resource
   end
 
+  def set_automatic_managed_to_false
+    powershell_code = <<~EOH
+      $computersys = Get-WmiObject Win32_ComputerSystem -EnableAllPrivileges;
+      $computersys.AutomaticManagedPagefile = $False;
+      $computersys.Put();
+    EOH
+    powershell_exec!(powershell_code)
+  end
+
   describe "Setting Up Pagefile Management" do
     context "Disable Automatic Management" do
       it "Verifies Automatic Management is Disabled" do
+        set_automatic_managed_to_false
         subject.path c_path
         subject.automatic_managed false
         subject.run_action(:set)

--- a/spec/functional/resource/windows_pagefile_spec.rb
+++ b/spec/functional/resource/windows_pagefile_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Resource::WindowsPagefile, :windows_only do
     powershell_exec!(powershell_code)
   end
 
-   def set_automatic_managed_to_true
+  def set_automatic_managed_to_true
     powershell_code = <<~EOH
       $computersys = Get-WmiObject Win32_ComputerSystem -EnableAllPrivileges;
       $computersys.AutomaticManagedPagefile = $True;


### PR DESCRIPTION
Refactored code to be more readable and changed a test to correct for starting out with Auto-Managed being false by default

Signed-off-by: John McCrae <john.mccrae@progress.com>

## Description
Windows Ad Hoc jobs were failing on a pagefile settings test. Windows nodes were randomly starting up with the pagefile "autmatically managed" set to True and False so the pagefile tests were failing. I updated some of the code to make it more readable, I updated one test to verify the state, and finally I added a method to set the pagefile state before the first test.  

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
