### PR TITLE
Move Gemfile.locks to 2.3.7 and disable .github kitchen install of 2.3.18

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -144,11 +144,11 @@ jobs:
         /opt/chef/bin/chef-client -v
         /opt/chef/bin/ohai -v
         /opt/chef/embedded/bin/rake --version
-        echo "Updating Bundler"
-        gem install bundler:2.3.18
-        echo "finished updating Bundler, now getting the version"
-        /opt/chef/embedded/bin/bundle -v
-        echo "finished getting the bundler version"
+        # echo "Updating Bundler"
+        # gem install bundler:2.3.18
+        # echo "finished updating Bundler, now getting the version"
+        # /opt/chef/embedded/bin/bundle -v
+        # echo "finished getting the bundler version"
     - name: 'Run end_to_end::default recipe'
       id: run
       run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,4 +440,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.18
+   2.3.7

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -479,4 +479,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   2.3.18
+   2.3.7


### PR DESCRIPTION
Signed-off-by: tpowell-progress <104777878+tpowell-progress@users.noreply.github.com>

## Description
Resolve error with ruby cleanup and multiple bundler versions.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
