### PR TITLE
Attempt to make berkshelf / kitchen-tests use current chef instead of ruby gems. DO NOT MERGE

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -207,9 +207,9 @@ jobs:
         gem list chef | grep "chef " | sed 's/^.*(\(.*\)).*$/\1/' | awk 'BEGIN {RS=", "} {if(NR>1) {print $0}}' | xargs -I {} gem uninstall chef -Ixv {}
         # gem list chef # debug the aftermath of bundle install
         # use the chef we just installed instead of network install
-        bundle exec rake build
+        #bundle exec rake build
 
-        gem list chef # debug
+        #gem list chef # debug
         echo "post gem install ohai / aruba"
         gem install --local `ls pkg/*.gem`
         gem list chef # debug

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -186,12 +186,7 @@ jobs:
 
         cd /Users/runner/work/chef/chef/kitchen-tests
         sudo berks vendor cookbooks
-        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
-    - name: 'Dump stacktrace if failure'
-      id: dump_stacktrace
-      if: ${{ failure() }}
-      run: |
-        sudo cat /Users/runner/.chef/local-mode-cache/cache/chef-stacktrace.out
+        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist || sudo cat /Users/runner/.chef/local-mode-cache/cache/chef-stacktrace.out
 
   linux:
     strategy:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -175,10 +175,15 @@ jobs:
         cd /Users/runner/work/chef/chef
         sudo bundle install
         cd kitchen-tests
+        echo ">>> bundle install"
         sudo bundle install --jobs=3 --retry=3
+        echo ">>> gem install kitchen"
         sudo gem install kitchen
+        echo ">>> gem install berkshelf"
         sudo gem install berkshelf --no-doc
+        echo ">>> berks vendor cookbooks"
         sudo berks vendor cookbooks
+        echo ">>> chef-client -z"
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
 
   linux:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-latest]
         ruby: ["3.1"] # macos-11.0 is not public for now
     runs-on: ${{ matrix.os }}
     steps:
@@ -175,15 +175,17 @@ jobs:
         cd /Users/runner/work/chef/chef
         sudo bundle install
         cd kitchen-tests
-        echo ">>> bundle install"
         sudo bundle install --jobs=3 --retry=3
-        echo ">>> gem install kitchen"
         sudo gem install kitchen
-        echo ">>> gem install berkshelf"
-        sudo gem install berkshelf --no-doc
-        echo ">>> berks vendor cookbooks"
+
+        cd /Users/runner/work/chef
+        git clone https://github.com/chef/berkshelf
+
+        cd berkshelf
+        sudo rake install
+
+        cd /Users/runner/work/chef/chef/kitchen-tests
         sudo berks vendor cookbooks
-        echo ">>> chef-client -z"
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
 
   linux:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -174,6 +174,8 @@ jobs:
         bundle --version
         cd /Users/runner/work/chef/chef
         sudo bundle install
+        # otherwise we only use rubygems
+        sudo rake install:local
         cd kitchen-tests
         sudo bundle install --jobs=3 --retry=3
         sudo gem install kitchen
@@ -186,8 +188,7 @@ jobs:
 
         cd /Users/runner/work/chef/chef/kitchen-tests
         sudo berks vendor cookbooks
-        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist || echo "it broke"
-        sudo cat /Users/runner/.chef/local-mode-cache/cache/chef-stacktrace.out
+        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
   linux:
     strategy:
       fail-fast: false

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -187,7 +187,7 @@ jobs:
         cd berkshelf
 
         # use the chef we just installed instead of network install
-        bundle install rake install:local
+        bundle exec rake install:local
 
         cd /Users/runner/work/chef/chef/kitchen-tests
         berks vendor cookbooks

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-12]
         ruby: ["3.1"] # macos-11.0 is not public for now
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -190,6 +190,7 @@ jobs:
         # use the chef we just installed instead of network install
         bundle exec rake build
 
+        gem install ohai # because we're doing a local install
         gem install --local `ls pkg/*.gem`
         cd /Users/runner/work/chef/chef/kitchen-tests
         berks vendor cookbooks

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -93,6 +93,7 @@ jobs:
 
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
+        echo $env:GITHUB_SHA
         appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
         Write-Output "Installed Chef / Ohai release:"

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -197,7 +197,9 @@ jobs:
         # gem install ohai # because we're doing a local install
         # gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
         # gem install cucumber -v "3.1.0" # because we didn't bundle berkshelf
