### PR TITLE
macos_userdefaults: Use string for property deprecated message

### DIFF
--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -69,7 +69,7 @@ class Chef
 
       property :global, [TrueClass, FalseClass],
         description: "Determines whether or not the domain is global.",
-        deprecated: true,
+        deprecated: "As of Chef Infra Client 17.8 the `global` property is no longer necessary.",
         default: false,
         desired_state: false
 
@@ -90,7 +90,7 @@ class Chef
         description: "The value type of the preference key.",
         equal_to: %w{bool string int float array dict},
         desired_state: false,
-        deprecated: true
+        deprecated: "As of Chef Infra Client 17.8 the `type` property is no longer necessary."
 
       property :user, [String, Symbol],
         description: "The system user that the default will be applied to. Set :current for current user, :all for all users or pass a valid username",
@@ -100,7 +100,7 @@ class Chef
         description: "Set to true if the setting you wish to modify requires privileged access. This requires passwordless sudo for the `/usr/bin/defaults` command to be setup for the user running #{ChefUtils::Dist::Infra::PRODUCT}.",
         default: false,
         desired_state: false,
-        deprecated: true
+        deprecated: "As of Chef Infra Client 17.8 the `sudo` property is no longer necessary."
 
       load_current_value do |new_resource|
         Chef::Log.debug "#load_current_value: attempting to read \"#{new_resource.domain}\" value from preferences to determine state"


### PR DESCRIPTION
Signed-off-by: Jared Weyer <v-jaredweyer@microsoft.com>

## Description
Switch from Boolean to String type as value for the `deprecated` property option.

## Related Issue
#13326 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
