### PR TITLE
Added the license functionality for the knife commands

### DIFF
--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -24,3 +24,7 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "main"
 gem "chef", path: ".."
 gem "chef-utils", path: File.expand_path("../chef-utils", __dir__) if File.exist?(File.expand_path("../chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("../chef-config", __dir__) if File.exist?(File.expand_path("../chef-config", __dir__))
+
+source "https://artifactory-internal.ps.chef.co/artifactory/api/gems/omnibus-gems-local/" do
+  gem "chef-licensing"
+end

--- a/knife/knife.gemspec
+++ b/knife/knife.gemspec
@@ -44,6 +44,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "proxifier2", "~> 1.1"
 
+  # s.add_dependency "chef-licensing", "~> 0.4"
+
   s.bindir       = "bin"
   s.executables  = %w{ knife }
 

--- a/knife/lib/chef/application/knife.rb
+++ b/knife/lib/chef/application/knife.rb
@@ -197,7 +197,7 @@ class Chef::Application::Knife < Chef::Application
     @ui.error "Software not entitled"
     exit(1)
   rescue ChefLicensing::Error => e
-    Chef::Log.warn "No license keys found on disk"
+    Chef::Log.error "No license keys found on disk"
     @ui.output "Please generate license first by running chef license command"
     exit(1)
   end

--- a/knife/lib/chef/application/knife.rb
+++ b/knife/lib/chef/application/knife.rb
@@ -173,18 +173,16 @@ class Chef::Application::Knife < Chef::Application
   private
 
   def validate_license_and_entitlement
-    begin
     @ui = Chef::Knife::UI.new(STDOUT, STDERR, STDIN, config)
     ChefLicensing.check_software_entitlement!
-    rescue ChefLicensing::SoftwareNotEntitled
-      Chef::Log.error "License is not entitled to use Knife."
-      @ui.error "Software not entitled"
-      exit(1)
-    rescue ChefLicensing::Error => e
-      Chef::Log.warn "No license keys found on disk"
-      @ui.output "Please generate license first by running chef license command"
-      exit(1)
-    end
+  rescue ChefLicensing::SoftwareNotEntitled
+    Chef::Log.error "License is not entitled to use Knife."
+    @ui.error "Software not entitled"
+    exit(1)
+  rescue ChefLicensing::Error => e
+    Chef::Log.warn "No license keys found on disk"
+    @ui.output "Please generate license first by running chef license command"
+    exit(1)
   end
 
   def quiet_traps

--- a/knife/lib/chef/application/knife.rb
+++ b/knife/lib/chef/application/knife.rb
@@ -173,12 +173,12 @@ class Chef::Application::Knife < Chef::Application
   private
 
   def check_license_flag
-    license_feature = File.join(Dir.home, ".chef/license_feature.json")
+    license_feature = File.join(Dir.home, ".chef/fbffb2ea48910514676e1b7a51c7248290ea958c")
     if ARGV.length > 0 && ARGV[0] != "license"
       File.exist?(license_feature) ? true : false
       # puts "Please enable license to use it - knife license enable true"
     elsif ARGV.length > 1 && ARGV[1] == "enable" && ARGV[2] == "true"
-      File.open(File.join(Dir.home, ".chef/license_feature.json"), "w") { |f| f.write("true") }
+      File.open(File.join(Dir.home, ".chef/fbffb2ea48910514676e1b7a51c7248290ea958c"), "w") { |f| f.write("true") }
       puts "Now you can use knife with the license feature"
       exit 0
     elsif ARGV.length > 1 && ARGV[1] == "enable" && ARGV[2] == "false"

--- a/knife/lib/chef/application/knife.rb
+++ b/knife/lib/chef/application/knife.rb
@@ -178,14 +178,14 @@ class Chef::Application::Knife < Chef::Application
       File.exist?(license_feature) ? true : false
       # puts "Please enable license to use it - knife license enable true"
     elsif ARGV.length > 1 && ARGV[1] == "enable" && ARGV[2] == "true"
-      File.open(File.join(Dir.home, ".chef/license_feature.json"), 'w') {|f| f.write("true") }
+      File.open(File.join(Dir.home, ".chef/license_feature.json"), "w") { |f| f.write("true") }
       puts "Now you can use knife with the license feature"
       exit 0
     elsif ARGV.length > 1 && ARGV[1] == "enable" && ARGV[2] == "false"
       File.exist?(license_feature) ? File.delete(license_feature) : (puts "Unable to disable the license feature")
       exit 0
     else
-      return false
+      false
     end
   end
 

--- a/knife/lib/chef/utils/licensing_config.rb
+++ b/knife/lib/chef/utils/licensing_config.rb
@@ -1,0 +1,6 @@
+require "chef-licensing"
+ChefLicensing.configure do |config|
+  config.chef_product_name = "Workstation"
+  config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
+  config.chef_executable_name = "Workstation"
+end


### PR DESCRIPTION

## Description
Added the license validation and software entitlement functionality for the knife commands except `( knife/knife --help|-h/ Knife --version|-v)`. The other commands will check for the license and software entitled or not. If not than the user would be ask to generate the license first. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
