### PR TITLE
Switch cookbook checksums from MD5 to SHA256

### DIFF
--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -77,7 +77,7 @@ class Chef
     # This is the one and only method that knows how cookbook files'
     # checksums are generated.
     def self.checksum_cookbook_file(filepath)
-      Chef::Digester.generate_md5_checksum_for_file(filepath)
+      Chef::Digester.generate_sha256_checksum_for_file(filepath)
     rescue Errno::ENOENT
       Chef::Log.trace("File #{filepath} does not exist, so there is no checksum to generate")
       nil

--- a/lib/chef/digester.rb
+++ b/lib/chef/digester.rb
@@ -40,10 +40,22 @@ class Chef
 
     def generate_checksum(file)
       if file.is_a?(StringIO)
-        checksum_io(file, OpenSSL::Digest.new("SHA256"))
+        generate_sha256_checksum(file)
       else
-        checksum_file(file, OpenSSL::Digest.new("SHA256"))
+        generate_sha256_checksum_for_file(file)
       end
+    end
+
+    def self.generate_sha256_checksum_for_file(*args)
+      instance.generate_sha256_checksum_for_file(*args)
+    end
+
+    def generate_sha256_checksum_for_file(file)
+      checksum_file(file, OpenSSL::Digest.new("SHA256"))
+    end
+
+    def generate_sha256_checksum(io)
+      checksum_io(io, OpenSSL::Digest.new("SHA256"))
     end
 
     def self.generate_md5_checksum_for_file(*args)

--- a/lib/chef/provider/remote_file/cache_control_data.rb
+++ b/lib/chef/provider/remote_file/cache_control_data.rb
@@ -186,6 +186,12 @@ class Chef
           cache_file_basename(uri_md5)
         end
 
+        def sanitized_cache_file_basename_sha256
+          # Old way of creating the file basename
+          uri_sha256 = Chef::Digester.instance.generate_sha256_checksum(StringIO.new(uri))
+          cache_file_basename(uri_sha256)
+        end
+
         def cache_file_basename(checksum)
           "#{scrubbed_uri}-#{checksum}.json"
         end

--- a/spec/unit/cookbook_manifest_spec.rb
+++ b/spec/unit/cookbook_manifest_spec.rb
@@ -131,7 +131,7 @@ describe Chef::CookbookManifest do
         {
           "name" => name,
           "path" => relative_path,
-          "checksum" => Chef::Digester.generate_md5_checksum_for_file(path),
+          "checksum" => Chef::Digester.generate_sha256_checksum_for_file(path),
           "specificity" => "default",
         }.tap do |fp|
           if full

--- a/spec/unit/digester_spec.rb
+++ b/spec/unit/digester_spec.rb
@@ -40,8 +40,8 @@ describe Chef::Digester do
 
     it "generates a checksum from a non-file IO object" do
       io = StringIO.new("riseofthemachines\nriseofthechefs\n")
-      expected_md5 = "0e157ac1e2dd73191b76067fb6b4bceb"
-      expect(@cache.generate_md5_checksum(io)).to eq(expected_md5)
+      expected_sha256 = "ab2b0c9f06d37b06111ecc1b9a2156fb6ae8454122978564e3541408aac3c5d8"
+      expect(@cache.generate_sha256_checksum(io)).to eq(expected_sha256)
     end
 
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

On FIPS systems, Ruby may be compiled with the bundled OpenSSL MD5 implementation, which is disabled. Switch to SHA256 for a more secure hashing implementation to avoid this issue.

Leave the MD5 checksum methods for backwards compatibility for dependencies (e.g. Berksfile).

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