-        bundle install # this is grabbing 17.10.* Chef, which also breaks the test
+        # bundle install # this is grabbing 17.10.* Chef, which also breaks the test
+        gem build berkshelf.gem spec
+        mv *.gem pkg/
 
         # just remove all but the most recent chefs
         gem list chef | grep "chef " | sed 's/^.*(\(.*\)).*$/\1/' | awk 'BEGIN {RS=", "} {if(NR>1) {print $0}}' | xargs -I {} gem uninstall chef -Ixv {}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -191,12 +191,13 @@ jobs:
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
-        # bundle install
+        # bundle install # this is grabbing 17.10.* Chef, which also breaks the test
         gem list chef # debug
         # use the chef we just installed instead of network install
         bundle exec rake build
 
         gem install ohai # because we're doing a local install
+        gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
         gem list chef # debug
         gem install --local `ls pkg/*.gem`
         gem list chef # debug

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -191,7 +191,7 @@ jobs:
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
-        bundle install
+        # bundle install
         gem list chef # debug
         # use the chef we just installed instead of network install
         bundle exec rake build

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -187,6 +187,10 @@ jobs:
         cd /Users/runner/work/chef/chef/kitchen-tests
         sudo berks vendor cookbooks
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
+    - name: 'Dump stacktrace if failure'
+      id: dump_stacktrace
+      if: ${{ failure() }}
+      run: |
         sudo cat /Users/runner/.chef/local-mode-cache/cache/chef-stacktrace.out
 
   linux:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -194,7 +194,7 @@ jobs:
         gem install --local `ls pkg/*.gem`
         cd /Users/runner/work/chef/chef/kitchen-tests
         berks vendor cookbooks
-        /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
+        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
   linux:
     strategy:
       fail-fast: false

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -196,6 +196,7 @@ jobs:
         cd berkshelf
         gem install ohai # because we're doing a local install
         gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
+        gem install cucumber -v "3.1.0" # because we didn't bundle berkshelf
         # bundle install # this is grabbing 17.10.* Chef, which also breaks the test
         # gem list chef # debug the aftermath of bundle install
         # use the chef we just installed instead of network install

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -204,7 +204,6 @@ jobs:
         mv *.gem pkg/
 
         # just remove all but the most recent chefs
-        gem list chef | grep "chef " | sed 's/^.*(\(.*\)).*$/\1/' | awk 'BEGIN {RS=", "} {if(NR>1) {print $0}}' | xargs -I {} gem uninstall chef -Ixv {}
         # gem list chef # debug the aftermath of bundle install
         # use the chef we just installed instead of network install
         #bundle exec rake build
@@ -215,6 +214,8 @@ jobs:
         gem list chef # debug
         cd /Users/runner/work/chef/chef/kitchen-tests
         berks vendor cookbooks
+        gem list chef # debug
+        gem list chef | grep "chef " | sed 's/^.*(\(.*\)).*$/\1/' | awk 'BEGIN {RS=", "} {if(NR>1) {print $0}}' | xargs -I {} gem uninstall chef -Ixv {}
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
   linux:
     strategy:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -93,7 +93,7 @@ jobs:
 
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
-        echo $env:GITHUB_SHA
+        gem install ffi-yajl #explicitly
         appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
         Write-Output "Installed Chef / Ohai release:"

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -175,23 +175,31 @@ jobs:
         bundle --version
         cd /Users/runner/work/chef/chef
         bundle install
+        gem list chef # debug
 
         # some dependencies aren't on RubyGems
         bundle exec rake install:local
+        gem list chef
         cd kitchen-tests
         bundle install --jobs=3 --retry=3
+        gem list chef # debug
         gem install kitchen
+        gem list chef # debug
+
 
         cd /Users/runner/work/chef
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
         bundle install
+        gem list chef # debug
         # use the chef we just installed instead of network install
         bundle exec rake build
 
         gem install ohai # because we're doing a local install
+        gem list chef # debug
         gem install --local `ls pkg/*.gem`
+        gem list chef # debug
         cd /Users/runner/work/chef/chef/kitchen-tests
         berks vendor cookbooks
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -175,16 +175,20 @@ jobs:
         bundle --version
         cd /Users/runner/work/chef/chef
         bundle install
-        gem list chef # debug
+        echo "post chef/chef bundle install"
+        gem list chef
 
         # some dependencies aren't on RubyGems
         bundle exec rake install:local
         gem list chef
+        echo "post chef/chef bundle exec rake install:local"
         cd kitchen-tests
         bundle install --jobs=3 --retry=3
         gem list chef # debug
+        echo "post chef/chef/kitchen-tests bundle install"
         gem install kitchen
         gem list chef # debug
+        echo "post chef/chef/kitchen-tests gem install kitchen"
 
 
         cd /Users/runner/work/chef
