### PR TITLE
Docs: Fix windows package docs examples

### DIFF
--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -78,7 +78,7 @@ class Chef
       ```ruby
       windows_package '7zip' do
         source 'http://www.7-zip.org/a/7z938-x64.msi'
-        checksum '7c8e873991c82ad9cfc123415254ea6101e9a645e12977dcd518979e50fdedf3'
+        checksum '7c8e873991c82ad9cfcdbdf45254ea6101e9a645e12977dcd518979e50fdedf3'
       end
       ```
 
@@ -91,7 +91,7 @@ class Chef
         source 'http://www.7-zip.org/a/7z938-x64.msi'
         remote_file_attributes ({
           :path => 'C:\\7zip.msi',
-          :checksum => '7c8e873991c82ad9cfc123415254ea6101e9a645e12977dcd518979e50fdedf3'
+          :checksum => '7c8e873991c82ad9cfcdbdf45254ea6101e9a645e12977dcd518979e50fdedf3'
         })
       end
       ```

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -100,7 +100,7 @@ class Chef
 
       ```ruby
       windows_package 'Mercurial 3.6.1 (64-bit)' do
-        source 'http://mercurial.selenic.com/release/windows/Mercurial-3.6.1-x64.exe'
+        source 'https://www.mercurial-scm.org/release/windows/Mercurial-3.6.1-x64.exe'
         checksum 'febd29578cb6736163d232708b834a2ddd119aa40abc536b2c313fc5e1b5831d'
       end
       ```


### PR DESCRIPTION
## Description
Fixes to `windows_package` docs:
* 7zip examples used an incorrect checksum.
* Mercurial example used an old hostname in the `source` URL property that lead to a HTTPS certificate validation error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
