### PR TITLE
Rollback omnibus-software 23.5.289 -> 23.3.287

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: a63bd71702f5bf350ca17ee0726ac36fc418d54e
+  revision: f06bbea744458f2cb63c98e6891f9cfb904a1f90
   branch: main
   specs:
     omnibus-software (23.5.289)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -19,10 +19,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 6a1c8896edf6c5606facc83b75ecaacf22019e2b
+  revision: a63bd71702f5bf350ca17ee0726ac36fc418d54e
   branch: main
   specs:
-    omnibus-software (23.3.287)
+    omnibus-software (4.0.0)
       omnibus (>= 9.0.0)
 
 GIT

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: a1ed55c2e0fdeb06b3c3f3041fe4d0c563233ba4
+  revision: 124d5960ab2d3ed15b321d12d8da5b475631e16b
   branch: main
   specs:
     omnibus (8.3.2)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -22,15 +22,15 @@ GIT
   revision: a63bd71702f5bf350ca17ee0726ac36fc418d54e
   branch: main
   specs:
-    omnibus-software (4.0.0)
-      omnibus (>= 9.0.0)
+    omnibus-software (23.5.289)
+      omnibus (>= 8.0.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
   revision: a1ed55c2e0fdeb06b3c3f3041fe4d0c563233ba4
   branch: main
   specs:
-    omnibus (9.0.18)
+    omnibus (8.3.2)
       aws-sdk-s3 (~> 1.116.0)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -19,10 +19,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: f06bbea744458f2cb63c98e6891f9cfb904a1f90
+  revision: 6a1c8896edf6c5606facc83b75ecaacf22019e2b
   branch: main
   specs:
-    omnibus-software (23.5.289)
+    omnibus-software (23.3.287)
       omnibus (>= 9.0.0)
 
 GIT

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -19,10 +19,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: f06bbea744458f2cb63c98e6891f9cfb904a1f90
+  revision: 769445f0a0b2a06356d70524ab922f7ce88761a3
   branch: main
   specs:
-    omnibus-software (23.5.289)
+    omnibus-software (4.0.0)
       omnibus (>= 8.0.0)
 
 GIT


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Roll back to an omnibus-software version that doesn't produce the following error

```
PS C:\Users\Administrator> chef-client
<internal:C:/opscode/chef/embedded/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': 126: The specifi
ed module could not be found.   - C:/opscode/chef/embedded/lib/ruby/3.0.0/x64-mingw32/openssl.so (LoadError)
        from <internal:C:/opscode/chef/embedded/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from C:/opscode/chef/embedded/lib/ruby/3.0.0/openssl.rb:15:in `<top (required)>'
        from <internal:C:/opscode/chef/embedded/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:C:/opscode/chef/embedded/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from C:/opscode/chef/bin/chef-client:9:in `<main>'
```

[Diff of the Omnibus changes](https://github.com/chef/omnibus-software/compare/23.3.287...23.5.289) implicated in the working vs broken builds]

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
