### PR TITLE
Cleanup MVPs file

### DIFF
--- a/CHEF_MVPS.md
+++ b/CHEF_MVPS.md
@@ -24,7 +24,7 @@ Each year at ChefConf, a number of individuals are awarded the Awesome Community
   - [Bastien Jove](https://github.com/tensibai)
   - [Lance Albertson](https://github.com/ramereth)
   - [Marc Chamberland](https://github.com/bobchaos)
-- [2019][USA](https://blog.chef.io/congratulations-to-our-2019-awesome-community-chefs/), [Europe](https://blog.chef.io/congratulations-to-our-chefconf-london-2019-award-winners/)
+- 2019 [USA](https://blog.chef.io/congratulations-to-our-2019-awesome-community-chefs/), [Europe](https://blog.chef.io/congratulations-to-our-chefconf-london-2019-award-winners/)
   - [Graham Weldon](https://github.com/predominant)
   - [Jason Field](https://github.com/xorima)
   - [Joshua Basch](https://github.com/HT154)
@@ -73,6 +73,7 @@ After receiving three MVP awards, we add someone to the hall of fame. We want to
 - Bryan Berry
 - Bryan McLellan
 - Jeff Blaine
+- Phil Dibowitz
 
 ## The MVP recipients
 


### PR DESCRIPTION
During the Advisory Council meeting, there was discussion of community
recognition - and the fact that this used to exist came up. I went to go
dig up this to share it with Jeff and George. But in doing so, I noticed
there was both a markdown format error and that the HoF was out of date
(I swear I didn't do this to add myself, it just worked out that way).

HoF math:
```
[phil@rider (main) chef]$ egrep '\[Client|Chef' CHEF_MVPS.md | awk -F\| '{print $4}' | sed -e 's/, /\n/g' -e 's/^ //g' -e 's/ $//g' | sort | uniq -c | sort | tail -5
      2 Xabier de Zuazo
      3 Jeff Blaine
      3 Matthew Kent
      3 Phil Dibowitz
```