### PR TITLE
add platform verification, aix ruby 3.0 support 

### DIFF
--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -10,6 +10,9 @@ ruby -v
 echo "bundler version:"
 bundle -v
 
+echo "OS version:"
+uname -a
+
 echo "--- Preparing Container..."
 
 export FORCE_FFI_YAJL="ext"

--- a/.expeditor/scripts/bk_linux_exec.sh
+++ b/.expeditor/scripts/bk_linux_exec.sh
@@ -29,6 +29,10 @@ export BUNDLE_GEMFILE=$PWD/kitchen-tests/Gemfile
 export FORCE_FFI_YAJL=ext
 export CHEF_LICENSE="accept-silent"
 
+# what OS is this REALLY?
+echo "--- Verifying OS"
+uname -a
+
 # Update Gems
 echo "--- Installing Gems"
 echo 'gem: --no-document' >> ~/.gemrc

--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -19,6 +19,9 @@ if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 Write-Output "--- configure winrm"
 winrm quickconfig -q
 
+Write-Output "--- Verifying the Windows version we're running on"
+Write-Output (Get-WMIObject win32_operatingsystem).name
+
 Write-Output "--- bundle install"
 bundle config set --local without 'omnibus_package'
 bundle install --jobs=3 --retry=3

--- a/.expeditor/scripts/bk_win_integration.ps1
+++ b/.expeditor/scripts/bk_win_integration.ps1
@@ -6,6 +6,9 @@ Set-Item -Path Env:Path -Value ("C:\Program Files\Git\mingw64\bin;C:\Program Fil
 
 winrm quickconfig -q
 
-echo "+++ bundle exec rake spec:integration"
+Write-Output "--- Verifying the Windows version we're running on"
+Write-Output (Get-WMIObject win32_operatingsystem).name
+
+Write-Output  "+++ bundle exec rake spec:integration"
 bundle exec rake spec:integration
 if (-not $?) { throw "Chef integration specs failing." }

--- a/.expeditor/scripts/bk_win_unit.ps1
+++ b/.expeditor/scripts/bk_win_unit.ps1
@@ -2,6 +2,9 @@ $CurrentDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $PrepScript = Join-Path $CurrentDirectory "bk_win_prep.ps1"
 Invoke-Expression $PrepScript
 
+Write-Output "--- Verifying the Windows version we're running on"
+Write-Output (Get-WMIObject win32_operatingsystem).name
+
 echo "+++ bundle exec rake"
 bundle exec rake spec:unit
 if (-not $?) { throw "Chef unit tests failing." }

--- a/.expeditor/scripts/verify-plan.ps1
+++ b/.expeditor/scripts/verify-plan.ps1
@@ -25,6 +25,9 @@ if (-not ($source.name -match "git.exe")) {
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 }
 
+Write-Output "--- :construction: Verifying the Windows version we're running on"
+Write-Output (Get-WMIObject win32_operatingsystem).name
+
 Write-Host "--- :key: Generating fake origin key"
 hab origin key generate $env:HAB_ORIGIN
 

--- a/.expeditor/scripts/verify-plan.sh
+++ b/.expeditor/scripts/verify-plan.sh
@@ -17,6 +17,10 @@ error () {
   exit 1
 }
 
+# what OS is this REALLY?
+echo "--- :construction: Verifying OS"
+uname -a
+
 echo "--- :8ball: :linux: Verifying $PLAN"
 project_root="$(git rev-parse --show-toplevel)"
 

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -22,7 +22,12 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://www.chef.io"
 
-  s.required_ruby_version = ">= 3.1.0"
+  if RUBY_PLATFORM =~ /aix/
+    s.required_ruby_version = ">= 3.0.3"
+  else
+    s.required_ruby_version = ">= 3.1.0"
+  end
+
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
   s.add_dependency "chef-utils", "= #{Chef::VERSION}"

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -1,6 +1,11 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
+# We have seen rare cases where the platform we think we are testing on is not the
+# platform we are really testing on.  We're outputting the complete OS name here
+# so that we can confirm the name in the build log when necessary.
+Write-Output (Get-WMIObject win32_operatingsystem).name
+
 # install chocolatey
 Set-ExecutionPolicy Bypass -Scope Process -Force
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -15,6 +15,11 @@ if [[ -f /etc/redhat-release ]]; then
   fi
 fi
 
+# We have seen rare cases where the platform we think we are testing on
+# is not the platform we are really testing on.  We're outputting the complete
+# uname string so that we can confirm platform and version in the build log when necessary
+echo "omnibus-test.sh: uname -a is '`uname -a`'"
+
 # Set up a custom tmpdir, and clean it up before and after the tests
 export TMPDIR="${TMPDIR:-/tmp}/cheftest"
 sudo rm -rf "$TMPDIR"

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -31,6 +31,9 @@ env_omnibus_windows_arch = :x86 unless %w{x86 x64}.include?(env_omnibus_windows_
 
 windows_arch env_omnibus_windows_arch
 
+# Allows us to verify that we're building on the platform we think we are.
+puts "RUBY PLATFORM @ omnibus-load time: #{RUBY_PLATFORM}"
+
 use_git_caching true
 
 # Enable S3 asset caching


### PR DESCRIPTION
This PR includes three commits:

1. allow aix to require ruby 3.0 instead of 3.1, until we are able to get a functional ruby 3.1 build on aix. 
2. add logging to the verification pipeline to capture OS name/version so that we can verify that the OS we are testing on matches the one we think we are testing on
3. add logging to omnibus build and omnibus verification tests for the same 

Normally I would split these into two PRs, but this saves us several hours of pipeline runs. The commits are separated so that it will be clear in history. 

 replaces #13204.  