### PR TITLE
[Chef-16] Fix solaris build and test failures in adhoc pipeline

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 83d8428abde4cb289a161f736822ba02563a884c
+  revision: 5bc091ab3ed4ab002ef85dad3923914c25bb3dcd
   branch: main
   specs:
-    omnibus (9.0.3)
+    omnibus (9.0.8)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)

--- a/spec/functional/shell_spec.rb
+++ b/spec/functional/shell_spec.rb
@@ -85,7 +85,6 @@ describe Shell do
       # and the value isn't propagating from the build environment TERM
       # variable
       ENV["TERM"] = "vt100" if ["", "unknown"].include?(ENV["TERM"].to_s)
-      
       config = File.expand_path("shef-config.rb", CHEF_SPEC_DATA)
       reader, writer, pid = PTY.spawn("bundle exec chef-shell --no-multiline --no-singleline --no-colorize -c #{config} #{options}")
       read_until(reader, "chef (#{Chef::VERSION})>")

--- a/spec/functional/shell_spec.rb
+++ b/spec/functional/shell_spec.rb
@@ -80,6 +80,12 @@ describe Shell do
       # so hide the require here
 
       require "pty"
+
+      # FIXME this is temporary... Solaris envs have TERM set to unknown
+      # and the value isn't propagating from the build environment TERM
+      # variable
+      ENV["TERM"] = "vt100" if ["", "unknown"].include?(ENV["TERM"].to_s)
+      
       config = File.expand_path("shef-config.rb", CHEF_SPEC_DATA)
       reader, writer, pid = PTY.spawn("bundle exec chef-shell --no-multiline --no-singleline --no-colorize -c #{config} #{options}")
       read_until(reader, "chef (#{Chef::VERSION})>")

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -170,11 +170,7 @@ describe Chef::Daemon do
 
       it "should log an appropriate error message and fail miserably" do
         allow(Process).to receive(:initgroups).and_raise(Errno::EPERM)
-        error = "Operation not permitted"
-        if RUBY_PLATFORM.match("solaris2") || RUBY_PLATFORM.match("aix")
-          error = "Not owner"
-        end
-        expect(Chef::Application).to receive(:fatal!).with("Permission denied when trying to change 999:999 to 501:20. #{error}")
+        expect(Chef::Application).to receive(:fatal!).with(/Permission denied when trying to change 999:999 to 501:20/)
         Chef::Daemon._change_privilege(testuser)
       end
     end


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
This change backports fixes here https://github.com/chef/chef/pull/13230/, adding as new commits instead of cherrypick as there are multiple commits

Solaris builds are failing with error
```
export/home/chef-ci/builds/chef/chef-chef-chef-16-omnibus-adhoc/omnibus/vendor/bundle/ruby/3.1.0/bundler/gems/omnibus-83d8428abde4/lib/omnibus/health_check.rb:108:in `block (2 levels) in run!': undefined method `include?' for nil:NilClass (NoMethodError)
 
          bad_omnibus_libs, bad_omnibus_bins = bad_libs.keys.partition { |k| k.include? "embedded/lib" }
                                                                              ^^^^^^^^^`
```
 This change updates the omnibus SHA in omnibus/Gemfile.lock so as to pull in those fixes from 
 (https://github.com/chef/omnibus/pull/1083)
 (https://github.com/chef/omnibus/pull/1082)

Details about test failures are [here](https://chefio.atlassian.net/browse/INFC-274)                                                                            

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
