### PR TITLE
Update deprecated "hab sup status" call (do not merge until hab / test pipeline is green again)

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_config.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_config.rb
@@ -7,7 +7,7 @@ end
 
 ruby_block "wait-for-sup-default-startup" do
   block do
-    raise unless system("hab sup status")
+    raise unless system("hab svc status")
   end
   retries 30
   retry_delay 1

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_config.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_config.rb
@@ -5,7 +5,7 @@ habitat_sup "default" do
   license "accept"
 end
 
-ruby_block "wait-for-sup-default-startup" do
+ruby_block "wait-for-svc-default-startup" do
   block do
     raise unless system("hab svc status")
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_service.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_service.rb
@@ -7,7 +7,7 @@ end
 # This pause is in place to make sure the supervisor is up and running before we proceed. The previous resource does the full install and initial startup. That can take a bit longer in the pipeline.
 ruby_block "wait-for-sup-default-startup" do
   block do
-    raise unless system("hab sup status")
+    raise unless system("hab svc status")
   end
   retries 30
   retry_delay 1

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_service.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_service.rb
@@ -5,7 +5,7 @@ habitat_sup "default" do
 end
 
 # This pause is in place to make sure the supervisor is up and running before we proceed. The previous resource does the full install and initial startup. That can take a bit longer in the pipeline.
-ruby_block "wait-for-sup-default-startup" do
+ruby_block "wait-for-svc-default-startup" do
   block do
     raise unless system("hab svc status")
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_sup.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_sup.rb
@@ -14,7 +14,7 @@ end
 
 ruby_block "wait-for-sup-default-startup" do
   block do
-    raise unless system("hab sup status")
+    raise unless system("hab svc status")
   end
   retries 30
   retry_delay 1

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_sup.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_sup.rb
@@ -12,7 +12,7 @@ habitat_sup "tester" do
   launcher_version "13458"
 end
 
-ruby_block "wait-for-sup-default-startup" do
+ruby_block "wait-for-svc-default-startup" do
   block do
     raise unless system("hab svc status")
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_user_toml.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_user_toml.rb
@@ -4,7 +4,7 @@ habitat_sup "default" do
   license "accept"
 end
 
-ruby_block "wait-for-sup-default-startup" do
+ruby_block "wait-for-svc-default-startup" do
   block do
     raise unless system("hab svc status")
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_user_toml.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_user_toml.rb
@@ -6,7 +6,7 @@ end
 
 ruby_block "wait-for-sup-default-startup" do
   block do
-    raise unless system("hab sup status")
+    raise unless system("hab svc status")
   end
   retries 30
   retry_delay 1

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_config.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_config.rb
@@ -2,7 +2,7 @@ habitat_sup "default" do
   license "accept"
 end
 
-ruby_block "wait-for-sup-default-startup" do
+ruby_block "wait-for-svc-default-startup" do
   block do
     raise unless system("hab svc status")
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_config.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_config.rb
@@ -4,7 +4,7 @@ end
 
 ruby_block "wait-for-sup-default-startup" do
   block do
-    raise unless system("hab sup status")
+    raise unless system("hab svc status")
   end
   retries 30
   retry_delay 1

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_service.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_service.rb
@@ -5,7 +5,7 @@ end
 
 ruby_block "wait-for-sup-default-startup" do
   block do
-    raise unless system("hab sup status")
+    raise unless system("hab svc status")
   end
   retries 30
   retry_delay 1

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_service.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_service.rb
@@ -3,7 +3,7 @@ habitat_sup "default" do
   gateway_auth_token "secret"
 end
 
-ruby_block "wait-for-sup-default-startup" do
+ruby_block "wait-for-svc-default-startup" do
   block do
     raise unless system("hab svc status")
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_sup.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_sup.rb
@@ -7,7 +7,7 @@ end
 
 ruby_block "wait-for-sup-default-startup" do
   block do
-    raise unless system("hab sup status")
+    raise unless system("hab svc status")
   end
   retries 30
   retry_delay 1

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_sup.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_sup.rb
@@ -5,7 +5,7 @@ habitat_sup "tester" do
   listen_gossip "0.0.0.0:9998"
 end
 
-ruby_block "wait-for-sup-default-startup" do
+ruby_block "wait-for-svc-default-startup" do
   block do
     raise unless system("hab svc status")
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_user_toml.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_user_toml.rb
@@ -2,7 +2,7 @@ habitat_sup "default" do
   license "accept"
 end
 
-ruby_block "wait-for-sup-default-startup" do
+ruby_block "wait-for-svc-default-startup" do
   block do
     raise unless system("hab svc status")
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_user_toml.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_user_toml.rb
@@ -4,7 +4,7 @@ end
 
 ruby_block "wait-for-sup-default-startup" do
   block do
-    raise unless system("hab sup status")
+    raise unless system("hab svc status")
   end
   retries 30
   retry_delay 1


### PR DESCRIPTION
## Description

This changes "hab sup status" calls to "hab svc status" calls to avoid this deprecation notice :

> * ruby_block[wait-for-sup-default-startup] action runØ 'hab sup status' as an alias for 'hab svc status' is deprecated. Please update your automation and processes accordingly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
