### PR TITLE
Avoid Invalid Memory Object error

### DIFF
--- a/lib/chef/win32/handle.rb
+++ b/lib/chef/win32/handle.rb
@@ -42,10 +42,7 @@ class Chef
         # to close the pseudo handle returned by the GetCurrentProcess function.  The docs also say that it doesn't hurt to call
         # CloseHandle on it. However, doing so from inside of Ruby always seems to produce an invalid handle error.
         # The recommendation is to use GetCurrentProcess instead of the const (HANDLE)-1, to ensure we're making the correct comparison.
-
-        # Chef::ReservedNames::Win32::Security.logon_user() creates a token with a handle this is an FFI::Pointer
-        # and not a valid handle.
-        return if handle.is_a?(FFI::Pointer) || handle == GetCurrentProcess()
+        return handle == GetCurrentProcess()
 
         unless CloseHandle(handle)
           Chef::ReservedNames::Win32::Error.raise!

--- a/lib/chef/win32/handle.rb
+++ b/lib/chef/win32/handle.rb
@@ -42,7 +42,10 @@ class Chef
         # to close the pseudo handle returned by the GetCurrentProcess function.  The docs also say that it doesn't hurt to call
         # CloseHandle on it. However, doing so from inside of Ruby always seems to produce an invalid handle error.
         # The recommendation is to use GetCurrentProcess instead of the const (HANDLE)-1, to ensure we're making the correct comparison.
-        return if handle == GetCurrentProcess()
+
+        # Chef::ReservedNames::Win32::Security.logon_user() creates a token with a handle this is an FFI::Pointer
+        # and not a valid handle.
+        return if handle.is_a?(FFI::Pointer) || handle == GetCurrentProcess()
 
         unless CloseHandle(handle)
           Chef::ReservedNames::Win32::Error.raise!

--- a/lib/chef/win32/handle.rb
+++ b/lib/chef/win32/handle.rb
@@ -42,7 +42,7 @@ class Chef
         # to close the pseudo handle returned by the GetCurrentProcess function.  The docs also say that it doesn't hurt to call
         # CloseHandle on it. However, doing so from inside of Ruby always seems to produce an invalid handle error.
         # The recommendation is to use GetCurrentProcess instead of the const (HANDLE)-1, to ensure we're making the correct comparison.
-        return handle == GetCurrentProcess()
+        return if handle == GetCurrentProcess()
 
         unless CloseHandle(handle)
           Chef::ReservedNames::Win32::Error.raise!

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -722,12 +722,12 @@ class Chef
           Chef::ReservedNames::Win32::Error.raise!
         end
 
-        # Handle.new(_non handle value_) is not ideal because the finalizer for Handle
-        # was silently failing when comparing the parameter with the return from
-        # `GetCurrentProcess()`. In this case, the value is an FFI::Pointer, but the logic
-        # for Token.new works the same otherwise, so I'm leaving this as is and guarding against
-        # trying to treat an FFI::Pointer as a Win32 handle in the finalizer.
-        Token.new(Handle.new(token.read_pointer))
+        # originally this was .read_pointer, but that is interpreted as a non-primitive
+        # class (FFI::Pointer) and causes an ArgumentError (Invalid Memory Object) when
+        # compared to GetCurrentProcess(), which returns a HANDLE (void *). Since a
+        # HANDLE is not a pointer to allocated memory that Ruby C extensions can understand,
+        # the Invalid Memory Object error is raised.
+        Token.new(Handle.new(token.read_ulong))
       end
 
       def self.test_and_raise_lsa_nt_status(result)

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -721,6 +721,12 @@ class Chef
         unless LogonUserW(username, domain, password, logon_type, logon_provider, token)
           Chef::ReservedNames::Win32::Error.raise!
         end
+
+        # Handle.new(_non handle value_) is not ideal because the finalizer for Handle
+        # was silently failing when comparing the parameter with the return from
+        # `GetCurrentProcess()`. In this case, the value is an FFI::Pointer, but the logic
+        # for Token.new works the same otherwise, so I'm leaving this as is and guarding against
+        # trying to treat an FFI::Pointer as a Win32 handle in the finalizer.
         Token.new(Handle.new(token.read_pointer))
       end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Windows runs of Chef get intermittent `ArgumentError`s for "Invalid Memory Object". This is due to an attempt to compare a legitimate Windows `HANDLE` retrieved from `GetCurrentProcess` with an `FFI::Pointer`. The "Invalid Memory Object" error itself comes from trying to compare a memory object (`FFI::Pointer` with the return value from `GetCurrentProcess()`, a `HANDLE` from Windows)

[Windows data types](https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types)

These errors do not result in breakage because of their happening in a finalizer, but 

### Error example
```
C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.2.9-x64-mingw-ucrt/lib/chef/win32/handle.rb:45:in `==': Invalid Memory object (ArgumentError)
	from C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.2.9-x64-mingw-ucrt/lib/chef/win32/handle.rb:45:in `close_handle'
	from C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.2.9-x64-mingw-ucrt/lib/chef/win32/handle.rb:37:in `block in close_handle_finalizer'
	from C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/ffi-win32-extensions-1.0.4/lib/ffi/win32/extensions.rb:60:in `read_utf16string'
	from C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-powershell-18.0.1/lib/chef-powershell/powershell.rb:120:in `exec'
	from C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-powershell-18.0.1/lib/chef-powershell/powershell.rb:45:in `initialize'
	from C:/opscode/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-powershell-18.0.1/lib/chef-powershell/powershell_exec.rb:116:in `new'
```

### Analysis

`Chef::ReservedNames::Win32::Security.open_process_token` passes a unsigned long and `Chef::ReservedNames::Win32::Process.get_current_process` the actual `HANDLE` from `GetCurrentProcess()`... these finalize properly, because they are compared as numerical values in `handle == GetCurrentProcess()`.

`Chef::ReservedNames::Win32::Security.logon_user` passes the result of `FFI::Buffer#read_pointer` to `Handle.new` instead, which results in an `FFI::Pointer` being stored as the handle.

Prior to Ruby 3.1/Chef 18/UCRT, this mismatch was at least not as noisy as it is in the current versions of everything.

### Solution

Use `FFI::Buffer#read_ulong` to prevent the 8-byte value from being interpreted as a Ruby memory object so that Ruby will assume it's comparing a primitive 8-byte value to the return value of `GetCurrentProcess()`. While `HANDLE` *is* a `void *` in Windows, Ruby has no type information or heap access to know what to do with the memory.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
