### PR TITLE
Add support for recursive, in-cookbook resource partials

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1508,7 +1508,13 @@ class Chef
         dirname = ::File.dirname(partial)
         basename = ::File.basename(partial, ".rb")
         basename = basename[1..] if basename.start_with?("_")
-        class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.path)))
+
+        # Support recursive `use`
+        callers = caller_locations
+        used_from = callers.first.label == 'use' ? callers.at(3).path : callers.first.path
+
+        fullpath = ::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(used_from))
+        class_eval IO.read(fullpath)
       end
     end
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1511,7 +1511,7 @@ class Chef
 
         # Support recursive `use`
         callers = caller_locations
-        used_from = callers.first.label == 'use' ? callers.at(3).path : callers.first.path
+        used_from = callers.first.label == "use" ? callers.at(3).path : callers.first.path
 
         fullpath = ::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(used_from))
         class_eval IO.read(fullpath)

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1511,7 +1511,11 @@ class Chef
 
         # Support recursive `use`
         callers = caller_locations
-        used_from = callers.first.label == "use" ? callers.at(3).path : callers.first.path
+        used_from = if callers.first.label == "use"
+                      callers.detect { |caller| caller.label == "class_from_file" }.path
+                    else
+                      callers.first.path
+                    end
 
         fullpath = ::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(used_from))
         class_eval IO.read(fullpath)

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -803,6 +803,72 @@ describe Chef::Resource do
     end
   end
 
+  describe "when using resource partials" do
+    let(:resource_using_core_partial) do
+      Class.new(Chef::Resource) do
+        use "core::core_partial"
+      end
+    end
+
+    let(:resource_using_cookbook_partial) do
+      Class.new(Chef::Resource) do
+        use "my_local_partial"
+      end
+    end
+
+    let(:resource_using_nested_partials) do
+      FakeCaller = Struct.new(:label, :path, keyword_init: true)
+      NonDynamicResource = Chef::Resource.dup
+
+      # Fake a caller_locations array, as RSpec uses a different execution path
+      NonDynamicResource.define_singleton_method(:caller_locations) do
+        [
+          FakeCaller.new(label: "use", path: File.join(__dir__, "resource.rb")),
+          FakeCaller.new(label: "noise", path: File.join(__dir__, "no_file")),
+          FakeCaller.new(label: "class_from_file", path: File.join(__dir__, "_level2_partial.rb")),
+          FakeCaller.new(label: "noise", path: File.join(__dir__, "no_file")),
+          FakeCaller.new(label: "class_from_file", path: File.join(__dir__, "_level1_partial.rb")),
+        ]
+      end
+
+      Class.new(NonDynamicResource) do
+        use "level1_partial"
+      end
+    end
+
+    it "correcly includes a core partial" do
+      expected_path = File.expand_path(File.join(__dir__, "../..", "lib/chef", "resource/_core_partial.rb"))
+      partial = "property :addon_property, default: true"
+
+      expect(IO).to receive(:read).with(expected_path).and_return(partial)
+      expect(resource_using_core_partial.properties.keys).to include(:addon_property)
+    end
+
+    it "correctly includes a cookbook partial" do
+      expected_path = File.expand_path(File.join(__dir__, "_my_local_partial.rb"))
+      partial = "property :addon_property, default: true"
+
+      expect(IO).to receive(:read).with(expected_path).and_return(partial)
+      expect(resource_using_cookbook_partial.properties.keys).to include(:addon_property)
+    end
+
+    it "correctly includes nested partials" do
+      level1_path = File.expand_path(File.join(__dir__, "_level1_partial.rb"))
+      level1_partial = <<-EOF
+        use 'level2_partial'
+        property :addon_property, default: true
+      EOF
+      expect(IO).to receive(:read).with(level1_path).and_return(level1_partial)
+
+      level2_path = File.expand_path(File.join(__dir__, "_level2_partial.rb"))
+      level2_partial = "property :base_property, default: true"
+      expect(IO).to receive(:read).with(level2_path).and_return(level2_partial)
+
+      expect(resource_using_nested_partials.properties.keys).to include(:addon_property)
+      expect(resource_using_nested_partials.properties.keys).to include(:base_property)
+    end
+  end
+
   describe "should_skip?" do
     before do
       resource = Chef::Resource::Cat.new("sugar", run_context)


### PR DESCRIPTION
## Description

Small change to support recursive resource partials in a cookbook. 

The current implementation crashes on chaining two `use` keywords inside a cookbook with ` FATAL: Errno::ENOENT: No such file or directory @ rb_sysopen - /_base_resource.rb`.

Chef 16's resource partials provide a way to create reusable code for resources by using composition, not inheritance. As a result you can overlay different logical elements to compose a completely new resource from.

For example, you could write a base partial to support an entirely new class of remote system interaction and then `use` it from multiple other resources to distinguish base functionality vs specific resource functionality.

This provides a clean, DSL-driven way to create e.g. REST resources but is applicable to all non-traditional targets.

## Related Issue

Future extensibility

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
