### PR TITLE
[Chef-16] Fix OpenSUSE failures in verify pipeline

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -131,6 +131,7 @@ steps:
 - label: "Integration openSUSE 15 :ruby: 2.7"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
     - zypper install -y cron insserv-compat
     - cd /workdir; bundle config set --local without omnibus_package
     - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle
@@ -144,6 +145,7 @@ steps:
 - label: "Functional openSUSE 15 :ruby: 2.7"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
     - zypper install -y cronie insserv-compat
     - cd /workdir; bundle config set --local without omnibus_package ruby_prof
     - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle
@@ -157,6 +159,7 @@ steps:
 - label: "Unit openSUSE 15 :ruby: 2.7"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
     - zypper install -y cron insserv-compat
     - bundle config set --local without omnibus_package ruby_prof
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle


### PR DESCRIPTION

Signed-off-by: John McCrae <john.mccrae@progress.com>
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
We are seeing similar failures in verify pipeline for OpenSUSE for chef16 as seen on main (e.g [build](https://buildkite.com/chef-oss/chef-chef-chef-16-verify/builds/1186#0183cc9d-b8a4-40c6-97ea-54bc17761c3e)
This change backports fix here https://github.com/chef/chef/pull/13237 but keeping the changes as per chef16 not main.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
