### PR TITLE
Setting the sudo_password to fix the sudo_missing_terminal error for latest versions of EL8

### DIFF
--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -67,11 +67,6 @@ class Chef
         description: "The number of seconds to wait for each connection operation to be acknowledged while running bootstrap.",
         default: 60
 
-      option :request_tty,
-        long: "--request-tty",
-        description: "Enable interactive SSH terminal to allow for password prompts.",
-        boolean: false
-
       # WinRM Authentication
       option :winrm_ssl_peer_fingerprint,
         long: "--winrm-ssl-peer-fingerprint FINGERPRINT",
@@ -657,7 +652,7 @@ class Chef
           EOM
           # FIXME: this should save the key to known_hosts but doesn't appear to be
           config[:ssh_verify_host_key] = :accept_new
-          conn_opts = connection_opts(reset: true)
+          conn_opts = connection_opts(reset: true, sudo_pass: opts[:password])
           opts.merge! conn_opts
           retry
         elsif (ssh? && e.cause && e.cause.class == Net::SSH::AuthenticationFailed) || (ssh? && e.class == Train::ClientError && e.reason == :no_ssh_password_or_key_available)
@@ -904,14 +899,14 @@ class Chef
 
       # @return a configuration hash suitable for connecting to the remote
       # host via train
-      def connection_opts(reset: false)
+      def connection_opts(reset: false, sudo_pass: nil )
         return @connection_opts unless @connection_opts.nil? || reset == true
 
         @connection_opts = {}
         @connection_opts.merge! base_opts
         @connection_opts.merge! host_verify_opts
         @connection_opts.merge! gateway_opts
-        @connection_opts.merge! sudo_opts
+        @connection_opts.merge! sudo_opts(sudo_pass)
         @connection_opts.merge! winrm_opts
         @connection_opts.merge! ssh_opts
         @connection_opts.merge! ssh_identity_opts
@@ -955,7 +950,7 @@ class Chef
         opts = {}
         return opts if winrm?
 
-        opts[:non_interactive] = config[:request_tty] ? false : true # Prevent password prompts from underlying net/ssh if request_tty is false
+        opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config[:ssh_forward_agent] === true)
         opts[:connection_timeout] = session_timeout
         opts
@@ -1023,14 +1018,14 @@ class Chef
       # --sudo-command COMMAND sudo command other than sudo
       # REVIEW NOTE: knife bootstrap did not pull sudo values from Chef::Config,
       #              should we change that for consistency?
-      def sudo_opts
+      def sudo_opts(sudo_pass)
         return {} if winrm?
 
         opts = { sudo: false }
         if config[:use_sudo]
           opts[:sudo] = true
           if config[:use_sudo_password]
-            opts[:sudo_password] = config[:connection_password]
+            opts[:sudo_password] = !config[:connection_password].nil? ? config[:connection_password] : sudo_pass
           end
           if config[:preserve_home]
             opts[:sudo_options] = "-H"

--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -69,7 +69,8 @@ class Chef
 
       option :request_tty,
         long: "--request-tty",
-        description: "Setting the non_interactive to false when request-tty is true",
+        description: "Enable interactive SSH terminal to allow for password prompts.",
+        boolean: false
 
       # WinRM Authentication
       option :winrm_ssl_peer_fingerprint,

--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -67,6 +67,10 @@ class Chef
         description: "The number of seconds to wait for each connection operation to be acknowledged while running bootstrap.",
         default: 60
 
+      option :request_tty,
+        long: "--request-tty",
+        description: "Setting the non_interactive to false when request-tty is true",
+
       # WinRM Authentication
       option :winrm_ssl_peer_fingerprint,
         long: "--winrm-ssl-peer-fingerprint FINGERPRINT",
@@ -950,23 +954,10 @@ class Chef
         opts = {}
         return opts if winrm?
 
-        opts[:non_interactive] = ssh_config_tty ? false : true # Prevent password prompts from underlying net/ssh
+        opts[:non_interactive] = config[:request_tty] ? false : true # Prevent password prompts from underlying net/ssh if request_tty is false
         opts[:forward_agent] = (config[:ssh_forward_agent] === true)
         opts[:connection_timeout] = session_timeout
         opts
