### PR TITLE
[chef-16] Fix hab package failures under windows plan in verify pipeline

### DIFF
--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,7 +1,8 @@
 [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
 if ($hab_version -lt [Version]"0.85.0" ) {
     Write-Host "--- :habicat: Installing the version of Habitat required"
-    install-habitat --version 0.85.0.20190916
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
     if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
 } else {
     Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"

--- a/.expeditor/scripts/verify-plan.ps1
+++ b/.expeditor/scripts/verify-plan.ps1
@@ -15,6 +15,17 @@ Write-Host "--- :8ball: :windows: Verifying $Plan"
 powershell -File "./.expeditor/scripts/ensure-minimum-viable-hab.ps1"
 if (-not $?) { throw "Could not ensure the minimum hab version required is installed." }
 
+# Do this to fix 'The term "hab" is not recognized as the name of a cmdlet' errors in windows_plan under verify pipeline.
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+Write-Host "--- :construction: Verifying Git is Installed"
+$source = Get-Command -Name Git -Verbose
+Write-Host "Which version of Git is installed? - " $source.version
+if (-not ($source.name -match "git.exe")) {
+    choco install git -y
+    # gotta refresh the path so you can actually use Git now
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+}
+
 Write-Host "--- :key: Generating fake origin key"
 hab origin key generate $env:HAB_ORIGIN
 


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Windows plan throws below erros:
e.g build https://buildkite.com/chef-oss/chef-chef-chef-16-verify/builds/1191#0183d1ca-9779-4c20-bdad-b436cd528647
```
install-habitat : The term 'install-habitat' is not recognized as the name of a cmdlet, function, script file, or
operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try
again.
At C:\bk0183d1cab436cd528647\.expeditor\scripts\ensure-minimum-viable-hab.ps1:4 char:5
+     install-habitat --version 0.85.0.20190916
+     ~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (install-habitat:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
 
Hab version is older than 0.85 and could not update it.
At C:\bk0183d1cab436cd528647\.expeditor\scripts\ensure-minimum-viable-hab.ps1:5 char:20
+ ... (-not $?) { throw "Hab version is older than 0.85 and could not updat ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Hab version is ... not update it.:String) [], RuntimeException
    + FullyQualifiedErrorId : Hab version is older than 0.85 and could not update it.
 
Could not ensure the minimum hab version required is installed.
At C:\bk0183d1cab436cd528647\.expeditor\scripts\verify-plan.ps1:16 char:16
+ ... (-not $?) { throw "Could not ensure the minimum hab version required  ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Could not ensur...d is installed.:String) [], RuntimeException
    + FullyQualifiedErrorId : Could not ensure the minimum hab version required is installed.
```

Once we fixed above issue, we get below failure:
Ref build: https://buildkite.com/chef-oss/chef-chef-chef-16-verify/builds/1194#0183eaca-5590-4007-9384-fd8dee327e24

```
hab : The term 'hab' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the
--
  | spelling of the name, or if a path was included, verify that the path is correct and try again.
  | At C:\bk0183eacafd8dee327e24\.expeditor\scripts\verify-plan.ps1:25 char:22
  | + $env:DO_CHECK=$true; hab pkg build .
  | +                      ~~~
  | + CategoryInfo          : ObjectNotFound: (hab:String) [], CommandNotFoundException
  | + FullyQualifiedErrorId : CommandNotFoundException
  |  
  | unable to build
  | At C:\bk0183eacafd8dee327e24\.expeditor\scripts\verify-plan.ps1:26 char:16
  | + if (-not $?) { throw "unable to build"}
  | +                ~~~~~~~~~~~~~~~~~~~~~~~
  | + CategoryInfo          : OperationStopped: (unable to build:String) [], RuntimeException
  | + FullyQualifiedErrorId : unable to build
  |  
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
