### PR TITLE
Remove the chef17 git clone step

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -211,8 +211,6 @@ jobs:
           ruby -v
           echo "Which ruby are we using?"
           which ruby
-          sudo mv /home/runner/work/chef/chef /home/runner/work/chef/chef17
-          git clone https://github.com/chef/chef.git /home/runner/work/chef/chef
           cd /home/runner/work/chef/chef
           bundle install
           gem install kitchen

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM busybox
 LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 
 ARG CHANNEL=stable
-ARG VERSION=17.9.26
+ARG VERSION=18.0.146
 ARG ARCH=x86_64
 ARG PKG_VERSION=6
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/rest-client
-  revision: f3e30a17e5dd826b5f5dce82edcecc52464548e3
+  revision: badd0bea3c31a2ed1f49590760d2e4b665ecbce3
   branch: jfm/ucrt_update1
   specs:
     rest-client (2.1.0)


### PR DESCRIPTION
Signed-off-by: Thomas Powell <powell@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Remove chef17 move and git clone that were added as part of debugging ruby 3.1 build.
Update hash of rest-client.

`chef17` `mv` and `git clone` were causing trouble (resetting the branch to `main`)

## Related Issue
INFC-267 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