-      end
-
-      # checks the ~/.ssh/config file to check RequestTTY is set to yes
-      def ssh_config_tty
-        if File.exists?(File.join(Dir.home, ".ssh/config"))
-          ssh_config_file = File.open(File.join(Dir.home, ".ssh/config")).read
-          if ssh_config_file.include?("RequestTTY")
-            tty_key_index = ssh_config_file.index("RequestTTY")
-            tty_value = ssh_config_file[tty_key_index...].split[1].downcase
-            return true if tty_value == "yes"
-          end
-        end
-        false
       end
 
       def ssh_identity_opts

--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -956,7 +956,7 @@ class Chef
         opts
       end
 
-      #checks the ~/.ssh/config file to check RequestTTY is set to yes
+      # checks the ~/.ssh/config file to check RequestTTY is set to yes
       def ssh_config_tty
         if File.exists?(File.join(Dir.home, ".ssh/config"))
           ssh_config_file = File.open(File.join(Dir.home, ".ssh/config")).read
@@ -966,7 +966,7 @@ class Chef
             return true if tty_value == "yes"
           end
         end
-        return false
+        false
       end
 
       def ssh_identity_opts

--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -950,7 +950,8 @@ class Chef
         opts = {}
         return opts if winrm?
 
-        opts[:non_interactive] = false # Prevent password prompts from underlying net/ssh
+        ssh_config_file = File.open(File.join(Dir.home, ".ssh/config")).read
+        ssh_config_file.include?("RequestTTY yes") ? opts[:non_interactive] = false : opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config[:ssh_forward_agent] === true)
         opts[:connection_timeout] = session_timeout
         opts

--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -950,7 +950,7 @@ class Chef
         opts = {}
         return opts if winrm?
 
-        ssh_config_tty ? opts[:non_interactive] = false : opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
+        opts[:non_interactive] = ssh_config_tty ? false : true # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config[:ssh_forward_agent] === true)
         opts[:connection_timeout] = session_timeout
         opts

--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -950,7 +950,7 @@ class Chef
         opts = {}
         return opts if winrm?
 
-        opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
+        opts[:non_interactive] = false # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config[:ssh_forward_agent] === true)
         opts[:connection_timeout] = session_timeout
         opts

--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -950,11 +950,23 @@ class Chef
         opts = {}
         return opts if winrm?
 
-        ssh_config_file = File.open(File.join(Dir.home, ".ssh/config")).read
-        ssh_config_file.include?("RequestTTY yes") ? opts[:non_interactive] = false : opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
+        ssh_config_tty ? opts[:non_interactive] = false : opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config[:ssh_forward_agent] === true)
         opts[:connection_timeout] = session_timeout
         opts
+      end
+
+      #checks the ~/.ssh/config file to check RequestTTY is set to yes
+      def ssh_config_tty
+        if File.exists?(File.join(Dir.home, ".ssh/config"))
+          ssh_config_file = File.open(File.join(Dir.home, ".ssh/config")).read
+          if ssh_config_file.include?("RequestTTY")
+            tty_key_index = ssh_config_file.index("RequestTTY")
+            tty_value = ssh_config_file[tty_key_index...].split[1].downcase
+            return true if tty_value == "yes"
+          end
+        end
+        return false
       end
 
       def ssh_identity_opts

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -1477,7 +1477,7 @@ describe Chef::Knife::Bootstrap do
             end
           end
 
-          # connection_password will take precedence here  
+          # connection_password will take precedence here
           context "when connection_password is  set, sudo_pass is  set" do
             before do
               knife.config[:connection_password] = "opscode"

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -1439,11 +1439,11 @@ describe Chef::Knife::Bootstrap do
           end
 
           context "when sudo_pass is passed" do
-            let(:sudo_pass) { "opscode" }
+            let(:sudo_pass) { "progress" }
             it "includes :connection_password value in a sudo-enabled configuration" do
               expect(knife.sudo_opts(sudo_pass)).to eq({
                 sudo: true,
-                sudo_password: "opscode",
+                sudo_password: "progress",
               })
             end
           end

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -1403,6 +1403,7 @@ describe Chef::Knife::Bootstrap do
 
   context "#sudo_opts" do
     let(:connection_protocol) { nil }
+    let(:sudo_pass) { nil }
     before do
       allow(knife).to receive(:connection_protocol).and_return connection_protocol
     end
@@ -1410,7 +1411,7 @@ describe Chef::Knife::Bootstrap do
     context "for winrm" do
       let(:connection_protocol) { "winrm" }
       it "returns an empty hash" do
