### PR TITLE
Windows Verify Plan fails during "Rake Install rest-client"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,13 +27,12 @@ GIT
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-
-GIT
-  remote: https://github.com/chef/ruby-proxifier
-  revision: 8b87d0b5b469adbd93eabc0d20f3e47007aef743
-  branch: lcg/ruby-3
-  specs:
-    proxifier (1.0.3)
+    rest-client (2.1.0-x64-mingw-ucrt)
+      ffi (~> 1.15)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
 
 GIT
   remote: https://github.com/chef/ruby-shadow
@@ -41,6 +40,13 @@ GIT
   branch: lcg/ruby-3.0
   specs:
     ruby-shadow (2.5.0)
+    
+GIT
+  remote: https://github.com/chef/ruby-proxifier
+  revision: 8b87d0b5b469adbd93eabc0d20f3e47007aef743
+  branch: lcg/ruby-3
+  specs:
+    proxifier (1.0.3)
 
 PATH
   remote: .


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

## Description
During the upgrade to Ruby 3.1 for Chef 18, we noticed that we were getting failures in the verify pipeline related to installing and consuming the rest-client gem on Windows (Specifically, the Windows Plan fails as executed by .\.expeditor\scripts\verify-plan.ps1. That script ultimately calls \habitat\plan.ps1). This only happens when the gem is being call via habitat. In investigating this further, we discovered some odd behavior that we had not encountered before. The error looks like this:
```shell
   chef-infra-client:  -- installing C:\hab\studios\bk01835b8d701e3fb37dc6\hab\pkgs\ci\chef-infra-client\18.0.147\20220920154415\vendor\bundler\gems\rest-client-badd0bea3c31
rake aborted!
Bundler::Dsl::DSLError:
[!] There was an error parsing `Gemfile`: There are no gemspecs at C:/hab/studios/bk01835b8d701e3fb37dc6/hab/pkgs/ci/chef-infra-client/18.0.147/20220920154415/vendor/bundler/gems/rest-client-badd0bea3c31. Bundler cannot continue.
 
 #  from C:/hab/studios/bk01835b8d701e3fb37dc6/hab/pkgs/ci/chef-infra-client/18.0.147/20220920154415/vendor/bundler/gems/rest-client-badd0bea3c31/Gemfile:4
 #  -------------------------------------------
 #    gem 'rake'
 >  end
 #  source "https://rubygems.org"
 #  -------------------------------------------
C:/hab/studios/bk01835b8d701e3fb37dc6/hab/pkgs/ci/chef-infra-client/18.0.147/20220920154415/vendor/gems/bundler-2.3.18/lib/bundler/dsl.rb:88:in `gemspec'
C:/hab/studios/bk01835b8d701e3fb37dc6/hab/pkgs/ci/chef-infra-client/18.0.147/20220920154415/vendor/bundler/gems/rest-client-badd0bea3c31/Gemfile:4:in 
```
The rest-client simply refuses to install by executing:
```powershell
push-location $gem_path #cd to the gem 
rake install $gem_path # try to install it
```
Initially, we had believed that these failures were related to changes we had made in a branch of the rest-client we were testing against. [That PR is here:](https://github.com/rest-client/rest-client/pull/781). 

However, in testing further we were unable to get that gem to install at all using "rake". We tested "rake install" under Ruby 3.0 and Chef-17 (on Windows) and got the same failure from the rest-client code completely outside of our PR. 

Incidentally, when you try to run that same command on Mac or Fedora, you get a Rakefile error telling you that 
```shell
[azureuser@fedora-1 rest-client]$ rake install .
rake aborted!
Don't know how to build task 'install' (See the list of available tasks with `rake --tasks`)
Did you mean?  ruby:install

(See full trace by running task with --trace)
```
At the end of the day, the Rakefile for the rest-client does not contain a task for "Install" so when we call Rake Install (see line ~109 or so of the plan.ps1) it will fail. Happily, the Rakefile itself merely calls "gem build -v" so we can bypass the problem altogether by calling gem build directly ourselves. 
