### PR TITLE
INFC-321 Uncomment "Upgrade Chef/Ohai Appbundler" build stage in kitchen tests

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -81,6 +81,7 @@ jobs:
         # This leads to failures during testing. Moving that file to its correct position here.
         # Another example of 'bad' that needs to be corrected
         $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
+        if ($output -is [Array]) { $output = $output[0] }
         $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
         Move-Item -Path $output.FullName -Destination $target_path
 

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -71,28 +71,28 @@ jobs:
         ohai -v
         rake --version
         bundle -v
-    # - name: 'Upgrade Chef/Ohai via Appbundler'
-    #   id: upgrade
-    #   run: |
-    #     $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
-    #     $env:OHAI_VERSION = ( Select-String -Path .\Gemfile.lock -Pattern '(?<=ohai \()\d.*(?=\))' | ForEach-Object { $_.Matches[0].Value } )
+    - name: 'Upgrade Chef/Ohai via Appbundler'
+      id: upgrade
+      run: |
+        $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
+        $env:OHAI_VERSION = ( Select-String -Path .\Gemfile.lock -Pattern '(?<=ohai \()\d.*(?=\))' | ForEach-Object { $_.Matches[0].Value } )
 
-    #     # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
-    #     # This leads to failures during testing. Moving that file to its correct position here.
-    #     # Another example of 'bad' that needs to be corrected
-    #     $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
-    #     $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-    #     Move-Item -Path $output.FullName -Destination $target_path
+        # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
+        # This leads to failures during testing. Moving that file to its correct position here.
+        # Another example of 'bad' that needs to be corrected
+        $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
+        $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
+        Move-Item -Path $output.FullName -Destination $target_path
 
-    #     gem install appbundler appbundle-updater --no-doc
-    #     If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    #     appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
-    #     If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    #     Write-Output "Installed Chef / Ohai release:"
-    #     chef-client -v
-    #     If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    #     ohai -v
-    #     If ($lastexitcode -ne 0) { Exit $lastexitcode }
+        gem install appbundler appbundle-updater --no-doc
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
+        appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
+        Write-Output "Installed Chef / Ohai release:"
+        chef-client -v
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
+        ohai -v
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
     - name: 'Run end_to_end::default recipe'
       id: run
       run: |

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -81,7 +81,13 @@ jobs:
         # This leads to failures during testing. Moving that file to its correct position here.
         # Another example of 'bad' that needs to be corrected
         $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
+
+        # As of Ruby 3.1, there are 3 ansidecl.h files found in the opscode path
+        # Grabbing the first (and shortest) path found is a bit of a :fingers-crossed: but
+        # making the leap that ansidecl.h isn't going to vary in a way that will fail
+        # subtly.
         if ($output -is [Array]) { $output = $output[0] }
+
         $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
         Move-Item -Path $output.FullName -Destination $target_path
 


### PR DESCRIPTION
Signed-off-by: Thomas Powell <powell@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Reenable the "Upgrade Chef/Ohai Appbundler" build stage in kitchen tests for GitHub Actions, with a slight tweak for 3.1 directory structure.

## Related Issue
[INFC-321 Investigate "Upgrade Chef/Ohai Appbundler removal" in kitchen tests](https://chefio.atlassian.net/browse/INFC-321)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
