### PR TITLE
[Chef-17] Jfm/chef17 ansidecl

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -7,7 +7,7 @@ expeditor:
       retry:
         automatic:
           limit: 1
-      timeout_in_minutes: 45
+      timeout_in_minutes: 60
 
 steps:
 
@@ -392,7 +392,7 @@ steps:
 - label: ":habicat: Windows plan"
   commands:
     - ./.expeditor/scripts/verify-plan.ps1
-  timeout_in_minutes: 60
+  timeout_in_minutes: 0
   expeditor:
     executor:
       windows:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -35,6 +35,7 @@ jobs:
         # This leads to failures during testing. Moving that file to its correct position here.
         If(-not(Test-Path C:\opscode\chef\embedded\msys64\mingw64\x86_64-w64-mingw32\include\ansidecl.h)){
           $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
+          Write-Output $output
           $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
           Copy-Item -Path $output.FullName -Destination $target_path
         }

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -34,9 +34,9 @@ jobs:
         # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
         # This leads to failures during testing. Moving that file to its correct position here.
         # Another example of 'bad' that needs to be corrected
-        $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
-        $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-        Move-Item -Path $output.FullName -Destination $target_path
+        # $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
+        # $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
+        # Move-Item -Path $output.FullName -Destination $target_path
 
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -33,10 +33,11 @@ jobs:
 
         # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
         # This leads to failures during testing. Moving that file to its correct position here.
-        # Another example of 'bad' that needs to be corrected
-        # $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
-        # $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-        # Move-Item -Path $output.FullName -Destination $target_path
+        If(-not(Test-Path C:\opscode\chef\embedded\msys64\mingw64\x86_64-w64-mingw32\include\ansidecl.h)){
+          $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
+          $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
+          Copy-Item -Path $output.FullName -Destination $target_path
+        }
 
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -39,7 +39,8 @@ jobs:
           $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
           Copy-Item -Path $output.FullName -Destination $target_path
         }
-
+        Write-Output "We're probably running on Chef-18/Ruby 3.1 - getting the Ruby version"
+        Ruby --version
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
         appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -97,7 +97,7 @@ function Invoke-Build {
         bundle exec rake install:local # this needs to be 'bundle exec'd because a Rakefile makes reference to Bundler
         if (-not $?) {
             Write-Warning " -- That didn't work. Let's try again."
-            bundle exec rake install:local # this needs to be 'bundle exec'd because a Rakefile makes reference to Bundler
+            bundle exec rake install:local --trace # this needs to be 'bundle exec'd because a Rakefile makes reference to Bundler
             if (-not $?) { throw "unable to install the gems that live in directories within this repo" }
         }
     } finally {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The Windows installers for the chef and chef-workstation clients have been broken for a while and weren't putting ansidecl.h into the correct folder structure. Matt Wrock corrected that but the corrected installers weren't merged yet so we added code to the kitchen.yml file to correct it. Now the chef* installers appear to be working again so I am commenting the fix out. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
