### PR TITLE
[WIP][Chef-16] Fix windows functional tests

### DIFF
--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -30,5 +30,5 @@ bundle install --jobs=3 --retry=3
 if (-not $?) { throw "Unable to install gem dependencies" }
 
 Write-Output "+++ bundle exec rake spec:functional"
-bundle exec rake spec:functional
+bundle exec rspec spec/functional
 if (-not $?) { throw "Chef functional specs failing." }

--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -30,5 +30,5 @@ bundle install --jobs=3 --retry=3
 if (-not $?) { throw "Unable to install gem dependencies" }
 
 Write-Output "+++ bundle exec rake spec:functional"
-bundle exec rspec spec/functional
+bundle exec rake spec:functional
 if (-not $?) { throw "Chef functional specs failing." }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ PATH
       bcrypt_pbkdf (~> 1.1)
       bundler (>= 1.10)
       chef-config (= 16.18.15)
+      chef-powershell (~> 1.0.12)
       chef-utils (= 16.18.15)
       chef-vault
       chef-zero (>= 14.0.11)
@@ -144,6 +145,9 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
     byebug (11.1.3)
+    chef-powershell (1.0.13)
+      ffi (~> 1.15)
+      ffi-yajl (~> 2.4)
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -15,6 +15,7 @@ gemspec.add_dependency "wmi-lite", "~> 1.0"
 gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
 gemspec.add_dependency "iso8601", ">= 0.12.1", "< 0.14" # validate 0.14 when it comes out
 gemspec.add_dependency "win32-certstore", "~> 0.5.0" # 0.5+ required for specifying user vs. system store
+gemspec.add_dependency "chef-powershell", "~> 1.0.12"
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")
 

--- a/lib/chef/mixin/powershell_exec.rb
+++ b/lib/chef/mixin/powershell_exec.rb
@@ -15,8 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "../powershell"
-require_relative "../pwsh"
+# Powershell is being run using chef-powershell gem. The code resides at https://github.com/chef/chef-powershell-shim
 
 # The powershell_exec mixin provides in-process access to the PowerShell engine.
 #
@@ -95,33 +94,15 @@ require_relative "../pwsh"
 #   credentials of the user running Chef Client are used.
 #
 
+if ChefUtils.windows?
+  require "chef-powershell"
+end
+
 class Chef
   module Mixin
     module PowershellExec
-      # Run a command under PowerShell via a managed (.NET) API.
-      #
-      # Requires: .NET Framework 4.0 or higher on the target machine.
-      #
-      # @param script [String] script to run
-      # @param interpreter [Symbol] the interpreter type, `:powershell` or `:pwsh`
-      # @return [Chef::PowerShell] output
-      def powershell_exec(script, interpreter = :powershell)
-        case interpreter
-        when :powershell
-          Chef::PowerShell.new(script)
-        when :pwsh
-          Chef::Pwsh.new(script)
-        else
-          raise ArgumentError, "Expected interpreter of :powershell or :pwsh"
-        end
-      end
-
-      # The same as the #powershell_exec method except this will raise
-      # Chef::PowerShell::CommandFailed if the command fails
-      def powershell_exec!(script, interpreter = :powershell)
-        cmd = powershell_exec(script, interpreter)
-        cmd.error!
-        cmd
+      if ChefUtils.windows?
+        include ChefPowerShell::ChefPowerShellModule::PowerShellExec
       end
     end
   end

--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -58,8 +58,8 @@ class Chef
       end
 
       def dsc_refresh_mode_disabled?(node)
-        require_relative "../powershell"
-        exec = Chef::PowerShell.new("Get-DscLocalConfigurationManager")
+        require "chef-powershell"
+        exec = ChefPowerShell::PowerShell.new("Get-DscLocalConfigurationManager")
         exec.error!
         exec.result["RefreshMode"] == "Disabled"
       end

