### PR TITLE
Add newline to end of sysctl files

### DIFF
--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -187,7 +187,7 @@ class Chef
 
           sysctl_lines << "#{new_resource.key} = #{new_resource.value}"
 
-          sysctl_lines.join("\n")
+          sysctl_lines.join("\n") + "\n"
         end
       end
 

--- a/spec/unit/resource/sysctl_spec.rb
+++ b/spec/unit/resource/sysctl_spec.rb
@@ -62,14 +62,14 @@ describe Chef::Resource::Sysctl do
     context "when comment is a String" do
       it "Returns content for use with a file resource" do
         resource.comment("This sets foo / bar on our system")
-        expect(provider.contruct_sysctl_content).to eql("# This sets foo / bar on our system\nfoo = bar")
+        expect(provider.contruct_sysctl_content).to eql("# This sets foo / bar on our system\nfoo = bar\n")
       end
     end
 
     context "when comment is an Array" do
       it "Returns content for use with a file resource" do
         resource.comment(["This sets foo / bar on our system", "We need for baz"])
-        expect(provider.contruct_sysctl_content).to eql("# This sets foo / bar on our system\n# We need for baz\nfoo = bar")
+        expect(provider.contruct_sysctl_content).to eql("# This sets foo / bar on our system\n# We need for baz\nfoo = bar\n")
       end
     end
   end


### PR DESCRIPTION
If the sysctl file doesn't end with a newline, then Ubuntu's CIS audit won't correctly
detect the sysctl configuration. Also, it is UNIX best practice to include a newline at the
end of the last line of text files.

Obvious fix.

Signed-off-by: Thayne McCombs <thayne@lucid.co>


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
