### PR TITLE
[chef-17] 27 of X - Updating EOL Support, Again

### DIFF
--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -321,6 +321,8 @@ describe Chef::Client do
 
     it "does not warn when running an non-EOL release" do
       stub_const("Chef::VERSION", 15)
+      # added a call to client because Time.now gets invoked multiple times during instantiation. Don't mock Time until after client initialized
+      client
       allow(Time).to receive(:now).and_return(Time.new(2021, 4, 31))
       expect(logger).to_not receive(:warn).with(/became end of life/)
       client.warn_if_eol


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Tests are failing on all Linux flavors but pass on Windows. Tweaking the second test to match the first so the Time.now value is consistent.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
