### PR TITLE
    Res validation should be aware of action prop reqs.

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -307,7 +307,7 @@ class Chef
     #
     def required?(action = nil)
       if !action.nil? && options[:required].is_a?(Array)
-        options[:required].include?(action)
+        (options[:required] & Array(action)).any?
       else
         !!options[:required]
       end
@@ -426,7 +426,7 @@ class Chef
         end
       end
 
-      if value.nil? && required?
+      if value.nil? && required?(resource_action(resource))
         raise Chef::Exceptions::ValidationFailed, "#{name} is a required property"
       else
         value
@@ -455,7 +455,7 @@ class Chef
         Chef.deprecated(:property, options[:deprecated])
       end
 
-      if value.nil? && required?
+      if value.nil? && required?(resource_action(resource))
         raise Chef::Exceptions::ValidationFailed, "#{name} is a required property"
       else
         value
@@ -767,6 +767,11 @@ class Chef
         obj
       end
       visitor.call(value)
+    end
+
+    # action from resource, if available
+    def resource_action(resource)
+      resource.action if resource.respond_to?(:action)
     end
   end
 end

--- a/spec/unit/property/validation_spec.rb
+++ b/spec/unit/property/validation_spec.rb
@@ -600,6 +600,36 @@ describe "Chef::Resource.property validation" do
       it "does not fail if it is not specified, on running the doit2 action" do
         expect { resource.run_action(:doit2) }.not_to raise_error
       end
+
+      context "when an action does not require it" do
+        before do
+          resource.action(:doit2)
+        end
+
+        it "retrieval succeeds if x is not set when resource uses the doit2 action" do
+          expect { resource.x }.not_to raise_error
+        end
+
+        it "succeeds with set to nil when resource uses the doit2 action" do
+          expect { resource.x nil }.not_to raise_error
+        end
+      end
+
+      context "when an action requires it" do
+        before do
+          # NOTE: this is already the default action, but it doesn't
+          # hurt to be clear about the situation.
+          resource.action(:doit)
+        end
+
+        it "if x is not specified, retrieval fails for the doit action" do
+          expect { resource.x }.to raise_error Chef::Exceptions::ValidationFailed
+        end
+
+        it "value nil is not valid for the doit action (required means 'not nil')" do
+          expect { resource.x nil }.to raise_error Chef::Exceptions::ValidationFailed
+        end
+      end
     end
 
     with_property ":x, String, required: true" do


### PR DESCRIPTION
Signed-off-by: Steve Abatangle <sabat@area51.org>

## Description
(Lamont has seen this patch before. It was never merged because of some confusion in the conversation, about a year ago. The bug remains in the most current Infra release.)

The `get` and `set` methods in the Property class (for resource validation) check that a property is required if its value is nil. However, they don't check to see whether the property was required for the *specific action* the resource is using, so any use of `get` and `set` will throw an exception if used with a resource that doesn't use a required property, even when the property is not required for that action.

What I'm describing is easier to understand with an example: the current version of the chef-client cookbook has a recipe (cron.rb) with a resource that uses the `:delete` action. When you try to `get` that resource, it throws an exception, explaining that `:command` is a required property—*but it's only required for the* `:create` *action, not for* `:delete`.

See https://github.com/chef-cookbooks/chef-client/blob/master/recipes/cron.rb#L95-L97

This PR fixes that by passing the resource's *action* to the `required?` method.

I have included a unit test update. I would also have included an integration test, but that seems to require deeper knowledge about Chef plumbing than I have.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).