### PR TITLE
Remove "free" command from buildkite run as it's not supported

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -6,7 +6,6 @@ set -eu
 [[ "$BUILDKITE_PIPELINE_NAME" =~ verify$ ]] || exit 0
 
 docker ps || true
-free -m || true
 
 # We've now seen cases where origin/main on the build hosts can get
 # out of date. This causes us to build components unnecessarily.


### PR DESCRIPTION
## Description

This removes the call to run "free" in the buildkite environment as that binary isn't present. The call to "free" gives this error

```
C:/bk018435762483229395ad/.buildkite/hooks/pre-command: line 9: free: command not found
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
