### PR TITLE
[WIP][Chef-16] Fix bundle install failure when running linting step under github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 2.7
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - run: bundle exec chefstyle -c .rubocop.yml


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
The chefstyle step in action actions has started failing due to it pulling in gem `semverse` 3.0.2 which is ruby 27 compatible whereas the step is setup for ruby 2.6
It used to pull in version 3.0.0 (e.g https://github.com/chef/chef/actions/runs/3281024063/jobs/5402520515)
Seems caching issue? 
Trial: Update ruby version used for testing chefstyle(linting) using github actions to 2.7  as bundle install for chefstyle is pulling in semaverse gem 3.0.2 which is ruby 2.7 compatible

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
