### PR TITLE
[chef-17] Update ncurses to 6.3 to fix build failures in adhoc pipeline on FreeBSD12

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -11,7 +11,7 @@ override "libxml2", version: "2.9.10" if windows?
 override "libxslt", version: "1.1.34" if windows?
 override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
-override "ncurses", version: "5.9"
+override "ncurses", version: "6.3"
 override "nokogiri", version: "1.13.1"
 override "openssl", version: mac_os_x? ? "1.1.1m" : "1.0.2zb"
 override "pkg-config-lite", version: "0.28-1"


### PR DESCRIPTION


Signed-off-by: Bapu L <bapu.labade@progress.com>

<!--- Provide a short summary of your changes in the Title above -->
We are seeing failures when building ncurses gem on FreeBSD12 in adhoc pipeline.
Ref build: https://buildkite.com/chef/chef-chef-chef-17-omnibus-adhoc/builds/51#0183c702-85c5-49fb-a820-72b9e00e6eed
To fix that, we've upgraded it to version 6.3.


## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
