### PR TITLE
[Chef-17] Backporting a fix for the Linux testers that fixes a resolver_conf issue

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -43,6 +43,7 @@ include_recipe "ntp" unless fedora? # fedora 34+ doesn't have NTP
 resolver_config "/etc/resolv.conf" do
   nameservers [ "8.8.8.8", "8.8.4.4" ]
   search [ "chef.io" ]
+  atomic_update false # otherwise EBUSY for linux docker containers
 end
 
 users_from_databag = search("users", "*:*")


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Kitchen tests on linux systems fail with the following error:
```ruby
Error executing action `set` on resource 'resolver_config[/etc/resolv.conf]'
           ================================================================================
           
           Errno::EBUSY
           ------------
           template[/etc/resolv.conf] (end_to_end::linux line 99) had an error: Errno::EBUSY: Device or resource busy @ rb_file_s_rename - (/etc/.chef-resolv20221019-2104-c7pfwm.conf, /etc/resolv.conf)
```
This PR addresses that by backporting the fix from Chef-18

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
