### PR TITLE
update ::File.exists? to ::File.exist?

### DIFF
--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -525,7 +525,7 @@ RSpec.describe ChefConfig::Config do
 
           context "when /var/chef does not exist and /var is accessible" do
             it "defaults to /var/chef" do
-              allow(File).to receive(:exists?).with(ChefConfig::Config.var_chef_dir).and_return(false)
+              allow(File).to receive(:exist?).with(ChefConfig::Config.var_chef_dir).and_return(false)
               allow(ChefConfig::Config).to receive(:path_accessible?).with(ChefConfig::Config.var_root_dir).and_return(true)
               expect(ChefConfig::Config[:cache_path]).to eq(primary_cache_path)
             end
@@ -533,7 +533,7 @@ RSpec.describe ChefConfig::Config do
 
           context "when /var/chef does not exist and /var is not accessible" do
             it "defaults to $HOME/.chef" do
-              allow(File).to receive(:exists?).with(ChefConfig::Config.var_chef_dir).and_return(false)
+              allow(File).to receive(:exist?).with(ChefConfig::Config.var_chef_dir).and_return(false)
               allow(ChefConfig::Config).to receive(:path_accessible?).with(ChefConfig::Config.var_root_dir).and_return(false)
               expect(ChefConfig::Config[:cache_path]).to eq(secondary_cache_path)
             end
@@ -541,7 +541,7 @@ RSpec.describe ChefConfig::Config do
 
           context "when /var/chef exists and is not accessible" do
             before do
-              allow(File).to receive(:exists?).with(ChefConfig::Config.var_chef_dir).and_return(true)
+              allow(File).to receive(:exist?).with(ChefConfig::Config.var_chef_dir).and_return(true)
               allow(File).to receive(:readable?).with(ChefConfig::Config.var_chef_dir).and_return(true)
               allow(File).to receive(:writable?).with(ChefConfig::Config.var_chef_dir).and_return(false)
             end

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -663,7 +663,7 @@ class Chef
           logger.trace("New client keys created in the Certificate Store - skipping registration")
         end
         events.skipping_registration(client_name, config)
-      elsif File.exists?(config[:client_key])
+      elsif File.exist?(config[:client_key])
         events.skipping_registration(client_name, config)
         logger.trace("Client key #{config[:client_key]} is present - skipping registration")
       else
@@ -1069,7 +1069,7 @@ class Chef
     end
 
     def empty_directory?(path)
-      !File.exists?(path) || (Dir.entries(path).size <= 2)
+      !File.exist?(path) || (Dir.entries(path).size <= 2)
     end
 
     def is_last_element?(index, object)

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -474,7 +474,7 @@ class Chef
     end
 
     def reload_metadata!
-      if File.exists?(metadata_json_file)
+      if File.exist?(metadata_json_file)
         metadata.from_json(IO.read(metadata_json_file))
       end
     end

--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -103,10 +103,10 @@ class Chef
         unless config[:ssl_client_cert] && config[:ssl_client_key]
           raise Chef::Exceptions::ConfigurationError, "You must configure ssl_client_cert and ssl_client_key together"
         end
-        unless ::File.exists?(config[:ssl_client_cert])
+        unless ::File.exist?(config[:ssl_client_cert])
           raise Chef::Exceptions::ConfigurationError, "The configured ssl_client_cert #{config[:ssl_client_cert]} does not exist"
         end
-        unless ::File.exists?(config[:ssl_client_key])
+        unless ::File.exist?(config[:ssl_client_key])
           raise Chef::Exceptions::ConfigurationError, "The configured ssl_client_key #{config[:ssl_client_key]} does not exist"
         end
 

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -52,7 +52,7 @@ class Chef
       end
 
       action :delete, description: "Delete a launchd property list. This will unload a daemon or agent, if loaded." do
-        if ::File.exists?(path)
+        if ::File.exist?(path)
           manage_service(:disable)
         end
         manage_plist(:delete)

--- a/lib/chef/provider/mount/linux.rb
+++ b/lib/chef/provider/mount/linux.rb
@@ -39,7 +39,7 @@ class Chef
 
         def mounted?
           mounted = false
-          real_mount_point = if ::File.exists? @new_resource.mount_point
+          real_mount_point = if ::File.exist? @new_resource.mount_point
                                ::File.realpath(@new_resource.mount_point)
                              else
                                @new_resource.mount_point

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -42,9 +42,9 @@ class Chef
 
         def mountable?
           # only check for existence of non-remote devices
-          if device_should_exist? && !::File.exists?(device_real)
+          if device_should_exist? && !::File.exist?(device_real)
             raise Chef::Exceptions::Mount, "Device #{@new_resource.device} does not exist"
