### PR TITLE
Updated the tests to add a registry key for Windows

### DIFF
--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -175,7 +175,7 @@ class Chef
         present.each do |secret|
           if secret[:name] == "PfxPass"
             password = decrypt_pfx_pass(secret[:data])
-            return password
+            return password.to_s
           end
         end
 

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -594,7 +594,7 @@ describe "chef-client" do
             cookbook_path "#{path_to("cookbooks")}"
           EOM
           result = shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir)
-          result.error!
+          expect(result.exitstatus).to eq(0)
 
           expect(IO.read(path_to("tempfile.txt")).strip).to eq("this is my file")
         end

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -72,13 +72,13 @@ describe "chef-client" do
 
   def verify_export_password_exists
     powershell_exec! <<~EOH
-    Try {
-      $response = Get-ItemProperty -Path "HKLM:\\Software\\Progress\\Authentication" -Name "PfxPass" -ErrorAction Stop
-      if ($response) {return $true}
+      Try {
+          $response = Get-ItemProperty -Path "HKLM:\\Software\\Progress\\Authentication" -Name "PfxPass" -ErrorAction Stop
+          if ($response) {return $true}
       }
-    Catch {
-        return $false
-    }
+      Catch {
+          return $false
+      }
     EOH
   end
 
@@ -628,8 +628,9 @@ describe "chef-client" do
     end
 
     it "should run the ohai plugin" do
-      result = shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir)
-      result.error!
+      # result = shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir)
+      # result.error!
+      expect{ shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir) }.not_to raise_error
 
       expect(IO.read(path_to("tempfile.txt"))).to eq("2014")
     end
@@ -650,8 +651,9 @@ describe "chef-client" do
       file "config/client.rb", <<~EOM
         chef_repo_path "#{tmp_dir}"
       EOM
-      result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", cwd: tmp_dir)
-      result.error!
+      # result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", cwd: tmp_dir)
+      # result.error!
+      expect{ shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", cwd: tmp_dir) }.not_to raise_error
     end
 
     it "should fail when passed --recipe-url and not passed -z" do

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -628,7 +628,8 @@ describe "chef-client" do
     end
 
     it "should run the ohai plugin" do
-      expect { shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir) }.not_to raise_error
+      command = shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir)
+      expect(command.exitstatus).to eq(0)
 
       expect(IO.read(path_to("tempfile.txt"))).to eq("2014")
     end
@@ -649,7 +650,8 @@ describe "chef-client" do
       file "config/client.rb", <<~EOM
         chef_repo_path "#{tmp_dir}"
       EOM
-      expect { shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", cwd: tmp_dir) }.not_to raise_error
+      command = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", cwd: tmp_dir)
+      expect(command.exitstatus).to eq(0)
     end
 
     it "should fail when passed --recipe-url and not passed -z" do
@@ -687,12 +689,12 @@ describe "chef-client" do
 
     it "the chef client run should succeed" do
       command = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir)
-      command.error!
+      expect(command.exitstatus).to eq(0)
     end
 
     it "a chef-solo run should succeed" do
       command = shell_out("#{chef_solo} -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir)
-      command.error!
+      expect(command.exitstatus).to eq(0)
     end
   end
 

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -628,9 +628,7 @@ describe "chef-client" do
     end
 
     it "should run the ohai plugin" do
-      # result = shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir)
-      # result.error!
-      expect{ shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir) }.not_to raise_error
+      expect { shell_out("#{chef_client} -l debug -c \"#{path_to("config/client.rb")}\" -o 'x::default' --no-fork", cwd: chef_dir) }.not_to raise_error
 
       expect(IO.read(path_to("tempfile.txt"))).to eq("2014")
     end
@@ -651,9 +649,7 @@ describe "chef-client" do
       file "config/client.rb", <<~EOM
         chef_repo_path "#{tmp_dir}"
       EOM
