### PR TITLE
Allow user providers to declare no support for ruby-shadow

### DIFF
--- a/lib/chef/provider/user/aix.rb
+++ b/lib/chef/provider/user/aix.rb
@@ -23,6 +23,11 @@ class Chef
         provides :user, os: "aix"
         provides :aix_user
 
+        # The ruby-shadow gem is not supported on aix.
+        def supports_ruby_shadow?
+          false
+        end
+
         def create_user
           shell_out!("useradd", universal_options, useradd_options, new_resource.username)
           add_password

--- a/spec/unit/provider/user_spec.rb
+++ b/spec/unit/provider/user_spec.rb
@@ -178,12 +178,30 @@ describe Chef::Provider::User do
         end
       end
 
-      it "should fail assertions when ruby-shadow cannot be loaded" do
-        expect(@provider).to receive(:require).with("shadow") { raise LoadError }
-        @provider.load_current_resource
-        @provider.action = :create
-        @provider.define_resource_requirements
-        expect { @provider.process_resource_requirements }.to raise_error Chef::Exceptions::MissingLibrary
+      context "when ruby-shadow is supported on the platform" do
+        before do
+          allow(@provider).to receive(:supports_ruby_shadow?).and_return true
+        end
+        it "should fail assertions when ruby-shadow cannot be loaded" do
+          expect(@provider).to receive(:require).with("shadow") { raise LoadError }
+          @provider.load_current_resource
+          @provider.action = :create
+          @provider.define_resource_requirements
+          expect { @provider.process_resource_requirements }.to raise_error Chef::Exceptions::MissingLibrary
+        end
+      end
+
+      context "when ruby-shadow is not supported on the platform" do
+        before do
+          allow(@provider).to receive(:supports_ruby_shadow?).and_return false
+        end
+        it "should not fail any assertions when ruby-shadow cannot be loaded" do
+          expect(@provider).to receive(:require).with("shadow") { raise LoadError }
+          @provider.load_current_resource
+          @provider.action = :create
+          @provider.define_resource_requirements
+          @provider.process_resource_requirements
+        end
       end
 
     end


### PR DESCRIPTION
The AIX platform does not support ruby-shadow, but we always attempt to load it. The load fails  on the AIX platform, which later causes our requirement assertion that `@shadow_lib_ok` be true to fail.

Instead we allow user resource providers to override `supports_ruby_shadow?` if they do not support it, so that we don't assert that it is required in those cases. We default the return value to `true` because most platforms are supported by this gem.


Replaces #13212
Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
