### PR TITLE
Fix output of cookbook list/show

### DIFF
--- a/knife/lib/chef/knife/core/generic_presenter.rb
+++ b/knife/lib/chef/knife/core/generic_presenter.rb
@@ -229,7 +229,7 @@ class Chef
                 cookbooks
               else
                 versions_by_cookbook
-              end
+            end
           end
         end
       end

--- a/knife/lib/chef/knife/core/generic_presenter.rb
+++ b/knife/lib/chef/knife/core/generic_presenter.rb
@@ -206,31 +206,31 @@ class Chef
         end
 
         def format_cookbook_list_for_display(item)
-          if config[:with_uri]
-            item.inject({}) do |collected, (cookbook, versions)|
+          versions_by_cookbook = item.inject({}) do |collected, ( cookbook, versions )|
+            if config[:with_uri]
               collected[cookbook] = {}
               versions["versions"].each do |ver|
                 collected[cookbook][ver["version"]] = ver["url"]
               end
-              collected
-            end
-          else
-            versions_by_cookbook = item.inject({}) do |collected, ( cookbook, versions )|
+            else
               collected[cookbook] = versions["versions"].map { |v| v["version"] }
-              collected
             end
+            collected.sort.to_h
+          end
+          if config[:with_uri]
+            versions_by_cookbook
+          else
             case parse_format_option
-              when :text, :summary
+              when :summary
                 key_length = versions_by_cookbook.empty? ? 0 : versions_by_cookbook.keys.map(&:size).max + 2
-                versions_by_cookbook.sort.map do |cookbook, versions|
+                versions_by_cookbook.map do |cookbook, versions|
                   "#{cookbook.ljust(key_length)} #{versions.join("  ")}"
                 end
               else
-                versions_by_cookbook.sort.to_h
-            end
+                versions_by_cookbook
+              end
           end
         end
-
       end
     end
   end

--- a/knife/lib/chef/knife/core/generic_presenter.rb
+++ b/knife/lib/chef/knife/core/generic_presenter.rb
@@ -29,19 +29,19 @@ class Chef
         def self.included(includer)
           includer.class_eval do
             option :field_separator,
-              short: "-S SEPARATOR",
-              long: "--field-separator SEPARATOR",
-              description: "Character separator used to delineate nesting in --attribute filters (default \".\")"
+                   short: "-S SEPARATOR",
+                   long: "--field-separator SEPARATOR",
+                   description: "Character separator used to delineate nesting in --attribute filters (default \".\")"
 
             option :attribute,
-              short: "-a ATTR1 [-a ATTR2]",
-              long: "--attribute ATTR1 [--attribute ATTR2] ",
-              description: "Show one or more attributes",
-              proc: Proc.new { |arg, accumulator|
-                accumulator ||= []
-                accumulator << arg
-                accumulator
-              }
+                   short: "-a ATTR1 [-a ATTR2]",
+                   long: "--attribute ATTR1 [--attribute ATTR2] ",
+                   description: "Show one or more attributes",
+                   proc: Proc.new { |arg, accumulator|
+                     accumulator ||= []
+                     accumulator << arg
+                     accumulator
+                   }
           end
         end
       end
@@ -67,10 +67,10 @@ class Chef
         # to produce invalid JSON output.
         def interchange?
           case parse_format_option
-          when :json, :yaml
-            true
-          else
-            false
+            when :json, :yaml
+              true
+            else
+              false
           end
         end
 
@@ -80,26 +80,26 @@ class Chef
         # `config[:format]` setting.
         def format(data)
           case parse_format_option
-          when :summary
-            summarize(data)
-          when :text
-            text_format(data)
-          when :json
-            Chef::JSONCompat.to_json_pretty(data)
-          when :yaml
-            require "yaml" unless defined?(YAML)
-            YAML.dump(data)
-          when :pp
-            require "stringio" unless defined?(StringIO)
-            # If you were looking for some attribute and there is only one match
-            # just dump the attribute value
-            if config[:attribute] && data.length == 1
-              data.values[0]
-            else
-              out = StringIO.new
-              PP.pp(data, out)
-              out.string
-            end
+            when :summary
+              summarize(data)
+            when :text
+              text_format(data)
+            when :json
+              Chef::JSONCompat.to_json_pretty(data)
+            when :yaml
+              require "yaml" unless defined?(YAML)
+              YAML.dump(data)
+            when :pp
+              require "stringio" unless defined?(StringIO)
+              # If you were looking for some attribute and there is only one match
+              # just dump the attribute value
+              if config[:attribute] && data.length == 1
+                data.values[0]
+              else
+                out = StringIO.new
+                PP.pp(data, out)
+                out.string
+              end
           end
         end
 
