### PR TITLE
[Chef-16] Fix kitchen test failure on ubuntu2204

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -113,7 +113,7 @@ jobs:
       CHEF_LICENSE: accept-no-persist
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -14,6 +14,7 @@ provisioner:
     diff_disabled: true
     always_dump_stacktrace: true
   chef_license: "accept-no-persist"
+  clean_dokken_sandbox: false
 
 lifecycle:
   pre_converge:


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Kitchen tests on ubuntu2204 for chef16 fail when restarting `apparmor` fired by [ntp cookbook](https://github.com/sous-chefs/ntp/blob/main/recipes/apparmor.rb#L29)
```
Recipe: nscd::default
         * service[nscd] action restart
           - restart service service[nscd]
         * template[/etc/cron.allow] action create
           - create new file /etc/cron.allow
           - update content in file /etc/cron.allow from none to 5bc5d0
           (diff output suppressed by config)
           - change mode from '' to '0600'
         * template[/etc/cron.deny] action create
           - create new file /etc/cron.deny
           - update content in file /etc/cron.deny from none to b3dea1
           (diff output suppressed by config)
           - change mode from '' to '0600'
       
       Running handlers:
       [2022-11-28T06:43:38-08:00] ERROR: Running exception handlers
       Running handlers complete
       [2022-11-28T06:43:38-08:00] ERROR: Exception handlers complete
       Chef Infra Client failed. 228 resources updated in 01 minutes 06 seconds
       [2022-11-28T06:43:38-08:00] FATAL: Stacktrace dumped to /opt/kitchen/cache/chef-stacktrace.out
       [2022-11-28T06:43:38-08:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2022-11-28T06:43:38-08:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: service[apparmor] (ntp::apparmor line 20) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
       ---- Begin output of ["/usr/bin/systemctl", "--system", "restart", "apparmor"] ----
       STDOUT: 
       STDERR: Assertion failed on job for apparmor.service.
       ---- End output of ["/usr/bin/systemctl", "--system", "restart", "apparmor"] ----
       Ran ["/usr/bin/systemctl", "--system", "restart", "apparmor"] returned 1
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/mixlib-shellout-3.2.7/lib/mixlib/shellout.rb:300:in `invalid!'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/mixlib-shellout-3.2.7/lib/mixlib/shellout.rb:287:in `error!'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/mixlib-shellout-3.2.7/lib/mixlib/shellout/helper.rb:130:in `shell_out_compacted!'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/mixlib-shellout-3.2.7/lib/mixlib/shellout/helper.rb:54:in `shell_out!'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/provider/service/systemd.rb:130:in `restart_service'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/provider/service.rb:163:in `block (2 levels) in <class:Service>'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/mixin/why_run.rb:51:in `add_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/provider.rb:265:in `converge_by'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/provider/service.rb:162:in `block in <class:Service>'
       (eval):2:in `block in action_restart'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/provider.rb:276:in `instance_eval'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/provider.rb:276:in `compile_and_converge_action'
       (eval):2:in `action_restart'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/provider.rb:217:in `run_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/resource.rb:599:in `block in run_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/resource.rb:626:in `with_umask'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/resource.rb:598:in `run_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/runner.rb:74:in `run_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/runner.rb:168:in `run_delayed_notification'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/runner.rb:155:in `block in run_delayed_notifications'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/runner.rb:154:in `each'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/runner.rb:154:in `run_delayed_notifications'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/runner.rb:144:in `converge'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/client.rb:687:in `block in converge'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/client.rb:682:in `catch'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/client.rb:682:in `converge'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/client.rb:706:in `converge_and_save'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/client.rb:286:in `run'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/application.rb:305:in `run_with_graceful_exit_option'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/application.rb:281:in `block in run_chef_client'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/local_mode.rb:42:in `with_server_connectivity'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/application.rb:264:in `run_chef_client'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/application/base.rb:337:in `run_application'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.16/lib/chef/application.rb:67:in `run'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-bin-16.18.16/bin/chef-client:25:in `<top (required)>'
       /opt/chef/bin/chef-client:162:in `load'
       /opt/chef/bin/chef-client:162:in `<main>'
```
(e.g log https://github.com/chef/chef/actions/runs/3243294533/jobs/5317802031)
If try on same kitchen dokken image, it works without any issue.
Similar thing is happening on main (e.g. [build](https://github.com/chef/chef/actions/runs/3565886720/jobs/5991621660#step:4:3163)), but test-kitchen does not exit with failure. 
Setting `clean_dokken_sandbox: false` in `chef/kitchen-tests/kitchen.yml` fixes this.

This pr also fixes minor issue in github checkout action was pointing to deprecated `master` branch

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
