### PR TITLE
Make action homebrew_bin_path public which is used in other hombrew resources

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -135,9 +135,10 @@ jobs:
         ruby: ["3.1"] # macos-11.0 is not public for now
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-      with:
-        clean: true
+    - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          clean: true
     - name: 'Setup Ruby'
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -135,62 +135,62 @@ jobs:
         ruby: ["3.1"] # macos-11.0 is not public for now
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Check out code
+      - name: Check out code
         uses: actions/checkout@v3
         with:
-          clean: true
-    - name: 'Setup Ruby'
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.1"
-          bundler-cache: false
-          working-directory: kitchen-tests
-    - name: 'Install Chef/Ohai from Omnitruck'
-      id: install_chef
-      run: |
-        brew install coreutils
-        curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current
-        /opt/chef/bin/chef-client -v
-        /opt/chef/bin/ohai -v
-        /opt/chef/embedded/bin/rake --version
-        # echo "Updating Bundler"
-        # gem install bundler:2.3.18
-        # echo "finished updating Bundler, now getting the version"
-        # /opt/chef/embedded/bin/bundle -v
-        # echo "finished getting the bundler version"
-    - name: 'Upgrade Chef/Ohai via Appbundler'
-      id: upgrade
-      run: |
-        gem install appbundler appbundle-updater --no-doc
-        sudo appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
-        echo "Installed Chef:"
-        chef-client -v
-        echo "Ohai release:"
-        ohai -v
-    - name: 'Run end_to_end::default recipe'
-      id: run
-      run: |
-        brew install rbenv ruby-build
-        touch ~/.zshrc
-        export PATH="$HOME/.rbenv/bin:$PATH"
-        export HOMEBREW_NO_ENV_HINTS="true"
-        echo 'eval "$(rbenv init - zsh)"' >> ~/.zshrc
-        source ~/.zshrc
-        rbenv install 3.1.2
-        rbenv global 3.1.2
-        gem install bundler:2.3.18
-        echo "which bundler are we using?"
-        which bundle
-        echo "what version is that?"
-        bundle --version
-        cd /Users/runner/work/chef/chef
-        sudo bundle install
-        cd kitchen-tests
-        sudo bundle install --jobs=3 --retry=3
-        sudo gem install kitchen
-        sudo gem install berkshelf --no-doc
-        sudo berks vendor cookbooks
-        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
+            clean: true
+      - name: 'Setup Ruby'
+          uses: ruby/setup-ruby@v1
+          with:
+            ruby-version: "3.1"
+            bundler-cache: false
+            working-directory: kitchen-tests
+      - name: 'Install Chef/Ohai from Omnitruck'
+        id: install_chef
+        run: |
+          brew install coreutils
+          curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current
+          /opt/chef/bin/chef-client -v
+          /opt/chef/bin/ohai -v
+          /opt/chef/embedded/bin/rake --version
+          # echo "Updating Bundler"
+          # gem install bundler:2.3.18
+          # echo "finished updating Bundler, now getting the version"
+          # /opt/chef/embedded/bin/bundle -v
+          # echo "finished getting the bundler version"
+      - name: 'Upgrade Chef/Ohai via Appbundler'
+        id: upgrade
+        run: |
+          gem install appbundler appbundle-updater --no-doc
+          sudo appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
+          echo "Installed Chef:"
+          chef-client -v
+          echo "Ohai release:"
+          ohai -v
+      - name: 'Run end_to_end::default recipe'
+        id: run
+        run: |
+          brew install rbenv ruby-build
+          touch ~/.zshrc
+          export PATH="$HOME/.rbenv/bin:$PATH"
+          export HOMEBREW_NO_ENV_HINTS="true"
+          echo 'eval "$(rbenv init - zsh)"' >> ~/.zshrc
+          source ~/.zshrc
+          rbenv install 3.1.2
+          rbenv global 3.1.2
+          gem install bundler:2.3.18
+          echo "which bundler are we using?"
+          which bundle
+          echo "what version is that?"
+          bundle --version
+          cd /Users/runner/work/chef/chef
+          sudo bundle install
+          cd kitchen-tests
+          sudo bundle install --jobs=3 --retry=3
+          sudo gem install kitchen
+          sudo gem install berkshelf --no-doc
+          sudo berks vendor cookbooks
+          sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
 
   linux:
     strategy:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -138,7 +138,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         clean: true
-    - name: Setup Ruby
+    - name: 'Setup Ruby'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -160,7 +160,7 @@ jobs:
       id: upgrade
       run: |
         gem install appbundler appbundle-updater --no-doc