--- a/spec/functional/resource/dsc_script_spec.rb
+++ b/spec/functional/resource/dsc_script_spec.rb
@@ -263,7 +263,7 @@ describe Chef::Resource::DscScript, :windows_powershell_dsc_only, :ruby64_only d
         dsc_test_resource.cwd(dsc_environment_fail_etc_directory)
         expect {
           dsc_test_resource.run_action(:run)
-        }.to raise_error(Chef::PowerShell::CommandFailed, /#{exception_message_signature}/)
+        }.to raise_error(ChefPowerShell::PowerShellExceptions::PowerShellCommandFailed, /#{exception_message_signature}/)
       end
     end
   end

--- a/spec/unit/mixin/powershell_exec_spec.rb
+++ b/spec/unit/mixin/powershell_exec_spec.rb
@@ -25,8 +25,8 @@ describe Chef::Mixin::PowershellExec, :windows_only do
 
   describe "#powershell_exec" do
     context "not specifying an interpreter" do
-      it "runs a basic command and returns a Chef::PowerShell object" do
-        expect(object.powershell_exec("$PSVersionTable")).to be_kind_of(Chef::PowerShell)
+      it "runs a basic command and returns a ChefPowerShell::PowerShell object" do
+        expect(object.powershell_exec("$PSVersionTable")).to be_kind_of(ChefPowerShell::PowerShell)
       end
 
       it "uses less than version 6" do
@@ -36,8 +36,8 @@ describe Chef::Mixin::PowershellExec, :windows_only do
     end
 
     context "using pwsh interpreter" do
-      it "runs a basic command and returns a Chef::PowerShell object" do
-        expect(object.powershell_exec("$PSVersionTable", :pwsh)).to be_kind_of(Chef::Pwsh)
+      it "runs a basic command and returns a ChefPowerShell::Pwsh object" do
+        expect(object.powershell_exec("$PSVersionTable", :pwsh)).to be_kind_of(ChefPowerShell::Pwsh)
       end
 
       it "uses greater than version 6" do
@@ -47,8 +47,8 @@ describe Chef::Mixin::PowershellExec, :windows_only do
     end
 
     context "using powershell interpreter" do
-      it "runs a basic command and returns a Chef::PowerShell object" do
-        expect(object.powershell_exec("$PSVersionTable", :powershell)).to be_kind_of(Chef::PowerShell)
+      it "runs a basic command and returns a ChefPowerShell::PowerShell object" do
+        expect(object.powershell_exec("$PSVersionTable", :powershell)).to be_kind_of(ChefPowerShell::PowerShell)
       end
 
       it "uses less than version 6" do
@@ -75,12 +75,12 @@ describe Chef::Mixin::PowershellExec, :windows_only do
   end
 
   describe "#powershell_exec!" do
-    it "runs a basic command and returns a Chef::PowerShell object" do
-      expect(object.powershell_exec!("$PSVersionTable")).to be_kind_of(Chef::PowerShell)
+    it "runs a basic command and returns a ChefPowerShell::PowerShell object" do
+      expect(object.powershell_exec!("$PSVersionTable")).to be_kind_of(ChefPowerShell::PowerShell)
     end
 
     it "raises an error if the command fails" do
-      expect { object.powershell_exec!("this-should-error") }.to raise_error(Chef::PowerShell::CommandFailed)
+      expect { object.powershell_exec!("this-should-error") }.to raise_error(ChefPowerShell::PowerShellExceptions::PowerShellCommandFailed)
     end
 
     it "raises an error if the interpreter is invalid" do

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -18,7 +18,7 @@
 
 require "spec_helper"
 
-describe "Chef::Platform#supports_dsc_invoke_resource?" do
+describe "Chef::Platform#supports_dsc_invoke_resource?", :windows_only do
   it "returns false if powershell is not present" do
     node = Chef::Node.new
     expect(Chef::Platform.supports_dsc_invoke_resource?(node)).to be_falsey
@@ -39,12 +39,12 @@ describe "Chef::Platform#supports_dsc_invoke_resource?" do
   end
 end
 
-describe "Chef::Platform#dsc_refresh_mode_disabled?" do
+describe "Chef::Platform#dsc_refresh_mode_disabled?", :windows_only do
   let(:node) { instance_double("Chef::Node") }
-  let(:powershell) { instance_double("Chef::PowerShell") }
+  let(:powershell) { instance_double("ChefPowerShell::PowerShell") }
 
   it "returns true when RefreshMode is Disabled" do
-    expect(Chef::PowerShell).to receive(:new)
+    expect(ChefPowerShell::PowerShell).to receive(:new)
       .with("Get-DscLocalConfigurationManager")
       .and_return(powershell)
     expect(powershell).to receive(:error!)
@@ -53,7 +53,7 @@ describe "Chef::Platform#dsc_refresh_mode_disabled?" do
   end
 
   it "returns false when RefreshMode is not Disabled" do
-    expect(Chef::PowerShell).to receive(:new)
+    expect(ChefPowerShell::PowerShell).to receive(:new)
       .with("Get-DscLocalConfigurationManager")
       .and_return(powershell)
     expect(powershell).to receive(:error!)

--- a/spec/unit/util/dsc/local_configuration_manager_spec.rb
+++ b/spec/unit/util/dsc/local_configuration_manager_spec.rb
@@ -50,7 +50,7 @@ describe Chef::Util::DSC::LocalConfigurationManager do
   end
 
   let(:powershell) do
-    double("Chef::PowerShell", errors: lcm_errors, error?: !lcm_errors.empty?, result: lcm_result)
+    double("ChefPowerShell::PowerShell", errors: lcm_errors, error?: !lcm_errors.empty?, result: lcm_result)
   end
 
   describe "test_configuration method invocation" do
@@ -185,7 +185,7 @@ describe Chef::Util::DSC::LocalConfigurationManager do
     context "when invalid dsc script is given" do
       it "raises exception" do
         configuration_document = "invalid-config"
-        expect { lcm.send(:run_configuration_cmdlet, configuration_document, true) }.to raise_error(Chef::PowerShell::CommandFailed)
+        expect { lcm.send(:run_configuration_cmdlet, configuration_document, true) }.to raise_error(ChefPowerShell::PowerShellExceptions::PowerShellCommandFailed)
       end
     end
   end


### PR DESCRIPTION

Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Run windows functional tests under verify pipeline using rspec directly instead of rake task which keeps getting timedout.
Running the rake task on a similar windows2019 system throws:

```
Unhandled Exception: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at ?A0xce4584d1.MI_Serializer_SerializeInstance_INTL(_MI_Serializer* serializer, UInt32 flags, _MI_Instance* instanceObject, Byte* clientBuffer, UInt32 clientBufferLength, UInt32* clientBufferNeeded)
   at Microsoft.Management.Infrastructure.Native.SerializerMethods.SerializeInstance(SerializerHandle serializerHandle, UInt32 flags, InstanceHandle instanceHandle, Byte[] outputBuffer, UInt32 offset, UInt32& outputBufferUsed)
   at Microsoft.Management.Infrastructure.Serialization.CimSerializer.Serialize(CimInstance cimInstance, InstanceSerializationOptions options, Byte[] buffer, UInt32& offset)
   at Microsoft.PowerShell.DesiredStateConfiguration.Commands.InvokeDscResourceMethodCommand.SerializeCimInstanceToMof(CimInstance cimInstance)
   at Microsoft.PowerShell.DesiredStateConfiguration.Commands.InvokeDscResourceMethodCommand.CreateParametersCollection()
   at Microsoft.PowerShell.DesiredStateConfiguration.Commands.InvokeDscResourceMethodCommand.ProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
   at System.Management.Automation.CommandProcessorBase.DoExecute()
   at System.Management.Automation.Internal.PipelineProcessor.SynchronousExecuteEnumerate(Object input)
   at System.Management.Automation.PipelineOps.InvokePipeline(Object input, Boolean ignoreInput, CommandParameterInternal[][] pipeElements, CommandBaseAst[] pipeElementAsts, CommandRedirection[][] commandRedirections, FunctionContext funcContext)
   at System.Management.Automation.Interpreter.ActionCallInstruction`6.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.DlrScriptCommandProcessor.RunClause(Action`1 clause, Object dollarUnderbar, Object inputToProcess)
   at System.Management.Automation.DlrScriptCommandProcessor.Complete()
   at System.Management.Automation.CommandProcessorBase.DoComplete()
   at System.Management.Automation.Internal.PipelineProcessor.DoCompleteCore(CommandProcessorBase commandRequestingUpstreamCommandsToStop)
   at System.Management.Automation.Internal.PipelineProcessor.SynchronousExecuteEnumerate(Object input)
   at System.Management.Automation.Runspaces.LocalPipeline.InvokeHelper()
   at System.Management.Automation.Runspaces.LocalPipeline.InvokeThreadProc()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
