### PR TITLE
FIx kitchen test failures in windows boxes due to dependency issue in proxifier

### DIFF
--- a/post-bundle-install.rb
+++ b/post-bundle-install.rb
@@ -18,7 +18,7 @@ Dir["#{gem_home}/bundler/gems/*"].each do |gempath|
   next unless gem_name
 
   # FIXME: should omit the gem which is in the current directory and not hard code chef
-  next if %w{chef chef-universal-mingw-ucrt}.include?(gem_name)
+  next if %w{chef chef-universal-mingw-ucrt proxifier}.include?(gem_name)
 
   puts "re-installing #{gem_name}..."
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Kitchen tests on windows fail when installing gems with error:

```
1 gem installed
  Successfully built RubyGem
  Name: rest-client
  Version: 2.1.0
  File: rest-client-2.1.0.gem
Successfully installed rest-client-2.1.0
1 gem installed
WARNING:  licenses is empty, but is recommended.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: proxifier
  Version: 1.0.3
  File: proxifier-1.0.3.gem
ERROR:  Error installing proxifier-1.0.3.gem:
	"pirb" from proxifier conflicts with installed executable from proxifier2
post-bundle-install.rb:27:in `block (2 levels) in <main>': gem install failed (RuntimeError)
	from post-bundle-install.rb:25:in `chdir'
	from post-bundle-install.rb:25:in `block in <main>'
	from post-bundle-install.rb:11:in `each'
	from post-bundle-install.rb:11:in `<main>'
fixing bundle installed gems in C:/opscode/chef/embedded/lib/ruby/gems/3.1.0
re-installing ohai...
re-installing ohai...
re-installing rest-client...
re-installing proxifier...
```
(Ref https://github.com/chef/chef/actions/runs/4477841478/jobs/7869877395?pr=13643#step:5:65)

We used to pull proxifier from git repo but now it is getting pulled from rubygems itself. 
But somehow github kitchen test windows boxes still have previously downloaded entry for git downloaded proxifier (the boxes are not cleaned up?) due to which post-bundle-install.rb tries to reinstall the git repo linked proxifier gem resulting in dependency issues between proxifier and proxifier2. The script post-bundle-install is specifically doing the job of re-installing gems which are pulled from git repos, which this failure is due to environment not getting cleaned up. The ruby bundler directory on those windows boxes still has proxifier which was downloaded from git repo. So we would just skip it.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