-        appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
+        sudo appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
         echo "Installed Chef:"
         chef-client -v
         echo "Ohai release:"

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -140,11 +140,11 @@ jobs:
         with:
             clean: true
       - name: 'Setup Ruby'
-          uses: ruby/setup-ruby@v1
-          with:
-            ruby-version: "3.1"
-            bundler-cache: false
-            working-directory: kitchen-tests
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: false
+          working-directory: kitchen-tests
       - name: 'Install Chef/Ohai from Omnitruck'
         id: install_chef
         run: |

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -165,6 +165,7 @@ jobs:
       - name: 'Run end_to_end::default recipe'
         id: run
         run: |
+          cd kitchen-tests
           sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
           sudo /opt/chef/embedded/bin/bundle config set --local path 'vendor/bundle'
           sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -153,43 +153,24 @@ jobs:
           /opt/chef/bin/chef-client -v
           /opt/chef/bin/ohai -v
           /opt/chef/embedded/bin/rake --version
-          # echo "Updating Bundler"
-          # gem install bundler:2.3.18
-          # echo "finished updating Bundler, now getting the version"
-          # /opt/chef/embedded/bin/bundle -v
-          # echo "finished getting the bundler version"
       - name: 'Upgrade Chef/Ohai via Appbundler'
         id: upgrade
         run: |
-          gem install appbundler appbundle-updater --no-doc
-          sudo appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
-          echo "Installed Chef:"
-          chef-client -v
-          echo "Ohai release:"
-          ohai -v
+          OHAI_VERSION=$(sed -n '/ohai .[0-9]/{s/.*(//;s/)//;p;}' Gemfile.lock)
+          sudo /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+          sudo /opt/chef/embedded/bin/appbundle-updater chef chef $GITHUB_SHA --tarball --github $GITHUB_REPOSITORY
+          echo "Installed Chef / Ohai release:"
+          /opt/chef/bin/chef-client -v
+          /opt/chef/bin/ohai -v
       - name: 'Run end_to_end::default recipe'
         id: run
         run: |
-          brew install rbenv ruby-build
-          touch ~/.zshrc
-          export PATH="$HOME/.rbenv/bin:$PATH"
-          export HOMEBREW_NO_ENV_HINTS="true"
-          echo 'eval "$(rbenv init - zsh)"' >> ~/.zshrc
-          source ~/.zshrc
-          rbenv install 3.1.2
-          rbenv global 3.1.2
-          gem install bundler:2.3.18
-          echo "which bundler are we using?"
-          which bundle
-          echo "what version is that?"
-          bundle --version
-          cd /Users/runner/work/chef/chef
-          sudo bundle install
-          cd kitchen-tests
-          sudo bundle install --jobs=3 --retry=3
-          sudo gem install kitchen
-          sudo gem install berkshelf --no-doc
-          sudo berks vendor cookbooks
+          sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
+          sudo /opt/chef/embedded/bin/bundle config set --local path 'vendor/bundle'
+          sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3
+          sudo rm -f /opt/chef/embedded/bin/{htmldiff,ldiff}
+          sudo /opt/chef/embedded/bin/gem install berkshelf --no-doc
+          sudo /opt/chef/embedded/bin/berks vendor cookbooks
           sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
 
   linux:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -156,6 +156,15 @@ jobs:
         # echo "finished updating Bundler, now getting the version"
         # /opt/chef/embedded/bin/bundle -v
         # echo "finished getting the bundler version"
+    - name: 'Upgrade Chef/Ohai via Appbundler'
+      id: upgrade
+      run: |
+        gem install appbundler appbundle-updater --no-doc
+        appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
+        echo "Installed Chef:"
+        chef-client -v
+        echo "Ohai release:"
+        ohai -v
     - name: 'Run end_to_end::default recipe'
       id: run
       run: |

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -138,11 +138,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         clean: true
-    - name: 'Upgrade Ruby Devkit on Macos'
-      id: upgrade_ruby
-      run: |
-        echo "This is the installed version of Ruby:"
-        brew info ruby
+    - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: false
+          working-directory: kitchen-tests
     - name: 'Install Chef/Ohai from Omnitruck'
       id: install_chef
       run: |

--- a/lib/chef/mixin/homebrew_user.rb
+++ b/lib/chef/mixin/homebrew_user.rb
@@ -57,8 +57,6 @@ class Chef
         @homebrew_owner_username
       end
 
-      private
-
       def homebrew_bin_path(brew_bin_path = nil)
         if brew_bin_path && ::File.exist?(brew_bin_path)
           brew_bin_path