-      # result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", cwd: tmp_dir)
-      # result.error!
-      expect{ shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", cwd: tmp_dir) }.not_to raise_error
+      expect { shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", cwd: tmp_dir) }.not_to raise_error
     end
 
     it "should fail when passed --recipe-url and not passed -z" do

--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -94,8 +94,7 @@ describe "chef-client" do
       end
 
       it "should complete with success" do
-        result = shell_out("#{chef_client_cmd} -o 'noop::default'", cwd: chef_dir)
-        result.error!
+        expect { shell_out("#{chef_client_cmd} -o 'noop::default'", cwd: chef_dir) }.not_to raise_error
       end
 
     end

--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -125,8 +125,7 @@ describe "chef-client" do
       end
 
       it "should complete with success" do
-        result = shell_out("#{chef_client_cmd} -o 'api-smoke-test::default'", cwd: chef_dir)
-        result.error!
+        expect { shell_out("#{chef_client_cmd} -o 'api-smoke-test::default'", cwd: chef_dir) }.not_to raise_error
       end
 
     end

--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -94,7 +94,8 @@ describe "chef-client" do
       end
 
       it "should complete with success" do
-        expect { shell_out("#{chef_client_cmd} -o 'noop::default'", cwd: chef_dir) }.not_to raise_error
+        command = shell_out("#{chef_client_cmd} -o 'noop::default'", cwd: chef_dir)
+        expect(command.exitstatus).to eq(0)
       end
 
     end
@@ -125,7 +126,8 @@ describe "chef-client" do
       end
 
       it "should complete with success" do
-        expect { shell_out("#{chef_client_cmd} -o 'api-smoke-test::default'", cwd: chef_dir) }.not_to raise_error
+        command = shell_out("#{chef_client_cmd} -o 'api-smoke-test::default'", cwd: chef_dir)
+        expect(command.exitstatus).to eq(0)
       end
 
     end

--- a/spec/integration/recipes/accumulator_spec.rb
+++ b/spec/integration/recipes/accumulator_spec.rb
@@ -235,7 +235,7 @@ describe "Accumulators" do
       EOM
 
       result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
-      result.error!
+      expect(result.exitstatus).to eq(0)
       # runs only a single template resource (in the outer run context, as a delayed resource)
       expect(result.stdout.scan(/template\S+ action create/).size).to eql(1)
       # hash order is insertion order in ruby >= 1.9, so this next line does test that all calls were in the correct order

--- a/spec/integration/recipes/accumulator_spec.rb
+++ b/spec/integration/recipes/accumulator_spec.rb
@@ -126,6 +126,7 @@ describe "Accumulators" do
         log_level :warn
       EOM
 
+      result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
       expect { shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir) }.not_to raise_error
       # runs only a single template resource (in the outer run context, as a delayed resource)
       expect(result.stdout.scan(/template\S+ action create/).size).to eql(1)

--- a/spec/integration/recipes/accumulator_spec.rb
+++ b/spec/integration/recipes/accumulator_spec.rb
@@ -126,8 +126,7 @@ describe "Accumulators" do
         log_level :warn
       EOM
 
-      result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
-      result.error!
+      expect { shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir) }.not_to raise_error
       # runs only a single template resource (in the outer run context, as a delayed resource)
       expect(result.stdout.scan(/template\S+ action create/).size).to eql(1)
       # hash order is insertion order in ruby >= 1.9, so this next line does test that all calls were in the correct order

--- a/spec/integration/recipes/accumulator_spec.rb
+++ b/spec/integration/recipes/accumulator_spec.rb
@@ -127,7 +127,7 @@ describe "Accumulators" do
       EOM
 
       result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
-      expect { shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir) }.not_to raise_error
+      expect(result.exitstatus).to eq(0)
       # runs only a single template resource (in the outer run context, as a delayed resource)
       expect(result.stdout.scan(/template\S+ action create/).size).to eql(1)
       # hash order is insertion order in ruby >= 1.9, so this next line does test that all calls were in the correct order

--- a/spec/integration/recipes/lwrp_inline_resources_spec.rb
+++ b/spec/integration/recipes/lwrp_inline_resources_spec.rb
@@ -158,16 +158,16 @@ describe "LWRPs with inline resources" do
 
       result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
       actual = result.stdout.lines.map(&:chomp).join("\n")
-      expected = <<EOM
-  * x_my_machine[me] action create
-    * x_do_nothing[a] action create (up to date)
-    * x_do_nothing[b] action create (up to date)
-     (up to date)
-  * x_my_machine[you] action create
-    * x_do_nothing[a] action create (up to date)
-    * x_do_nothing[b] action create (up to date)
-     (up to date)
-EOM
+      expected = <<~EOM
+        * x_my_machine[me] action create
+          * x_do_nothing[a] action create (up to date)
+          * x_do_nothing[b] action create (up to date)
+          (up to date)
+        * x_my_machine[you] action create
+          * x_do_nothing[a] action create (up to date)
+          * x_do_nothing[b] action create (up to date)
+          (up to date)
+      EOM
       expected = expected.lines.map(&:chomp).join("\n")
       expect(actual).to include(expected)
       result.error!

--- a/spec/integration/recipes/lwrp_inline_resources_spec.rb
+++ b/spec/integration/recipes/lwrp_inline_resources_spec.rb
@@ -158,16 +158,16 @@ describe "LWRPs with inline resources" do
 
       result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
       actual = result.stdout.lines.map(&:chomp).join("\n")
