### PR TITLE
Update omnibus-software for FIPS issues

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: fc901c6446e6354058133b89a29a6ef8e2995b3d
+  revision: 46eb85278c88c508a3b2b370bd2e46b9fa10748f
   branch: main
   specs:
-    omnibus-software (4.0.0)
+    omnibus-software (22.11.249)
       omnibus (>= 9.0.0)
 
 GIT

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,6 +1,14 @@
 describe "chef-client fips" do
   def enable_fips_if_supported
-    OpenSSL.fips_mode = ENV["OMNIBUS_FIPS_MODE"].to_s.downcase == "true"
+    if ENV["OMNIBUS_FIPS_MODE"].to_s.downcase == "true"
+      OpenSSL.fips_mode = true
+      # This is a really bizarre thing, yes, but in my testing
+      # I found that I was getting false negatives on whether
+      # fips_mode was broken due to exiting the process before
+      # whatever cascade of things behind the scenes needed to happen
+      # happened.
+      OpenSSL.fips_mode = false
+    end
   end
   it "Should not error on enabling fips_mode" do
     expect { enable_fips_if_supported }.not_to raise_error

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,16 +1,16 @@
+require 'spec_helper'
 describe "chef-client fips" do
-  def enable_fips_if_supported
-    if ENV["OMNIBUS_FIPS_MODE"].to_s.downcase == "true"
-      OpenSSL.fips_mode = true
-      # This is a really bizarre thing, yes, but in my testing
-      # I found that I was getting false negatives on whether
-      # fips_mode was broken due to exiting the process before
-      # whatever cascade of things behind the scenes needed to happen
-      # happened.
-      OpenSSL.fips_mode = false
-    end
+  def enable_fips
+    OpenSSL.fips_mode = true
   end
-  it "Should not error on enabling fips_mode" do
-    expect { enable_fips_if_supported }.not_to raise_error
+
+  # For non-FIPS OSes/builds of Ruby, enabling FIPS should error
+  example "Error enabling fips_mode if FIPS not linked", fips_mode: false do
+    expect { enable_fips }.to raise_error(OpenSSL::OpenSSLError)
+  end
+
+  # For FIPS OSes/builds of Ruby, enabling FIPS should not error
+  example "Do not error enabling fips_mode if FIPS linked", fips_mode: true do
+    expect { enable_fips }.not_to raise_error
   end
 end

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,0 +1,5 @@
+describe "chef-client fips", :windows_only do
+  it "Should not error on enabling fips_mode" do
+    expect { OpenSSL.fips_mode = true }.not_to raise_error
+  end
+end

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,5 +1,8 @@
 describe "chef-client fips", :windows_only do
+  def enable_fips_if_supported
+    OpenSSL.fips_mode = true if ENV["OMNIBUS_FIPS_MODE"]
+  end
   it "Should not error on enabling fips_mode" do
-    expect { OpenSSL.fips_mode = true }.not_to raise_error
+    expect { enable_fips_if_supported }.not_to raise_error
   end
 end

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,4 +1,5 @@
-require 'spec_helper'
+require "spec_helper"
+
 describe "chef-client fips" do
   def enable_fips
     OpenSSL.fips_mode = true

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,4 +1,4 @@
-describe "chef-client fips", :windows_only do
+describe "chef-client fips" do
   def enable_fips_if_supported
     OpenSSL.fips_mode = true if ENV["OMNIBUS_FIPS_MODE"]
   end

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -5,6 +5,9 @@ describe "chef-client fips" do
     OpenSSL.fips_mode = true
   end
 
+  # All tests assume fips mode is off at present
+  after { OpenSSL.fips_mode = false }
+
   # For non-FIPS OSes/builds of Ruby, enabling FIPS should error
   example "Error enabling fips_mode if FIPS not linked", fips_mode: false do
     expect { enable_fips }.to raise_error(OpenSSL::OpenSSLError)

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,6 +1,6 @@
 describe "chef-client fips" do
   def enable_fips_if_supported
-    OpenSSL.fips_mode = ENV["OMNIBUS_FIPS_MODE"].to_s.downcase == 'true'
+    OpenSSL.fips_mode = ENV["OMNIBUS_FIPS_MODE"].to_s.downcase == "true"
   end
   it "Should not error on enabling fips_mode" do
     expect { enable_fips_if_supported }.not_to raise_error

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,6 +1,6 @@
 describe "chef-client fips" do
   def enable_fips_if_supported
-    OpenSSL.fips_mode = true if ENV["OMNIBUS_FIPS_MODE"]
+    OpenSSL.fips_mode = ENV["OMNIBUS_FIPS_MODE"].to_s.downcase == 'true'
   end
   it "Should not error on enabling fips_mode" do
     expect { enable_fips_if_supported }.not_to raise_error

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,7 +138,9 @@ RSpec.configure do |config|
 
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
-  config.filter_run_excluding fips_mode: !fips_mode_build?
+  config.filter_run_excluding fips_mode: !fips_mode_build? unless opensuse?
+  # RubyDistros OpenSUSE docker images have a broken fips
+  config.filter_run_excluding :fips_mode if opensuse?
 
   config.filter_run_excluding windows_only: true unless windows?
   config.filter_run_excluding not_supported_on_windows: true if windows?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,6 +138,8 @@ RSpec.configure do |config|
 
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
+
+  config.filter_run_excluding fips_mode: !omnibus_fips_mode_build?
   config.filter_run_excluding windows_only: true unless windows?
   config.filter_run_excluding not_supported_on_windows: true if windows?
   config.filter_run_excluding not_supported_on_macos: true if macos?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,7 +138,7 @@ RSpec.configure do |config|
 
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
-  config.filter_run_excluding fips_mode: !omnibus_fips_mode_build?
+  config.filter_run_excluding fips_mode: !fips_mode_build?
 
   config.filter_run_excluding windows_only: true unless windows?
   config.filter_run_excluding not_supported_on_windows: true if windows?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,8 +138,8 @@ RSpec.configure do |config|
 
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
-
   config.filter_run_excluding fips_mode: !omnibus_fips_mode_build?
+
   config.filter_run_excluding windows_only: true unless windows?
   config.filter_run_excluding not_supported_on_windows: true if windows?
   config.filter_run_excluding not_supported_on_macos: true if macos?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -223,8 +223,8 @@ def aes_256_gcm?
   OpenSSL::Cipher.ciphers.include?("aes-256-gcm")
 end
 
-def omnibus_fips_mode_build?
-  ENV["OMNIBUS_FIPS_MODE"].to_s.downcase == "true"
+def fips_mode_build?
+  OpenSSL::OPENSSL_FIPS
 end
 
 def fips?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -223,6 +223,10 @@ def aes_256_gcm?
   OpenSSL::Cipher.ciphers.include?("aes-256-gcm")
 end
 
+def omnibus_fips_mode_build?
+  ENV["OMNIBUS_FIPS_MODE"].to_s.downcase == "true"
+end
+
 def fips?
   ENV["CHEF_FIPS"] == "1"
 end


### PR DESCRIPTION
New version of omnibus-software should have disable-dynamicbase option on for the all DLLs involve with openssl for FIPS build as well as keying off of mingw64 "platform" argument to ./Configure script.

OpenSUSE RubyDistros build has a FIPS ruby but the docker image has a fingerprint error as well. Otherwise, having OpenSSL itself tell us that FIPS is enabled `OpenSSL::OPENSSLFIPS`

Signed-off-by: Thomas Powell <powell@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
INFC-289

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
