### PR TITLE
Refactor knife cookbook upload for non-CLI use

### DIFF
--- a/knife/lib/chef/knife.rb
+++ b/knife/lib/chef/knife.rb
@@ -68,6 +68,7 @@ class Chef
 
     attr_accessor :name_args
     attr_accessor :ui
+    attr_accessor :calling_request
 
     # knife acl subcommands are grouped in this category using this constant to verify.
     OPSCODE_HOSTED_CHEF_ACCESS_CONTROL = %w{acl group user}.freeze
@@ -311,6 +312,7 @@ class Chef
 
       command_name_words = self.class.snake_case_name.split("_")
 
+      @calling_request = "CLI"
       # Mixlib::CLI ignores the embedded name_args
       @name_args = parse_options(argv)
       @name_args.delete(command_name_words.join("-"))

--- a/knife/lib/chef/knife/cookbook_upload.rb
+++ b/knife/lib/chef/knife/cookbook_upload.rb
@@ -163,6 +163,13 @@ class Chef
             end
           end
         end
+        { "status" => 200, "message" => "Success" } if @calling_request != "CLI"
+      rescue Exception => e
+        if calling_request == "API"
+          raise Exceptions::UnprocessableEntityAPI, e
+        else
+          raise
+        end
       end
 
       def server_side_cookbooks

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -103,6 +103,14 @@ class Chef
     # Cookbook loader used to raise an argument error when cookbook not found.
     # for back compat, need to raise an error that inherits from ArgumentError
     class CookbookNotFoundInRepo < ArgumentError; end
+
+    class UnprocessableEntityAPI < StandardError
+      def initialize(msg, exception_type = "API exception")
+        @exception_type = exception_type
+        super( { message: msg, status: 422 }.to_json)
+      end
+    end
+
     class CookbookMergingError < RuntimeError; end
     class RecipeNotFound < ArgumentError; end
     # AttributeNotFound really means the attribute file could not be found


### PR DESCRIPTION
Signed-off-by: sachin007jain <sachin.jain@chef.io>

<!--- Provide a short summary of your changes in the Title above -->
The relevant method(s) in knife cookbook upload module needs to refactored so that it can be consumed by the CLI as well as API. 

Command refactored

`knife cookbook upload cookbook_name`

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
