### PR TITLE
Relax inspec-core to allow 5.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "cheffish", ">= 17"
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec-core-bin", "~> 4.24" # need to provide the binaries for inspec
+  gem "inspec-core-bin", ">= 4.24", "< 6" # need to provide the binaries for inspec
   gem "chef-vault"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ PATH
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
-      inspec-core (~> 4.23)
+      inspec-core (>= 4.23, < 6)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
@@ -92,7 +92,7 @@ PATH
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
-      inspec-core (~> 4.23)
+      inspec-core (>= 4.23, < 6)
       iso8601 (>= 0.12.1, < 0.14)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
@@ -513,7 +513,7 @@ DEPENDENCIES
   chefstyle!
   ed25519 (~> 1.2)
   fauxhai-ng
-  inspec-core-bin (~> 4.24)
+  inspec-core-bin (>= 4.24, < 6)
   ohai!
   proxifier!
   pry (= 0.13.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 18.0"
-  s.add_dependency "inspec-core", "~> 4.23"
+  s.add_dependency "inspec-core", ">= 4.23", "< 6"
 
   s.add_dependency "ffi", ">= 1.5.0"
   s.add_dependency "ffi-yajl", "~> 2.2"


### PR DESCRIPTION
## Description
Allow users to use [inspec-core](https://rubygems.org/gems/inspec-core/versions) / [inspec-core-bin](https://rubygems.org/gems/inspec-core-bin/versions) 5.x.

## Related Issue
Closes #13131

## Types of changes
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
