### PR TITLE
The functional tests currently timeout at 45 mins.

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -7,7 +7,7 @@ expeditor:
       retry:
         automatic:
           limit: 1
-      timeout_in_minutes: 45
+      timeout_in_minutes: 60
 
 steps:
 


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>
https://buildkite.com/chef-oss/chef-chef-main-verify/builds/13004#018237fa-a520-414a-9226-7b7d23440e35

It might be a separate task to figure out why the tests are taking longer to run. (https://chefio.atlassian.net/browse/INFC-224)