### PR TITLE
[Chef-16] Replace deprecated macos-10.15 instances with macos-11

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11] # Github has deprecated macos-10.15 runner https://github.com/actions/runner-images/issues/5583
+        os: [macos-12] # Github has deprecated macos-10.15 runner https://github.com/actions/runner-images/issues/5583
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -15,7 +15,7 @@ jobs:
         os: [windows-2022, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: 'Install Chef/Ohai from Omnitruck'
       id: install_chef
       run: |
@@ -59,7 +59,7 @@ jobs:
         os: [macos-11] # Github has deprecated macos-10.15 runner https://github.com/actions/runner-images/issues/5583
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: 'Install Chef/Ohai from Omnitruck'
       id: install_chef
       run: |
@@ -113,7 +113,7 @@ jobs:
       CHEF_LICENSE: accept-no-persist
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15] # macos-11.0 is not public for now
+        os: [macos-11] # Github has deprecated macos-10.15 runner https://github.com/actions/runner-images/issues/5583
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11] # Github has deprecated macos-10.15 runner https://github.com/actions/runner-images/issues/5583
+        os: [macos-12] # Github has deprecated macos-10.15 runner https://github.com/actions/runner-images/issues/5583
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: ['2.7']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15] # macos-11.0 is not public for now
+        os: [macos-11] # Github has deprecated macos-10.15 runner https://github.com/actions/runner-images/issues/5583
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: ['2.7']
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION

Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->
Github actions has deprecated macos10.15 and is going to completely remove it on Dec22, so replace it with macos11, for which we have been getting warning in builds.
Refer https://github.com/actions/runner-images/issues/5583

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
