### PR TITLE
Lock ruby to 3.1.2 for GitHub Actions unit specs

### DIFF
--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -16,7 +16,7 @@ jobs:
         clean: true
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: "3.1.2"
         bundler-cache: false
     - run: bundle update --bundler
     - run: bundle install


### PR DESCRIPTION
in `generate_key!': pkeys are immutable on OpenSSL 3.0 (OpenSSL::PKey::PKeyError)

## Description

Two tests were broken in GitHub Actions on the upgrade from Ruby 3.1.2 to Ruby 3.1.3

rspec ./spec/unit/mixin/openssl_helper_spec.rb:94 # Chef::Mixin::OpenSSLHelper#dhparam_pem_valid? When the dhparam.pem file does exist, and does contain a vaild dhparam key returns true
[16363](https://github.com/chef/chef/actions/runs/3568070229/jobs/5996516177#step:6:16364)
rspec ./spec/unit/mixin/openssl_helper_spec.rb:320 # Chef::Mixin::OpenSSLHelper#gen_ec_priv_key When a proper curve is given Generates an ec key object

## Related Issue
INFC-357

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
