### PR TITLE
Bundle with for 2.3.7 and cleanup with minimal gem bumps

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -16,10 +16,10 @@ builder-to-testers-map:
     - aix-7.1-powerpc
     - aix-7.2-powerpc
     - aix-7.3-powerpc
-  amazon-2022-aarch64:
-    - amazon-2022-aarch64
-  amazon-2022-x86_64:
-    - amazon-2022-x86_64
+      #  amazon-2022-aarch64:
+      #    - amazon-2022-aarch64
+      #  amazon-2022-x86_64:
+      #    - amazon-2022-x86_64
   debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
@@ -87,7 +87,7 @@ builder-to-testers-map:
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64
-    - windows-8-x86_64
+      #    - windows-8-x86_64
     - windows-10-x86_64
     - windows-11-x86_64
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,4 +502,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.7
+   2.3.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,4 +502,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.18
+   2.3.7

--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -64,10 +64,10 @@ dependency "openssl-customization"
 # devkit needs to come dead last these days so we do not use it to compile any gems
 dependency "ruby-msys2-devkit" if windows?
 
-# dependency "ruby-cleanup"
+dependency "ruby-cleanup"
 
 # further gem cleanup other projects might not yet want to use
-# dependency "more-ruby-cleanup"
+dependency "more-ruby-cleanup"
 
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
* Supersedes [PR 13158](https://github.com/chef/chef/pull/13158)
* ruby cleanup dependencies
* Disabling Win 8 (broken, won't fix) and Amazon 2022 (no builders available) builds.

## Related Issue
See [PR 13165](https://github.com/chef/chef/pull/13165) for original changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