@@ -112,18 +112,18 @@ class Chef
         # determined from the value of `config[:format]`
         def parse_format_option
           case config[:format]
-          when "summary", /^s/, nil
-            :summary
-          when "text", /^t/
-            :text
-          when "json", /^j/
-            :json
-          when "yaml", /^y/
-            :yaml
-          when "pp", /^p/
-            :pp
-          else
-            raise ArgumentError, "Unknown output format #{config[:format]}"
+            when "summary", /^s/, nil
+              :summary
+            when "text", /^t/
+              :text
+            when "json", /^j/
+              :json
+            when "yaml", /^y/
+              :yaml
+            when "pp", /^p/
+              :pp
+            else
+              raise ArgumentError, "Unknown output format #{config[:format]}"
           end
         end
 
@@ -202,7 +202,7 @@ class Chef
               end
           end
           # necessary (?) for coercing objects (the run_list object?) to hashes
-          ( !data.is_a?(Array) && data.respond_to?(:to_hash) ) ? data.to_hash : data
+          (!data.is_a?(Array) && data.respond_to?(:to_hash)) ? data.to_hash : data
         end
 
         def format_cookbook_list_for_display(item)
@@ -215,14 +215,20 @@ class Chef
               collected
             end
           else
-            versions_by_cookbook = item.inject({}) do |collected, ( cookbook, versions )|
+            versions_by_cookbook = item.inject({}) do |collected, (cookbook, versions)|
               collected[cookbook] = versions["versions"].map { |v| v["version"] }
               collected
             end
-            key_length = versions_by_cookbook.empty? ? 0 : versions_by_cookbook.keys.map(&:size).max + 2
-            versions_by_cookbook.sort.map do |cookbook, versions|
-              "#{cookbook.ljust(key_length)} #{versions.join("  ")}"
+            case parse_format_option
+              when :text, :summary
+                key_length = versions_by_cookbook.empty? ? 0 : versions_by_cookbook.keys.map(&:size).max + 2
+                versions_by_cookbook.sort.map do |cookbook, versions|
+                  "#{cookbook.ljust(key_length)} #{versions.join("  ")}"
+                end
+              else
+                versions_by_cookbook
             end
+
           end
         end
 

--- a/knife/lib/chef/knife/core/generic_presenter.rb
+++ b/knife/lib/chef/knife/core/generic_presenter.rb
@@ -226,7 +226,7 @@ class Chef
                   "#{cookbook.ljust(key_length)} #{versions.join("  ")}"
                 end
               else
-                versions_by_cookbook
+                versions_by_cookbook.sort.to_h
             end
           end
         end

--- a/knife/lib/chef/knife/core/generic_presenter.rb
+++ b/knife/lib/chef/knife/core/generic_presenter.rb
@@ -222,10 +222,11 @@ class Chef
           else
             case parse_format_option
               when :summary
-                key_length = versions_by_cookbook.empty? ? 0 : versions_by_cookbook.keys.map(&:size).max + 2
+                cookbooks = {}
                 versions_by_cookbook.map do |cookbook, versions|
-                  "#{cookbook.ljust(key_length)} #{versions.join("  ")}"
+                  cookbooks[cookbook] = versions.join(" ")
                 end
+                cookbooks
               else
                 versions_by_cookbook
               end

--- a/knife/lib/chef/knife/core/generic_presenter.rb
+++ b/knife/lib/chef/knife/core/generic_presenter.rb
@@ -29,19 +29,19 @@ class Chef
         def self.included(includer)
           includer.class_eval do
             option :field_separator,
