### PR TITLE
Correcting Cert creation for rspec tests

### DIFF
--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -38,7 +38,7 @@ describe "chef-client" do
   def install_certificate_in_store(client_name)
     if ChefUtils.windows?
       powershell_exec! <<~EOH
-        if (-not ($PSVersionTable.PSVersion.Major -ge 5)) {
+        if (-not (($PSVersionTable.PSVersion.Major -ge 5) -and ($PSVersionTable.PSVersion.Build -ge 22000)) ) {
           New-SelfSignedCertificate -CertStoreLocation Cert:\\LocalMachine\\My -DnsName "#{client_name}"
         }
         else {


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

Correcting Cert creation for rspec tests

## Description
We create self-signed certificates in ./spec/integration/client/client_spec.rb. Previously that code was updated to account for older versions of Windows but it did not correctly account for PowerShell 5.1 builds which are radically different between various shipping versions. Build 22000, shipping in current versions, has the certificate fields needed to correctly create the certificates we need. Older builds do not. This update corrects for that.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
