### PR TITLE
[launchd] Force string values for program_arguments property

### DIFF
--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -202,7 +202,11 @@ class Chef
         description: "The first argument of `execvp`, typically the file name associated with the file to be executed. This value must be specified if `program_arguments` is not specified, and vice-versa."
 
       property :program_arguments, Array,
-        description: "The second argument of `execvp`. If program is not specified, this property must be specified and will be handled as if it were the first argument."
+        description: "The second argument of `execvp`. If program is not specified, this property must be specified and will be handled as if it were the first argument.",
+        coerce: proc { |args|
+          # Cast all values to a string.  Launchd only supports string values
+          args.map(&:to_s)
+        }
 
       property :queue_directories, Array,
         description: "An array of non-empty directories which, if any are modified, will cause a job to be started."


### PR DESCRIPTION
## Description
Man page for launchd specifies ProgramArguments should be an array of strings 

```
ProgramArguments <array of strings>
     This key maps to the second argument of [execvp(3)](https://www.manpagez.com/man/3/execvp/).  This key is required
     in the absence of the Program key. Please note: many people are confused
     by this key. Please read [execvp(3)](https://www.manpagez.com/man/3/execvp/) very carefully! 
```

Recently my org discovered launchd behaves oddly (kernel panics)  if an integer value is passed to program_arguments. (We have a open case with Apple as well)  To address this,  we've added this patch to our fleet and looking to fix the issue upstream.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
