### PR TITLE
Disable platforms still under development

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -15,7 +15,7 @@ builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc
     - aix-7.2-powerpc
-    - aix-7.3-powerpc
+    # - aix-7.3-powerpc
       #  amazon-2022-aarch64:
       #    - amazon-2022-aarch64
       #  amazon-2022-x86_64:
@@ -68,10 +68,10 @@ builder-to-testers-map:
     - sles-15-x86_64
   sles-15-aarch64:
     - sles-15-aarch64
-  solaris2-5.11-i386:
-    - solaris2-5.11-i386
-  solaris2-5.11-sparc:
-    - solaris2-5.11-sparc
+  # solaris2-5.11-i386:
+  #   - solaris2-5.11-i386
+  # solaris2-5.11-sparc:
+  #   - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
@@ -82,12 +82,11 @@ builder-to-testers-map:
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
   windows-2012r2-x86_64:
-    - windows-2012-x86_64
+    # - windows-2012-x86_64
     - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64
-      #    - windows-8-x86_64
     - windows-10-x86_64
     - windows-11-x86_64
 


### PR DESCRIPTION
Temporarily disabling platforms that are still under development for chef 18, so that we can release the chef-18 RC without blocking on them.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
