### PR TITLE
[Chef-17] Correcting for Hab not being installed

### DIFF
--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -29,5 +29,8 @@ catch {
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+    $test_output = gci -path c:\ -File "hab.exe"
+    Write-Host "Here's Hab`n"
+    Write-Host $test_output
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\ProgramData\Habitat\"
 }

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -4,6 +4,7 @@ try {
         Write-Host "--- :habicat: Installing the version of Habitat required"
         Set-ExecutionPolicy Bypass -Scope Process -Force
         Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
         if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
     } else {
         Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
@@ -14,5 +15,6 @@ catch {
     Write-Host "--- :habicat: Installing the version of Habitat required"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 }
-$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -15,3 +15,4 @@ catch {
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -3,10 +3,11 @@ try {
     if ($hab_version -lt [Version]"0.85.0" ) {
         Write-Host "--- :habicat: Installing the version of Habitat required"
         Write-Output "What version of Windows and PowerShell is this?`n"
+        write-output "`n"
         $PSVersionTable
         [System.Environment]::OSVersion
         Write-Output "What version of Hab is this? $((hab --version).split(" ")[1].split("/")[0])"
-        write-ouput "`n"
+        write-output "`n"
         Get-Command Hab
         Set-ExecutionPolicy Bypass -Scope Process -Force
         Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
@@ -18,9 +19,10 @@ try {
 }
 catch {
     Write-Output "What version of Windows and PowerShell is this?`n"
+    write-output "`n"
     $PSVersionTable
     [System.Environment]::OSVersion
-    write-ouput "`n"
+    write-output "`n"
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -3,8 +3,9 @@ try {
     if ($hab_version -lt [Version]"0.85.0" ) {
         Write-Host "--- :habicat: Installing the version of Habitat required"
         Write-Host "What version of Windows and PowerShell is this?`n"
-        Write-Host "`n"
         $PSVersionTable
+        Write-Host "`n"
+        Write-Host "This is the OS Version"
         [System.Environment]::OSVersion
         Write-Host "What version of Hab is this? $((hab --version).split(" ")[1].split("/")[0])"
         Write-Host "`n"
@@ -12,6 +13,9 @@ try {
         Set-ExecutionPolicy Bypass -Scope Process -Force
         Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+        $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse
+        Write-Host "Here's Hab`n"
+        Write-Host $test_output
         if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
     } else {
         Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
@@ -23,13 +27,14 @@ catch {
     $PSVersionTable
     [System.Environment]::OSVersion
     Write-Host "`n"
+    Write-Host "Looking for Hab in all the wrong places"
     Get-Command Hab
     Write-Host "`n"
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
-    $test_output = gci -path c:\ -File "hab.exe"
+    $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse
     Write-Host "Here's Hab`n"
     Write-Host $test_output
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\ProgramData\Habitat\"

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,6 +1,8 @@
 try {
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]"0.85.0" ) {
+        # $foo = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+        # $foo.IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
         Write-Host "--- :habicat: Installing the version of Habitat required"
         Write-Host "What version of Windows and PowerShell is this?`n"
         $PSVersionTable
@@ -13,7 +15,7 @@ try {
         Set-ExecutionPolicy Bypass -Scope Process -Force
         Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-        $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse
+        $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse -ErrorAction SilentlyContinue
         Write-Host "Here's Hab`n"
         Write-Host $test_output
         if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
@@ -34,7 +36,7 @@ catch {
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
-    $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse
+    $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse -ErrorAction SilentlyContinue
     Write-Host "Here's Hab`n"
     Write-Host $test_output
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\ProgramData\Habitat\"

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -12,7 +12,7 @@ try {
 }
 catch {
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
-    Write-Host "--- :habicat: Installing the version of Habitat required"
+    Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -13,8 +13,9 @@ try {
         Write-Host "`n"
         Get-Command Hab
         Set-ExecutionPolicy Bypass -Scope Process -Force
-        choco install habitat
-        # Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+        # choco feature enable -n=allowGlobalConfirmation
+        # choco install habitat
+        Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
         $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse -ErrorAction SilentlyContinue
         Write-Host "Here's Hab`n"
@@ -36,6 +37,7 @@ catch {
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force
+    choco feature enable -n=allowGlobalConfirmation
     choco install habitat
     # Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
     $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse -ErrorAction SilentlyContinue

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -5,6 +5,7 @@ try {
         Write-Output "What version of Windows and PowerShell is this?`n"
         $PSVersionTable
         [System.Environment]::OSVersion
+        Write-Output "What version of Hab is this? $((hab --version).split(" ")[1].split("/")[0])"
         write-ouput "`n"
         Get-Command Hab
         Set-ExecutionPolicy Bypass -Scope Process -Force
@@ -26,4 +27,3 @@ catch {
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\ProgramData\Habitat\"
 }
-

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -13,7 +13,8 @@ try {
         Write-Host "`n"
         Get-Command Hab
         Set-ExecutionPolicy Bypass -Scope Process -Force
-        Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+        choco install habitat
+        # Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
         $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse -ErrorAction SilentlyContinue
         Write-Host "Here's Hab`n"
@@ -35,7 +36,8 @@ catch {
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force
-    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+    choco install habitat
+    # Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
     $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse -ErrorAction SilentlyContinue
     Write-Host "Here's Hab`n"
     Write-Host $test_output

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -2,6 +2,10 @@ try {
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]"0.85.0" ) {
         Write-Host "--- :habicat: Installing the version of Habitat required"
+        Write-Output "What version of Windows and PowerShell is this?`n"
+        $PSVersionTable
+        write-ouput "`n"
+        Get-Command Hab
         Set-ExecutionPolicy Bypass -Scope Process -Force
         Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -15,6 +15,6 @@ catch {
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\ProgramData\Habitat\"
 }
 

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,47 +1,17 @@
 try {
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]"0.85.0" ) {
-        # $foo = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-        # $foo.IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
-        Write-Host "--- :habicat: Installing the version of Habitat required"
-        Write-Host "What version of Windows and PowerShell is this?`n"
-        $PSVersionTable
-        Write-Host "`n"
-        Write-Host "This is the OS Version"
-        [System.Environment]::OSVersion
-        Write-Host "What version of Hab is this? $((hab --version).split(" ")[1].split("/")[0])"
-        Write-Host "`n"
-        Get-Command Hab
-        Set-ExecutionPolicy Bypass -Scope Process -Force
-        # choco feature enable -n=allowGlobalConfirmation
-        # choco install habitat
         Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-        $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse -ErrorAction SilentlyContinue
-        Write-Host "Here's Hab`n"
-        Write-Host $test_output
         if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
     } else {
         Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
     }
 }
 catch {
-    Write-Host "What version of Windows and PowerShell is this?`n"
-    Write-Host "`n"
-    $PSVersionTable
-    [System.Environment]::OSVersion
-    Write-Host "`n"
-    Write-Host "Looking for Hab in all the wrong places"
-    Get-Command Hab
-    Write-Host "`n"
-    # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     choco feature enable -n=allowGlobalConfirmation
     choco install habitat
-    # Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
-    $test_output = Get-ChildItem -path c:\ -File "hab.exe" -Recurse -ErrorAction SilentlyContinue
-    Write-Host "Here's Hab`n"
-    Write-Host $test_output
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\ProgramData\Habitat\"
 }

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -4,6 +4,7 @@ try {
         Write-Host "--- :habicat: Installing the version of Habitat required"
         Write-Output "What version of Windows and PowerShell is this?`n"
         $PSVersionTable
+        [System.Environment]::OSVersion
         write-ouput "`n"
         Get-Command Hab
         Set-ExecutionPolicy Bypass -Scope Process -Force
@@ -17,6 +18,7 @@ try {
 catch {
     Write-Output "What version of Windows and PowerShell is this?`n"
     $PSVersionTable
+    [System.Environment]::OSVersion
     write-ouput "`n"
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,8 +1,17 @@
-[Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
-if ($hab_version -lt [Version]"0.85.0" ) {
+try {
+    [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
+    if ($hab_version -lt [Version]"0.85.0" ) {
+        Write-Host "--- :habicat: Installing the version of Habitat required"
+        Set-ExecutionPolicy Bypass -Scope Process -Force
+        Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+        if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
+    } else {
+        Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
+    }
+}
+catch {
+    # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Installing the version of Habitat required"
-    install-habitat --version 0.85.0.20190916
-    if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
-} else {
-    Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -11,6 +11,9 @@ try {
     }
 }
 catch {
+    Write-Output "What version of Windows and PowerShell is this?`n"
+    $PSVersionTable
+    write-ouput "`n"
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -22,6 +22,9 @@ catch {
     write-output "`n"
     $PSVersionTable
     [System.Environment]::OSVersion
+    Write-Output "What version of Hab is this? $((hab --version).split(" ")[1].split("/")[0])"
+    write-output "`n"
+    Get-Command Hab
     write-output "`n"
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -2,12 +2,12 @@ try {
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]"0.85.0" ) {
         Write-Host "--- :habicat: Installing the version of Habitat required"
-        Write-Output "What version of Windows and PowerShell is this?`n"
-        write-output "`n"
+        Write-Host "What version of Windows and PowerShell is this?`n"
+        Write-Host "`n"
         $PSVersionTable
         [System.Environment]::OSVersion
-        Write-Output "What version of Hab is this? $((hab --version).split(" ")[1].split("/")[0])"
-        write-output "`n"
+        Write-Host "What version of Hab is this? $((hab --version).split(" ")[1].split("/")[0])"
+        Write-Host "`n"
         Get-Command Hab
         Set-ExecutionPolicy Bypass -Scope Process -Force
         Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
@@ -18,14 +18,13 @@ try {
     }
 }
 catch {
-    Write-Output "What version of Windows and PowerShell is this?`n"
-    write-output "`n"
+    Write-Host "What version of Windows and PowerShell is this?`n"
+    Write-Host "`n"
     $PSVersionTable
     [System.Environment]::OSVersion
-    Write-Output "What version of Hab is this? $((hab --version).split(" ")[1].split("/")[0])"
-    write-output "`n"
+    Write-Host "`n"
     Get-Command Hab
-    write-output "`n"
+    Write-Host "`n"
     # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Forcing an install of habitat"
     Set-ExecutionPolicy Bypass -Scope Process -Force

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -19,7 +19,7 @@ jobs:
     - name: 'Install Chef/Ohai from Omnitruck'
       id: install_chef
       run: |
-        . { Invoke-WebRequest -useb https://omnitruck.chef.io/install.ps1 } | Invoke-Expression; Install-Project -project chef -channel current
+        . { Invoke-WebRequest -useb https://omnitruck.chef.io/install.ps1 } | Invoke-Expression; Install-Project -project chef -channel current -v 17
         $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
         chef-client -v
         ohai -v


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
In some instances, Habitat is not installed on Windows already and the version check in the verify plan fails. This resolves that by ensuring a version is either installed or updated as appropriate

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
