### PR TITLE
Testing on Github fails with Ruby version mismatch errors

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -219,4 +219,6 @@ jobs:
           echo "looking for my friend, Ruby"
           which ruby
           ruby --version
-          bundle exec kitchen test end-to-end-${{ matrix.os }}
+          echo "now checking for any chef-client version"
+          which chef-client
+          # bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -124,8 +124,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        ruby: ["3.1"] # macos-11.0 is not public for now
+        os: [macos-latest] # macos-11.0 is not public for now
+        ruby: ["3.1"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -176,21 +176,21 @@ jobs:
   linux:
     strategy:
       fail-fast: false
-      # matrix:
-      #   os:
-      #     - 'amazonlinux-2'
-      #     - 'centos-6'
-      #     - 'centos-7'
-      #     - 'almalinux-8'
-      #     - 'debian-9'
-      #     - 'debian-10'
-      #     - 'debian-11'
-      #     - 'fedora-latest'
-      #     - 'opensuse-leap-15'
-      #     - 'ubuntu-1804'
-      #     - 'ubuntu-2004'
-      #     - 'ubuntu-2204'
-      #   ruby: ['3.1']
+      matrix:
+        os:
+          - 'amazonlinux-2'
+          - 'centos-6'
+          - 'centos-7'
+          - 'almalinux-8'
+          - 'debian-9'
+          - 'debian-10'
+          - 'debian-11'
+          - 'fedora-latest'
+          - 'opensuse-leap-15'
+          - 'ubuntu-1804'
+          - 'ubuntu-2004'
+          - 'ubuntu-2204'
+        ruby: ['3.1']
     runs-on: ubuntu-latest
     env:
       FORCE_FFI_YAJL: ext
@@ -207,14 +207,8 @@ jobs:
       - name: Run Test Kitchen
         working-directory: kitchen-tests
         run:  |
-<<<<<<< HEAD
-          ruby -v
-          echo "Which ruby are we using?"
-          which ruby
-=======
           sudo mv /home/runner/work/chef/chef /home/runner/work/chef/chef17
           git clone https://github.com/chef/chef.git /home/runner/work/chef/chef
->>>>>>> 46813caf39 (Now adding debugging to kitchen for more detail)
           cd /home/runner/work/chef/chef
           gem install bundler:2.3.7
           bundle install

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -213,7 +213,7 @@ jobs:
           cd /home/runner/work/chef/chef
           gem install bundler:2.3.7
           bundle install
-          # gem install kitchen
-          # cd /home/runner/work/chef/chef/kitchen-tests
+          gem install kitchen
+          cd /home/runner/work/chef/chef/kitchen-tests
           # bundle install
           # bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -220,5 +220,5 @@ jobs:
           which ruby
           ruby --version
           echo "now checking for any chef-client version"
-          which chef-client
+          sudo find / -name chef
           # bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -221,4 +221,5 @@ jobs:
           ruby --version
           echo "now checking for any chef-client version"
           sudo find / -name chef
-          # bundle exec kitchen test end-to-end-${{ matrix.os }}
+          echo -=r "\r\n\r\n\r\n"
+          bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -176,21 +176,21 @@ jobs:
   linux:
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - 'amazonlinux-2'
-          - 'centos-6'
-          - 'centos-7'
-          - 'almalinux-8'
-          - 'debian-9'
-          - 'debian-10'
-          - 'debian-11'
-          - 'fedora-latest'
-          - 'opensuse-leap-15'
-          - 'ubuntu-1804'
-          - 'ubuntu-2004'
-          - 'ubuntu-2204'
-        ruby: ['3.1']
+      # matrix:
+      #   os:
+      #     - 'amazonlinux-2'
+      #     - 'centos-6'
+      #     - 'centos-7'
+      #     - 'almalinux-8'
+      #     - 'debian-9'
+      #     - 'debian-10'
+      #     - 'debian-11'
+      #     - 'fedora-latest'
+      #     - 'opensuse-leap-15'
+      #     - 'ubuntu-1804'
+      #     - 'ubuntu-2004'
+      #     - 'ubuntu-2204'
+      #   ruby: ['3.1']
     runs-on: ubuntu-latest
     env:
       FORCE_FFI_YAJL: ext
@@ -201,7 +201,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: '3.1'
           bundler-cache: false
           working-directory: kitchen-tests
       - name: Run Test Kitchen
@@ -212,6 +212,7 @@ jobs:
           which ruby
           cd /home/runner/work/chef/chef
           bundle install
+          gem install bundler:2.3.7
           gem install kitchen
           cd /home/runner/work/chef/chef/kitchen-tests
           bundle install

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -160,7 +160,6 @@ jobs:
         source ~/.zshrc
         rbenv install 3.1.2
         rbenv global 3.1.2
-        gem install bundler:2.3.18
         echo "which bundler are we using?"
         which bundle
         echo "what version is that?"

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -215,5 +215,5 @@ jobs:
           bundle install
           gem install kitchen
           cd /home/runner/work/chef/chef/kitchen-tests
-          # bundle install
+          bundle install
           # bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -207,19 +207,18 @@ jobs:
       - name: Run Test Kitchen
         working-directory: kitchen-tests
         run:  |
+<<<<<<< HEAD
           ruby -v
           echo "Which ruby are we using?"
           which ruby
+=======
+          sudo mv /home/runner/work/chef/chef /home/runner/work/chef/chef17
+          git clone https://github.com/chef/chef.git /home/runner/work/chef/chef
+>>>>>>> 46813caf39 (Now adding debugging to kitchen for more detail)
           cd /home/runner/work/chef/chef
           gem install bundler:2.3.7
           bundle install
           gem install kitchen
           cd /home/runner/work/chef/chef/kitchen-tests
           bundle install
-          echo "looking for my friend, Ruby"
-          which ruby
-          ruby --version
-          echo "now checking for any chef-client version"
-          sudo find / -name chef
-          echo -=r "\r\n\r\n\r\n"
           bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -211,9 +211,9 @@ jobs:
           echo "Which ruby are we using?"
           which ruby
           cd /home/runner/work/chef/chef
-          bundle install
           gem install bundler:2.3.7
-          gem install kitchen
-          cd /home/runner/work/chef/chef/kitchen-tests
           bundle install
-          bundle exec kitchen test end-to-end-${{ matrix.os }}
+          # gem install kitchen
+          # cd /home/runner/work/chef/chef/kitchen-tests
+          # bundle install
+          # bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -216,4 +216,7 @@ jobs:
           gem install kitchen
           cd /home/runner/work/chef/chef/kitchen-tests
           bundle install
+          echo "looking for my friend, Ruby"
+          which ruby
+          ruby --version
           # bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -219,4 +219,4 @@ jobs:
           echo "looking for my friend, Ruby"
           which ruby
           ruby --version
-          # bundle exec kitchen test end-to-end-${{ matrix.os }}
+          bundle exec kitchen test end-to-end-${{ matrix.os }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,4 +446,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.18
+   2.3.7

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -25,12 +25,14 @@ lifecycle:
     - remote: /opt/chef/bin/ohai -v
     - remote: echo "Installing appbundler and appbundle-updater gems:"
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+    - remote: export BUILDKITE_COMMIT=tp/ruby_revert_to_ruby31
     - remote: scl enable devtoolset-7 '/opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['BUILDKITE_COMMIT']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>'
       includes:
         - centos-6
         - centos-7
         - oraclelinux-7
     - remote: echo "Updating Chef using appbundler-updater:"
+    - remote: export BUILDKITE_COMMIT=tp/ruby_revert_to_ruby31
     - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['BUILDKITE_COMMIT']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>
       excludes:
         - centos-6

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -16,7 +16,6 @@ provisioner:
   chef_license: "accept-no-persist"
   slow_resource_report: true
   clean_dokken_sandbox: false
-  log_level: debug
 
 lifecycle:
   pre_converge:

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -25,6 +25,7 @@ lifecycle:
     - remote: /opt/chef/bin/ohai -v
     - remote: echo "Installing appbundler and appbundle-updater gems:"
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+    - remote: echo "Exporting a buildkite environment variable"
     - remote: export BUILDKITE_COMMIT=tp/ruby_revert_to_ruby31
     - remote: scl enable devtoolset-7 '/opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['BUILDKITE_COMMIT']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>'
       includes:

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -16,6 +16,7 @@ provisioner:
   chef_license: "accept-no-persist"
   slow_resource_report: true
   clean_dokken_sandbox: false
+  log_level: debug
 
 lifecycle:
   pre_converge:


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

Verify pipeline is failing right now for almost all OS's except Windows. The issue is that ruby_cleanup has code to check for multiple bundler versions and errors out if it finds this. In updating to Ruby 3.1 we explicitly added an update to bundler for Mac and the Linux nodes are picking up a new version as a function of a new Ruby install maybe? Either way, we agreed as a team to standardize on Ruby 2.3.7 to match what the Packages team needs. This PR is intended to straighten out bundler.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
