### PR TITLE
[WIP][Chef-16] Fix kitchen test failure in AmazonLinux2 when setting timezone

### DIFF
--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -47,6 +47,8 @@ platforms:
   driver:
     image: dokken/amazonlinux-2
     pid_one_command: /usr/lib/systemd/systemd
+    privileged: true
+    binds: /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro
     intermediate_instructions:
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 

--- a/lib/chef/resource/timezone.rb
+++ b/lib/chef/resource/timezone.rb
@@ -86,7 +86,7 @@ class Chef
       # @return [String] timezone id
       def current_systemd_tz
         tz_shellout = shell_out(["/usr/bin/timedatectl", "status"])
-        raise "There was an error running the timedatectl command error: #{tz_shellout.error.inspect}" if tz_shellout.error?
+        raise "There was an error running the timedatectl command error: #{tz_shellout.format_for_exception}" if tz_shellout.error?
 
         # https://rubular.com/r/eV68MX9XXbyG4k
         /Time zone: (.*) \(.*/.match(tz_shellout.stdout)[1]

--- a/lib/chef/resource/timezone.rb
+++ b/lib/chef/resource/timezone.rb
@@ -86,7 +86,7 @@ class Chef
       # @return [String] timezone id
       def current_systemd_tz
         tz_shellout = shell_out(["/usr/bin/timedatectl", "status"])
-        raise "There was an error running the timedatectl command" if tz_shellout.error?
+        raise "There was an error running the timedatectl command error: #{tz_shellout.error.inspect}" if tz_shellout.error?
 
         # https://rubular.com/r/eV68MX9XXbyG4k
         /Time zone: (.*) \(.*/.match(tz_shellout.stdout)[1]


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
```
 * timezone[America/Los_Angeles] action set
           
           ================================================================================
           Error executing action `set` on resource 'timezone[America/Los_Angeles]'
           ================================================================================
           
           RuntimeError
           ------------
           There was an error running the timedatectl command
           
           Resource Declaration:
           ---------------------
           # In /opt/kitchen/cache/cookbooks/end_to_end/recipes/linux.rb
           
            26: timezone "America/Los_Angeles"
            27: 
           
           Compiled Resource:
           ------------------
           # Declared in /opt/kitchen/cache/cookbooks/end_to_end/recipes/linux.rb:26:in `from_file'
           
           timezone("America/Los_Angeles") do
             action [:set]
             default_guard_interpreter :default
             declared_type :timezone
             cookbook_name "end_to_end"
             recipe_name "linux"
           end
           
           System Info:
           ------------
           chef_version=16.18.22
           platform=amazon
           platform_version=2
           ruby=ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [x86_64-linux]
           program_name=/opt/chef/bin/chef-client
           executable=/opt/chef/bin/chef-client
           
       
       Running handlers:
       [2022-12-21T11:52:00+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2022-12-21T11:52:00+00:00] ERROR: Exception handlers complete
       Chef Infra Client failed. 19 resources updated in 08 seconds
       [2022-12-21T11:52:01+00:00] FATAL: Stacktrace dumped to /opt/kitchen/cache/chef-stacktrace.out
       [2022-12-21T11:52:01+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2022-12-21T11:52:01+00:00] FATAL: RuntimeError: timezone[America/Los_Angeles] (end_to_end::linux line 26) had an error: RuntimeError: There was an error running the timedatectl command
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource/timezone.rb:89:in `current_systemd_tz'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource/timezone.rb:108:in `block in <class:Timezone>'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource/action_class.rb:51:in `return_load_current_value'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource/action_class.rb:62:in `load_current_resource'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/provider.rb:200:in `run_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource.rb:599:in `block in run_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource.rb:626:in `with_umask'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource.rb:598:in `run_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/runner.rb:74:in `run_action'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/runner.rb:108:in `block in run_all_actions'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/runner.rb:108:in `each'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/runner.rb:108:in `run_all_actions'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/runner.rb:132:in `block in converge'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource_collection/resource_list.rb:96:in `block in execute_each_resource'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource_collection/stepable_iterator.rb:114:in `call_iterator_block'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource_collection/stepable_iterator.rb:103:in `iterate'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource_collection/stepable_iterator.rb:54:in `each_with_index'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/resource_collection/resource_list.rb:94:in `execute_each_resource'
       /opt/chef/embedded/lib/ruby/2.7.0/forwardable.rb:235:in `execute_each_resource'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/runner.rb:130:in `converge'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/client.rb:687:in `block in converge'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/client.rb:682:in `catch'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/client.rb:682:in `converge'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/client.rb:706:in `converge_and_save'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/client.rb:286:in `run'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/application.rb:305:in `run_with_graceful_exit_option'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/application.rb:281:in `block in run_chef_client'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/local_mode.rb:42:in `with_server_connectivity'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/application.rb:264:in `run_chef_client'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/application/base.rb:337:in `run_application'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-16.18.22/lib/chef/application.rb:67:in `run'
       /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-bin-16.18.22/bin/chef-client:25:in `<top (required)>'
       /opt/chef/bin/chef-client:170:in `load'
       /opt/chef/bin/chef-client:170:in `<main>'
       [2022-12-21T11:52:01+00:00] FATAL: RuntimeError: timezone[America/Los_Angeles] (end_to_end::linux line 26) had an error: RuntimeError: There was an error running the timedatectl command
```
e.g build https://github.com/chef/chef/actions/runs/3749002668/jobs/6366983689#step:4:1402
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