@@ -192,13 +196,14 @@ jobs:
 
         cd berkshelf
         # bundle install # this is grabbing 17.10.* Chef, which also breaks the test
-        gem list chef # debug
+        # gem list chef # debug the aftermath of bundle install
         # use the chef we just installed instead of network install
         bundle exec rake build
 
         gem install ohai # because we're doing a local install
         gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
         gem list chef # debug
+        echo "post gem install ohai / aruba"
         gem install --local `ls pkg/*.gem`
         gem list chef # debug
         cd /Users/runner/work/chef/chef/kitchen-tests

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -198,7 +198,7 @@ jobs:
         # gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
         # gem install cucumber -v "3.1.0" # because we didn't bundle berkshelf
         # bundle install # this is grabbing 17.10.* Chef, which also breaks the test
-        gem build berkshelf.gem spec
+        gem build berkshelf.gemspec
         mv *.gem pkg/
 
         # just remove all but the most recent chefs

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -186,8 +186,8 @@ jobs:
 
         cd /Users/runner/work/chef/chef/kitchen-tests
         sudo berks vendor cookbooks
-        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist || sudo cat /Users/runner/.chef/local-mode-cache/cache/chef-stacktrace.out
-
+        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist || echo "it broke"
+        sudo cat /Users/runner/.chef/local-mode-cache/cache/chef-stacktrace.out
   linux:
     strategy:
       fail-fast: false

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -187,6 +187,7 @@ jobs:
         cd /Users/runner/work/chef/chef/kitchen-tests
         sudo berks vendor cookbooks
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
+        sudo cat /Users/runner/.chef/local-mode-cache/cache/chef-stacktrace.out
 
   linux:
     strategy:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -174,7 +174,8 @@ jobs:
         bundle --version
         cd /Users/runner/work/chef/chef
         bundle install
-        # otherwise we only use rubygems
+
+        # some dependencies aren't on RubyGems
         bundle exec rake install:local
         cd kitchen-tests
         bundle install --jobs=3 --retry=3
@@ -184,7 +185,9 @@ jobs:
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
-        rake install
+
+        # use the chef we just installed instead of network install
+        bundle install rake install:local
 
         cd /Users/runner/work/chef/chef/kitchen-tests
         berks vendor cookbooks

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -199,6 +199,8 @@ jobs:
         # gem install cucumber -v "3.1.0" # because we didn't bundle berkshelf
         # bundle install # this is grabbing 17.10.* Chef, which also breaks the test
         gem build berkshelf.gemspec
+
+        test -d pkg || mkdir pkg
         mv *.gem pkg/
 
         # just remove all but the most recent chefs

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -93,7 +93,6 @@ jobs:
 
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
-        gem install ffi-yajl
         appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
         Write-Output "Installed Chef / Ohai release:"
@@ -195,13 +194,13 @@ jobs:
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
+        gem install ohai # because we're doing a local install
+        gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
         # bundle install # this is grabbing 17.10.* Chef, which also breaks the test
         # gem list chef # debug the aftermath of bundle install
         # use the chef we just installed instead of network install
         bundle exec rake build
 
-        gem install ohai # because we're doing a local install
-        gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
         gem list chef # debug
         echo "post gem install ohai / aruba"
         gem install --local `ls pkg/*.gem`

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -185,7 +185,7 @@ jobs:
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
-
+        bundle install
         # use the chef we just installed instead of network install
         bundle exec rake install:local
 

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -194,7 +194,7 @@ jobs:
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
-        # gem install ohai # because we're doing a local install
+        gem install ohai # because we're doing a local install
         # gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
         # gem install cucumber -v "3.1.0" # because we didn't bundle berkshelf
         # bundle install # this is grabbing 17.10.* Chef, which also breaks the test

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -93,7 +93,7 @@ jobs:
 
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
-        gem install ffi-yajl #explicitly
+        gem install ffi-yajl
         appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
         Write-Output "Installed Chef / Ohai release:"
@@ -188,10 +188,10 @@ jobs:
         cd berkshelf
         bundle install
         # use the chef we just installed instead of network install
-        bundle exec rake install:local
+        sudo bundle exec rake install:local
 
         cd /Users/runner/work/chef/chef/kitchen-tests
-        berks vendor cookbooks
+        sudo berks vendor cookbooks
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
   linux:
     strategy:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -173,21 +173,21 @@ jobs:
         echo "what version is that?"
         bundle --version
         cd /Users/runner/work/chef/chef
-        sudo bundle install
+        bundle install
         # otherwise we only use rubygems
-        sudo rake install:local
+        bundle exec rake install:local
         cd kitchen-tests
