### PR TITLE
Inspect lazy result

### DIFF
--- a/lib/chef/delayed_evaluator.rb
+++ b/lib/chef/delayed_evaluator.rb
@@ -22,20 +22,8 @@ class Chef
       self.class.new(&super) # rubocop:disable Layout/SpaceAroundKeyword
     end
     
-    def call
-      # This doesn't always store the result of `#call` due to how Chef runs.
-      @called = true
-      @call_result = super
-    end
-    
     def inspect
-      "lazy { (evaluates to) #{call_result.inspect} }"
-    end
- 
-  private
-    
-    def call_result
-      @called ? @call_result : call
+      "lazy { (evaluates to) #{call.inspect} }"
     end
   end
 end

--- a/lib/chef/delayed_evaluator.rb
+++ b/lib/chef/delayed_evaluator.rb
@@ -21,5 +21,21 @@ class Chef
       # super returns a "Proc" (which seems buggy) so re-wrap it
       self.class.new(&super) # rubocop:disable Layout/SpaceAroundKeyword
     end
+    
+    def call
+      # This doesn't always store the result of `#call` due to how Chef runs.
+      @called = true
+      @call_result = super
+    end
+    
+    def inspect
+      "lazy { (evaluates to) #{call_result.inspect} }"
+    end
+ 
+  private
+    
+    def call_result
+      @called ? @call_result : call
+    end
   end
 end

--- a/spec/unit/delayed_evaluator_spec.rb
+++ b/spec/unit/delayed_evaluator_spec.rb
@@ -19,20 +19,20 @@
 # limitations under the License.
 #
 
-require "spec_helper"
+require 'spec_helper'
 
 describe Chef::DelayedEvaluator do
-  let(:magic) { "This is magic!" }
+  let(:magic) { 'This is magic!' }
   let(:de) { Chef::DelayedEvaluator.new { magic } }
   
   describe '#inspect' do
-    it "inspects the result rather than the Proc" do
+    it 'inspects the result rather than the Proc' do
       expect(de.inspect).to eq("lazy { (evaluates to) #{magic.inspect} }")
     end
   end
 
   describe '#call' do
-    it "evaluates correctly" do
+    it 'evaluates correctly' do
       expect(de.call).to eq(magic)
     end
   end

--- a/spec/unit/delayed_evaluator_spec.rb
+++ b/spec/unit/delayed_evaluator_spec.rb
@@ -1,0 +1,39 @@
+#
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Christopher Walters (<cw@chef.io>)
+# Author:: Tim Hinderliter (<tim@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::DelayedEvaluator do
+  let(:magic) { "This is magic!" }
+  let(:de) { Chef::DelayedEvaluator { magic } }
+  
+  describe '#inspect'
+    it "inspects the result rather than the Proc" do
+      expect(de.inspect).to eq("lazy { (evaluates to) #{magic.inspect} }")
+    end
+  end
+
+  describe '#call'
+    it "evaluates correctly" do
+      expect(de.call).to eq(magic)
+    end
+  end
+end

--- a/spec/unit/delayed_evaluator_spec.rb
+++ b/spec/unit/delayed_evaluator_spec.rb
@@ -23,7 +23,7 @@ require "spec_helper"
 
 describe Chef::DelayedEvaluator do
   let(:magic) { "This is magic!" }
-  let(:de) { Chef::DelayedEvaluator { magic } }
+  let(:de) { Chef::DelayedEvaluator.new { magic } }
   
   describe '#inspect'
     it "inspects the result rather than the Proc" do

--- a/spec/unit/delayed_evaluator_spec.rb
+++ b/spec/unit/delayed_evaluator_spec.rb
@@ -25,13 +25,13 @@ describe Chef::DelayedEvaluator do
   let(:magic) { "This is magic!" }
   let(:de) { Chef::DelayedEvaluator.new { magic } }
   
-  describe '#inspect'
+  describe '#inspect' do
     it "inspects the result rather than the Proc" do
       expect(de.inspect).to eq("lazy { (evaluates to) #{magic.inspect} }")
     end
   end
 
-  describe '#call'
+  describe '#call' do
     it "evaluates correctly" do
       expect(de.call).to eq(magic)
     end

--- a/spec/unit/delayed_evaluator_spec.rb
+++ b/spec/unit/delayed_evaluator_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) Progress Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/delayed_evaluator_spec.rb
+++ b/spec/unit/delayed_evaluator_spec.rb
@@ -1,8 +1,4 @@
 #
-# Author:: Adam Jacob (<adam@chef.io>)
-# Author:: Christopher Walters (<cw@chef.io>)
-# Author:: Tim Hinderliter (<tim@chef.io>)
-# Author:: Seth Chisamore (<schisamo@chef.io>)
 # Copyright:: Copyright (c) Progress Software Inc.
 # License:: Apache License, Version 2.0
 #

--- a/spec/unit/delayed_evaluator_spec.rb
+++ b/spec/unit/delayed_evaluator_spec.rb
@@ -15,20 +15,20 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Chef::DelayedEvaluator do
-  let(:magic) { 'This is magic!' }
+  let(:magic) { "This is magic!" }
   let(:de) { Chef::DelayedEvaluator.new { magic } }
 
-  describe '#inspect' do
-    it 'inspects the result rather than the Proc' do
+  describe "#inspect" do
+    it "inspects the result rather than the Proc" do
       expect(de.inspect).to eq("lazy { (evaluates to) #{magic.inspect} }")
     end
   end
 
-  describe '#call' do
-    it 'evaluates correctly' do
+  describe "#call" do
+    it "evaluates correctly" do
       expect(de.call).to eq(magic)
     end
   end

--- a/spec/unit/delayed_evaluator_spec.rb
+++ b/spec/unit/delayed_evaluator_spec.rb
@@ -24,7 +24,7 @@ require 'spec_helper'
 describe Chef::DelayedEvaluator do
   let(:magic) { 'This is magic!' }
   let(:de) { Chef::DelayedEvaluator.new { magic } }
-  
+
   describe '#inspect' do
     it 'inspects the result rather than the Proc' do
       expect(de.inspect).to eq("lazy { (evaluates to) #{magic.inspect} }")


### PR DESCRIPTION
Show lazy results in logs and stack traces.

Signed-off-by: Barry Allard <ball@meta.com>


## Description

`  path #<Chef::DelayedEvaluator:0x012345812384 path/to/file>` is unhelpful in resource logs and stack traces. This change fixes that. It assumes dumb, non-idempotent stuff doesn't happen in the lazy evaluation runtime phase. This will hopefully go away when `unified_mode` is possible to use with our API cookbook model.

`  path lazy { (evaluates to) "C:\Program Files\Foobar\Widgets.exe" }`

`  path lazy { (evaluates to) "/home/foo/.your-magic-file" }`

are much nicer.

## Related Issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
