### PR TITLE
Fix rubygem tests for 17

### DIFF
--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -9,18 +9,16 @@ name: unit_specs
 
 jobs:
   unit:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-12]
-        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ['3.0']
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        clean: true
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
+        ruby-version: "3.0"
+        bundler-cache: false
+    - run: bundle update --bundler
+    - run: bundle install
     - run: bundle exec rake spec:unit
     - run: bundle exec rake component_specs

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -143,7 +143,7 @@ describe Chef::Provider::Package::Rubygems::CurrentGemEnvironment do
         .to_return(status: 200, body: File.binread(File.join(CHEF_SPEC_DATA, "rubygems.org", "sexp_processor-4.15.1.gemspec.rz")))
 
       dep = Gem::Dependency.new("sexp_processor", ">= 0")
-      expect(@gem_env.candidate_version_from_remote(dep, "https://rubygems2.org")).to be_kind_of(Gem::Version)
+      expect(@gem_env.candidate_version_from_remote(dep, "https://rubygems2.org")).to be_nil
     end
   end
 


### PR DESCRIPTION
## Description
When the API server doesn't have a response, we expect nil, not a Ruby version. This was already fixed on 18, I'm just backporting.

Also we only run uint tests on mac, so don't call them "mac" - just like 18.

## Related Issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