@@ -67,6 +65,8 @@ class Chef
           brew_bin_path || nil
         end
       end
+
+      private
 
       def calculate_owner
         brew_path = homebrew_bin_path


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
PR https://github.com/chef/chef/pull/13669 refactored some code and private method `homebrew_bin_path`  was added, which was being called in other resource files after requiring the file.
Kitchen tests on macos have below failures:
```
* homebrew_tap[homebrew/cask] action tap (up to date)
    
    ================================================================================
    Error executing action `install` on resource 'homebrew_cask[do-not-disturb]'
    ================================================================================
    
    NoMethodError
    -------------
    undefined method `homebrew_bin_path' for #<#<Class:0x000000010fce5148>:0x00000001112ef290 @new_resource=<homebrew_cask[do-not-disturb] @name: "do-not-disturb" @before: nil @params: {} @provider: nil @allowed_actions: [:nothing, :install, :remove] @action: [:install] @updated: false @updated_by_last_action: false @source_line: "/Users/runner/.chef/local-mode-cache/cache/cookbooks/end_to_end/recipes/macos.rb:105:in `from_file'" @guard_interpreter: nil @default_guard_interpreter: :default @elapsed_time: 0 @declared_type: :homebrew_cask @cookbook_name: "end_to_end" @recipe_name: "macos" @homebrew_owner_uid: 501 @homebrew_owner_username: "runner" @owner: "runner" @cask_name: "do-not-disturb">, @action=:install, @current_resource=nil, @after_resource=nil, @run_context=#<Chef::RunContext:0x000000010bdc9c20 @events=#<Chef::EventDispatch::Dispatcher:0x000000011074ec38 @subscribers=[#<Chef::Formatters::Doc:0x000000011074fcc8 @output=#<Chef::Formatters::IndentableOutputStream:0x000000011074fb88 @err=#<IO:<STDERR>>, @out=#<IO:<STDOUT>>, @indent=4, @line_started=false, @semaphore=#<Thread::Mutex:0x000000011074fac0>, @pastel=#<Pastel styles=[]>, @current_stream=<homebrew_tap[homebrew/cask] @name: "homebrew/cask" @before: nil @params: nil @provider: nil @allowed_actions: [:nothing, :tap, :untap] @action: [:tap] @updated: false @updated_by_last_action: false @source_line: "/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-18.2.31/lib/chef/resource/homebrew_cask.rb:57:in `block in <class:HomebrewCask>'" @guard_interpreter: nil @default_guard_interpreter: :default @elapsed_time: 0.023582 @declared_type: :homebrew_tap @cookbook_name: "end_to_end" @recipe_name: "macos" @homebrew_path: "/usr/local/bin/brew" @owner: "runner" @tap_name: "homebrew/cask">>, @updated_resources=65, @up_to_date_resources=12, @start_time=2023-06-14 07:13:00.617231 -0700, @end_time=2023-06-14 07:13:00.617231 -0700, @skipped_resources=8, @progress={}, @deprecations={"As of Chef Infra Client 17.8 the `type` property is no longer necessary."=>{:url=>"https://docs.chef.io/deprecations_property/", :locations=>#<Set: {"/Users/runner/.chef/local-mode-cache/cache/cookbooks/end_to_end/recipes/_macos_userdefaults.rb:20:in `block in from_file'", "/Users/runner/.chef/local-mode-
```

e.g https://github.com/chef/chef/actions/runs/5268103287/jobs/9524304572?pr=13805#step:5:1334

**Why the pipeline didn't throw the error for Pr https://github.com/chef/chef/pull/13669: **
The kitchen test script for Macos  https://github.com/chef/chef/blob/main/.github/workflows/kitchen.yml#L130 is wrong. (Has been since long)
It isn’t testing changes against a commit in a PR but only last available build in current channel. (that’s why the failure started showing after the PR was merged, the nightly adhoc build started created a release)
If you see the Macos section, it downloads the latest build from current channel using omnitruck but doesnot upgrade it using Appbundler, so the commit in PR never gets tested.
And all of this has happened (or got removed) here  [https://github.com/chef/chef/commit/2f5dbd1ee69c970fc06870477dbbca6c5c3555c4#diff-e8ec3ff5286f76fd71f48ae74b5f1[…]3522ddb5bd22a9ae1c78b4ecea8009bL94](https://github.com/chef/chef/commit/2f5dbd1ee69c970fc06870477dbbca6c5c3555c4#diff-e8ec3ff5286f76fd71f48ae74b5f16bcc3522ddb5bd22a9ae1c78b4ecea8009bL94)
So we are also fixing the the kitchen.yml here in this PR.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
