### PR TITLE
updating builders to add server 2012 back in

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -82,7 +82,7 @@ builder-to-testers-map:
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
   windows-2012r2-x86_64:
-    # - windows-2012-x86_64
+    - windows-2012-x86_64
     - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
MP recently merged a change to account for problems with handles in server 2012. Now we need the actual server 2012 images to show up in the pipelines to verify this all works as expected.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
