### PR TITLE
[Chef-16]Add back nightly adhoc builds for chef16

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -17,6 +17,13 @@ rubygems:
   - chef-bin
   - chef-utils
 
+# At the given time, trigger the following scheduled workloads
+# https://expeditor.chef.io/docs/getting-started/subscriptions/#scheduling-workloads
+schedules:
+  - name: nightly_build_chef_16
+    description: "Run a nightly build in the Buildkite pipeline"
+    cronline: "0 2 * * *"
+
 pipelines:
   - verify:
       public: true
@@ -230,3 +237,6 @@ subscriptions:
   - workload: ruby_gem_published:fauxhai-ng-*
     actions:
       - bash:.expeditor/update_dep.sh
+  - workload: schedule_triggered:chef/chef:chef-16:nightly_build_chef_16:*
+    actions:
+      - trigger_pipeline:omnibus/adhoc


### PR DESCRIPTION

Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->
The version bumps are not getting triggered for chef16. So I was trying to bring back config.yml to stage when it last triggered and hence removed nightly builds. But that hasn't fixed the bumping. So adding it back

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
