### PR TITLE
Correcting the habitat pipeline issue for Windows

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -37,17 +37,13 @@ steps:
 
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
-    - $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS = 'chef/chef-infra-client/18.0.179/20221109104144'
-    - . ./.expeditor/scripts/ensure-minimum-viable-hab.ps1
-    - Write-Host "--- Installing $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
-    - $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-    - hab pkg install $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
-    - . ./habitat/tests/test.ps1 -PackageIdentifier $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
+    - /workdir/.expeditor/scripts/habitat-test.ps1
   expeditor:
     executor:
       windows:
         privileged: true
         single-use: true
+        shell: ["powershell", "-Command"]
 
 # Wait for the package testing to succeed before promoting whatever was tested.
 - wait

--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -37,7 +37,7 @@ steps:
 
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
-    - /workdir/.expeditor/scripts/habitat-test.ps1
+    - .expeditor/scripts/habitat-test.ps1
   expeditor:
     executor:
       windows:

--- a/.expeditor/scripts/habitat-test.ps1
+++ b/.expeditor/scripts/habitat-test.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS = 'chef/chef-infra-client/18.0.179/20221109104144'
+$ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
+& "$ScriptRoute"
+# . ./scripts/ensure-minimum-viable-hab.ps1
+Write-Host "--- Installing $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+hab pkg install $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
+. ./habitat/tests/test.ps1 -PackageIdentifier $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS


### PR DESCRIPTION
Signed-off-by: John <john.mccrae@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
The habitat-test.yml file was calling PowerShell command directly. This is hugely problematic since things like the $env variable weren't respected and that resulted in errors;  for example calling `$env:path` would result in an error similar to `:path is not recognized` notice that the `$env` variable was chopped. In total this resulted in improper and incomplete execution. This update fixes that by moving the offending code to a distinct .ps1 file and calling on that; which does work.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
