### PR TITLE
revert chef-foundation changes in chef omnibus config

### DIFF
--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -68,7 +68,7 @@ for platform in ${omnibus_build_platforms[@]}; do
     echo '        - "c:\\buildkite-agent:c:\\buildkite-agent"'
     echo "  commands:"
     echo "    - ./.expeditor/scripts/omnibus_chef_build.ps1"
-    echo "  timeout_in_minutes: 60"
+    echo "  timeout_in_minutes: 120"
   fi
 done
 
@@ -106,7 +106,7 @@ for platform in ${omnibus_test_platforms[@]}; do
     echo "  commands:"
     echo "    - ./.expeditor/scripts/download_built_omnibus_pkgs.ps1"
     echo "    - ./omnibus/omnibus-test.ps1"
-    echo "  timeout_in_minutes: 60"
+    echo "  timeout_in_minutes: 120"
   fi
 done
 

--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -168,6 +168,6 @@ for plan in ${habitat_plans[@]}; do
 done
 
 # include build and test omnibus pipeline
-DIR="${BASH_SOURCE%/*}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
-source "$DIR/build-test-omnibus.sh"
+# DIR="${BASH_SOURCE%/*}"
+# if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+# source "$DIR/build-test-omnibus.sh"

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,18 +30,18 @@ pipelines:
       public: true
       env:
         - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems.
-  - verify/release:
+  - validate/release:
       definition: .expeditor/verify.pipeline.yml
       env:
         - IGNORE_CACHE: true # caching causes constant build failures
         - IGNORE_ARTIFACTORY_RUBY_PROXY: true
-  - verify/adhoc:
+  - validate/adhoc:
       definition: .expeditor/verify.adhoc.pipeline.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true # caching causes constant build failures
         - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems.
-  - verify/adhoc-canary:
+  - validate/adhoc-canary:
       canary: true
       definition: .expeditor/verify.adhoc.pipeline.yml
       env:
@@ -148,7 +148,7 @@ subscriptions:
             - "Expeditor: Skip Omnibus"
             - "Expeditor: Skip All"
           only_if: built_in:bump_version
-      - trigger_pipeline:verify/release:
+      - trigger_pipeline:validate/release:
           ignore_labels:
             - "Expeditor: Skip Omnibus"
             - "Expeditor: Skip All"

--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -45,7 +45,29 @@ override :chef, version: "local_source"
 overrides_path = File.expand_path("../../../../omnibus_overrides.rb", current_file)
 instance_eval(IO.read(overrides_path), overrides_path)
 
-dependency "chef-local-source"
+dependency "preparation"
+# dependency "chef-local-source"
+
+dependency "chef"
+
+#
+# addons which require omnibus software defns (not direct deps of chef itself - RFC-063)
+#
+dependency "nokogiri" # (nokogiri cannot go in the Gemfile, see wall of text in the software defn)
+
+# FIXME?: might make sense to move dependencies below into the omnibus-software chef
+#  definition or into a chef-complete definition added to omnibus-software.
+dependency "gem-permissions"
+dependency "shebang-cleanup"
+dependency "version-manifest"
+dependency "openssl-customization"
+
+# devkit needs to come dead last these days so we do not use it to compile any gems
+dependency "ruby-msys2-devkit" if windows?
+
+dependency "ruby-cleanup"
+
+# further gem cleanup other projects might not yet want to use
 
 dependency "more-ruby-cleanup"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,9 +138,9 @@ RSpec.configure do |config|
 
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
-  config.filter_run_excluding fips_mode: !fips_mode_build? unless windows?
+  config.filter_run_excluding fips_mode: !fips_mode_build?
   # Skip fips on windows
-  config.filter_run_excluding :fips_mode if windows?
+  # config.filter_run_excluding :fips_mode if windows?
 
   config.filter_run_excluding windows_only: true unless windows?
   config.filter_run_excluding not_supported_on_windows: true if windows?


### PR DESCRIPTION
Signed-off-by: Evan Ahlberg <evanahlberg@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Omnibus release is currently failing because chef-foundation isn't installed on all platforms.  This reverts the changes made to Omnibus to remove chef-foundation.
- Fix Integration tests related to fips and Windows
- Rename verify* pipelines because they are running on every PR
- Increase timeout to 120 mins on Windows Omnibus builds

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
