### PR TITLE
[chef-17] 19 of X - Refactoring the badssl.com code

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
@@ -5,7 +5,7 @@
 
 # First, grab it
 out = Mixlib::ShellOut.new(
-  %w{openssl s_client -showcerts -connect self-signed.badssl.com:443}
+  %w{openssl s_client -servername self-signed.badssl.com -showcerts -connect self-signed.badssl.com:443}
 ).run_command.stdout
 
 cert = Mixlib::ShellOut.new(%w{openssl x509}, input: out).run_command.stdout


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We switched to using a code block to update the certs we test with. It was mostly working but failed on Windows, Centos and Linux 2004 (Amazon and OracleLinux) with errors saying it could not verify the certificate against the website. The main culprit was that we were not providing enough specificity in the first shellOut. We have corrected that here

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
