### PR TITLE
CHEF-17 - Rewriting the zypper code to run only on openSUSE 15

### DIFF
--- a/.expeditor/scripts/zypper_prep.sh
+++ b/.expeditor/scripts/zypper_prep.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+VERSION_STRING=$(cat /etc/os-release | grep '^VERSION=' | sed 's/VERSION=\"\([0-9]\+\).*/\1/')
+if [[ $VERSION_STRING == "15" ]]
+then
+  echo "--- :hammer_and_wrench: Updating Zypper Repos on openSUSE 15"
+  find /etc/zypp/repos.d -name "SMT-*" -execdir rm -f -- '{}' \;
+  zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
+  zypper --gpg-auto-import-keys ref
+else
+  echo "--- :hammer_and_wrench: Not Running on openSUSE 15, nothing to do"
+fi

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -175,8 +175,8 @@ steps:
 
 - label: "Integration openSUSE 15 :ruby: 3.0"
   commands:
-    - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - /workdir/.expeditor/scripts/zypper_prep.sh
     - zypper install -y cron insserv-compat
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -190,8 +190,8 @@ steps:
 
 - label: "Functional openSUSE 15 :ruby: 3.0"
   commands:
-    - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - /workdir/.expeditor/scripts/zypper_prep.sh
     - zypper install -y cronie insserv-compat
     - zypper install -y libarchive-devel
     - cd /workdir; bundle config set --local without omnibus_package
@@ -206,8 +206,8 @@ steps:
 
 - label: "Unit openSUSE 15 :ruby: 3.0"
   commands:
-    - zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
     - /workdir/.expeditor/scripts/bk_container_prep.sh
+    - /workdir/.expeditor/scripts/zypper_prep.sh
     - zypper install -y cron insserv-compat libarchive-devel
     - bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -86,7 +86,7 @@ jobs:
       id: install_chef
       run: |
         brew install coreutils
-        curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -v 17
+        curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -c stable -v 17
         /opt/chef/bin/chef-client -v
         /opt/chef/bin/ohai -v
         /opt/chef/embedded/bin/rake --version

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -19,7 +19,7 @@ jobs:
     - name: 'Install Chef/Ohai from Omnitruck'
       id: install_chef
       run: |
-        . { Invoke-WebRequest -useb https://omnitruck.chef.io/install.ps1 } | Invoke-Expression; Install-Project -project chef -channel current -v 17
+        . { Invoke-WebRequest -useb https://omnitruck.chef.io/install.ps1 } | Invoke-Expression; Install-Project -project chef -channel stable -v 17
         $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
         chef-client -v
         ohai -v


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
To overcome some issues with expired zypper repositories borking builds and tests, we created a chefzypper-repo (in code) that points to a working zypper mirror on the interwebs and we put that as a step in the verify-pipeline.yml file.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