-                   short: "-S SEPARATOR",
-                   long: "--field-separator SEPARATOR",
-                   description: "Character separator used to delineate nesting in --attribute filters (default \".\")"
+              short: "-S SEPARATOR",
+              long: "--field-separator SEPARATOR",
+              description: "Character separator used to delineate nesting in --attribute filters (default \".\")"
 
             option :attribute,
-                   short: "-a ATTR1 [-a ATTR2]",
-                   long: "--attribute ATTR1 [--attribute ATTR2] ",
-                   description: "Show one or more attributes",
-                   proc: Proc.new { |arg, accumulator|
-                     accumulator ||= []
-                     accumulator << arg
-                     accumulator
-                   }
+              short: "-a ATTR1 [-a ATTR2]",
+              long: "--attribute ATTR1 [--attribute ATTR2] ",
+              description: "Show one or more attributes",
+              proc: Proc.new { |arg, accumulator|
+                accumulator ||= []
+                accumulator << arg
+                accumulator
+              }
           end
         end
       end
@@ -67,10 +67,10 @@ class Chef
         # to produce invalid JSON output.
         def interchange?
           case parse_format_option
-            when :json, :yaml
-              true
-            else
-              false
+          when :json, :yaml
+            true
+          else
+            false
           end
         end
 
@@ -80,26 +80,26 @@ class Chef
         # `config[:format]` setting.
         def format(data)
           case parse_format_option
-            when :summary
-              summarize(data)
-            when :text
-              text_format(data)
-            when :json
-              Chef::JSONCompat.to_json_pretty(data)
-            when :yaml
-              require "yaml" unless defined?(YAML)
-              YAML.dump(data)
-            when :pp
-              require "stringio" unless defined?(StringIO)
-              # If you were looking for some attribute and there is only one match
-              # just dump the attribute value
-              if config[:attribute] && data.length == 1
-                data.values[0]
-              else
-                out = StringIO.new
-                PP.pp(data, out)
-                out.string
-              end
+          when :summary
+            summarize(data)
+          when :text
+            text_format(data)
+          when :json
+            Chef::JSONCompat.to_json_pretty(data)
+          when :yaml
+            require "yaml" unless defined?(YAML)
+            YAML.dump(data)
+          when :pp
+            require "stringio" unless defined?(StringIO)
+            # If you were looking for some attribute and there is only one match
+            # just dump the attribute value
+            if config[:attribute] && data.length == 1
+              data.values[0]
+            else
+              out = StringIO.new
+              PP.pp(data, out)
+              out.string
+            end
           end
         end
 
@@ -112,18 +112,18 @@ class Chef
         # determined from the value of `config[:format]`
         def parse_format_option
           case config[:format]
-            when "summary", /^s/, nil
-              :summary
-            when "text", /^t/
-              :text
-            when "json", /^j/
-              :json
-            when "yaml", /^y/
-              :yaml
-            when "pp", /^p/
-              :pp
-            else
-              raise ArgumentError, "Unknown output format #{config[:format]}"
+          when "summary", /^s/, nil
+            :summary
+          when "text", /^t/
+            :text
+          when "json", /^j/
+            :json
+          when "yaml", /^y/
+            :yaml
+          when "pp", /^p/
+            :pp
+          else
+            raise ArgumentError, "Unknown output format #{config[:format]}"
           end
         end
 
@@ -202,7 +202,7 @@ class Chef
               end
           end
           # necessary (?) for coercing objects (the run_list object?) to hashes
-          (!data.is_a?(Array) && data.respond_to?(:to_hash)) ? data.to_hash : data
+          ( !data.is_a?(Array) && data.respond_to?(:to_hash) ) ? data.to_hash : data
         end
 
         def format_cookbook_list_for_display(item)
@@ -215,7 +215,7 @@ class Chef
               collected
             end
           else
-            versions_by_cookbook = item.inject({}) do |collected, (cookbook, versions)|
+            versions_by_cookbook = item.inject({}) do |collected, ( cookbook, versions )|
               collected[cookbook] = versions["versions"].map { |v| v["version"] }
               collected
             end
@@ -228,7 +228,6 @@ class Chef
               else
                 versions_by_cookbook
             end
-
           end
         end
 

