### PR TITLE
remove eol warning

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -305,8 +305,6 @@ class Chef
         # keep this inside the main loop to get exception backtraces
         end_profiling
 
-        warn_if_eol
-
         # rebooting has to be the last thing we do, no exceptions.
         Chef::Platform::Rebooter.reboot_if_needed!(node)
       rescue Exception => run_error
@@ -334,19 +332,6 @@ class Chef
     # Private API
     # @todo make this stuff protected or private
     #
-
-    # @api private
-    def warn_if_eol
-      require_relative "version"
-
-      # We make a release every year so take the version you're on + 2006 and you get
-      # the year it goes EOL
-      eol_year = 2006 + Gem::Version.new(Chef::VERSION).segments.first
-
-      if Time.now > Time.new(eol_year, 5, 01)
-        logger.warn("This release of #{ChefUtils::Dist::Infra::PRODUCT} became end of life (EOL) on May 1st #{eol_year}. Please update to a supported release to receive new features, bug fixes, and security updates.")
-      end
-    end
 
     # @api private
     def configure_formatters

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -384,22 +384,6 @@ describe Chef::Client do
     end
   end
 
-  describe "eol release warning" do
-    it "warns when running an EOL release" do
-      stub_const("Chef::VERSION", 15)
-      allow(Time).to receive(:now).and_return(Time.new(2021, 5, 1, 5))
-      expect(logger).to receive(:warn).with(/This release of.*became end of life \(EOL\) on May 1st 2021/)
-      client.warn_if_eol
-    end
-
-    it "does not warn when running an non-EOL release" do
-      stub_const("Chef::VERSION", 15)
-      allow(Time).to receive(:now).and_return(Time.new(2021, 4, 31))
-      expect(logger).to_not receive(:warn).with(/became end of life/)
-      client.warn_if_eol
-    end
-  end
-
   describe "authentication protocol selection" do
     context "when FIPS is disabled" do
       before do


### PR DESCRIPTION
## Description
Since EOL is arbitrary based on company releases having a hard coded time doesn't make sense and is causing confusion when triggered and version is still active.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
