### PR TITLE
Example of bash resource doubled escape characters

### DIFF
--- a/lib/chef/resource/bash.rb
+++ b/lib/chef/resource/bash.rb
@@ -42,11 +42,11 @@ class Chef
         EOH
       end
       ```
-      
-      **Beware escape characters**
-      
-      The interpreter here uses up the required find command escape character, so we have to preserve it with double escape characters:
-      
+
+      **Using escape characters in a string of code**
+
+      In the following example, the `find` command uses an escape character (`\`). Use a second escape character (`\\`) to preserve the escape character in the code string:
+
       ```ruby
       bash 'delete some archives ' do
         code <<-EOH

--- a/lib/chef/resource/bash.rb
+++ b/lib/chef/resource/bash.rb
@@ -55,7 +55,7 @@ class Chef
         ignore_failure true
       end
       ```
-      
+
       **Install a file from a remote location**
 
       The following is an example of how to install the foo123 module for Nginx. This module adds shell-style functionality to an Nginx configuration file and does the following:

--- a/lib/chef/resource/bash.rb
+++ b/lib/chef/resource/bash.rb
@@ -42,7 +42,20 @@ class Chef
         EOH
       end
       ```
-
+      
+      **Beware escape characters**
+      
+      The interpreter here uses up the required find command escape character, so we have to preserve it with double escape characters:
+      
+      ```ruby
+      bash 'delete some archives ' do
+        code <<-EOH
+          find ./ -name "*.tar.Z" -mtime +180 -exec rm -f {} \\;
+        EOH
+        ignore_failure true
+      end
+      ```
+      
       **Install a file from a remote location**
 
       The following is an example of how to install the foo123 module for Nginx. This module adds shell-style functionality to an Nginx configuration file and does the following:


### PR DESCRIPTION
## Description
Let's show an example of doubled escape characters.

The chef-client bash interpreter gets one, and find gets one.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
