### PR TITLE
Reenable Solaris build/release

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -68,10 +68,10 @@ builder-to-testers-map:
     - sles-15-x86_64
   sles-15-aarch64:
     - sles-15-aarch64
-  # solaris2-5.11-i386:
-  #   - solaris2-5.11-i386
-  # solaris2-5.11-sparc:
-  #   - solaris2-5.11-sparc
+  solaris2-5.11-i386:
+    - solaris2-5.11-i386
+  solaris2-5.11-sparc:
+    - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64


### PR DESCRIPTION
Signed-off-by: Thomas Powell <powell@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Solaris builds have been temporarily disabled in order to a release build out for other environments. Now that Solaris build is green, reenable for release.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
