### PR TITLE
Add aarch64 builder-testers to map

### DIFF
--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -9,16 +9,29 @@ fi
 FILTER="${OMNIBUS_FILTER:=*}"
 
 # array of all container platforms in the format test-platform:build-platform
-container_platforms=("amazon-2:centos-7" "centos-6:centos-6" "centos-7:centos-7" "centos-8:centos-8" "rhel-9:rhel-9" "debian-9:debian-9" "debian-10:debian-9" "debian-11:debian-9" "ubuntu-1604:ubuntu-1604" "ubuntu-1804:ubuntu-1604" "ubuntu-2004:ubuntu-1604" "ubuntu-2204:ubuntu-1604" "sles-15:sles-15" "windows-2019:windows-2019")
+container_platforms=( "amazon-2:centos-7" "centos-6:centos-6" "centos-7:centos-7" "centos-8:centos-8"
+"rhel-9:rhel-9" "debian-9:debian-9" "debian-10:debian-9" "debian-11:debian-9"
+"ubuntu-1604:ubuntu-1604" "ubuntu-1804:ubuntu-1604" "ubuntu-2004:ubuntu-1604" "ubuntu-2204:ubuntu-1604"
+"sles-15:sles-15" "windows-2019:windows-2019" )
 
 # add rest of windows platforms to tests, if not on chef-oss org
 if [ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]
 then
-  container_platforms=( "${container_platforms[@]}" "windows-2012:windows-2019" "windows-2012r2:windows-2019" "windows-2016:windows-2019" "windows-2022:windows-2019" "windows-10:windows-2019" "windows-11:windows-2019" )
+  container_platforms=( "${container_platforms[@]}"
+  "windows-2012:windows-2019" "windows-2012r2:windows-2019" "windows-2016:windows-2019"
+  "windows-2022:windows-2019" "windows-10:windows-2019" "windows-11:windows-2019" )
 fi
 
 # array of all esoteric platforms in the format test-platform:build-platform
-esoteric_platforms=("el-7-ppc64:el-7-ppc64" "el-7-ppc64le:el-7-ppc64le" "el-7-s390x:el-7-s390x" "el-8-s390x:el-7-s390x" "freebsd-12-amd64:freebsd-12-amd64" "freebsd-13-amd64:freebsd-12-amd64" "mac_os_x-10.15-x86_64:mac_os_x-10.15-x86_64" "mac_os_x-11-x86_64:mac_os_x-10.15-x86_64" "mac_os_x-12-x86_64:mac_os_x-10.15-x86_64" "mac_os_x-11-arm64:mac_os_x-11-arm64" "mac_os_x-12-arm64:mac_os_x-11-arm64" "solaris2-5.11-i386:solaris2-5.11-i386" "solaris2-5.11-sparc:solaris2-5.11-sparc" "sles-12-s390x:sles-12-s390x" "sles-15-s390x:sles-12-s390x")
+esoteric_platforms=( "el-7-ppc64:el-7-ppc64" "el-7-ppc64le:el-7-ppc64le" "el-7-s390x:el-7-s390x" "el-8-s390x:el-7-s390x"
+"freebsd-12-amd64:freebsd-12-amd64" "freebsd-13-amd64:freebsd-12-amd64"
+"mac_os_x-10.15-x86_64:mac_os_x-10.15-x86_64" "mac_os_x-11-x86_64:mac_os_x-10.15-x86_64"
+"mac_os_x-12-x86_64:mac_os_x-10.15-x86_64" "mac_os_x-11-arm64:mac_os_x-11-arm64" "mac_os_x-12-arm64:mac_os_x-11-arm64"
+"solaris2-5.11-i386:solaris2-5.11-i386" "solaris2-5.11-sparc:solaris2-5.11-sparc"
+"sles-12-s390x:sles-12-s390x" "sles-15-s390x:sles-12-s390x" "sles-15-aarch64:sles-15-aarch64"
+"debian-10-aarch64:debian-10-aarch64" "debian-11-aarch64:debian-10-aarch64"
+"el-7-aarch64:el-7-aarch64" "el-8-aarch64:el-8-aarch64" "el-9-aarch64:el-9-aarch64"
+"ubuntu-18.04-aarch64:ubuntu-18.04-aarch64" "ubuntu-20.04-aarch64:ubuntu-18.04-aarch64" "ubuntu-22.04-aarch64:ubuntu-18.04-aarch64" )
 
 omnibus_build_platforms=()
 omnibus_test_platforms=()


### PR DESCRIPTION
## Description
The `aarch64` builders/testers were missing in the pipeline construction. Added those using the earlier `release.omnibus.yml` mapping as reference.

- [x] Ad hoc build based on `aarch64` includes the relevant builders/ testers & passes

## Related Issue
`aarch64` packages aren't getting built for Chef Infra Client when the new `chef-foundation` based pipeline runs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
