### PR TITLE
[chef-17] 25 of X - Backport Checksum Validation

### DIFF
--- a/lib/chef/mixin/checksum.rb
+++ b/lib/chef/mixin/checksum.rb
@@ -31,6 +31,12 @@ class Chef
 
         checksum.slice(0, 6)
       end
+
+      def checksum_match?(ref_checksum, diff_checksum)
+        return false if ref_checksum.nil? || diff_checksum.nil?
+
+        ref_checksum.casecmp?(diff_checksum)
+      end
     end
   end
 end

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -336,7 +336,7 @@ class Chef
       end
 
       def do_validate_content
-        if new_resource.checksum && tempfile && ( new_resource.checksum != tempfile_checksum )
+        if new_resource.checksum && tempfile && !checksum_match?(new_resource.checksum, tempfile_checksum)
           raise Chef::Exceptions::ChecksumMismatch.new(short_cksum(new_resource.checksum), short_cksum(tempfile_checksum))
         end
 
@@ -450,7 +450,7 @@ class Chef
 
       def contents_changed?
         logger.trace "calculating checksum of #{tempfile.path} to compare with #{current_resource.checksum}"
-        tempfile_checksum != current_resource.checksum
+        !checksum_match?(tempfile_checksum, current_resource.checksum)
       end
 
       def tempfile

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -38,7 +38,7 @@ class Chef
         def define_resource_requirements
           if new_resource.checksum
             requirements.assert(:install) do |a|
-              a.assertion { new_resource.checksum == checksum(source_location) }
+              a.assertion { checksum_match?(new_resource.checksum, checksum(source_location)) }
               a.failure_message Chef::Exceptions::Package, "Checksum on resource (#{short_cksum(new_resource.checksum)}) does not match checksum on content (#{short_cksum(source_location)})"
             end
           end

--- a/spec/unit/mixin/checksum_spec.rb
+++ b/spec/unit/mixin/checksum_spec.rb
@@ -51,4 +51,32 @@ describe Chef::Mixin::Checksum do
     end
   end
 
+  describe "checksum_match?" do
+    context "when checksum cases match" do
+      it "returns true" do
+        expect(@checksum_user.checksum_match?("u7ghbxikk3i9blsimmy2y2ionmxx", "u7ghbxikk3i9blsimmy2y2ionmxx")).to be true
+      end
+    end
+
+    context "when one checksum is uppercase and other is lowercase" do
+      it "returns true" do
+        expect(@checksum_user.checksum_match?("U7GHBXIKK3I9BLSIMMY2Y2IONMXX", "u7ghbxikk3i9blsimmy2y2ionmxx")).to be true
+      end
+    end
+
+    context "when checksums do not match" do
+      it "returns false" do
+        expect(@checksum_user.checksum_match?("u7ghbxikk3i9blsimmy2y2ionmxx", "09ee9c8cc70501763563bcf9c218")).to be false
+      end
+    end
+
+    context "when checksum is nil" do
+      it "returns false" do
+        expect(@checksum_user.checksum_match?("u7ghbxikk3i9blsimmy2y2ionmxx", nil)).to be false
+        expect(@checksum_user.checksum_match?(nil, "09ee9c8cc70501763563bcf9c218")).to be false
+        expect(@checksum_user.checksum_match?(nil, nil)).to be false
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Original PR: https://github.com/chef/chef/pull/13210.

This fixes a bug where checksum validation fails when creating/updating files because the two checksums are in different letter cases. The existing checksum validation logic was using case sensitive equality checks.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
