### PR TITLE
Force errors after bundler in omnibus_chef_build

### DIFF
--- a/.expeditor/scripts/omnibus_chef_build.ps1
+++ b/.expeditor/scripts/omnibus_chef_build.ps1
@@ -3,17 +3,17 @@ $ScriptDir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 if ($env:BUILDKITE_ORGANIZATION_SLUG -eq "chef-oss" )
 {
   Write-Output "--- Generating self-signed Windows package signing certificate"
-  $thumb = (New-SelfSignedCertificate -Type Custom -Subject "CN=Chef Software, O=Progress, C=US" -KeyUsage DigitalSignature -FriendlyName "Chef Software Inc." -CertStoreLocation "Cert:\LocalMachine\My" -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")).Thumbprint 
+  $thumb = (New-SelfSignedCertificate -Type Custom -Subject "CN=Chef Software, O=Progress, C=US" -KeyUsage DigitalSignature -FriendlyName "Chef Software Inc." -CertStoreLocation "Cert:\LocalMachine\My" -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")).Thumbprint
 }
 else
 {
   Write-Output "--- Installing Windows package signing certificate"
   $windows_certificate_json = "windows-package-signing-certificate.json"
   $windows_certificate_pfx = "windows-package-signing-certificate.pfx"
-  
+
   aws ssm get-parameter --name "windows-package-signing-cert" --with-decryption --region "us-west-1" --query Parameter.Value --output text | Set-Content -Path $windows_certificate_json
   If ($lastexitcode -ne 0) { Throw $lastexitcode }
-  
+
   $cert_passphrase = Get-Content $windows_certificate_json | ConvertFrom-Json | Select-Object -ExpandProperty cert_passphrase | ConvertTo-SecureString -asplaintext -force
   Get-Content $windows_certificate_json | ConvertFrom-Json | Select-Object -ExpandProperty cert_content_base64 | Set-Content -Path $windows_certificate_pfx
   Remove-Item -Force $windows_certificate_json
@@ -54,9 +54,11 @@ Write-Output "--- Running bundle install for Omnibus"
 Set-Location "$($ScriptDir)/../../omnibus"
 bundle config set --local without development
 bundle install
+if ( -not $? ) { throw "Running bundle install failed" }
 
 Write-Output "--- Building Chef"
 bundle exec omnibus build chef -l internal --override append_timestamp:false
+if ( -not $? ) { throw "omnibus build chef failed" }
 
 Write-Output "--- Uploading package to BuildKite"
 C:\buildkite-agent\bin\buildkite-agent.exe artifact upload "pkg/*.msi*"
@@ -68,4 +70,5 @@ if ($env:BUILDKITE_ORGANIZATION_SLUG -ne "chef-oss" )
 
   Write-Output "--- Publishing package to Artifactory"
   bundle exec ruby "${ScriptDir}/omnibus_chef_publish.rb"
+  if ( -not $? ) { throw "chef publish failed" }
 }


### PR DESCRIPTION
## Description

Omnibus Chef Build silently fails if intermediate bundler steps fail. Throw an exception instead if `$?` is non-zero

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
