### PR TITLE
Save Key secret in HKEY_CURRENT_USER

### DIFF
--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -165,7 +165,7 @@ class Chef
 
       def self.get_cert_password
         @win32registry = Chef::Win32::Registry.new
-        path = "HKEY_LOCAL_MACHINE\\Software\\Progress\\Authentication"
+        path = "HKEY_CURRENT_USER\\Software\\Progress\\Authentication"
         # does the registry key even exist?
         present = @win32registry.get_values(path)
         if present.nil? || present.empty?
@@ -184,7 +184,7 @@ class Chef
       rescue Chef::Exceptions::Win32RegKeyMissing
         # if we don't have a password, log that and generate one
         Chef::Log.warn "Authentication Hive and values not present in registry, creating them now"
-        new_path = "HKEY_LOCAL_MACHINE\\Software\\Progress\\Authentication"
+        new_path = "HKEY_CURRENT_USER\\Software\\Progress\\Authentication"
         unless @win32registry.key_exists?(new_path)
           @win32registry.create_key(new_path, true)
         end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Save the PfxPass in HKEY_CURRENT_USER so that a Windows User without admin rights can create the key.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
At the moment the key is saved in HKEY_LOCAL_MACHINE and a windows user without admin rights can not save the key in this location.
Therefore at the moment a windows user without admin rights gets the following error when trying to run chef:

```
[2022-12-07T13:55:56+01:00] WARN: Authentication Hive and values not present in registry, creating them now

Running handlers:
[2022-12-07T13:55:57+01:00] ERROR: Running exception handlers
Running handlers complete
[2022-12-07T13:55:57+01:00] ERROR: Exception handlers complete
Infra Phase failed. 0 resources updated in 21 seconds
[2022-12-07T13:55:57+01:00] FATAL: Stacktrace dumped to C:/Users/Berater/.chef/state/cache/chef-stacktrace.out
[2022-12-07T13:55:57+01:00] FATAL: ---------------------------------------------------------------------------------------
[2022-12-07T13:55:57+01:00] FATAL: PLEASE PROVIDE THE CONTENTS OF THE stacktrace.out FILE (above) IF YOU FILE A BUG REPORT
[2022-12-07T13:55:57+01:00] FATAL: ---------------------------------------------------------------------------------------
[2022-12-07T13:55:57+01:00] DEBUG: Win32::Registry::Error: Zugriff verweigert
C:/opscode/chef/embedded/lib/ruby/3.1.0/win32/registry.rb:289:in `OpenKey'
C:/opscode/chef/embedded/lib/ruby/3.1.0/win32/registry.rb:431:in `open'
C:/opscode/chef/embedded/lib/ruby/3.1.0/win32/registry.rb:542:in `open'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/win32/registry.rb:81:in `set_value'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:196:in `rescue in get_cert_password'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:166:in `get_cert_password'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:222:in `retrieve_certificate_key'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:98:in `retrieve_certificate_key'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:140:in `load_signing_key'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:45:in `initialize'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http.rb:104:in `new'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http.rb:104:in `block in initialize'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http.rb:103:in `each'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http.rb:103:in `initialize'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/server_api.rb:40:in `initialize'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/client.rb:393:in `new'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/client.rb:393:in `rest'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/client.rb:266:in `run'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application.rb:305:in `run_with_graceful_exit_option'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application.rb:281:in `block in run_chef_client'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/local_mode.rb:42:in `with_server_connectivity'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application.rb:264:in `run_chef_client'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application/base.rb:352:in `run_application'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application.rb:67:in `run'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-bin-18.0.185/bin/chef-client:25:in `<top (required)>'
C:/opscode/chef/embedded/bin/chef-client:32:in `load'
C:/opscode/chef/embedded/bin/chef-client:32:in `<main>'

>>>> Caused by Chef::Exceptions::Win32RegKeyMissing: Chef::Exceptions::Win32RegKeyMissing
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:172:in `get_cert_password'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:222:in `retrieve_certificate_key'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:98:in `retrieve_certificate_key'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:140:in `load_signing_key'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http/authenticator.rb:45:in `initialize'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http.rb:104:in `new'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http.rb:104:in `block in initialize'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http.rb:103:in `each'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/http.rb:103:in `initialize'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/server_api.rb:40:in `initialize'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/client.rb:393:in `new'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/client.rb:393:in `rest'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/client.rb:266:in `run'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application.rb:305:in `run_with_graceful_exit_option'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application.rb:281:in `block in run_chef_client'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/local_mode.rb:42:in `with_server_connectivity'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application.rb:264:in `run_chef_client'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application/base.rb:352:in `run_application'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.0.185-x64-mingw-ucrt/lib/chef/application.rb:67:in `run'
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-bin-18.0.185/bin/chef-client:25:in `<top (required)>'
C:/opscode/chef/embedded/bin/chef-client:32:in `load'
C:/opscode/chef/embedded/bin/chef-client:32:in `<main>'
[2022-12-07T13:55:57+01:00] FATAL: Win32::Registry::Error: Zugriff verweigert
```

This also fixes #13402 because now each user gets it's own PfxPassword. (Strings encrypted mit ConvertTo-Secure-String can only be decrypted by the user wich encrypted the string.)
I have tested the change on a windows vm and can run chef with a user without admin rights with this change.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#13402

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
