### PR TITLE
[Chef-16] Backport: Updating Zypper to overcome repository errors

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -131,7 +131,9 @@ steps:
 - label: "Integration openSUSE 15 :ruby: 2.7"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - find /etc/zypp/repos.d -name "SMT-*" -execdir rm -f -- '{}' \;
     - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
+    - zypper --gpg-auto-import-keys ref
     - zypper install -y cron insserv-compat
     - cd /workdir; bundle config set --local without omnibus_package
     - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle
@@ -145,7 +147,9 @@ steps:
 - label: "Functional openSUSE 15 :ruby: 2.7"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - find /etc/zypp/repos.d -name "SMT-*" -execdir rm -f -- '{}' \;
     - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
+    - zypper --gpg-auto-import-keys ref
     - zypper install -y cronie insserv-compat
     - cd /workdir; bundle config set --local without omnibus_package ruby_prof
     - cd /workdir; bundle install --jobs=3 --retry=3 --path=vendor/bundle
@@ -159,7 +163,9 @@ steps:
 - label: "Unit openSUSE 15 :ruby: 2.7"
   commands:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - find /etc/zypp/repos.d -name "SMT-*" -execdir rm -f -- '{}' \;
     - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
+    - zypper --gpg-auto-import-keys ref
     - zypper install -y cron insserv-compat
     - bundle config set --local without omnibus_package ruby_prof
     - bundle install --jobs=3 --retry=3 --path=vendor/bundle


### PR DESCRIPTION
Signed-off-by: John <john.mccrae@progress.com>

s390x images were throwing errors when loading updates because they were attempting to connect to the localhost instead of the Internet to get updates.

<!--- Provide a short summary of your changes in the Title above -->

## Description
The issue for this turned out to be that at some point in the automation process before the chef-client code runs, something is creating/adding Zypper respositories that point to the localhost. That is totally busted since there are no files locally to support that and there is no way to pull down new files outside of the busted local repos.

The cause of that issue has not been fully determined but we did workaround that issue by doing 2 things: 1) Sean manually deleted the borked repos on those images. (they don’t get recycled like other OS images do). and 2) I added to code to programmatically do what he did if/when new s390x images show up.

The fix is to 1) Simply nuke the existing repos, 2) Add my new chefzypper-repo and 3) Use gpg to sign the new repo so we don’t get weirdo crypto errors.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