-          elsif @new_resource.mount_point != "none" && !::File.exists?(@new_resource.mount_point)
+          elsif @new_resource.mount_point != "none" && !::File.exist?(@new_resource.mount_point)
             raise Chef::Exceptions::Mount, "Mount point #{@new_resource.mount_point} does not exist"
           end
 
@@ -81,7 +81,7 @@ class Chef
           # "mount" outputs the mount points as real paths. Convert
           # the mount_point of the resource to a real path in case it
           # contains symlinks in its parents dirs.
-          real_mount_point = if ::File.exists? @new_resource.mount_point
+          real_mount_point = if ::File.exist? @new_resource.mount_point
                                ::File.realpath(@new_resource.mount_point)
                              else
                                @new_resource.mount_point

--- a/spec/functional/resource/execute_spec.rb
+++ b/spec/functional/resource/execute_spec.rb
@@ -62,7 +62,7 @@ describe Chef::Resource::Execute do
   end
 
   describe "when parent resource sets :cwd" do
-    let(:guard) { %{ruby -e 'exit 1 unless File.exists?("./nested.json")'} }
+    let(:guard) { %{ruby -e 'exit 1 unless File.exist?("./nested.json")'} }
 
     it "guard inherits :cwd from resource and runs" do
       resource.cwd CHEF_SPEC_DATA

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -119,8 +119,8 @@ shared_context "a client run" do
     #   Make sure Client#register thinks the client key doesn't
     #   exist, so it tries to register and create one.
     allow(Chef::HTTP::Authenticator).to receive(:detect_certificate_key).with(fqdn).and_return(false)
-    allow(File).to receive(:exists?).and_call_original
-    expect(File).to receive(:exists?)
+    allow(File).to receive(:exist?).and_call_original
+    expect(File).to receive(:exist?)
       .with(Chef::Config[:client_key])
       .exactly(:once)
       .and_return(api_client_exists?)

--- a/spec/unit/provider/launchd_spec.rb
+++ b/spec/unit/provider/launchd_spec.rb
@@ -197,7 +197,7 @@ describe Chef::Provider::Launchd do
     describe "with an :delete action" do
       describe "and the ld file is present" do
         before(:each) do
-          allow(File).to receive(:exists?).and_return(true)
+          allow(File).to receive(:exist?).and_return(true)
           allow(provider).to receive(
             :manage_service
           ).with(:disable).and_return(true)
@@ -218,7 +218,7 @@ describe Chef::Provider::Launchd do
 
       describe "and the ld file is not present" do
         before(:each) do
-          allow(File).to receive(:exists?).and_return(false)
+          allow(File).to receive(:exist?).and_return(false)
           allow(provider).to receive(
             :manage_plist
           ).with(:delete).and_return(true)

--- a/spec/unit/provider/mount/aix_spec.rb
+++ b/spec/unit/provider/mount/aix_spec.rb
@@ -65,8 +65,8 @@ describe Chef::Provider::Mount::Aix do
 
     @provider = Chef::Provider::Mount::Aix.new(@new_resource, @run_context)
 
-    allow(::File).to receive(:exists?).with("/dev/sdz1").and_return true
-    allow(::File).to receive(:exists?).with("/tmp/foo").and_return true
+    allow(::File).to receive(:exist?).with("/dev/sdz1").and_return true
+    allow(::File).to receive(:exist?).with("/tmp/foo").and_return true
   end
 
   def stub_mounted(provider, mounted_output)

--- a/spec/unit/provider/mount/linux_spec.rb
+++ b/spec/unit/provider/mount/linux_spec.rb
@@ -22,10 +22,11 @@ describe Chef::Provider::Mount::Linux do
   end
 
   before(:each) do
-    allow(::File).to receive(:exists?).with("/dev/sdz1").and_return true
-    allow(::File).to receive(:exists?).with("/tmp/foo").and_return true
-    allow(::File).to receive(:exists?).with("//192.168.11.102/Share/backup").and_return true
-    allow(::File).to receive(:exists?).with("//192.168.11.102/Share/backup folder").and_return true
+    allow(::File).to receive(:exist?).with("/etc/fstab").and_call_original
+    allow(::File).to receive(:exist?).with("/dev/sdz1").and_return true
+    allow(::File).to receive(:exist?).with("/tmp/foo").and_return true
+    allow(::File).to receive(:exist?).with("//192.168.11.102/Share/backup").and_return true
+    allow(::File).to receive(:exist?).with("//192.168.11.102/Share/backup folder").and_return true
     allow(::File).to receive(:realpath).with("/dev/sdz1").and_return "/dev/sdz1"
     allow(::File).to receive(:realpath).with("/tmp/foo").and_return "/tmp/foo"
   end

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -34,8 +34,8 @@ describe Chef::Provider::Mount::Mount do
 
     @provider = Chef::Provider::Mount::Mount.new(@new_resource, @run_context)
 
