### PR TITLE
fix adhoc pipelines and centos 6 omnibus test

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -3,7 +3,7 @@
 set -eu
 
 # Only execute in the verify pipeline
-[[ "$BUILDKITE_PIPELINE_NAME" =~ verify$ ]] || exit 0
+[[ "$BUILDKITE_PIPELINE_NAME" =~ verify$ ]] || [[ "$BUILDKITE_PIPELINE_NAME" =~ validate/release$ ]] || [[ "$BUILDKITE_PIPELINE_NAME" =~ validate/adhoc$ ]]  || [[ "$BUILDKITE_PIPELINE_NAME" =~ validate/adhoc-canary$ ]] || exit 0
 
 docker ps || true
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -3,7 +3,7 @@
 set -eu
 
 # Only execute in the verify pipeline
-[[ "$BUILDKITE_PIPELINE_NAME" =~ verify$ ]] || [[ "$BUILDKITE_PIPELINE_NAME" =~ validate/release$ ]] || [[ "$BUILDKITE_PIPELINE_NAME" =~ validate/adhoc$ ]]  || [[ "$BUILDKITE_PIPELINE_NAME" =~ validate/adhoc-canary$ ]] || exit 0
+[[ "$BUILDKITE_PIPELINE_NAME" =~ verify$ ]] || [[ "$BUILDKITE_PIPELINE_NAME" =~ validate/.* ]] || exit 0
 
 docker ps || true
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -16,10 +16,10 @@ OMNIBUS_TOOLCHAIN_VERSION=$(cat .buildkite-platform.json | jq -r '.omnibus_toolc
 export OMNIBUS_TOOLCHAIN_VERSION
 echo $OMNIBUS_TOOLCHAIN_VERSION
 
-if [ $BUILDKITE_STEP_KEY == "build-windows-2019" ] && [ $BUILDKITE_ORGANIZATION_SLUG == "chef" ]
+if [ $BUILDKITE_STEP_KEY == "build-windows-2019" ] && [[ "$BUILDKITE_ORGANIZATION_SLUG" =~ chef(-canary)?$ ]]
 then
   TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-  RESPONSE=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/iam/security-credentials/default-windows-2019-privileged-chef-Role)
+  RESPONSE=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/iam/security-credentials/default-windows-2019-privileged-$BUILDKITE_ORGANIZATION_SLUG-Role)
   AWS_ACCESS_KEY_ID=$(echo $RESPONSE | jq -r '.AccessKeyId')
   export AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY=$(echo $RESPONSE | jq -r '.SecretAccessKey')

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -120,14 +120,5 @@ export CHEF_LICENSE=accept-no-persist
 
 cd "$chef_gem"
 
-# # only add -E if not on centos 6
-# sudo_path="$(command -v sudo)"
-# # cspell:disable-next-line
-# rhel_sudo="/opt/rh/devtoolset-7/root/usr/bin/sudo"
-# if [[ "$sudo_path" != "$rhel_sudo" ]]; then
-  sudo -E bundle install --jobs=3 --retry=3
-  sudo -E bundle exec rspec --profile -f progress
-# else
-#   sudo bundle install --jobs=3 --retry=3
-#   sudo bundle exec rspec --profile -f progress
-# fi
+sudo -E bundle install --jobs=3 --retry=3
+sudo -E bundle exec rspec --profile -f progress

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -120,16 +120,14 @@ export CHEF_LICENSE=accept-no-persist
 
 cd "$chef_gem"
 
-# only add -E if not on centos 6
-sudo_path="$(command -v sudo)"
-# cspell:disable-next-line
-rhel_sudo="/opt/rh/devtoolset-7/root/usr/bin/sudo"
-sudo_args=""
-if [[ "$sudo_path" != "$rhel_sudo" ]]; then
-  echo "HERE"
+# # only add -E if not on centos 6
+# sudo_path="$(command -v sudo)"
+# # cspell:disable-next-line
+# rhel_sudo="/opt/rh/devtoolset-7/root/usr/bin/sudo"
+# if [[ "$sudo_path" != "$rhel_sudo" ]]; then
   sudo -E bundle install --jobs=3 --retry=3
   sudo -E bundle exec rspec --profile -f progress
-else
-  sudo bundle install --jobs=3 --retry=3
-  sudo bundle exec rspec --profile -f progress
-fi
+# else
+#   sudo bundle install --jobs=3 --retry=3
+#   sudo bundle exec rspec --profile -f progress
+# fi


### PR DESCRIPTION
Signed-off-by: Evan Ahlberg <evanahlberg@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Make the pre-command run on the new validate adhoc/release pipelines.
Revert change to omnibus-test.sh to fix failing centos 6 test changed in this PR:
https://github.com/chef/chef/pull/13489

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
