### PR TITLE
On AIX, add delay to ensure members added to group are visible to tests

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -15,7 +15,7 @@ builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc
     - aix-7.2-powerpc
-    # - aix-7.3-powerpc
+    - aix-7.3-powerpc
       #  amazon-2022-aarch64:
       #    - amazon-2022-aarch64
       #  amazon-2022-x86_64:

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -44,10 +44,10 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       members.shift # Get rid of GroupMembership: string
       members.include?(user)
     else
-      # TODO For some reason our temporary AIX 7.2 system does not correctly report group membership immediately after changes have been made.
-      # Adding a 2 second delay for this platform is enough to get correct results.
-      # We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617
-      sleep 2 if aix? && (ohai[:platform_version] == "7.2")
+      # NOTE: For some reason our temporary AIX 7.x systems do not correctly report group membership immediately after changes have been made.
+      # Adding a delay for this platform is enough to get correct results.
+      # reference: https://github.com/chef/release-engineering/issues/1617
+      sleep 3 if aix?
       Etc.getgrnam(group_name).mem.include?(user)
     end
   end
@@ -133,6 +133,10 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       temp_resource.append(true)
       temp_resource.run_action(:modify)
       members.each do |member|
+        # NOTE For some reason our temporary AIX 7.x systems do not correctly report group membership immediately after changes have been made.
+        # Adding a delay for this platform is enough to get correct results.
+        # reference: https://github.com/chef/release-engineering/issues/1617
+        sleep 3 if aix?
         expect(user_exist_in_group?(member)).to eq(true)
       end
     end

--- a/spec/functional/resource/link_spec.rb
+++ b/spec/functional/resource/link_spec.rb
@@ -345,17 +345,17 @@ describe Chef::Resource::Link do
             let(:test_user) { "test-link-user" }
             before do
               user(test_user).run_action(:create)
-              # TODO For some reason our temporary AIX 7.2 system does not correctly report user existence immediately after changes have been made.
-              # Adding a 2 second delay for this platform is enough to get correct results.
-              # We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617
-              sleep 2 if aix? && (ohai[:platform_version] == "7.2")
+              # NOTE: For some reason our temporary AIX 7.x systems do not correctly report user existence immediately after changes have been made.
+              # Adding a delay for this platform is enough to get correct results.
+              # reference: https://github.com/chef/release-engineering/issues/1617
+              sleep 3 if aix?
             end
             after do
               user(test_user).run_action(:remove)
-              # TODO For some reason our temporary AIX 7.2 system does not correctly report user existence immediately after changes have been made.
-              # Adding a 2 second delay for this platform is enough to get correct results.
-              # We hope to remove this delay after we get more permanent AIX 7.2 systems in our CI pipeline. reference: https://github.com/chef/release-engineering/issues/1617
-              sleep 2 if aix? && (ohai[:platform_version] == "7.2")
+              # TODO For some reason our temporary AIX 7.x systems do not correctly report user existence immediately after changes have been made.
+              # Adding a delay for this platform is enough to get correct results.
+              # reference: https://github.com/chef/release-engineering/issues/1617
+              sleep 3 if aix?
             end
             before(:each) do
               resource.owner(test_user)


### PR DESCRIPTION
We have found on AIX 7.x, it can be a varying amount of time before
the system reflects that member(s) have been added to a group.  This
change increases the delay on AIX from 2 seconds to 3 after adding a
user to a group.

This ensures that the new group members are visible before we verify
that they are added correctly.

This change also removes the limitation that only applies this delay on AIX 7.2
since we have found it affects 7.3 as well. For consistency, it is now applied
on all AIX platform versions.

With these tests passing, it is now possible to re-enable the AIX
pipeline (which has also been done in this change).

Signed-off-by: Neha Pansare <neha.pansare@progress.com>
Signed-off-by: John McCrae <john.mccrae@progress.com>
Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>