### PR TITLE
Adding TLS for Habitat-test.ps1 under Windows PowerShell

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-# install chocolatey 
+# install chocolatey
 function installChoco {
 
   if (!(Test-Path "$($env:ProgramData)\chocolatey\choco.exe")) {
@@ -13,12 +13,12 @@ function installChoco {
               iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
           }
 
-          catch { 
+          catch {
                 Write-Error $_.Exception.Message
           }
   }
 
-  else { 
+  else {
       Write-Output "Chocolatey is already installed"
   }
 }
@@ -26,7 +26,11 @@ function installChoco {
 installChoco
 
 # install powershell core
-Invoke-WebRequest "https://github.com/PowerShell/PowerShell/releases/download/v7.0.3/PowerShell-7.0.3-win-x64.msi" -UseBasicParsing -OutFile powershell.msi
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+  $TLS12Protocol = [System.Net.SecurityProtocolType] 'Ssl3 , Tls12'
+  [System.Net.ServicePointManager]::SecurityProtocol = $TLS12Protocol
+}
+Invoke-WebRequest "https://github.com/PowerShell/PowerShell/releases/download/v7.3.0/PowerShell-7.3.0-win-x64.msi" -UseBasicParsing -OutFile powershell.msi
 Start-Process msiexec.exe -Wait -ArgumentList "/package PowerShell.msi /quiet"
 $env:path += ";C:\Program Files\PowerShell\7"
 


### PR DESCRIPTION
Updating the habitat-test.ps1 to properly check for Windows PowerShell (vs PowerShell 7) and set a TLS security value appropriately.

Windows PowerShell and PowerShell each handle TLS security for downloads slightly differently. For PS7, TLS is set for you but in Windows PowerShell you have to set a TLS version. The code was trying to download Chocolatey and dying on Windows PowerShell because TLS was not set. 

Signed-off-by: John <john.mccrae@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
