### PR TITLE
Fix kitchen tests for Amazon Linux 2 and

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -122,6 +122,8 @@ jobs:
         working-directory: kitchen-tests
         run:  |
           bundle exec kitchen test end-to-end-${{ matrix.os }}
+  # Amazon Linux 2 and Oracle Linux 7 dokken images have systemctl issues
+  # on Ubuntu 22.04 host platforms and later. Pin these to Ubuntu 20.04
   linux-2004-host:
     strategy:
       fail-fast: false

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -93,7 +93,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - 'amazonlinux-2'
           - 'centos-6'
           - 'centos-7'
           - 'centos-8'
@@ -102,12 +101,35 @@ jobs:
           - 'debian-11'
           - 'fedora-latest'
           - 'opensuse-leap-15'
-          - 'oraclelinux-7'
           - 'oraclelinux-8'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
           - 'ubuntu-2204'
     runs-on: ubuntu-latest
+    env:
+      FORCE_FFI_YAJL: ext
+      CHEF_LICENSE: accept-no-persist
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+          working-directory: kitchen-tests
+      - name: Run Test Kitchen
+        working-directory: kitchen-tests
+        run:  |
+          bundle exec kitchen test end-to-end-${{ matrix.os }}
+  linux-2004-host:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - 'amazonlinux-2'
+          - 'oraclelinux-7'
+    runs-on: ubuntu-20.04
     env:
       FORCE_FFI_YAJL: ext
       CHEF_LICENSE: accept-no-persist


### PR DESCRIPTION
Oracle Linux 7: INFC-384 and INFC-385

Signed-off-by: Thomas Powell <powell@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Move Oracle Linux 7 and Amazon Linux 2 kitchen tests to Ubuntu 20.04 host

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
