### PR TITLE
Correcting a typo in the resource

### DIFF
--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -113,7 +113,7 @@ class Chef
         end
 
         def last_modified_time_from(response)
-          response["last_modified"] || response["date"]
+          response["last-modified"] || response["date"]
         end
 
         def etag_from(response)

--- a/spec/unit/provider/remote_file/http_spec.rb
+++ b/spec/unit/provider/remote_file/http_spec.rb
@@ -251,7 +251,7 @@ describe Chef::Provider::RemoteFile::HTTP do
       end
 
       context "and the response has no Date or Last-Modified header" do
-        let(:last_response) { { "date" => nil, "last_modified" => nil } }
+        let(:last_response) { { "date" => nil, "last-modified" => nil } }
         it "does not set an mtime in the result" do
           # RFC 2616 suggests that servers that do not set a Date header do not
           # have a reliable clock, so no use in making them deal with dates.
@@ -265,19 +265,19 @@ describe Chef::Provider::RemoteFile::HTTP do
       context "and the response has a Last-Modified header" do
         let(:last_response) do
           # Last-Modified should be preferred to Date if both are set
-          { "date" => "Fri, 17 May 2013 23:23:23 GMT", "last_modified" => "Fri, 17 May 2013 11:11:11 GMT" }
+          { "date" => "Fri, 17 May 2013 23:23:23 GMT", "last-modified" => "Fri, 17 May 2013 11:11:11 GMT" }
         end
 
         it "sets the mtime to the Last-Modified time in the response" do
           fetcher.fetch
           expect(cache_control_data.etag).to be_nil
-          expect(cache_control_data.mtime).to eq(last_response["last_modified"])
+          expect(cache_control_data.mtime).to eq(last_response["last-modified"])
         end
       end
 
       context "and the response has a Date header but no Last-Modified header" do
         let(:last_response) do
-          { "date" => "Fri, 17 May 2013 23:23:23 GMT", "last_modified" => nil }
+          { "date" => "Fri, 17 May 2013 23:23:23 GMT", "last-modified" => nil }
         end
 
         it "sets the mtime to the Date in the response" do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR comes to us from https://github.com/chef/chef/issues/13446 which describes the problem of a mis-spelled property returning a nil for a date value. The fix is to correct the spelling for the object which we are doing here. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
