### PR TITLE
refactoring the hab powershell script to ensure habitat gets installe…

### DIFF
--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,3 +1,4 @@
+Write-Host "--- :habicat: Verifying that Hab is installed and updating as necessary"
 try {
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]"0.85.0" ) {
@@ -16,5 +17,5 @@ catch {
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
-
+Write-Host "--- :habicat: Refreshing the Path"
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -16,3 +16,5 @@ catch {
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
+
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,9 +1,18 @@
-[Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
-if ($hab_version -lt [Version]"0.85.0" ) {
+try {
+    [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
+    if ($hab_version -lt [Version]"0.85.0" ) {
+        Write-Host "--- :habicat: Installing the version of Habitat required"
+        Set-ExecutionPolicy Bypass -Scope Process -Force
+        Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+        if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
+    }
+    else {
+        Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
+    }
+}
+catch {
+    # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Installing the version of Habitat required"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
-    if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
-} else {
-    Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
 }

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -19,3 +19,9 @@ catch {
 }
 Write-Host "--- :habicat: Refreshing the Path"
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+Write-Host "--- :habicat: Finding Habitat using Get-Command"
+Get-Command hab
+
+Write-Host "--- :habicat: Finding Habitat using Get-ChildItem"
+Get-ChildItem -Path c:\ -Name hab.exe -Recurse

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -18,10 +18,4 @@ catch {
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
 Write-Host "--- :habicat: Refreshing the Path"
-$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-
-Write-Host "--- :habicat: Finding Habitat using Get-Command"
-Get-Command hab
-
-Write-Host "--- :habicat: Finding Habitat using Get-ChildItem"
-Get-ChildItem -Path c:\ -Name hab.exe -Recurse
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\ProgramData\Habitat;"


### PR DESCRIPTION
…d. Backport from chef-18

Signed-off-by: John <john.mccrae@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
We have a PowerShell script (ensure-minimum-viable-hab.ps1) that was supposed to make sure we had a version of habitat installed on Windows nodes that was great than v0.85. It was not firing properly. I refactored that to use the code we added for Chef-18 that corrected the same issue. The fix is essentially to wrap the installer in a better try-catch block that guarantees an installation of habitat. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
