### PR TITLE
[Chef-16] Backport 10122: Fix windows_share resource is not idempotent

### DIFF
--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -70,17 +70,17 @@ class Chef
       # Specifies which accounts are granted full permission to access the share. Use a comma-separated list to specify multiple accounts. An account may not be specified more than once in the FullAccess, ChangeAccess, or ReadAccess parameter lists, but may be specified once in the FullAccess, ChangeAccess, or ReadAccess parameter list and once in the NoAccess parameter list.
       property :full_users, Array,
         description: "The users that should have 'Full control' permissions on the share in domain\\username format.",
-        default: lazy { [] }, coerce: proc { |u| u.sort }
+        default: lazy { [] }, coerce: proc { |u| add_hostname(u).sort }
 
       # Specifies which users are granted modify permission to access the share
       property :change_users, Array,
         description: "The users that should have 'modify' permission on the share in domain\\username format.",
-        default: lazy { [] }, coerce: proc { |u| u.sort }
+        default: lazy { [] }, coerce: proc { |u| add_hostname(u).sort }
 
       # Specifies which users are granted read permission to access the share. Multiple users can be specified by supplying a comma-separated list.
       property :read_users, Array,
         description: "The users that should have 'read' permission on the share in domain\\username format.",
-        default: lazy { [] }, coerce: proc { |u| u.sort }
+        default: lazy { [] }, coerce: proc { |u| add_hostname(u).sort }
 
       # Specifies the lifetime of the new SMB share. A temporary share does not persist beyond the next restart of the computer. By default, new SMB shares are persistent, and non-temporary.
       property :temporary, [TrueClass, FalseClass],
@@ -177,44 +177,41 @@ class Chef
           next unless perm["AccessControlType"] == 0 # allow
 
           case perm["AccessRight"]
-          when 0 then f_users << stripped_account(perm["AccountName"]) # 0 full control
-          when 1 then c_users << stripped_account(perm["AccountName"]) # 1 == change
-          when 2 then r_users << stripped_account(perm["AccountName"]) # 2 == read
+          when 0 then f_users << perm["AccountName"] # 0 full control
+          when 1 then c_users << perm["AccountName"] # 1 == change
+          when 2 then r_users << perm["AccountName"] # 2 == read
           end
         end
         [f_users, c_users, r_users]
       end
 
-      # local names are returned from Get-SmbShareAccess in the full format MACHINE\\NAME
-      # but users of this resource would simply say NAME so we need to strip the values for comparison
-      def stripped_account(name)
-        name.slice!("#{node["hostname"]}\\")
-        name
-      end
-
       action :create do
         description "Create and modify Windows shares."
-
+        new_resource_users
         # we do this here instead of requiring the property because :delete doesn't need path set
         raise "No path property set" unless new_resource.path
 
-        converge_if_changed do
-          # you can't actually change the path so you have to delete the old share first
-          if different_path?
-            Chef::Log.debug("The path has changed so we will delete and recreate share")
-            delete_share
-            create_share
-          elsif current_resource.nil?
-            # powershell cmdlet for create is different than updates
-            Chef::Log.debug("The current resource is nil so we will create a new share")
-            create_share
-          else
-            Chef::Log.debug("The current resource was not nil so we will update an existing share")
-            update_share
-          end
+        unless current_resource.nil? || users_changed? || different_path?
+          logger.debug("Skipping update of #{new_resource}: has not changed any of the specified properties.")
+        else
+          converge_by("create #{new_resource}") do
+            # you can't actually change the path so you have to delete the old share first
+            if different_path?
+              Chef::Log.debug("The path has changed so we will delete and recreate share")
+              delete_share
+              create_share
+            elsif current_resource.nil?
+              # powershell cmdlet for create is different than updates
+              Chef::Log.debug("The current resource is nil so we will create a new share")
+              create_share
+            else
+              Chef::Log.debug("The current resource was not nil so we will update an existing share")
+              update_share
+            end
 
-          # creating the share does not set permissions so we need to update
-          update_permissions
+            # creating the share does not set permissions so we need to update
+            update_permissions
+          end
         end
       end
 
@@ -337,6 +334,34 @@ class Chef
         def bool_string(bool)
           # bool ? 1 : 0
           bool ? "$true" : "$false"