--- a/knife/spec/integration/cookbook_bulk_delete_spec.rb
+++ b/knife/spec/integration/cookbook_bulk_delete_spec.rb
@@ -55,8 +55,8 @@ describe "knife cookbook bulk delete", :workstation do
       knife("cookbook bulk delete ^fo.*", input: "Y").should_succeed(stderr: stderr, stdout: stdout)
 
       knife("cookbook list -a").should_succeed <<~EOM
-        fax   0.6.0
-        zfa   0.6.5
+        fax: 0.6.0
+        zfa: 0.6.5
       EOM
     end
     # rubocop:enable Layout/TrailingWhitespace

--- a/knife/spec/integration/cookbook_list_spec.rb
+++ b/knife/spec/integration/cookbook_list_spec.rb
@@ -37,17 +37,17 @@ describe "knife cookbook list", :workstation do
 
     it "knife cookbook list shows all the cookbooks" do
       knife("cookbook list").should_succeed <<~EOM
-        x   1.0.0
-        y   0.6.5
-        z   0.6.5
+        x: 1.0.0
+        y: 0.6.5
+        z: 0.6.5
       EOM
     end
 
     it "knife cookbook list -a shows all the versions of all the cookbooks" do
       knife("cookbook list -a").should_succeed <<~EOM
-        x   1.0.0  0.6.5  0.6.0
-        y   0.6.5  0.6.0
-        z   0.6.5
+        x: 1.0.0 0.6.5 0.6.0
+        y: 0.6.5 0.6.0
+        z: 0.6.5
       EOM
     end
 

--- a/knife/spec/integration/cookbook_show_spec.rb
+++ b/knife/spec/integration/cookbook_show_spec.rb
@@ -32,7 +32,7 @@ describe "knife cookbook show", :workstation do
     end
 
     it "knife cookbook show x shows all the versions" do
-      knife("cookbook show x").should_succeed "x   1.0.0  0.6.5\n"
+      knife("cookbook show x").should_succeed "x: 1.0.0 0.6.5\n"
     end
 
     # rubocop:disable Layout/TrailingWhitespace

--- a/knife/spec/unit/knife/cookbook_list_spec.rb
+++ b/knife/spec/unit/knife/cookbook_list_spec.rb
@@ -79,7 +79,7 @@ describe Chef::Knife::CookbookList do
           .and_return(@cookbook_data)
         @knife.run
         @cookbook_names.each do |item|
