### PR TITLE
Optimize Chef::CookbookSynchronizer#remove_deleted_files

### DIFF
--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -219,14 +219,31 @@ class Chef
 
     # remove deleted files in cookbooks that are being used on the node
     def remove_deleted_files
+      cache_file_hash = {}
+      @cookbooks_by_name.each_key do |k|
+        cache_file_hash[k] = {}
+      end
+
+      # First populate files from cache
       cache.find(File.join(%w{cookbooks ** {*,.*}})).each do |cache_file|
         md = cache_file.match(%r{^cookbooks/([^/]+)/([^/]+)/(.*)})
         next unless md
 
-        ( cookbook_name, segment, file ) = md[1..3]
+        (cookbook_name, segment, file) = md[1..3]
         if have_cookbook?(cookbook_name)
+          cache_file_hash[cookbook_name][segment] ||= {}
+          cache_file_hash[cookbook_name][segment]["#{segment}/#{file}"] = cache_file
+        end
+      end
+      # Determine which files don't match manifest
+      @cookbooks_by_name.each_key do |cookbook_name|
+        cache_file_hash[cookbook_name].each_key do |segment|
           manifest_segment = cookbook_segment(cookbook_name, segment)
-          if manifest_segment.select { |manifest_record| manifest_record["path"] == "#{segment}/#{file}" }.empty?
+          manifest_record_paths = manifest_segment.map { |manifest_record| manifest_record["path"] }
+          to_be_removed = cache_file_hash[cookbook_name][segment].keys - manifest_record_paths
+          to_be_removed.each do |path|
+            cache_file = cache_file_hash[cookbook_name][segment][path]
+
             Chef::Log.info("Removing #{cache_file} from the cache; its is no longer in the cookbook manifest.")
             cache.delete(cache_file)
             @events.removed_cookbook_file(cache_file)

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -18,6 +18,7 @@ require_relative "../util/threaded_job_queue"
 require_relative "../server_api"
 require "singleton" unless defined?(Singleton)
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
+require "set" unless defined?(Set)
 
 class Chef
 
@@ -239,8 +240,8 @@ class Chef
       @cookbooks_by_name.each_key do |cookbook_name|
         cache_file_hash[cookbook_name].each_key do |segment|
           manifest_segment = cookbook_segment(cookbook_name, segment)
-          manifest_record_paths = manifest_segment.map { |manifest_record| manifest_record["path"] }
-          to_be_removed = cache_file_hash[cookbook_name][segment].keys - manifest_record_paths
+          manifest_record_paths = manifest_segment.map { |manifest_record| manifest_record["path"] }.to_set
+          to_be_removed = cache_file_hash[cookbook_name][segment].keys.to_set - manifest_record_paths
           to_be_removed.each do |path|
             cache_file = cache_file_hash[cookbook_name][segment][path]
 


### PR DESCRIPTION
## Description
The existing implementation of the remove_deleted_files method is inefficient on large numbers of cached files.

As an example, assume you have 100 active cookbooks with 25 recipes each. In the old code, this meant:
- [`cookbook_segment`](https://github.com/dafyddcrosby/chef/blob/main/lib/chef/cookbook/synchronizer.rb#L115) called 2500 times (which isn't cheap, see [files_for](https://github.com/dafyddcrosby/chef/blob/main/lib/chef/cookbook_manifest.rb#L173))
- `manifest_segment.select` bit means 2500 array creations, with 25 manifest_record comparisons for every file (62,500 total)

The proposed new version:
- `cookbook_segment` called 100 times
- `manifest_record_paths` has 100 array creations
- `to_be_removed` has 100 arrays created, 100 array comparisons

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
