### PR TITLE
zypper_package: Fix idempotency issue

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -141,6 +141,7 @@ class Chef
             if md = line.match(/^(\S*)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(.*)$/)
               (status, name, type, version, arch, repo) = [ md[1], md[2], md[3], md[4], md[5], md[6] ]
               next if version == "Version" # header
+              next if name != package_name
 
               # sometimes even though we request a specific version in the search string above and have match exact, we wind up
               # with other versions in the output, particularly getting the installed version when downgrading.

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -491,4 +491,14 @@ describe Chef::Provider::Package::Zypper do
       provider.remove_package(%w{emacs vim}, ["1.0", "2.0"])
     end
   end
+
+  describe "resolve_available_version" do
+    it "should return correct version if multiple packages are shown" do
+      status = double(stdout: "S  | Name                     | Type    | Version             | Arch   | Repository\n---+--------------------------+---------+---------------------+--------+-------------------------------------------------------------\n   | apache2-mod_wsgi         | package | 4.7.1-150400.3.3.1  | x86_64 | Update repository with updates from SUSE Linux Enterprise 15\n   | apache2-mod_wsgi         | package | 4.7.1-150400.1.52   | x86_64 | Main Repository\ni+ | apache2-mod_wsgi-python3 | package | 4.5.18-150000.4.6.1 | x86_64 | Update repository with updates from SUSE Linux Enterprise 15\nv  | apache2-mod_wsgi-python3 | package | 4.5.18-4.3.1        | x86_64 | Main Repository\n", exitstatus: 0)
+
+      allow(provider).to receive(:shell_out_compacted!).and_return(status)
+      result = provider.send(:resolve_available_version, "apache2-mod_wsgi-python3", nil)
+      expect(result).to eq("4.5.18-150000.4.6.1")
+    end
+  end
 end


### PR DESCRIPTION
Installing the `apache2-mod_wsgi-python3` package is not idempotent due to the fact that zypper will also return the `apache2-mod_wsgi` package. The `resolve_available_version` method, incorrectly assumes this will only return one item, but in this case it returns four items and will pick the first package listed.

To work around this, we should verify that the package name listed in the output matches what we are expecting to install.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