-        sudo bundle install --jobs=3 --retry=3
-        sudo gem install kitchen
+        bundle install --jobs=3 --retry=3
+        gem install kitchen
 
         cd /Users/runner/work/chef
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
-        sudo rake install
+        rake install
 
         cd /Users/runner/work/chef/chef/kitchen-tests
-        sudo berks vendor cookbooks
+        berks vendor cookbooks
         sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
   linux:
     strategy:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -194,10 +194,13 @@ jobs:
         git clone https://github.com/chef/berkshelf
 
         cd berkshelf
-        gem install ohai # because we're doing a local install
-        gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
-        gem install cucumber -v "3.1.0" # because we didn't bundle berkshelf
-        # bundle install # this is grabbing 17.10.* Chef, which also breaks the test
+        # gem install ohai # because we're doing a local install
+        # gem install aruba -v "0.14.14" # because we didn't bundle berkshelf
+        # gem install cucumber -v "3.1.0" # because we didn't bundle berkshelf
+        bundle install # this is grabbing 17.10.* Chef, which also breaks the test
+
+        # just remove all but the most recent chefs
+        gem list chef | grep "chef " | sed 's/^.*(\(.*\)).*$/\1/' | awk 'BEGIN {RS=", "} {if(NR>1) {print $0}}' | xargs -I {} gem uninstall chef -Ixv {}
         # gem list chef # debug the aftermath of bundle install
         # use the chef we just installed instead of network install
         bundle exec rake build

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -188,11 +188,12 @@ jobs:
         cd berkshelf
         bundle install
         # use the chef we just installed instead of network install
-        sudo bundle exec rake install:local
+        bundle exec rake build
 
+        gem install --local `ls pkg/*.gem`
         cd /Users/runner/work/chef/chef/kitchen-tests
-        sudo berks vendor cookbooks
-        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
+        berks vendor cookbooks
+        /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
   linux:
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ Vagrantfile
 kitchen-tests/nodes/*
 kitchen-tests/Gemfile.lock
 kitchen-tests/Berksfile.lock
+kitchen-tests/cookbooks/*
+!kitchen-tests/cookbooks/end_to_end
 
 # Temporary files present during spec runs
 spec/data/test-dir

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
-    ffi-yajl (2.4.0)
+    ffi-yajl (2.5.0)
       libyajl2 (>= 1.2)
     fuzzyurl (0.9.0)
     gssapi (1.3.1)

--- a/kitchen-tests/cookbooks/end_to_end/metadata.json
+++ b/kitchen-tests/cookbooks/end_to_end/metadata.json
@@ -1,0 +1,50 @@
+{
+  "name": "end_to_end",
+  "description": "Installs/Configures base",
+  "long_description": "",
+  "maintainer": "",
+  "maintainer_email": "",
+  "license": "Apache-2.0",
+  "platforms": {
+    "ubuntu": ">= 0.0.0",
+    "debian": ">= 0.0.0",
+    "centos": ">= 0.0.0",
+    "opensuseleap": ">= 0.0.0",
+    "fedora": ">= 0.0.0",
+    "amazon": ">= 0.0.0"
+  },
+  "dependencies": {
+    "logrotate": ">= 0.0.0",
+    "multipackage": ">= 0.0.0",
+    "nscd": ">= 0.0.0",
+    "ntp": ">= 0.0.0",
+    "openssh": ">= 0.0.0",
+    "resolver": ">= 0.0.0",
+    "users": "< 7.1",
+    "git": ">= 0.0.0"
+  },
+  "providing": {
+
+  },
+  "recipes": {
+
+  },
+  "version": "1.0.0",
+  "source_url": "https://github.com/chef/chef",
+  "issues_url": "https://github.com/chef/chef/issues",
+  "privacy": false,
+  "chef_versions": [
+    [
+      ">= 16"
+    ]
+  ],
+  "ohai_versions": [
+
+  ],
+  "gems": [
+    [
+      "chef-sugar"
+    ]
+  ],
+  "eager_load_libraries": true
+}

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
       chef-config (= 18.1.29)
-      chef-powershell (~> 1.0.12)
+      chef-powershell (~> 18.0.3)
       chef-utils (= 18.1.29)
       chef-vault
       chef-zero (>= 14.0.11)
@@ -155,9 +155,9 @@ GEM
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
-    chef-powershell (1.0.13)
+    chef-powershell (18.0.3)
       ffi (~> 1.15)
-      ffi-yajl (~> 2.4)
+      ffi-yajl (~> 2.5)
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
-    ffi-yajl (2.4.0)
+    ffi-yajl (2.5.0)
       libyajl2 (>= 1.2)
     fuzzyurl (0.9.0)
     gssapi (1.3.1)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
