### PR TITLE
Fix notarize error due to unsigned binaries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,13 @@ GIT
       netrc (~> 0.8)
 
 GIT
+  remote: https://github.com/chef/ruby-shadow
+  revision: 3b8ea40b0e943b5de721d956741308ce805a5c3c
+  branch: lcg/ruby-3.0
+  specs:
+    ruby-shadow (2.5.0)
+
+GIT
   remote: https://github.com/chef/ruby-proxifier
   revision: 8b87d0b5b469adbd93eabc0d20f3e47007aef743
   branch: lcg/ruby-3
@@ -499,7 +506,8 @@ DEPENDENCIES
   rb-readline
   rest-client!
   rspec
+  ruby-shadow!
   webmock
 
 BUNDLED WITH
-   2.3.18
+   2.3.7

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -479,4 +479,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   2.3.18
+   2.3.7

--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -64,10 +64,10 @@ dependency "openssl-customization"
 # devkit needs to come dead last these days so we do not use it to compile any gems
 dependency "ruby-msys2-devkit" if windows?
 
-# dependency "ruby-cleanup"
+dependency "ruby-cleanup"
 
 # further gem cleanup other projects might not yet want to use
-# dependency "more-ruby-cleanup"
+dependency "more-ruby-cleanup"
 
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Reintroduce omnibus ruby-cleanup, ruby-shadow gem dep & keep bundler version in sync with Ruby 3.1 default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
