### PR TITLE
Fix missing require and small error in REST implementation

### DIFF
--- a/lib/chef/dsl/rest_resource.rb
+++ b/lib/chef/dsl/rest_resource.rb
@@ -31,13 +31,20 @@ class Chef
 
       # URL to collection
       def rest_api_collection(rest_api_collection = NOT_PASSED)
-        @rest_api_collection = rest_api_collection if rest_api_collection != NOT_PASSED
+        if rest_api_collection != NOT_PASSED
+          raise ArgumentError, "You must pass an absolute path to rest_api_collection" unless rest_api_collection.start_with? "/"
+
+          @rest_api_collection = rest_api_collection
+        end
+
         @rest_api_collection
       end
 
       # RFC6570-Templated URL to document
       def rest_api_document(rest_api_document = NOT_PASSED, first_element_only: false)
         if rest_api_document != NOT_PASSED
+          raise ArgumentError, "You must pass an absolute path to rest_api_document" unless rest_api_document.start_with? "/"
+
           @rest_api_document = rest_api_document
           @rest_api_document_first_element_only = first_element_only
         end

--- a/lib/chef/resource/_rest_resource.rb
+++ b/lib/chef/resource/_rest_resource.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+require "addressable/template" unless defined?(Addressable::Template)
 require "rest-client" unless defined?(RestClient)
 require "jmespath" unless defined?(JMESPath)
 require "chef/dsl/rest_resource" unless defined?(Chef::DSL::RestResource)
@@ -221,7 +222,9 @@ action_class do
     response = rest_postprocess(response)
 
     first_only = current_resource.class.rest_api_document_first_element_only
-    first_only && response.is_a?(Array) ? response.first : response
+    response.data = response.data.first if first_only && response.data.is_a?(Array)
+
+    response
   rescue RestClient::Exception => e
     rest_errorhandler(e)
   end


### PR DESCRIPTION
## Description

Added missing require of `addressable/template` to parse REST URL templates.
Fixed returns from `rest_get` method

## Related Issue

none

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
