### PR TITLE
Fix failures releted to ruby-shadow being loaded on AIX systems in build pipelines

### DIFF
--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -66,7 +66,7 @@ class Chef
           end
           current_resource.comment(user_info.gecos)
 
-          # NOTE: The if condition `new_resource.password && current_resource.password == "x"` needs to be checked first so that `require "shadow"`` is not run on AIX, which will result in spec failures.
+          # NOTE: The if condition `new_resource.password && current_resource.password == "x"` needs to be checked first so that `require "shadow"`` is not run on AIX, which will result in spec failures in why_run. define_resource_requirements assumes that the libraries not supported on a platform will never load on it. i.e: ruby_shadow should never be loaded on AIX platform. Ref error: https://buildkite.com/chef/chef-chef-main-omnibus-release/builds/1667#51867452-352c-45ff-b402-9518d88c7d8d
           # On AIX platforms ruby_shadow does not work as it does not store encrypted passwords in the /etc/passwd file but in /etc/security/passwd file.
           # Ruby's ETC.getpwnam also makes use of /etc/passwd file (https://github.com/ruby/etc/blob/master/ext/etc/etc.c), which returns "x" for a nil password, whereas
           # on AIX it returns a "*" (https://www.ibm.com/docs/bg/aix/7.2?topic=passwords-using-etcpasswd-file)

--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -67,9 +67,9 @@ class Chef
           current_resource.comment(user_info.gecos)
 
           # NOTE: The if condition `new_resource.password && current_resource.password == "x"` needs to be checked first so that `require "shadow"`` is not run on AIX, which will result in spec failures.
-          # On AIX platforms ruby_shadow does not work as it doesnot store encrypted passwords in the /etc/passwd file but in /etc/security/passwd file.
-          # Ruby's ETC.getpwnam also makes use of /etc/passwd file (https://github.com/ruby/etc/blob/master/ext/etc/etc.c), which returns "x" for a nil password, whereas 
-          # on AIX it returns a "*" (https://www.ibm.com/docs/bg/aix/7.2?topic=passwords-using-etcpasswd-file) 
+          # On AIX platforms ruby_shadow does not work as it does not store encrypted passwords in the /etc/passwd file but in /etc/security/passwd file.
+          # Ruby's ETC.getpwnam also makes use of /etc/passwd file (https://github.com/ruby/etc/blob/master/ext/etc/etc.c), which returns "x" for a nil password, whereas
+          # on AIX it returns a "*" (https://www.ibm.com/docs/bg/aix/7.2?topic=passwords-using-etcpasswd-file)
           if new_resource.password && current_resource.password == "x"
             begin
               require "shadow"


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Adhoc/release [builds]([here](https://buildkite.com/chef/chef-chef-main-omnibus-adhoc/builds/1503#01836bf4-cc09-4d65-8342-75a223008207)) are failing on AIX due to ruby-shadow being required on those systems, which is non supported for it. 
This issue was caused due to changes made in User resource in [pr](https://github.com/chef/chef/pull/11659), due to which the line `require "shadow"` started running on AIX. Additional details have been added in the comment.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