-        expect(knife.sudo_opts).to eq({})
+        expect(knife.sudo_opts(sudo_pass)).to eq({})
       end
     end
 
@@ -1422,7 +1423,7 @@ describe Chef::Knife::Bootstrap do
         end
 
         it "returns a config that enables sudo" do
-          expect(knife.sudo_opts).to eq( { sudo: true } )
+          expect(knife.sudo_opts(sudo_pass)).to eq( { sudo: true } )
         end
 
         context "when use_sudo_password is also set" do
@@ -1431,10 +1432,20 @@ describe Chef::Knife::Bootstrap do
             knife.config[:connection_password] = "opscode"
           end
           it "includes :connection_password value in a sudo-enabled configuration" do
-            expect(knife.sudo_opts).to eq({
+            expect(knife.sudo_opts(sudo_pass)).to eq({
               sudo: true,
               sudo_password: "opscode",
             })
+          end
+
+          context "when sudo_pass is passed" do
+            let(:sudo_pass) { "opscode" }
+            it "includes :connection_password value in a sudo-enabled configuration" do
+              expect(knife.sudo_opts(sudo_pass)).to eq({
+                sudo: true,
+                sudo_password: "opscode",
+              })
+            end
           end
         end
 
@@ -1443,7 +1454,7 @@ describe Chef::Knife::Bootstrap do
             knife.config[:preserve_home] = true
           end
           it "enables sudo with sudo_option to preserve home" do
-            expect(knife.sudo_opts).to eq({
+            expect(knife.sudo_opts(sudo_pass)).to eq({
               sudo_options: "-H",
               sudo: true,
             })
@@ -1457,7 +1468,7 @@ describe Chef::Knife::Bootstrap do
           knife.config[:preserve_home] = true
         end
         it "returns configuration for sudo off, ignoring other related options" do
-          expect(knife.sudo_opts).to eq( { sudo: false } )
+          expect(knife.sudo_opts(sudo_pass)).to eq( { sudo: false } )
         end
       end
     end

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -1438,7 +1438,10 @@ describe Chef::Knife::Bootstrap do
             })
           end
 
-          context "when sudo_pass is passed" do
+          context "when sudo_pass is set, connection_password is not set" do
+            before do
+              knife.config[:connection_password] = nil
+            end
             let(:sudo_pass) { "progress" }
             it "includes :connection_password value in a sudo-enabled configuration" do
               expect(knife.sudo_opts(sudo_pass)).to eq({
@@ -1447,6 +1450,47 @@ describe Chef::Knife::Bootstrap do
               })
             end
           end
+
+          context "when connection_password is set, sudo_pass is not set" do
+            before do
+              knife.config[:connection_password] = "opscode"
+            end
+            let(:sudo_pass) { nil }
+            it "includes :connection_password value in a sudo-enabled configuration" do
+              expect(knife.sudo_opts(sudo_pass)).to eq({
+                sudo: true,
+                sudo_password: "opscode",
+              })
+            end
+          end
+
+          context "when connection_password is not set, sudo_pass is not set" do
+            before do
+              knife.config[:connection_password] = nil
+            end
+            let(:sudo_pass) { nil }
+            it "includes :connection_password value in a sudo-enabled configuration" do
+              expect(knife.sudo_opts(sudo_pass)).to eq({
+                sudo: true,
+                sudo_password: nil,
+              })
+            end
+          end
+
+          # connection_password will take precedence here  
+          context "when connection_password is  set, sudo_pass is  set" do
+            before do
+              knife.config[:connection_password] = "opscode"
+            end
+            let(:sudo_pass) { "progress" }
+            it "includes :connection_password value in a sudo-enabled configuration" do
+              expect(knife.sudo_opts(sudo_pass)).to eq({
+                sudo: true,
+                sudo_password: "opscode",
+              })
+            end
+          end
+
         end
 
         context "when preserve_home is set" do


### PR DESCRIPTION
## Description
`sudo_password` is set to nil while making a ssh connection on knife bootstrap execution which leads to sudo_missing_terminal error in the latest versions of EL8.
We are setting this sudo_password with the password given when its prompted in terminal and than make a call to train gem for ssh connection which makes a successful Knife bootstrap execution without exposing their admin password in shell

## Related Issue
fixed:  #13271 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
