### PR TITLE
Do not raise if we can't close win resource handle

### DIFF
--- a/lib/chef/win32/handle.rb
+++ b/lib/chef/win32/handle.rb
@@ -26,10 +26,6 @@ class Chef
     class Handle
       extend Chef::ReservedNames::Win32::API::Process
 
-      # See http://msdn.microsoft.com/en-us/library/windows/desktop/ms683179(v=vs.85).aspx
-      # The handle value returned by the GetCurrentProcess function is the pseudo handle (HANDLE)-1 (which is 0xFFFFFFFF)
-      CURRENT_PROCESS_HANDLE = 4294967295
-
       def initialize(handle)
         @handle = handle
         ObjectSpace.define_finalizer(self, Handle.close_handle_finalizer(handle))
@@ -38,13 +34,16 @@ class Chef
       attr_reader :handle
 
       def self.close_handle_finalizer(handle)
-        # According to http://msdn.microsoft.com/en-us/library/windows/desktop/ms683179(v=vs.85).aspx, it is not necessary
-        # to close the pseudo handle returned by the GetCurrentProcess function.  The docs also say that it doesn't hurt to call
-        # CloseHandle on it. However, doing so from inside of Ruby always seems to produce an invalid handle error.
-        proc { close_handle(handle) unless handle == CURRENT_PROCESS_HANDLE }
+        proc { close_handle(handle) }
       end
 
       def self.close_handle(handle)
+        # According to http://msdn.microsoft.com/en-us/library/windows/desktop/ms683179(v=vs.85).aspx, it is not necessary
+        # to close the pseudo handle returned by the GetCurrentProcess function.  The docs also say that it doesn't hurt to call
+        # CloseHandle on it. However, doing so from inside of Ruby always seems to produce an invalid handle error.
+        # The recommendation is to use GetCurrentProcess instead of the const (HANDLE)-1, to ensure we're making the correct comparison.
+        return if handle == GetCurrentProcess()
+
         unless CloseHandle(handle)
           Chef::ReservedNames::Win32::Error.raise!
         end

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -41,12 +41,8 @@ end
 
 describe "Chef::Platform#dsc_refresh_mode_disabled?", :windows_only do
   let(:node) { instance_double("Chef::Node") }
-  let(:powershell) { Class.new { include ChefPowerShell::ChefPowerShellModule::PowerShellExec } }
-  subject(:object) { powershell.new }
 
   it "returns true when RefreshMode is Disabled" do
-    execution = object.powershell_exec("Get-DscLocalConfigurationManager", :powershell, timeout: -1)
-    expect(execution.result["RefreshMode"]).to eq "PUSH"
     expect(Chef::Platform.dsc_refresh_mode_disabled?(node)).to be false
   end
 end


### PR DESCRIPTION
On Windows 2012, we are seeing frequent errors during the finalizer for
Win32::Handle, which invokes CloseHandle:

'The handle is invalid' (error code 6)

Debugging and testing has shown that every instance of this error is
caused by the handle 18446744073709551615 (which converts to "ffffffffffffffff").  We have also seen
that this matches the value passed into the constructor of Handle,
provided directly from GetCurrentHandle.

We were previously comparing this to the const `ffffffff` and skipping
the CloseHandle call on the assumption that `ffffffff == (HANDLE)-1`
based on the docs here: http://msdn.microsoft.com/en-us/library/windows/desktop/ms683179(v=vs.85).aspx

But given that we are directly seeing the GetCurrentHandle returning
"ffffffffffffffff", it seems HANDLE (a LPVOID) is 64 bit instead of 32, so the 
default pseudo-handle is more likely to be `ffffffffffffffff` than `ffffffff`. 

 Instead of worrying about the correct value of that const, this PR
 makes it so that we're following the recommended approach in the link
 above - if we want to check if a handle == current process pseudo-handle , we
 compare it to GetCurrentHandle instead of the const.

 In the process, it resolves the errors we're seeing on the Windows
 Server 2012 platform, where we are failing when CloseHandle returns
 "invalid handle".

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
Signed-off-by: John McCrae <john.mccrae@progress.com>