### PR TITLE
Fix fedora kitchen test failure

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -61,7 +61,7 @@ ssh_known_hosts_entry "github.com"
 
 include_recipe "openssh"
 
-include_recipe "nscd"
+include_recipe "nscd" unless fedora? # fedora 35+ doesn't have nscd
 
 logrotate_package "logrotate"
 

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -61,7 +61,7 @@ ssh_known_hosts_entry "github.com"
 
 include_recipe "openssh"
 
-include_recipe "nscd" unless fedora? # fedora 35+ doesn't have nscd
+include_recipe "nscd" unless fedora? # fedora 34+ doesn't have nscd
 
 logrotate_package "logrotate"
 


### PR DESCRIPTION
Added condition to prevent installation of nscd on fedora in end_to_end kitchen tests as package has been removed from fedora 35 onward.
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

## Description
Kitchen tests had been failing on fedora with error 
`nscd` package has been removed from fedora 35. It was warned for deprecation in fedora 34.
Currently `systemd-resolved` is enabled by default for DNS caching in Fedora, and `sssd` is capable of caching the remaining named services that `nscd` handles.
Our kitchen instance is running on fedora 36, hence it throws `nscd` package not being available error.
More details can be found at https://fedoraproject.org/wiki/Changes/RemoveNSCD

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
