### PR TITLE
chore: Use the `chef_dictionary` directly.

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,14 +1,13 @@
 // cSpell Settings
 {
-  // Version of the setting file.  Always 0.1
-  "version": "0.1",
+  "version": "0.2",
   // language - current active spelling language
   "language": "en",
   "dictionaryDefinitions": [
     {
-        "name": "chef",
-        "file": "./chef_dictionary.txt",
-        "description": "Custom Chef Dictionary"
+      "name": "chef",
+      "path": "https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt",
+      "description": "Custom Chef Dictionary"
     }
   ],
   "dictionaries": ["chef"],
@@ -1552,9 +1551,7 @@
   // flagWords - list of words to be always considered incorrect
   // This is useful for offensive words and common spelling errors.
   // For example "hte" should be "the"
-  "flagWords": [
-    "hte"
-  ],
+  "flagWords": ["hte"],
   "ignorePaths": [
     "CHEF_MVPS.md",
     "CHANGELOG.md",

--- a/tasks/spellcheck.rb
+++ b/tasks/spellcheck.rb
@@ -20,32 +20,10 @@ namespace :spellcheck do
     sh 'cspell lint --no-progress "**/*"'
   end
 
-  task prereqs: %i{curl_check cspell_check config_check fetch_common}
-
-  task :curl_check do
-    curl_version = begin
-                     `curl --version`
-                   rescue
-                     nil
-                   end
-
-    curl_version.is_a?(String) || abort(<<~INSTALL_CURL)
-      curl is not available, cannot download chef_dictionary.txt
-    INSTALL_CURL
-  end
-
-  task :fetch_common do
-    sh "curl -s https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt -o chef_dictionary.txt"
-  end
+  task prereqs: %i{cspell_check config_check}
 
   task :config_check do
     require "json"
-
-    chef_dictionary = "chef_dictionary.txt"
-
-    unless File.readable?(chef_dictionary)
-      abort "Dictionary file '#{chef_dictionary}' not found, skipping spellcheck"
-    end
 
     config_file = "cspell.json"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
`cspell` and `cspell-action` now support fetching remote dictionaries.

## Description

In order to spell check the repository, the shared [chef_dictionary](https://github.com/chef/chef_dictionary) has to be downloaded. This change will have `cspell` download the dictionary instead.

Note: I am adding Chef to cspell integration tests to ensure that changes to cspell don't break spell checking the Chef repository when I hit a error because `chef_dictionary.txt` was missing.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Jason Dent <jason@steetsidesoftware.nl>