### PR TITLE
[WIP] Expeditor will fail of chef.wiki exists on the box. Pre-emptively delete it to avoid errors with the release.

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -2,6 +2,9 @@
 
 set -eou pipefail
 
+# The expeditor process will error out if the wiki remains on the box for some reason.
+# Pre-emptively delete it to avoid the error
+rm -fr chef.wiki.git
 git clone https://x-access-token:${GITHUB_TOKEN}@github.com/chef/chef.wiki.git
 
 pushd ./chef.wiki


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

```
[2022-10-27 20:37:01 +0000] action bash:.expeditor/publish-release-notes.sh started
Downloading .expeditor/publish-release-notes.sh from chef/chef:main
fatal: destination path 'chef.wiki' already exists and is not an empty directory.
```