### PR TITLE
[Chef-16] Ignore artifactory for omnibus release and adhoc pipelines

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -35,10 +35,12 @@ pipelines:
   - omnibus/release:
       env:
         - IGNORE_CACHE: true # caching causes constant build failures
+        - IGNORE_ARTIFACTORY_RUBY_PROXY: true
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
+        - IGNORE_ARTIFACTORY_RUBY_PROXY: true
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Ignore artifactory for both release and adhoc omnibus buildkite pipelines due to failures of artifactory gem not found.
Ref: https://buildkite.com/chef/chef-chef-chef-16-omnibus-adhoc/builds/256

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
