### PR TITLE
Attempt to explicitly include Resolv

### DIFF
--- a/lib/chef/monkey_patches/net-http.rb
+++ b/lib/chef/monkey_patches/net-http.rb
@@ -76,7 +76,7 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
           # to IP address
           verify_hostname = @ssl_context.verify_hostname
 
-          require 'resolv' unless defined?(Resolv)
+          require "resolv" unless defined?(Resolv)
           # Server Name Indication (SNI) RFC 3546/6066
           case @address
           when ::Resolv::IPv4::Regex, ::Resolv::IPv6::Regex

--- a/lib/chef/monkey_patches/net-http.rb
+++ b/lib/chef/monkey_patches/net-http.rb
@@ -1,6 +1,5 @@
 if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
   require "net/http" unless defined?(Net::HTTP)
-  require "resolv" unless defined?(Resolv)
   # This is monkey-patch for ruby 3.1.x
   # Due to change https://github.com/ruby/net-http/pull/10, when making net/http requests to a url which supports only IPv6 and not IPv4,
   # ruby waits for IPv4 request to timeout first, then makes IPv6 request. This increased response time.
@@ -79,7 +78,7 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
 
           # Server Name Indication (SNI) RFC 3546/6066
           case @address
-          when Resolv::IPv4::Regex, Resolv::IPv6::Regex
+          when ::Resolv::IPv4::Regex, ::Resolv::IPv6::Regex
             # don't set SNI, as IP addresses in SNI is not valid
             # per RFC 6066, section 3.
 

--- a/lib/chef/monkey_patches/net-http.rb
+++ b/lib/chef/monkey_patches/net-http.rb
@@ -76,7 +76,10 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
           # to IP address
           verify_hostname = @ssl_context.verify_hostname
 
+          # requiring 'resolv' near the top of the file causes registry.rb monkey patch to fail
+          # Windows 2012 R2 somehow fails to have Resolv defined unless we require it manually
           require "resolv" unless defined?(Resolv)
+
           # Server Name Indication (SNI) RFC 3546/6066
           case @address
           when ::Resolv::IPv4::Regex, ::Resolv::IPv6::Regex

--- a/lib/chef/monkey_patches/net-http.rb
+++ b/lib/chef/monkey_patches/net-http.rb
@@ -1,5 +1,6 @@
 if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
   require "net/http" unless defined?(Net::HTTP)
+  require "resolv" unless defined?(Resolv)
   # This is monkey-patch for ruby 3.1.x
   # Due to change https://github.com/ruby/net-http/pull/10, when making net/http requests to a url which supports only IPv6 and not IPv4,
   # ruby waits for IPv4 request to timeout first, then makes IPv6 request. This increased response time.

--- a/lib/chef/monkey_patches/net-http.rb
+++ b/lib/chef/monkey_patches/net-http.rb
@@ -76,6 +76,7 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
           # to IP address
           verify_hostname = @ssl_context.verify_hostname
 
+          require 'resolv' unless defined?(Resolv)
           # Server Name Indication (SNI) RFC 3546/6066
           case @address
           when ::Resolv::IPv4::Regex, ::Resolv::IPv6::Regex


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Something with Windows 2012r2 loading makes `Resolv` interpreted as in the namespace of `Net::HTTP`:

```
# NameError:
--
  | #   uninitialized constant Net::HTTP::Resolv
  | #
  | #             when Resolv::IPv4::Regex, Resolv::IPv6::Regex

```



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
