### PR TITLE
Added option to set release version when using activation keys

### DIFF
--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -92,7 +92,7 @@ class Chef
 
       property :release,
         [Float, String],
-        description: "Sets the operating system minor release to use for subscriptions for the system. Products and updates are limited to the specified minor release version. This is used only used with the `auto_attach` option.  For example, `release '6.4'` will append `--release=6.4` to the register command.",
+        description: "Sets the operating system minor release to use for subscriptions for the system. Products and updates are limited to the specified minor release version. This is used used with the `auto_attach` option, it may also be used with activation keys.  For example, `release '6.4'` will append `--release=6.4` to the register command.",
         introduced: "17.8"
 
       action :register, description: "Register the node with RHSM." do
@@ -205,6 +205,7 @@ class Chef
               command << "--name=#{Shellwords.shellescape(new_resource.system_name)}" if new_resource.system_name
               command << "--serverurl=#{Shellwords.shellescape(new_resource.server_url)}" if new_resource.server_url
               command << "--baseurl=#{Shellwords.shellescape(new_resource.base_url)}" if new_resource.base_url
+              command << "--release=#{Shellwords.shellescape(new_resource.release)}" if new_resource.release
               command << "--force" if new_resource.force
 
               return command.join(" ")

--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -92,7 +92,7 @@ class Chef
 
       property :release,
         [Float, String],
-        description: "Sets the operating system minor release to use for subscriptions for the system. Products and updates are limited to the specified minor release version. This is used used with the `auto_attach` option, it may also be used with activation keys.  For example, `release '6.4'` will append `--release=6.4` to the register command.",
+        description: "Sets the operating system minor release to use for subscriptions for the system. Products and updates are limited to the specified minor release version. This is used with the `auto_attach` option, it may also be used with activation keys.  For example, `release '6.4'` will append `--release=6.4` to the register command.",
         introduced: "17.8"
 
       action :register, description: "Register the node with RHSM." do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Currently when using activation keys to register to RHSM/Satellite you cannot specify the release version. As activation keys do not necessarily specify the release version this causes failures when it tries to flush the cache.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/13351

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have read the **CONTRIBUTING** document.
- [] I have run the pre-merge tests locally and they pass.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
- [] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
