### PR TITLE
Add ruby-cleanup to clear the bundler/gems and cache folder

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 6a1c8896edf6c5606facc83b75ecaacf22019e2b
+  revision: 8e242c1b616744701471495db261d3774b11cbdf
   branch: main
   specs:
-    omnibus-software (23.3.287)
+    omnibus-software (23.4.288)
       omnibus (>= 9.0.0)
 
 GIT

--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -44,6 +44,7 @@ override :chef, version: "local_source"
 dependency "chef-local-source"
 dependency "shebang-cleanup"
 
+dependency "ruby-cleanup"
 # further gem cleanup other projects might not yet want to use
 dependency "more-ruby-cleanup"
 


### PR DESCRIPTION
Signed-off-by: poorndm@progress.com
## Description
The size of the installer on platforms has doubled after moving to chef-foundation.

Fix Includes cleanup of the bundler caches. This will remove ohai,rest-client,ruby-proxifier,and ruby-shadow caches. On cleaning the cache and bundler folder reduces the overall package size.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
