### PR TITLE
Fixes bug in compare_user on Linux systems

### DIFF
--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -29,7 +29,10 @@ class Chef
         end
 
         def compare_user
-          super
+          user_changed = super
+
+          @change_desc ||= []
+
           %i{expire_date inactive}.each do |user_attrib|
             new_val = new_resource.send(user_attrib)
             cur_val = current_resource.send(user_attrib)
@@ -37,6 +40,8 @@ class Chef
               @change_desc << "change #{user_attrib} from #{cur_val} to #{new_val}"
             end
           end
+
+          user_changed || !@change_desc.empty?
         end
 
         def create_user

--- a/spec/functional/resource/user/linux_user_spec.rb
+++ b/spec/functional/resource/user/linux_user_spec.rb
@@ -1,0 +1,120 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef/mixin/shell_out"
+
+metadata = {
+  requires_root: true,
+}
+
+describe "Chef::Resource::User with Chef::Provider::User::LinuxUser provider", metadata do
+  include Chef::Mixin::ShellOut
+
+  def clean_user
+    shell_out!("/usr/sbin/userdel #{username}")
+  rescue Mixlib::ShellOut::ShellCommandFailed
+    # Raised when the user is already cleaned
+  end
+
+  def ensure_file_cache_path_exists
+    path = Chef::Config["file_cache_path"]
+    FileUtils.mkdir_p(path) unless File.directory?(path)
+  end
+
+  def user_should_exist
+    expect(shell_out("grep -q #{username} /etc/passwd").error?).to be(false)
+  end
+
+  def check_password(pass, user)
+    expect(shell_out("grep ^#{user}: /etc/shadow | cut -d: -f2 | grep ^#{pass}$").exitstatus).to eq(0)
+  end
+
+  let(:node) do
+    n = Chef::Node.new
+    n.consume_external_attrs(OHAI_SYSTEM.data.dup, {})
+    n
+  end
+
+  let(:events) do
+    Chef::EventDispatch::Dispatcher.new
+  end
+
+  let(:run_context) do
+    Chef::RunContext.new(node, {}, events)
+  end
+
+  let(:username) do
+    "greatchef"
+  end
+
+  let(:uid) { nil }
+  let(:gid) { 20 }
+  let(:home) { nil }
+  let(:manage_home) { false }
+  let(:password) { "XXXYYYZZZ" }
+  let(:comment) { "Great Chef" }
+  let(:shell) { "/bin/bash" }
+  let(:salt) { nil }
+
+  let(:user_resource) do
+    r = Chef::Resource::User::LinuxUser.new("TEST USER RESOURCE", run_context)
+    r.username(username)
+    r.uid(uid)
+    r.gid(gid)
+    r.home(home)
+    r.shell(shell)
+    r.comment(comment)
+    r.manage_home(manage_home)
+    r.password(password)
+    r.salt(salt)
+    r
+  end
+
+  before do
+    clean_user
+    ensure_file_cache_path_exists
+  end
+
+  after(:each) do
+    clean_user
+  end
+
+  describe "action :create" do
+    it "should create the user" do
+      user_resource.run_action(:create)
+      user_should_exist
+      check_password(password, username)
+    end
+  end
+
+  describe "when user exists" do
+    before do
+      existing_resource = user_resource.dup
+      existing_resource.run_action(:create)
+      user_should_exist
+    end
+
+    describe "when password is updated" do
+      it "should update the password of the user" do
+        user_resource.password("mykitchen")
+        user_resource.run_action(:create)
+        check_password("mykitchen", username)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

d4c3b8ad111ec7ff6b32ebccf9edd1b6a2f9e8e2 introduced a bug making `compare_user` on Linux systems return `%i{expire_date inactive}` instead of wether `@change_desc` is empty.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