-      expected = <<~EOM
-        * x_my_machine[me] action create
-          * x_do_nothing[a] action create (up to date)
-          * x_do_nothing[b] action create (up to date)
-          (up to date)
-        * x_my_machine[you] action create
-          * x_do_nothing[a] action create (up to date)
-          * x_do_nothing[b] action create (up to date)
-          (up to date)
-      EOM
+      expected = <<EOM
+  * x_my_machine[me] action create
+    * x_do_nothing[a] action create (up to date)
+    * x_do_nothing[b] action create (up to date)
+     (up to date)
+  * x_my_machine[you] action create
+    * x_do_nothing[a] action create (up to date)
+    * x_do_nothing[b] action create (up to date)
+     (up to date)
+EOM
       expected = expected.lines.map(&:chomp).join("\n")
       expect(actual).to include(expected)
       result.error!

--- a/spec/integration/recipes/notifies_spec.rb
+++ b/spec/integration/recipes/notifies_spec.rb
@@ -18,9 +18,16 @@ require "spec_helper"
 require "support/shared/integration/integration_helper"
 require "chef/mixin/shell_out"
 
+begin
+  require "chef-powershell"
+rescue LoadError
+  puts "Not loading powershell_exec during testing"
+end
+
 describe "notifications" do
   include IntegrationSupport
   include Chef::Mixin::ShellOut
+  include ChefPowerShell::ChefPowerShellModule::PowerShellExec
 
   let(:chef_dir) { File.expand_path("../../..", __dir__) }
   let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }
@@ -35,7 +42,7 @@ describe "notifications" do
 
   when_the_repository "notifies a nameless resource" do
     before do
-      create_registry_key
+      create_registry_key if windows?
       directory "cookbooks/x" do
         file "recipes/default.rb", <<-EOM
           apt_update do
@@ -432,7 +439,7 @@ describe "notifications" do
     end
 
     after do
-      remove_registry_key
+      remove_registry_key if windows?
     end
 
     it "notifying the resource should work" do

--- a/spec/integration/recipes/notifies_spec.rb
+++ b/spec/integration/recipes/notifies_spec.rb
@@ -27,7 +27,7 @@ end
 describe "notifications" do
   include IntegrationSupport
   include Chef::Mixin::ShellOut
-  include ChefPowerShell::ChefPowerShellModule::PowerShellExec
+  include ChefPowerShell::ChefPowerShellModule::PowerShellExec if windows?
 
   let(:chef_dir) { File.expand_path("../../..", __dir__) }
   let(:chef_client) { "bundle exec #{ChefUtils::Dist::Infra::CLIENT} --minimal-ohai --always-dump-stacktrace" }

--- a/spec/integration/recipes/unified_mode_spec.rb
+++ b/spec/integration/recipes/unified_mode_spec.rb
@@ -872,7 +872,7 @@ describe "Unified Mode" do
       # in recipe mode we should still run normally with a compile/converge mode
       expect(result.stdout).to include("first: bar")
       expect(result.stdout).not_to include("first: foo")
-      result.error!
+      expect(result.exitstatus).to eq(0)
     end
   end
 

--- a/spec/integration/recipes/unified_mode_spec.rb
+++ b/spec/integration/recipes/unified_mode_spec.rb
@@ -566,7 +566,7 @@ describe "Unified Mode" do
       expect(result.stdout).not_to include("first: baz")
       expect(result.stdout).not_to include("second: foo")
       expect(result.stdout).not_to include("second: bar")
-      result.error!
+      expect(result.exitstatus).to eq(0)
     end
   end
 
@@ -622,7 +622,7 @@ describe "Unified Mode" do
       expect(result.stdout).not_to include("first: bar")
       expect(result.stdout).not_to include("second: foo")
       expect(result.stdout).not_to include("second: baz")
-      result.error!
+      expect(result.exitstatus).to eq(0)
     end
   end
 

--- a/spec/integration/recipes/unified_mode_spec.rb
+++ b/spec/integration/recipes/unified_mode_spec.rb
@@ -830,7 +830,8 @@ describe "Unified Mode" do
 
       result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
       # this fires first normally before the error
-      expect(result.stdout).to include("notifying: foo")
+      expect(result.stdout.to_s).to match(/notifying: foo/)
+      # expect(result.stdout).to include("notifying: foo")
       # everything else does not run
       expect(result.stdout).not_to include("notified: foo")
       expect(result.stdout).not_to include("notified: bar")


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

## Description
In the Ad Hoc pipeline we have a number of tests that fail with a strange FFI::Yajl error usually around trying to extract something via PowerShell from the registry. In one consistent case, I discovered that the code was attempting to retrieve a client key password from the registry but the registry key did not exist. I updated the test to correctly add and remove the registry. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