+        end
+
+        # Grant-SmbShareAccess sets only one permission to one user so we need to remove from the lower permission access
+        # For change_users remove common full_users from it
+        # For read_users remove common full_users as well as change_users
+        def new_resource_users
+          @full_users = new_resource.full_users
+          @change_users = new_resource.change_users - new_resource.full_users
+          @read_users = new_resource.read_users - (new_resource.full_users + new_resource.change_users)
+        end
+
+        # Compare the full_users, change_users and read_users from current_resource and new_resource
+        # @returns boolean True/False
+        def users_changed?
+          !(current_resource.full_users == @full_users && current_resource.change_users == @change_users && current_resource.read_users == @read_users)
+        end
+      end
+
+      # local names are returned from Get-SmbShareAccess in the full format MACHINE\\NAME
+      # but users of this resource would simply say NAME so we need to add hostname for comparison
+      # If hostname is not present in front of user then add hostname from node
+
+      # @input_params [Array]
+      # @returns [Array]
+      def add_hostname(users)
+        users.map do |user|
+          user = "#{node["hostname"]}\\" + user unless user.include?("\\")
+          user.downcase
         end
       end
 

--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -309,6 +309,10 @@ class Chef
         def permissions_need_update?(type)
           property_name = "#{type}_users"
 
+          puts " ==== Logging for property #{type}_users"
+          puts " ==== When using send: #{new_resource.send(property_name)}"
+          puts " ==== When using instance var:", instance_variable_get("@#{property_name}")
+
           # brand new share, but nothing to set
           return false if current_resource.nil? && new_resource.send(property_name).empty?
 

--- a/spec/unit/resource/windows_share_spec.rb
+++ b/spec/unit/resource/windows_share_spec.rb
@@ -17,8 +17,16 @@
 
 require "spec_helper"
 
-describe Chef::Resource::WindowsShare do
-  let(:resource) { Chef::Resource::WindowsShare.new("foobar") }
+describe Chef::Resource::WindowsShare, :windows_only do
+  let(:node) do
+    Chef::Node.new.tap do |n|
+      n.automatic[:hostname] = "hostname"
+    end
+  end
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::WindowsShare.new("foobar", run_context) }
+  let(:provider) { resource.provider_for_action(:create) }
 
   it "sets resource name as :windows_share" do
     expect(resource.resource_name).to eql(:windows_share)
@@ -44,5 +52,64 @@ describe Chef::Resource::WindowsShare do
     expect(resource.path).to eql("C:\\chef")
     resource.path("C:/chef".dup)
     expect(resource.path).to eql("C:\\chef")
+  end
+
+  shared_examples "when users are passed" do
+    it "add hostname to user with hostname" do
+      expect(users_with_hostname).to eq(result_with_hostname)
+    end
+
+    it "add hostname to user without hostname" do
+      expect(users_without_hostname).to eq(result_without_hostname)
+    end
+
+    it "add hostname to user with users name downcase" do
+      expect(users_with_capital_case).to eq(result_with_downcase)
+    end
+  end
+
+  %w{full_users change_users read_users}.each do |users|
+    context "when #{users} are passed" do
+      it_behaves_like "when users are passed" do
+        let(:users_without_hostname) { resource.send(users, ["mygroup"]) }
+        let(:result_without_hostname) { ["hostname\\mygroup"] }
+        let(:users_with_hostname) { resource.send(users, ["hostname1\\mygroup"]) }
+        let(:result_with_hostname) { ["hostname1\\mygroup"] }
+        let(:users_with_capital_case) { resource.send(users, ["MYGROUP"]) }
+        let(:result_with_downcase) { ["hostname\\mygroup"] }
+      end
+    end
+  end
+
+  it "#new_resource_users" do
+    resource.read_users(["mygroup"])
+    resource.change_users(["mygroup"])
+    provider.send(:new_resource_users)
+    expect(provider.instance_variable_get(:@full_users)).to eq([])
+    expect(provider.instance_variable_get(:@change_users)).to eq(["hostname\\mygroup"])
+    expect(provider.instance_variable_get(:@read_users)).to eq([])
+  end
+
+  context "check user permissions need to update or not" do
+    before do
+      resource.read_users(["mygroup"])
+      resource.change_users(["mygroup"])
+      provider.send(:new_resource_users)
+    end
+
+    it "check user read permissions to update" do
+      result = provider.send(:permissions_need_update?, "read")
+      expect(result).to eq(false)
+    end
+
+    it "check user change permissions to update" do
+      result = provider.send(:permissions_need_update?, "change")
+      expect(result).to eq(true)
+    end
+
+    it "check user full permissions to update" do
+      result = provider.send(:permissions_need_update?, "full")
+      expect(result).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: Neha Pansare <neha.pansare@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Fix `windows_share` resource is not idempotent.
This PR backports https://github.com/chef/chef/pull/10122 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
