### PR TITLE
Support Homebrew resources on AArch64.

### DIFF
--- a/lib/chef/mixin/homebrew_user.rb
+++ b/lib/chef/mixin/homebrew_user.rb
@@ -60,7 +60,7 @@ class Chef
       private
 
       def calculate_owner
-        default_brew_path = arm? ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew"
+        default_brew_path = ChefUtils.arm? ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew"
         if ::File.exist?(default_brew_path)
           # By default, this follows symlinks which is what we want
           owner = ::File.stat(default_brew_path).uid

--- a/lib/chef/mixin/homebrew_user.rb
+++ b/lib/chef/mixin/homebrew_user.rb
@@ -60,7 +60,7 @@ class Chef
       private
 
       def calculate_owner
-        default_brew_path = "/usr/local/bin/brew"
+        default_brew_path = arm? ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew"
         if ::File.exist?(default_brew_path)
           # By default, this follows symlinks which is what we want
           owner = ::File.stat(default_brew_path).uid
@@ -68,7 +68,7 @@ class Chef
           owner = ::File.stat(brew_path).uid
         else
           raise Chef::Exceptions::CannotDetermineHomebrewOwner,
-            'Could not find the "brew" executable in /usr/local/bin or anywhere on the path.'
+            "Could not find the 'brew' executable at #{default_brew_path} or anywhere in PATH."
         end
 
         Chef::Log.debug "Found Homebrew owner #{Etc.getpwuid(owner).name}; executing `brew` commands as them"

--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -46,7 +46,7 @@ class Chef
 
       property :homebrew_path, String,
         description: "The path to the homebrew binary.",
-        default: "/usr/local/bin/brew"
+        default: lazy { arm? ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew" }
 
       property :owner, [String, Integer],
         description: "The owner of the Homebrew installation.",

--- a/lib/chef/resource/homebrew_package.rb
+++ b/lib/chef/resource/homebrew_package.rb
@@ -63,7 +63,7 @@ class Chef
       allowed_actions :install, :upgrade, :remove, :purge
 
       property :homebrew_user, [ String, Integer ],
-        description: "The name or uid of the Homebrew owner to be used by #{ChefUtils::Dist::Infra::PRODUCT} when executing a command.\n\n#{ChefUtils::Dist::Infra::PRODUCT}, by default, will attempt to execute a Homebrew command as the owner of the `/usr/local/bin/brew` executable. If that executable does not exist, #{ChefUtils::Dist::Infra::PRODUCT} will attempt to find the user by executing `which brew`. If that executable cannot be found, #{ChefUtils::Dist::Infra::PRODUCT} will print an error message: `Could not find the 'brew' executable in /usr/local/bin or anywhere on the path.`.\n\nSet this property to specify the Homebrew owner for situations where Chef Infra Client cannot automatically detect the correct owner.'"
+        description: "The name or uid of the Homebrew owner to be used by #{ChefUtils::Dist::Infra::PRODUCT} when executing a command.\n\n#{ChefUtils::Dist::Infra::PRODUCT}, by default, will attempt to execute a Homebrew command as the owner of the `brew` executable. If that executable does not exist, #{ChefUtils::Dist::Infra::PRODUCT} will attempt to find the user by executing `which brew`. If that executable cannot be found, #{ChefUtils::Dist::Infra::PRODUCT} will print an error message: `Could not find the 'brew' executable at /usr/local/bin or anywhere in PATH.`.\n\nSet this property to specify the Homebrew owner for situations where Chef Infra Client cannot automatically detect the correct owner.'"
 
     end
   end

--- a/lib/chef/resource/homebrew_tap.rb
+++ b/lib/chef/resource/homebrew_tap.rb
@@ -29,6 +29,14 @@ class Chef
       description "Use the **homebrew_tap** resource to add additional formula repositories to the Homebrew package manager."
       introduced "14.0"
 
+      examples <<~DOC
+      **Tap a repository**:
+
+      ```ruby
+      homebrew_tap 'petere/postgresql'
+      ```
+      DOC
+
       include Chef::Mixin::HomebrewUser
 
       property :tap_name, String,
@@ -42,7 +50,7 @@ class Chef
 
       property :homebrew_path, String,
         description: "The path to the Homebrew binary.",
-        default: "/usr/local/bin/brew"
+        default: lazy { arm? ? "/opt/homebrew/bin/brew" : "/usr/local/bin/brew" }
 
       property :owner, String,
         description: "The owner of the Homebrew installation.",
@@ -71,12 +79,13 @@ class Chef
         end
       end
 
-      # Is the passed tap already tapped
+      # Check if the passed tap is already tapped
       #
       # @return [Boolean]
       def tapped?(name)
+        base_path = arm? ? "/opt/homebrew" : "/usr/local/Homebrew"
         tap_dir = name.gsub("/", "/homebrew-")
-        ::File.directory?("/usr/local/Homebrew/Library/Taps/#{tap_dir}")
+        ::File.directory?("#{base_path}/Library/Taps/#{tap_dir}")
       end
     end
   end


### PR DESCRIPTION
## Description
Homebrew uses a [different path](https://github.com/Homebrew/install/blob/master/install.sh#L131) when installed on M1/M2/Apple Silicon/ARM/ARM64/AArch64 which causes Homebrew resources to fail unless `homebrew_path` and `owner` are passed. The `homebrew_tap` resource is currently not idempotent on ARM since it checks the wrong path and returns false each run. This PR uses the `arm?` helper to determine the proper paths for a particular architecture.

## Related Issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
