### PR TITLE
better clarify user and principal in windows_user_privilege resource

### DIFF
--- a/lib/chef/resource/windows_user_privilege.rb
+++ b/lib/chef/resource/windows_user_privilege.rb
@@ -135,20 +135,20 @@ class Chef
                           }.freeze
 
       property :principal, String,
-        description: "An optional property to add the privilege for given principal. Use only with add and remove action. Principal can either be a User/Group or one of special identities found here Ref: https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/special-identities",
-        name_property: true
+               description: "An optional property to add the privilege for given principal. Use only with add and remove action. Principal can either be a User/Group or one of special identities found here Ref: https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/special-identities",
+               name_property: true
 
       property :users, [Array, String],
-        description: "An optional property to set the privilege for given users. Use only with set action.",
-        coerce: proc { |v| Array(v) }
+               description: "An optional property to set the privilege for given users. Use only with set action.",
+               coerce: proc { |v| Array(v) }
 
       property :privilege, [Array, String],
-        description: "One or more privileges to set for principal or users/groups. For more information on what each privilege does Ref: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/user-rights-assignment",
-        required: true,
-        coerce: proc { |v| Array(v) },
-        callbacks: {
-          "Privilege property restricted to the following values: #{PRIVILEGE_OPTS}" => lambda { |n| (n - PRIVILEGE_OPTS).empty? },
-        }, identity: true
+               description: "One or more privileges to set for principal or users/groups. For more information on what each privilege does Ref: https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/user-rights-assignment",
+               required: true,
+               coerce: proc { |v| Array(v) },
+               callbacks: {
+                 "Privilege property restricted to the following values: #{PRIVILEGE_OPTS}" => lambda { |n| (n - PRIVILEGE_OPTS).empty? },
+               }, identity: true
 
       load_current_value do |new_resource|
         if new_resource.principal && (new_resource.action.include?(:add) || new_resource.action.include?(:remove))


### PR DESCRIPTION
## Description
Better clarification on how to use :add and :set actions for users or principals. Principal option and users option are mutually exclusive when using :add or :set actions. Furthermore Principal does not take system users or groups but rather special identity groups found in this list. https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-special-identities-groups

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
