### PR TITLE
[Chef-17] 2 of X - Removing i386 support

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -66,8 +66,6 @@ builder-to-testers-map:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
-  # windows-2012r2-i386:
-  #   - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64

--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -66,8 +66,8 @@ builder-to-testers-map:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
-  windows-2012r2-i386:
-    - windows-2012r2-i386
+  # windows-2012r2-i386:
+  #   - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -55,8 +55,8 @@ builder-to-testers-map:
     - sles-15-x86_64
   sles-15-aarch64:
     - sles-15-aarch64
-  solaris2-5.11-i386:
-    - solaris2-5.11-i386
+  # solaris2-5.11-i386:
+  #   - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:
@@ -66,8 +66,8 @@ builder-to-testers-map:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
-  windows-2012r2-i386:
-    - windows-2012r2-i386
+  # windows-2012r2-i386:
+  #   - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -55,8 +55,6 @@ builder-to-testers-map:
     - sles-15-x86_64
   sles-15-aarch64:
     - sles-15-aarch64
-  # solaris2-5.11-i386:
-  #   - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:
@@ -66,8 +64,6 @@ builder-to-testers-map:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
-  # windows-2012r2-i386:
-  #   - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We no longer build for 32-bit processors. This PR removes support for that from the adhoc and release pipelines.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
