### PR TITLE
Fix  to pick pinned  version of  chef-foundation  on windows

### DIFF
--- a/.expeditor/scripts/omnibus_chef_build.ps1
+++ b/.expeditor/scripts/omnibus_chef_build.ps1
@@ -28,8 +28,9 @@ $env:ARTIFACTORY_BASE_PATH="com/getchef"
 $env:ARTIFACTORY_ENDPOINT="https://artifactory-internal.ps.chef.co/artifactory"
 $env:ARTIFACTORY_USERNAME="buildkite"
 
-Write-Output "--- Install Chef Foundation"
-. { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v $CHEF_FOUNDATION_VERSION
+
+Write-Output "--- Installing Chef Foundation $CHEF_FOUNDATION_VERSION"
+. { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v ${env:CHEF_FOUNDATION_VERSION}
 
 $env:PROJECT_NAME="chef"
 $env:OMNIBUS_PIPELINE_DEFINITION_PATH="${ScriptDir}/../release.omnibus.yml"

--- a/.expeditor/scripts/omnibus_chef_build.ps1
+++ b/.expeditor/scripts/omnibus_chef_build.ps1
@@ -29,7 +29,7 @@ $env:ARTIFACTORY_ENDPOINT="https://artifactory-internal.ps.chef.co/artifactory"
 $env:ARTIFACTORY_USERNAME="buildkite"
 
 
-Write-Output "--- Installing Chef Foundation $CHEF_FOUNDATION_VERSION"
+Write-Output "--- Installing Chef Foundation ${env:CHEF_FOUNDATION_VERSION}"
 . { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v ${env:CHEF_FOUNDATION_VERSION}
 
 $env:PROJECT_NAME="chef"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
On the Windows build agent, instead of the pinned chef-foundation version as defined in [.buildkite-platform.json](https://github.com/chef/chef/blob/main/.buildkite-platform.json#L2) file, the latest version of chef-foundation gets installed. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
