### PR TITLE
Prevent TypeError to be raised in condition evaluation

### DIFF
--- a/lib/chef/provider/yum_repository.rb
+++ b/lib/chef/provider/yum_repository.rb
@@ -45,7 +45,7 @@ class Chef
           if new_resource.make_cache
             notifies :run, "execute[yum clean metadata #{new_resource.repositoryid}]", :immediately if new_resource.clean_metadata || new_resource.clean_headers
             # makecache fast only works on non-dnf systems.
-            if !which "dnf" && new_resource.makecache_fast
+            if !which("dnf") && new_resource.makecache_fast
               notifies :run, "execute[yum-makecache-fast-#{new_resource.repositoryid}]", :immediately
             else
               notifies :run, "execute[yum-makecache-#{new_resource.repositoryid}]", :immediately


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
When running the yum_repository.rb, we can face the current issue: FATAL: TypeError: yum_repository[xxx] (xxx) had an error: TypeError: no implicit conversion of false into String There is probably a precedence issue which can be easily solved by parenthesis addition
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/13829

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
