### PR TITLE
Remove redundant code for chef16/17 nightlies from main branch

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -23,12 +23,6 @@ schedules:
   - name: nightly_build_main
     description: "Run a nightly build in the Buildkite pipeline"
     cronline: "0 6 * * *"
-  - name: nightly_build_chef_17
-    description: "Run a nightly build in the Buildkite pipeline"
-    cronline: "30 9 * * 2,4"
-  - name: nightly_build_chef_16
-    description: "Run a nightly build in the Buildkite pipeline"
-    cronline: "30 2 * * 2"
 
 pipelines:
   - verify:
@@ -281,11 +275,5 @@ subscriptions:
     actions:
       - bash:.expeditor/update_dep.sh
   - workload: schedule_triggered:chef/chef:main:nightly_build_main:*
-    actions:
-      - trigger_pipeline:omnibus/adhoc
-  - workload: schedule_triggered:chef/chef:chef-17:nightly_build_chef_17:*
-    actions:
-      - trigger_pipeline:omnibus/adhoc
-  - workload: schedule_triggered:chef/chef:chef-16:nightly_build_chef_16:*
     actions:
       - trigger_pipeline:omnibus/adhoc


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Nightly scheduler needs to be in that branch, so the block for chef16/17 is really not doing anything.
We are moving it to corresponding chef16/17 branch.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
