### PR TITLE
Add efivarfs to list of non-existent mount devices

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -324,6 +324,7 @@
     "eckey",
     "ecparam",
     "edir",
+    "efivarfs",
     "egid",
     "egrep",
     "ELOOP",

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -186,7 +186,7 @@ class Chef
         def device_should_exist?
           ( @new_resource.device != "none" ) &&
             ( not network_device? ) &&
-            ( not %w{ cgroup tmpfs fuse vboxsf zfs }.include? @new_resource.fstype )
+            ( not %w{ cgroup tmpfs fuse vboxsf zfs efivarfs }.include? @new_resource.fstype )
         end
 
         private


### PR DESCRIPTION
## Description
efivarfs is a non-existent device that can be mounted using mount command and/or fstab.

The following fails at `:mount` because of this. This PR adds that as it is ok for it to not exist.
```
mount "/sys/firmware/efi/efivars" do
  device "efivarfs"
  fstype "efivarfs"
  options "nosuid,noexec,nodev"
  pass 0
  action [:enable, :mount]
end
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