-    allow(::File).to receive(:exists?).with("/dev/sdz1").and_return true
-    allow(::File).to receive(:exists?).with("/tmp/foo").and_return true
+    allow(::File).to receive(:exist?).with("/dev/sdz1").and_return true
+    allow(::File).to receive(:exist?).with("/tmp/foo").and_return true
     allow(::File).to receive(:realpath).with("/dev/sdz1").and_return "/dev/sdz1"
     allow(::File).to receive(:realpath).with("/tmp/foo").and_return "/tmp/foo"
   end
@@ -83,12 +83,12 @@ describe Chef::Provider::Mount::Mount do
     end
 
     it "should raise an error if the mount device does not exist" do
-      allow(::File).to receive(:exists?).with("/dev/sdz1").and_return false
+      allow(::File).to receive(:exist?).with("/dev/sdz1").and_return false
       expect { @provider.load_current_resource; @provider.mountable? }.to raise_error(Chef::Exceptions::Mount)
     end
 
     it "should not call mountable? with load_current_resource - CHEF-1565" do
-      allow(::File).to receive(:exists?).with("/dev/sdz1").and_return false
+      allow(::File).to receive(:exist?).with("/dev/sdz1").and_return false
       expect(@provider).to receive(:mounted?).and_return(true)
       expect(@provider).to receive(:enabled?).and_return(true)
       expect(@provider).not_to receive(:mountable?)
@@ -100,12 +100,12 @@ describe Chef::Provider::Mount::Mount do
       @new_resource.device_type :uuid
       @new_resource.device "d21afe51-a0fe-4dc6-9152-ac733763ae0a"
       expect(@provider).to receive(:shell_out_compacted).with("/sbin/findfs", "UUID=d21afe51-a0fe-4dc6-9152-ac733763ae0a").and_return(status)
-      expect(::File).to receive(:exists?).with("").and_return(false)
+      expect(::File).to receive(:exist?).with("").and_return(false)
       expect { @provider.load_current_resource; @provider.mountable? }.to raise_error(Chef::Exceptions::Mount)
     end
 
     it "should raise an error if the mount point does not exist" do
-      allow(::File).to receive(:exists?).with("/tmp/foo").and_return false
+      allow(::File).to receive(:exist?).with("/tmp/foo").and_return false
       expect { @provider.load_current_resource; @provider.mountable? }.to raise_error(Chef::Exceptions::Mount)
     end
 
@@ -521,8 +521,8 @@ describe Chef::Provider::Mount::Mount do
 
         @provider = Chef::Provider::Mount::Mount.new(@new_resource, @run_context)
 
-        allow(::File).to receive(:exists?).with("cephserver:6789:/").and_return true
-        allow(::File).to receive(:exists?).with("/tmp/bar").and_return true
+        allow(::File).to receive(:exist?).with("cephserver:6789:/").and_return true
+        allow(::File).to receive(:exist?).with("/tmp/bar").and_return true
         allow(::File).to receive(:realpath).with("cephserver:6789:/").and_return "cephserver:6789:/"
         allow(::File).to receive(:realpath).with("/tmp/bar").and_return "/tmp/foo"
       end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -41,7 +41,7 @@ describe Chef::Provider::Package::Rpm do
   let(:rpm_q_status) { instance_double("Mixlib::ShellOut", exitstatus: rpm_q_exitstatus, stdout: rpm_q_stdout) }
 
   before(:each) do
-    allow(::File).to receive(:exist?).with("PLEASE STUB File.exists? EXACTLY").and_return(true)
+    allow(::File).to receive(:exist?).with("PLEASE STUB File.exist? EXACTLY").and_return(true)
 
     # Ensure all shell out usage is stubbed with exact arguments
     allow(provider).to receive(:shell_out_compacted!).with("PLEASE STUB YOUR SHELLOUT CALLS").and_return(nil)
@@ -412,7 +412,7 @@ describe Chef::Provider::Package::Rpm do
 
     let(:new_resource) do
       # When we pass a source in as the name, then #initialize in the
-      # provider will call File.exists?. Because of the ordering in our
+      # provider will call File.exist?. Because of the ordering in our
       # let() bindings and such, we have to set the stub here and not in a
       # before block.
       allow(::File).to receive(:exist?).with(package_source).and_return(true)


### PR DESCRIPTION
## Description

This removes all uses of deprecated `::File.exists?` so that when Chef adopts Ruby 3.2 there won't be problems. This is also helpful for folks who happen to use Ruby 3.2 when unit testing Chef outside of Chef Workstation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
