### PR TITLE
feat(apt_repository): Allow specifying arbitrary options

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -218,6 +218,7 @@
     "cookbookname",
     "copypasta",
     "coreutils",
+    "corretto",
     "cpio",
     "Crae",
     "CREAT",

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -98,6 +98,18 @@ class Chef
         end
         ```
 
+        **Add repository that needs custom options**:
+        ```ruby
+        apt_repository 'corretto' do
+          uri          'https://apt.corretto.aws'
+          arch         'amd64'
+          distribution 'stable'
+          components   ['main']
+          options      ['target-=Contents-deb']
+          key          'https://apt.corretto.aws/corretto.key'
+        end
+        ```
+
         **Remove a repository from the list**:
 
         ```ruby
@@ -158,6 +170,10 @@ class Chef
       property :cache_rebuild, [TrueClass, FalseClass],
         description: "Determines whether to rebuild the APT package cache.",
         default: true, desired_state: false
+
+      property :options, [String, Array],
+        description: "Additional options to set for the repository",
+        default: [], coerce: proc { |x| Array(x) }
 
       default_action :add
       allowed_actions :add, :remove
@@ -388,19 +404,21 @@ class Chef
         # @param [Array] components
         # @param [Boolean] trusted
         # @param [String] arch
+        # @param [Array] options
         # @param [Boolean] add_src
         #
         # @return [String] complete repo config text
-        def build_repo(uri, distribution, components, trusted, arch, add_src = false)
+        def build_repo(uri, distribution, components, trusted, arch, options, add_src = false)
           uri = make_ppa_url(uri) if is_ppa_url?(uri)
 
           uri = Addressable::URI.parse(uri)
           components = Array(components).join(" ")
-          options = []
-          options << "arch=#{arch}" if arch
-          options << "trusted=yes" if trusted
-          optstr = unless options.empty?
-                     "[" + options.join(" ") + "]"
+          options_list = []
+          options_list << "arch=#{arch}" if arch
+          options_list << "trusted=yes" if trusted
+          options_list += options
+          optstr = unless options_list.empty?
+                     "[" + options_list.join(" ") + "]"
                    end
           info = [ optstr, uri.normalize.to_s, distribution, components ].compact.join(" ")
           repo =  "deb      #{info}\n"
@@ -461,6 +479,7 @@ class Chef
           repo_components,
           new_resource.trusted,
           new_resource.arch,
+          new_resource.options,
           new_resource.deb_src
         )
 

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -246,33 +246,43 @@ C5986B4F1257FFA86632CBA746181433FBB75451
   describe "#build_repo" do
     it "creates a repository string" do
       target = "deb      http://test/uri unstable main\n"
-      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil)).to eql(target)
+      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, [])).to eql(target)
     end
 
     it "creates a repository string with spaces" do
       target = "deb      http://test/uri%20with%20spaces unstable main\n"
-      expect(provider.build_repo("http://test/uri with spaces", "unstable", "main", false, nil)).to eql(target)
+      expect(provider.build_repo("http://test/uri with spaces", "unstable", "main", false, nil, [])).to eql(target)
     end
 
     it "creates a repository string with no distribution" do
       target = "deb      http://test/uri main\n"
-      expect(provider.build_repo("http://test/uri", nil, "main", false, nil)).to eql(target)
+      expect(provider.build_repo("http://test/uri", nil, "main", false, nil, [])).to eql(target)
     end
 
     it "creates a repository string with source" do
       target = "deb      http://test/uri unstable main\ndeb-src  http://test/uri unstable main\n"
-      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, true)).to eql(target)
+      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, [], true)).to eql(target)
     end
 
-    it "creates a repository string with options" do
+    it "creates a repository string with trusted" do
       target = "deb      [trusted=yes] http://test/uri unstable main\n"
-      expect(provider.build_repo("http://test/uri", "unstable", "main", true, nil)).to eql(target)
+      expect(provider.build_repo("http://test/uri", "unstable", "main", true, nil, [])).to eql(target)
+    end
+
+    it "creates a repository string with custom options" do
+      target = "deb      [by-hash=no] http://test/uri unstable main\n"
+      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, ["by-hash=no"])).to eql(target)
+    end
+
+    it "creates a repository string with trusted, arch, and custom options" do
+      target = "deb      [arch=amd64 trusted=yes by-hash=no] http://test/uri unstable main\n"
+      expect(provider.build_repo("http://test/uri", "unstable", "main", true, "amd64", ["by-hash=no"])).to eql(target)
     end
 
     it "handles a ppa repo" do
       target = "deb      http://ppa.launchpad.net/chef/main/ubuntu unstable main\n"
       expect(provider).to receive(:make_ppa_url).with("ppa:chef/main").and_return("http://ppa.launchpad.net/chef/main/ubuntu")
-      expect(provider.build_repo("ppa:chef/main", "unstable", "main", false, nil)).to eql(target)
+      expect(provider.build_repo("ppa:chef/main", "unstable", "main", false, nil, [])).to eql(target)
     end
   end
 end

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -68,6 +68,11 @@ describe Chef::Resource::AptRepository do
     expect(resource.key).to eql(["key1"])
   end
 
+  it "allows setting options to a String and coerces it to an Array" do
+    resource.options = "by-hash=no"
+    expect(resource.options).to eql(["by-hash=no"])
+  end
+
   it "fails if the user provides a repo_name with a forward slash" do
     expect { resource.repo_name "foo/bar" }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
This allows specifying additional options to apt repositories, in addition to `trusted` and `arch`.

By using an array of strings we also allow using multivalue operators like -= and +=

## Related Issue
Fixes: #13727

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