-          expect(@stdout.string).to match(/#{item}\s+1\.0\.1\s+1\.0\.0/)
+          expect(@stdout.string).to match(/#{item}:\s+1\.0\.1\s+1\.0\.0/)
         end
       end
     end

--- a/knife/spec/unit/knife/cookbook_list_spec.rb
+++ b/knife/spec/unit/knife/cookbook_list_spec.rb
@@ -41,7 +41,7 @@ describe Chef::Knife::CookbookList do
         .and_return(@cookbook_data)
       @knife.run
       @cookbook_names.each do |item|
-        expect(@stdout.string).to match(/#{item}\s+1\.0\.1/)
+        expect(@stdout.string).to match(/#{item}:\s+1\.0\.1/)
       end
     end
 

--- a/knife/spec/unit/knife/core/ui_spec.rb
+++ b/knife/spec/unit/knife/core/ui_spec.rb
@@ -459,8 +459,8 @@ describe Chef::Knife::UI do
       }
     end
 
-    it "should return an array of the cookbooks with versions" do
-      expected_response = [ "cookbook_name   3.0.0  2.0.0  1.0.0" ]
+    it "should return an hash of the cookbooks with versions" do
+      expected_response = { "cookbook_name" => "3.0.0 2.0.0 1.0.0" }
       response = @ui.format_cookbook_list_for_display(@item)
       expect(response).to eq(expected_response)
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR turns the output from the following:
```json
$ knife cookbook list -a -F json
[
  "7-zip                       1.0.2",
  "api_docs                    0.1.0",
  "apt                         1.1.1",
  "ark                         4.0.0  3.1.1  0.9.0  0.3.0",
  "audit-cis                   0.4.0",
  "authenticator               0.1.5  0.1.4",
  "aws-static-ip-ha            0.1.0",
  "aws-tools                   0.0.5"
]
```
to this
```json
$ knife cookbook list -a -F json
{
  "7-zip": [
    "1.0.2"
  ],
  "api_docs": [
    "0.1.0"
  ],
  "apt": [
    "1.1.1"
  ],
  "ark": [
    "4.0.0",
    "3.1.1",
    "0.9.0",
    "0.3.0"
  ],
  "audit-cis": [
    "0.4.0"
  ],
  "authenticator": [
    "0.1.5",
    "0.1.4"
  ],
  "aws-static-ip-ha": [
    "0.1.0"
  ],
  "aws-tools": [
    "0.0.5"
  ]
}
```

This has a potential of breaking peoples script if they adjusted to the broken format, that is why this is marked as a breaking change.

This brings the output of the following in line with other listings coming out of chef

### Examples of the affected outputs:
#### knife cookbook show
summary(default)
```
$ knife cookbook show ark
ark: 4.0.0 3.1.1 0.9.0 0.3.0
```
text
```
$ knife cookbook show ark -F text
ark:
  4.0.0
  3.1.1
  0.9.0
  0.3.0
```
json
```json
$ knife cookbook show ark -F json
{
  "ark": [
    "4.0.0",
    "3.1.1",
    "0.9.0",
    "0.3.0"
  ]
}
```
yaml
```yaml
$ knife cookbook show ark -F yaml
---
ark:
- 4.0.0
- 3.1.1
- 0.9.0
- 0.3.0
```
pp
```
$ knife cookbook show ark -F pp
{"ark"=>["4.0.0", "3.1.1", "0.9.0", "0.3.0"]}
```
#### knife cookbook list
summary(default)
```
$ knife cookbook list -a
7-zip:                     1.0.2
api_docs:                  0.1.0
apt:                       1.1.1
ark:                       4.0.0 3.1.1 0.9.0 0.3.0
audit-cis:                 0.4.0
auditbeat:                 0.0.42
authenticator:             0.1.5 0.1.4
aws-static-ip-ha:          0.1.0
aws-tools:                 0.0.5
```
text
```
$ knife cookbook list -a -F text
7-zip:                     1.0.2
api_docs:                  0.1.0
apt:                       1.1.1
ark:
  4.0.0
  3.1.1
  0.9.0
  0.3.0
audit-cis:                 0.4.0
auditbeat:                 0.0.42
authenticator:
  0.1.5
  0.1.4
aws-static-ip-ha:          0.1.0
aws-tools:                 0.0.5
```
json
```json
$ knife cookbook list -a -F json
{
  "7-zip": [
    "1.0.2"
  ],
  "api_docs": [
    "0.1.0"
  ],
  "apt": [
    "1.1.1"
  ],
  "ark": [
    "4.0.0",
    "3.1.1",
    "0.9.0",
    "0.3.0"
  ],
  "audit-cis": [
    "0.4.0"
  ],
  "authenticator": [
    "0.1.5",
    "0.1.4"
  ],
  "aws-static-ip-ha": [
    "0.1.0"
  ],
  "aws-tools": [
    "0.0.5"
  ],
}
```
yaml
```yaml
$ knife cookbook list -a -F yaml
---
7-zip:
- 1.0.2
api_docs:
- 0.1.0
apt:
- 1.1.1
ark:
- 4.0.0
- 3.1.1
- 0.9.0
- 0.3.0
audit-cis:
- 0.4.0
authenticator:
- 0.1.5
- 0.1.4
aws-static-ip-ha:
- 0.1.0
aws-tools:
- 0.0.5
```
pp
```
$ knife cookbook list -a -F pp
{"7-zip"=>["1.0.2"],
 "api_docs"=>["0.1.0"],
 "apt"=>["1.1.1"],
 "ark"=>["4.0.0", "3.1.1", "0.9.0", "0.3.0"],
 "audit-cis"=>["0.4.0"],
 "authenticator"=>["0.1.5", "0.1.4"],
 "aws-static-ip-ha"=>["0.1.0"],
 "aws-tools"=>["0.0.5"],
}
```

## Related Issue
This is a PR for #13653

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
