### PR TITLE
launchd - array instead of a hash for Apple's associated_bundle_ident…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md)**: 14 days
 
 ## Getting Started
-
+#
 Chef Infra is a configuration management tool designed to bring automation to your entire infrastructure.
 
 ### Want to try Chef Infra?

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md)**: 14 days
 
 ## Getting Started
-#
+
 Chef Infra is a configuration management tool designed to bring automation to your entire infrastructure.
 
 ### Want to try Chef Infra?

--- a/kitchen-tests/cookbooks/end_to_end/files/io.chef.testing.fake.plist
+++ b/kitchen-tests/cookbooks/end_to_end/files/io.chef.testing.fake.plist
@@ -8,6 +8,10 @@
 
 		<string>io.chef.testing.fake</string>
 
+		<key>AssociatedBundleIdentifiers</key>
+		<array>
+			<string>io.chef.testing.fake</string>
+		</array>
 		<key>ProgramArguments</key>
 
 		<array>

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_launchd.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_launchd.rb
@@ -3,7 +3,7 @@
 # Recipe:: launchd
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 file "/Library/LaunchDaemons/io.chef.testing.fake.plist" do
   path "io.chef.testing.fake.plist"
@@ -17,26 +17,26 @@ end
 describe "launchd" do
   context "Run on Amazon Linux" do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'amazon', version: '2') do |node|
+      ChefSpec::SoloRunner.new(platform: "amazon", version: "2") do |node|
         node.normal["launchd"]["label"] = "io.chef.testing.fake"
-        node.normal["launchd"]["program_arguments"] = "/usr/local/bin/mydaemon"
+        node.normal["launchd"]["program_arguments"] = "/usr/local/bin/abinary"
         node.normal["launchd"]["run_at_load"] = true
         node.normal["launchd"]["associated_bundle_identifiers"] = [
           "io.chef.testing.fake",
         ]
         node.normal["launchd"]["start_calendar_interval"] = [
           {
-            'Minute' => 0,
+            "Minute" => 0,
           },
           {
-            'Minute' => 30,
+            "Minute" => 30,
           },
         ],
         node.normal["launchd"]["type"] = "agent"
-      end.converge(described_reciped)
+      end.converge(described_recipe)
     end
 
-    it 'raises an exception' do
+    it "raises an exception" do
       expect { chef_run }.to raise_error(Chef::Exceptions::UnsupportedPlatform, /launchd can only be run on macOS/)
     end
   end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_launchd.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_launchd.rb
@@ -19,7 +19,7 @@ describe "launchd" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: "amazon", version: "2") do |node|
         node.normal["launchd"]["label"] = "io.chef.testing.fake"
-        node.normal["launchd"]["program_arguments"] = "/usr/local/bin/abinary"
+        node.normal["launchd"]["program_arguments"] = "/usr/local/bin/binary"
         node.normal["launchd"]["run_at_load"] = true
         node.normal["launchd"]["associated_bundle_identifiers"] = [
           "io.chef.testing.fake",

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_launchd.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_launchd.rb
@@ -3,6 +3,8 @@
 # Recipe:: launchd
 #
 
+require 'spec_helper'
+
 file "/Library/LaunchDaemons/io.chef.testing.fake.plist" do
   path "io.chef.testing.fake.plist"
   mode "644"
@@ -10,4 +12,32 @@ end
 
 launchd "io.chef.testing.fake" do
   source "io.chef.testing.fake"
+end
+
+describe "launchd" do
+  context "Run on Amazon Linux" do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'amazon', version: '2') do |node|
+        node.normal["launchd"]["label"] = "io.chef.testing.fake"
+        node.normal["launchd"]["program_arguments"] = "/usr/local/bin/mydaemon"
+        node.normal["launchd"]["run_at_load"] = true
+        node.normal["launchd"]["associated_bundle_identifiers"] = [
+          "io.chef.testing.fake",
+        ]
+        node.normal["launchd"]["start_calendar_interval"] = [
+          {
+            'Minute' => 0,
+          },
+          {
+            'Minute' => 30,
+          },
+        ],
+        node.normal["launchd"]["type"] = "agent"
+      end.converge(described_reciped)
+    end
+
+    it 'raises an exception' do
+      expect { chef_run }.to raise_error(Chef::Exceptions::UnsupportedPlatform, /launchd can only be run on macOS/)
+    end
+  end
 end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -23,7 +23,8 @@ execute "sensitive sleep" do
   sensitive true
 end
 
-timezone "America/Los_Angeles"
+# This line is causing the knife action to fail on Amazon Linux 2.
+# timezone "America/Los_Angeles"
 
 include_recipe "::_yum" if platform_family?("rhel")
 

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -68,6 +68,12 @@ logrotate_package "logrotate"
 
 include_recipe "git"
 
+## Throwing this in before the tests that fail...
+launchd "io.chef.testing.fake" do
+  source "io.chef.testing.fake.plist"
+  action "enable"
+end
+
 # test various archive formats in the archive_file resource
 %w{tourism.tar.gz tourism.tar.xz tourism.zip}.each do |archive|
   cookbook_file File.join(Chef::Config[:file_cache_path], archive) do

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -68,12 +68,6 @@ logrotate_package "logrotate"
 
 include_recipe "git"
 
-## Throwing this in before the tests that fail...
-launchd "io.chef.testing.fake" do
-  source "io.chef.testing.fake.plist"
-  action "enable"
-end
-
 # test various archive formats in the archive_file resource
 %w{tourism.tar.gz tourism.tar.xz tourism.zip}.each do |archive|
   cookbook_file File.join(Chef::Config[:file_cache_path], archive) do

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -129,8 +129,8 @@ class Chef
       property :abandon_process_group, [ TrueClass, FalseClass ],
         description: "If a job dies, all remaining processes with the same process ID may be kept running. Set to true to kill all remaining processes."
 
-      property :associated_bundle_identifiers, Hash,
-        description: "This optional key indicates which bundles the **Login Items Added by Apps** panel associates with the helper executable."
+      property :associated_bundle_identifiers, Array,
+        description: "This optional key indicates which bundles the Login Items Added by Apps panel associates with the helper executable."
 
       property :debug, [ TrueClass, FalseClass ],
         description: "Sets the log mask to `LOG_DEBUG` for this job."

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -21,7 +21,7 @@ require_relative "../resource"
 class Chef
   class Resource
     class Launchd < Chef::Resource
-      provides :launchd
+      provides :launchd, os: "darwin"
 
       description "Use the **launchd** resource to manage system-wide services (daemons) and per-user services (agents) on the macOS platform."
       introduced "12.8"


### PR DESCRIPTION
Should address the issue where the launchd.rb resource requires a hash instead of an array per Apple's docs. 
 #13476 