### PR TITLE
Allow more train plugins for the knife bootstrap command

### DIFF
--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -32,8 +32,8 @@ class Chef
       include DataBagSecretOptions
       include LicenseAcceptance::CLIFlags::MixlibCLI
 
-      SUPPORTED_CONNECTION_PROTOCOLS ||= %w{ssh winrm}.freeze
       WINRM_AUTH_PROTOCOL_LIST ||= %w{plaintext kerberos ssl negotiate}.freeze
+      TRANSPORTS_BLACKLIST ||= %w{train-core train-aws train-azure train-habitat train-rest}.freeze
 
       # Common connectivity options
       option :connection_user,
@@ -54,8 +54,7 @@ class Chef
       option :connection_protocol,
         short: "-o PROTOCOL",
         long: "--connection-protocol PROTOCOL",
-        description: "The protocol to use to connect to the target node.",
-        in: SUPPORTED_CONNECTION_PROTOCOLS
+        description: "The protocol to use to connect to the target node."
 
       option :max_wait,
         short: "-W SECONDS",
@@ -810,11 +809,11 @@ class Chef
           exit 1
         end
 
-        unless SUPPORTED_CONNECTION_PROTOCOLS.include?(connection_protocol)
+        unless supported_connection_protocols.include?(connection_protocol)
           ui.error <<~EOM
             Unsupported protocol '#{connection_protocol}'.
 
-            Supported protocols are: #{SUPPORTED_CONNECTION_PROTOCOLS.join(" ")}
+            Supported protocols are: #{supported_connection_protocols.join(" ")}
           EOM
           exit 1
         end
@@ -1187,6 +1186,24 @@ class Chef
         return unless opts.is_a?(Hash) || !opts.empty?
 
         connection&.connection&.transport_options&.merge! opts
+      end
+
+      # List Train transports available (but not loaded) on system.
+      #
+      # Will filter out train-core, API transports, and other incompatible ones.
+      #
+      # @return [Array] transport_names which can be used for command execution
+      def transports_available
+        train_gems = Gem::Specification.select { |spec| spec.name.start_with? "train-" }
+        train_gems.delete_if { |spec| TRANSPORTS_BLACKLIST.include? spec.name }
+        train_gems.map { |spec| spec.name.delete_prefix "train-" }
+      end
+
+      # Return all supported connection types, classical and Train-based
+      #
+      # @return [Array] connection types supported
+      def supported_connection_protocols
+        %w{ssh winrm} | transports_available
       end
     end
   end

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -681,8 +681,7 @@ describe Chef::Knife::Bootstrap do
     end
 
     context "and the protocol is supported" do
-
-      Chef::Knife::Bootstrap::SUPPORTED_CONNECTION_PROTOCOLS.each do |proto|
+      %w{winrm ssh}.each do |proto|
         let(:connection_protocol) { proto }
         it "returns true for #{proto}" do
           expect(knife.validate_protocol!).to eq true
@@ -695,6 +694,33 @@ describe Chef::Knife::Bootstrap do
       it "outputs an error and exits" do
         expect(knife.ui).to receive(:error).with(/Unsupported protocol '#{connection_protocol}'/)
         expect { knife.validate_protocol! }.to raise_error SystemExit
+      end
+    end
+
+    context "when additional Train transports are present" do
+      before do
+        Gem::Specification.new do |spec|
+          spec.name = "train-rfc2549"
+          spec.version = "0.0.1"
+          spec.summary = "Train transport to use IPoAC"
+        end.activate
+
+        Gem.refresh
+      end
+
+      context "and their usage is supported" do
+        let(:connection_protocol) { "rfc2549" }
+        it "accepts the transport as protocol" do
+          expect(knife.validate_protocol!).to eq true
+        end
+      end
+
+      context "and invalid proctocols are still revused" do
+        let(:connection_protocol) { "rfc6216" }
+        it "accepts the transport as protocol" do
+          expect(knife.ui).to receive(:error).with(/Unsupported protocol '#{connection_protocol}'/)
+          expect { knife.validate_protocol! }.to raise_error SystemExit
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

These changes supported protocols for `knife bootstrap` to dynamic detection of installed Train transports instead of just static `ssh` and `winrm`.

With this,  alternative connection options such as AWS Systems Manager, Telnet, Serial/USB, and others get viable for easy onboarding of Chef nodes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally, and they pass.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
