### PR TITLE
Update the version of ruby-shadow to remove license error message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ruby-shadow
-  revision: 3b8ea40b0e943b5de721d956741308ce805a5c3c
+  revision: f135b3fd52d0a638f2eb9b17a8952a7f0f317688
   branch: lcg/ruby-3.0
   specs:
-    ruby-shadow (2.5.0)
+    ruby-shadow (2.5.1)
 
 GIT
   remote: https://github.com/chef/ruby-proxifier


### PR DESCRIPTION
## Description

This takes the newest version of `ruby-shadow` which fixes the error message

```
       re-installing ruby-shadow...
       WARNING:  license value 'Public Domain License' is invalid.  Use a license identifier from
       http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
       Did you mean 'Unlicense'?
       WARNING:  See https://guides.rubygems.org/specification-reference/ for help
         Successfully built RubyGem
         Name: ruby-shadow
         Version: 2.5.0
         File: ruby-shadow-2.5.0.gem
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
