### PR TITLE
For building linux-aarch64 support for Effortless pattern

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1130,6 +1130,7 @@
     "rname",
     "roundrobin",
     "rpartition",
+    "rpath",
     "rpmdb",
     "rpmdep",
     "rpmds",

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -82,6 +82,7 @@ do_prepare() {
     bundle config --local shebang "$(pkg_path_for "$_chef_client_ruby")/bin/ruby"
     bundle config --local retry 5
     bundle config --local silence_root_warning 1
+    bundle config --local build.ffi "--with-ldflags=-Wl,-rpath=${LD_RUN_PATH}"
   )
 
   build_line "Setting link for /usr/bin/env to 'coreutils'"
@@ -97,6 +98,7 @@ do_build() {
     build_line "Installing gems from git repos properly ..."
     ruby ./post-bundle-install.rb
     build_line "Installing this project's gems ..."
+    fix_interpreter "${pkg_prefix}/vendor/bin/*" "$_chef_client_ruby" ruby
     bundle exec rake install:local
   )
 }
@@ -105,7 +107,6 @@ do_install() {
   ( cd "$pkg_prefix" || exit_with "unable to enter pkg prefix directory" 1
     export BUNDLE_GEMFILE="${CACHE_PATH}/Gemfile"
     build_line "** fixing binstub shebangs"
-    fix_interpreter "${pkg_prefix}/vendor/bin/*" "$_chef_client_ruby" bin/ruby
     export BUNDLE_GEMFILE="${CACHE_PATH}/Gemfile"
     for gem in chef-bin chef inspec-core-bin ohai; do
       build_line "** generating binstubs for $gem with precise version pins"


### PR DESCRIPTION
For building linux-aarch64 target for testing effortless pattern for linux-aarch64 target.

## Description
nitially we were getting build error for linux-aarch64 target, after adding "fix_interpreter "${pkg_prefix}/vendor/bin/*" "$_chef_client_ruby" ruby" build was successful. But still getting runtime error while running "chef -version". So then we added line "bundle config --local build.ffi "--with-ldflags=-Wl,-rpath=${LD_RUN_PATH}"

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
