### PR TITLE
Use sed to bump version of chef gems in Gemfile.lock

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -12,6 +12,7 @@
 set -evx
 
 VERSION=$(cat VERSION)
+ORIGINAL_VERSION=$(git show main:VERSION)
 
 sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"${VERSION}\"/" chef-config/lib/chef-config/version.rb
 sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"${VERSION}\"/" chef-bin/lib/chef-bin/version.rb
@@ -21,7 +22,10 @@ sed -i -r "s/VersionString\.new\(\".+\"\)/VersionString.new(\"${VERSION}\")/" li
 asdf global ruby "3.1.0"
 
 # Update the version inside Gemfile.lock
-bundle update chef chef-config chef-utils --jobs=7 --conservative
+sed -i -r "s/(^\s+chef\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.lock
+sed -i -r "s/(^\s+chef-bin\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.lock
+sed -i -r "s/(^\s+chef-config\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.lock
+sed -i -r "s/(^\s+chef-utils\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.lock
 
 # Once Expeditor finishes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,4 +440,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.18
+   2.3.7


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Use `sed` to update Gemfile.lock versions instead of trusting bundler to not pull in additional bumps [example](https://github.com/chef/chef/commit/683fa4219f950bea41076838733a9db0f99c738a#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731f)

Reset `BUNDLED_WITH` back to 2.3.7

## Related Issue
Rebase and addition to [PR #13005](https://github.com/chef/chef/pull/13005)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
