### PR TITLE
Run Amazon Linux 2 kitchen tests on ubuntu-20.04

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -223,6 +223,9 @@ jobs:
           cd /home/runner/work/chef/chef/kitchen-tests
           bundle install
           bundle exec kitchen test end-to-end-${{ matrix.os }}
+  # Amazon Linux 2 has an issue with systemctl (throws a timedatectl error)
+  # if dokken container hosted on Ubuntu 22.04 or later. Lock to Ubuntu 20.04
+  # for now.
   linux-2004-host:
     strategy:
       fail-fast: false

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -199,7 +199,7 @@ jobs:
           - 'ubuntu-2004'
           - 'ubuntu-2204'
         ruby: ['3.1']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       FORCE_FFI_YAJL: ext
       CHEF_LICENSE: accept-no-persist

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -186,7 +186,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - 'amazonlinux-2'
           - 'centos-6'
           - 'centos-7'
           - 'almalinux-8'
@@ -198,6 +197,38 @@ jobs:
           - 'ubuntu-1804'
           - 'ubuntu-2004'
           - 'ubuntu-2204'
+        ruby: ['3.1']
+    runs-on: ubuntu-latest
+    env:
+      FORCE_FFI_YAJL: ext
+      CHEF_LICENSE: accept-no-persist
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: false
+          working-directory: kitchen-tests
+      - name: Run Test Kitchen
+        working-directory: kitchen-tests
+        run:  |
+          ruby -v
+          echo "Which ruby are we using?"
+          which ruby
+          cd /home/runner/work/chef/chef
+          bundle install
+          gem install kitchen
+          cd /home/runner/work/chef/chef/kitchen-tests
+          bundle install
+          bundle exec kitchen test end-to-end-${{ matrix.os }}
+  linux-2004-host:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - 'amazonlinux-2'
         ruby: ['3.1']
     runs-on: ubuntu-20.04
     env:


### PR DESCRIPTION
Break out Amazon Linux to run on Ubuntu 20.04 due to systemctl issues on 22.04

Signed-off-by: Thomas Powell <powell@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
```
  * timezone[America/Los_Angeles] action set
2           
3           ================================================================================
4           Error executing action `set` on resource 'timezone[America/Los_Angeles]'
5           ================================================================================
6           
7           RuntimeError
8           ------------
9           There was an error running the timedatectl command
10           
11           Resource Declaration:
12           ---------------------
13           # In /opt/kitchen/cache/cookbooks/end_to_end/recipes/linux.rb
14           
15            26: timezone "America/Los_Angeles"
16            27: 
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
