### PR TITLE
Fix for missing S3 region if run with EC2 instance profile

### DIFF
--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -386,8 +386,10 @@ class Chef::Application::Base < Chef::Application
     elsif uri.scheme == "s3"
       require "aws-sdk-s3" unless defined?(Aws::S3)
 
-      s3 = Aws::S3::Client.new
-      object = s3.get_object(bucket: uri.hostname, key: uri.path[1..-1])
+      bucket_name = uri.hostname
+      s3 = Aws::S3::Client.new(region: s3_bucket_location(bucket_name))
+
+      object = s3.get_object(bucket: bucket_name, key: uri.path[1..-1])
       File.open(path, "wb") do |f|
         f.write(object.body.read)
       end
@@ -401,6 +403,20 @@ class Chef::Application::Base < Chef::Application
       Chef::Application.fatal! "You specified --recipe-url but the value is neither a valid URL, an S3 bucket nor a path to a file that exists on disk." +
         "Please confirm the location of the tarball and try again."
     end
+  end
+
+  def s3_bucket_location(bucket_name)
+    s3 = Aws::S3::Client.new(region: aws_api_region)
+
+    resp = s3.get_bucket_location(bucket: bucket_name)
+    resp.location_constraint
+  rescue Aws::S3::Errors::AccessDenied => _e
+    Chef::Log.warn("Missing s3:GetBucketLocation privilege, trying currently configured region #{aws_api_region}")
+    aws_api_region
+  end
+
+  def aws_api_region
+    ENV["AWS_REGION"] || Aws.shared_config.region || Aws::EC2Metadata.new.get("/latest/meta-data/placement/region")
   end
 
   def interval_run_chef_client


### PR DESCRIPTION
## Description

Running Chef and fetching a cookbook bundle from S3 via `--recipe-url` crashes if EC2 instance profiles are used, instead of local configuration.

## Related Issue

#13524 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
