### PR TITLE
Ensuring a version of choco < 2.0 is installed

### DIFF
--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -2,6 +2,109 @@ Write-Output "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
+# Beginning of Choco 2.0 workaround
+# Choco 2.0 has shipped and changes the behavior of the choco 'list' command. Thhe changes here
+# put us back to the behavior of choco 1.4.0. This is a long term problem
+# for us because we have a lot of tests that depend on the old behavior. We need to
+# update them for choco 2.0
+
+$VerbosePreference = 'Continue'
+if (-not $env:ChocolateyInstall) {
+    $message = @(
+        "The ChocolateyInstall environment variable was not found."
+        "Chocolatey is not detected as installed. Nothing to do."
+    ) -join "`n"
+
+    Write-Warning $message
+    return
+}
+
+if (-not (Test-Path $env:ChocolateyInstall)) {
+    $message = @(
+        "No Chocolatey installation detected at '$env:ChocolateyInstall'."
+        "Nothing to do."
+    ) -join "`n"
+
+    Write-Warning $message
+    return
+}
+
+<#
+    Using the .NET registry calls is necessary here in order to preserve environment variables embedded in PATH values;
+    Powershell's registry provider doesn't provide a method of preserving variable references, and we don't want to
+    accidentally overwrite them with absolute path values. Where the registry allows us to see "%SystemRoot%" in a PATH
+    entry, PowerShell's registry provider only sees "C:\Windows", for example.
+#>
+$userKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment',$true)
+$userPath = $userKey.GetValue('PATH', [string]::Empty, 'DoNotExpandEnvironmentNames').ToString()
+
+$machineKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\ControlSet001\Control\Session Manager\Environment\',$true)
+$machinePath = $machineKey.GetValue('PATH', [string]::Empty, 'DoNotExpandEnvironmentNames').ToString()
+
+$backupPATHs = @(
+    "User PATH: $userPath"
+    "Machine PATH: $machinePath"
+)
+$backupFile = "C:\PATH_backups_ChocolateyUninstall.txt"
+$backupPATHs | Set-Content -Path $backupFile -Encoding UTF8 -Force
+
+$warningMessage = @"
+    This could cause issues after reboot where nothing is found if something goes wrong.
+    In that case, look at the backup file for the original PATH values in '$backupFile'.
+"@
+
+if ($userPath -like "*$env:ChocolateyInstall*") {
+    Write-Verbose "Chocolatey Install location found in User Path. Removing..."
+    Write-Warning $warningMessage
+
+    $newUserPATH = @(
+        $userPath -split [System.IO.Path]::PathSeparator |
+            Where-Object { $_ -and $_ -ne "$env:ChocolateyInstall\bin" }
+    ) -join [System.IO.Path]::PathSeparator
+
+    # NEVER use [Environment]::SetEnvironmentVariable() for PATH values; see https://github.com/dotnet/corefx/issues/36449
+    # This issue exists in ALL released versions of .NET and .NET Core as of 12/19/2019
+    $userKey.SetValue('PATH', $newUserPATH, 'ExpandString')
+}
+
+if ($machinePath -like "*$env:ChocolateyInstall*") {
+    Write-Verbose "Chocolatey Install location found in Machine Path. Removing..."
+    Write-Warning $warningMessage
+
+    $newMachinePATH = @(
+        $machinePath -split [System.IO.Path]::PathSeparator |
+            Where-Object { $_ -and $_ -ne "$env:ChocolateyInstall\bin" }
+    ) -join [System.IO.Path]::PathSeparator
+
+    # NEVER use [Environment]::SetEnvironmentVariable() for PATH values; see https://github.com/dotnet/corefx/issues/36449
+    # This issue exists in ALL released versions of .NET and .NET Core as of 12/19/2019
+    $machineKey.SetValue('PATH', $newMachinePATH, 'ExpandString')
+}
+
+# Adapt for any services running in subfolders of ChocolateyInstall
+$agentService = Get-Service -Name chocolatey-agent -ErrorAction SilentlyContinue
+if ($agentService -and $agentService.Status -eq 'Running') {
+    $agentService.Stop()
+}
+# TODO: add other services here
+
+Remove-Item -Path $env:ChocolateyInstall -Recurse -Force 
+
+'ChocolateyInstall', 'ChocolateyLastPathUpdate' | ForEach-Object {
+    foreach ($scope in 'User', 'Machine') {
+        [Environment]::SetEnvironmentVariable($_, [string]::Empty, $scope)
+    }
+}
+
+$machineKey.Close()
+$userKey.Close()
+
+$env:chocolateyVersion = "1.4.0"
+Set-ExecutionPolicy Bypass -Scope Process -Force
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+# end of choco 2.0 workaround
+
 # chocolatey functional tests fail so delete the chocolatey binary to avoid triggering them
 Remove-Item -Path C:\ProgramData\chocolatey\bin\choco.exe -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Current windows images are pulling in an incompatible version of chocolatey. This update ensures we are using a suitable version. This update should be considered a temporary one and we should update all the chocolatey tests to use the correct syntax for "choco list" introduced in version 2.0 of choco May 2023

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
