### PR TITLE
Permit ruby 3.0 for AIX

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
     s.required_ruby_version = ">= 3.1.0"
   end
 
-
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
   s.add_dependency "chef-utils", "= #{Chef::VERSION}"
   s.add_dependency "train-core", "~> 3.10", ">= 3.2.28" # 3.2.28 fixes sudo prompts. See https://github.com/chef/chef/pull/9635

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -22,7 +22,12 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://www.chef.io"
 
-  s.required_ruby_version = ">= 3.1.0"
+  if RUBY_PLATFORM =~ /aix/
+    s.required_ruby_version = ">= 3.0.3"
+  else
+    s.required_ruby_version = ">= 3.1.0"
+  end
+
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
   s.add_dependency "chef-utils", "= #{Chef::VERSION}"


### PR DESCRIPTION
We have not been able to build ruby 3.1 on AIX at this time. Until we are able to do so, we are leaving chef-18 on Ruby 3.0 for that platform.

Replaces #13205 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
