### PR TITLE
Add linux_only: true to new linux user specs

### DIFF
--- a/spec/functional/resource/user/linux_user_spec.rb
+++ b/spec/functional/resource/user/linux_user_spec.rb
@@ -20,6 +20,7 @@ require "chef/mixin/shell_out"
 
 metadata = {
   requires_root: true,
+  linux_only: true
 }
 
 describe "Chef::Resource::User with Chef::Provider::User::LinuxUser provider", metadata do

--- a/spec/functional/resource/user/linux_user_spec.rb
+++ b/spec/functional/resource/user/linux_user_spec.rb
@@ -20,7 +20,7 @@ require "chef/mixin/shell_out"
 
 metadata = {
   requires_root: true,
-  linux_only: true
+  linux_only: true,
 }
 
 describe "Chef::Resource::User with Chef::Provider::User::LinuxUser provider", metadata do
@@ -64,7 +64,12 @@ describe "Chef::Resource::User with Chef::Provider::User::LinuxUser provider", m
   end
 
   let(:uid) { nil }
-  let(:gid) { 20 }
+  let(:gid) do
+    # SLES 15 doesn't have the "20" group and
+    # so lets just pick the last group... no,
+    # Etc.group.map(&:gid).last does not work
+    Etc.enum_for(:group).map(&:gid).last
+  end
   let(:home) { nil }
   let(:manage_home) { false }
   let(:password) { "XXXYYYZZZ" }
@@ -77,6 +82,7 @@ describe "Chef::Resource::User with Chef::Provider::User::LinuxUser provider", m
     r.username(username)
     r.uid(uid)
     r.gid(gid)
+
     r.home(home)
     r.shell(shell)
     r.comment(comment)

--- a/spec/unit/provider/user/linux_spec.rb
+++ b/spec/unit/provider/user/linux_spec.rb
@@ -20,7 +20,7 @@
 
 require "spec_helper"
 
-describe Chef::Provider::User::Linux do
+describe Chef::Provider::User::Linux, linux_only: true do
 
   subject(:provider) do
     p = described_class.new(@new_resource, @run_context)


### PR DESCRIPTION
Signed-off-by: Thomas Powell <powell@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

#13223 fixed a bug in `compare_user` and tests were added to prevent regression in the future. However, the tests were not tagged to run on Linux only, and therefore pipeline breakage occurred on non-Linux Unix-like platforms, including macOS.

## Related Issue
[Pipeline breakage on linux user specs running on non-linux.](https://chefio.atlassian.net/browse/INFC-304)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
