### PR TITLE
Fix Chef 16 Habitat Test pipeline

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -35,15 +35,13 @@ steps:
 
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
-    - powershell -File ./.expeditor/scripts/ensure-minimum-viable-hab.ps1
-    - 'Write-Host "--- :hammer_and_wrench: Installing $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"'
-    - hab pkg install $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
-    - powershell -File ./habitat/tests/test.ps1 -PackageIdentifier $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
+    - .expeditor/scripts/habitat-test.ps1
   expeditor:
     executor:
       windows:
         privileged: true
         single-use: true
+        shell: ["powershell", "-Command"]
 
 # Wait for the package testing to succeed before promoting whatever was tested.
 - wait

--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -35,7 +35,7 @@ steps:
 
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
-    - .expeditor/scripts/habitat-test.ps1
+    - .expeditor/scripts/habitat-test.ps1 $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
   expeditor:
     executor:
       windows:

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,3 +1,4 @@
+Write-Host "--- :habicat: Verifying that Hab is installed and updating as necessary"
 try {
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]"0.85.0" ) {
@@ -16,5 +17,5 @@ catch {
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
-
+Write-Host "--- :habicat: Refreshing the Path"
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -16,3 +16,5 @@ catch {
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
+
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,9 +1,18 @@
-[Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
-if ($hab_version -lt [Version]"0.85.0" ) {
+try {
+    [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
+    if ($hab_version -lt [Version]"0.85.0" ) {
+        Write-Host "--- :habicat: Installing the version of Habitat required"
+        Set-ExecutionPolicy Bypass -Scope Process -Force
+        Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
+        if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
+    }
+    else {
+        Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
+    }
+}
+catch {
+    # This install fails if Hab isn't on the path when we check for the version. This ensures it is installed
     Write-Host "--- :habicat: Installing the version of Habitat required"
     Set-ExecutionPolicy Bypass -Scope Process -Force
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
-    if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
-} else {
-    Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
 }

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -19,3 +19,9 @@ catch {
 }
 Write-Host "--- :habicat: Refreshing the Path"
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+Write-Host "--- :habicat: Finding Habitat using Get-Command"
+Get-Command hab
+
+Write-Host "--- :habicat: Finding Habitat using Get-ChildItem"
+Get-ChildItem -Path c:\ -Name hab.exe -Recurse

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -18,10 +18,4 @@ catch {
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
 Write-Host "--- :habicat: Refreshing the Path"
-$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-
-Write-Host "--- :habicat: Finding Habitat using Get-Command"
-Get-Command hab
-
-Write-Host "--- :habicat: Finding Habitat using Get-ChildItem"
-Get-ChildItem -Path c:\ -Name hab.exe -Recurse
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User") + ";C:\ProgramData\Habitat;"

--- a/.expeditor/scripts/habitat-test.ps1
+++ b/.expeditor/scripts/habitat-test.ps1
@@ -1,11 +1,15 @@
 $ErrorActionPreference = 'Stop'
 
-$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS=$args[0]
-
 $ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
 & "$ScriptRoute"
 # . ./scripts/ensure-minimum-viable-hab.ps1
 Write-Host "--- Installing $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 hab pkg install $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
+
+if (-not $?) { throw "Unable to install $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS" }
+
 . ./habitat/tests/test.ps1 -PackageIdentifier $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
+
+if (-not $?) { throw "Habitat tests failed" }
+

--- a/.expeditor/scripts/habitat-test.ps1
+++ b/.expeditor/scripts/habitat-test.ps1
@@ -1,6 +1,5 @@
 $ErrorActionPreference = 'Stop'
 
-$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS = 'chef/chef-infra-client/18.0.179/20221109104144'
 $ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
 & "$ScriptRoute"
 # . ./scripts/ensure-minimum-viable-hab.ps1

--- a/.expeditor/scripts/habitat-test.ps1
+++ b/.expeditor/scripts/habitat-test.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS = 'chef/chef-infra-client/18.0.179/20221109104144'
+$ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
+& "$ScriptRoute"
+# . ./scripts/ensure-minimum-viable-hab.ps1
+Write-Host "--- Installing $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+hab pkg install $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
+. ./habitat/tests/test.ps1 -PackageIdentifier $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS

--- a/.expeditor/scripts/habitat-test.ps1
+++ b/.expeditor/scripts/habitat-test.ps1
@@ -1,5 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
+$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS=$args[0]
+
 $ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
 & "$ScriptRoute"
 # . ./scripts/ensure-minimum-viable-hab.ps1


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
* Refactor tests into `habitat-test.ps1`, similar to `main`, to prevent missing `hab` issue.
* Pass `$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS` to `habitat-test.ps1`
* Add error handling for `habitat-test.ps1`


## Related Issue
INFC-397 - Fix habitat-test pipeline for chef 16

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
