### PR TITLE
File exists? -> exist? deprecation

### DIFF
--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -440,7 +440,7 @@ class Chef
         def export_cert(cert_obj, output_path:, store_name:, store_location:, pfx_password:)
           # Delete the cert if it exists on disk already.
           # We want to ensure we're not randomly loading an old stinky cert.
-          if ::File.exists?(output_path)
+          if ::File.exist?(output_path)
             ::File.delete(output_path)
           end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
```
C:/projects/chef/lib/chef/resource/windows_certificate.rb:443:in `exists?': warning: File.exists? is deprecated; use File.exist? instead (StructuredWarnings::BuiltInWarning)
```

Note: we define `.exist?` methods, so need to research and confirm that we aren't invoking those still. Ultimately, we need to deal with the deprecation, but it could get messy.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
