### PR TITLE
[Chef-17] 7 of X - Updating Berkshelf version

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -6,14 +6,15 @@ gem "artifactory"
 
 gem "pedump"
 
+# Use Berkshelf for resolving cookbook dependencies
+# Using a branch here that calls out a berkshelf version for chef-17
+gem "berkshelf", git: "https://github.com/chef/berkshelf.git", branch: "main"
+
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
 # the Test Kitchen-based build lab. You can skip these unnecessary dependencies
 # by running `bundle config set --local without development && bundle install` to speed up build times.
 group :development do
-  # Use Berkshelf for resolving cookbook dependencies
-  gem "berkshelf", ">= 7.0"
-
   # Use Test Kitchen with Vagrant for converging the build environment
   gem "test-kitchen", ">= 1.23"
   gem "kitchen-vagrant", ">= 1.3.1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The version of Berkshelf on the main branch causes chef-17 to pull in a version that targets Chef-18 and causes build/test failures. I created a branch that checks which version of Ruby is loaded and pulls in the correct version accordingly.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
