### PR TITLE
Use artifactory rubygems proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
-source "https://rubygems.org"
+if ENV.fetch("OMNIBUS_USE_INTERNAL_SOURCES", false)
+  source "https://artifactory-internal.ps.chef.co/artifactory/rubygems-proxy"
+else
+  source "https://rubygems.org"
+end
 
 gem "chef", path: "."
 

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,4 +1,8 @@
-source "https://rubygems.org"
+if ENV.fetch("OMNIBUS_USE_INTERNAL_SOURCES", false)
+  source "https://artifactory-internal.ps.chef.co/artifactory/rubygems-proxy"
+else
+  source "https://rubygems.org"
+end
 
 gem "omnibus", github: ENV.fetch("OMNIBUS_GITHUB_REPO", "chef/omnibus"), branch: ENV.fetch("OMNIBUS_GITHUB_BRANCH", "main")
 


### PR DESCRIPTION
Signed-off-by: Gregory Schofield <grschofi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

This will use chef's internal gem proxy to build & test chef...but only if the there is an environment variable telling it to do so. This will come later so this change effectively does nothing until we add the `OMNIBUS_USE_INTERNAL_SOURCES=true` environment variable. The reason we want to do this is so that chef can eventually build completely from internal sources.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
