### PR TITLE
AttrArray#<<: Use __path__ when invalidating cache

### DIFF
--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -44,6 +44,12 @@ class Chef
         end
       end
 
+      def <<(obj)
+        ret = super(obj)
+        send_reset_cache(__path__)
+        ret
+      end
+
       def delete(key, &block)
         send_reset_cache(__path__, key)
         super

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -39,6 +39,7 @@ class Chef
       MUTATOR_METHODS.each do |mutator|
         define_method(mutator) do |*args, &block|
           ret = super(*args, &block)
+          # TODO: use `send_reset_cache(__path__)` for all mutator methods?
           send_reset_cache
           ret
         end
@@ -46,6 +47,7 @@ class Chef
 
       def <<(obj)
         ret = super(obj)
+        # NOTE: Expecting __path__ to be top-level attribute only
         send_reset_cache(__path__)
         ret
       end

--- a/spec/unit/node/vivid_mash_spec.rb
+++ b/spec/unit/node/vivid_mash_spec.rb
@@ -377,15 +377,34 @@ describe Chef::Node::AttrArray do
       expect(array[3][0]["three"].class).to eql(Chef::Node::AttrArray)
     end
 
-    it "does not send reset_cache with nil if there is a path" do
+    it "does not invalidate root DeepMergeCache if VividMash top-level key" do
+      # We're checking that __path__ is used to avoid full DeepMergeCache invalidation
       expect(root).to receive(:reset_cache).with("array")
       expect(root).not_to receive(:reset_cache).with(nil)
+
       attr_array = Chef::Node::AttrArray.new([ 0, 1, 2 ])
       vivid = Chef::Node::VividMash.new(
-        { "one" => { "two" => { "three" => "four" } }, "array" => attr_array},
+        { "one" => { "two" => { "three" => "four" } }, "array" => attr_array },
         root
       )
       vivid["array"] << 3
+    end
+
+    it "does not send reset_cache with nil if VividMashi nested key" do
+      # We're checking that __path__ is used to avoid full DeepMergeCache invalidation,
+      # and that it is invalidating the top-level key
+      expect(root).to receive(:reset_cache).with("array")
+      expect(root).not_to receive(:reset_cache).with(nil)
+
+      attr_array = Chef::Node::AttrArray.new([ 0, 1, 2 ])
+      vivid = Chef::Node::VividMash.new(
+        {
+          "one" => { "two" => { "three" => "four" } },
+          "array" => { "nested" => attr_array },
+        },
+        root
+      )
+      vivid["array"]["nested"] << 3
     end
   end
 

--- a/spec/unit/node/vivid_mash_spec.rb
+++ b/spec/unit/node/vivid_mash_spec.rb
@@ -364,20 +364,34 @@ describe Chef::Node::AttrArray do
 
   context "#<<" do
     it "converts a Hash appended with #<< to a VividMash" do
+      expect(root).to receive(:reset_cache).with(nil)
       array << { "three" => "four" }
       expect(array[3].class).to eql(Chef::Node::VividMash)
     end
 
     it "deeply converts objects appended with #<<" do
+      expect(root).to receive(:reset_cache).with(nil)
       array << [ { "three" => [ 0, 1] } ]
       expect(array[3].class).to eql(Chef::Node::AttrArray)
       expect(array[3][0].class).to eql(Chef::Node::VividMash)
       expect(array[3][0]["three"].class).to eql(Chef::Node::AttrArray)
     end
+
+    it "does not send reset_cache with nil if there is a path" do
+      expect(root).to receive(:reset_cache).with("array")
+      expect(root).not_to receive(:reset_cache).with(nil)
+      attr_array = Chef::Node::AttrArray.new([ 0, 1, 2 ])
+      vivid = Chef::Node::VividMash.new(
+        { "one" => { "two" => { "three" => "four" } }, "array" => attr_array},
+        root
+      )
+      vivid["array"] << 3
+    end
   end
 
   context "#[]=" do
     it "assigning a Hash into an array converts it to VividMash" do
+      expect(root).to receive(:reset_cache).with(nil)
       array[0] = { "zero" => "zero2" }
       expect(array[0].class).to eql(Chef::Node::VividMash)
     end
@@ -385,6 +399,7 @@ describe Chef::Node::AttrArray do
 
   context "#push" do
     it "pushing a Hash into an array converts it to VividMash" do
+      expect(root).to receive(:reset_cache).with(nil)
       array.push({ "three" => "four" })
       expect(array[3].class).to eql(Chef::Node::VividMash)
     end
@@ -392,6 +407,7 @@ describe Chef::Node::AttrArray do
 
   context "#unshift" do
     it "unshifting a Hash into an array converts it to VividMash" do
+      expect(root).to receive(:reset_cache).with(nil)
       array.unshift({ "zero" => "zero2" })
       expect(array[0].class).to eql(Chef::Node::VividMash)
     end
@@ -399,6 +415,7 @@ describe Chef::Node::AttrArray do
 
   context "#insert" do
     it "inserting a Hash into an array converts it to VividMash" do
+      expect(root).to receive(:reset_cache).with(nil)
       array.insert(1, { "zero" => "zero2" })
       expect(array[1].class).to eql(Chef::Node::VividMash)
     end
@@ -406,6 +423,7 @@ describe Chef::Node::AttrArray do
 
   context "#collect!" do
     it "converts Hashes" do
+      expect(root).to receive(:reset_cache).at_least(:once).with(nil)
       array.collect! { |x| { "zero" => "zero2" } }
       expect(array[1].class).to eql(Chef::Node::VividMash)
     end
@@ -413,6 +431,7 @@ describe Chef::Node::AttrArray do
 
   context "#map!" do
     it "converts Hashes" do
+      expect(root).to receive(:reset_cache).with(nil)
       array.map! { |x| { "zero" => "zero2" } }
       expect(array[1].class).to eql(Chef::Node::VividMash)
     end
@@ -420,6 +439,7 @@ describe Chef::Node::AttrArray do
 
   context "#compact!" do
     it "VividMashes remain VividMashes" do
+      expect(root).to receive(:reset_cache).with(nil)
       array = Chef::Node::AttrArray.new(
         [ nil, { "one" => "two" }, nil ],
         root
@@ -432,6 +452,7 @@ describe Chef::Node::AttrArray do
 
   context "#fill" do
     it "inserts VividMashes for Hashes" do
+      expect(root).to receive(:reset_cache).at_least(:once).with(nil)
       array.fill({ "one" => "two" })
       expect(array[0].class).to eql(Chef::Node::VividMash)
     end
@@ -439,6 +460,7 @@ describe Chef::Node::AttrArray do
 
   context "#flatten!" do
     it "flattens sub-arrays maintaining VividMashes in them" do
+      expect(root).to receive(:reset_cache).with(nil)
       array = Chef::Node::AttrArray.new(
         [ [ { "one" => "two" } ], [ { "one" => "two" } ] ],
         root
@@ -451,6 +473,7 @@ describe Chef::Node::AttrArray do
 
   context "#replace" do
     it "replaces the array converting hashes to mashes" do
+      expect(root).to receive(:reset_cache).with(nil)
       array.replace([ { "foo" => "bar" } ])
       expect(array[0].class).to eql(Chef::Node::VividMash)
     end


### PR DESCRIPTION
## Description

I've been doing some investigation into DeepMergeCache invalidation, and one result that was surprising was that doing something like the following triggers a full DeepMergeCache invalidation:
```
node.default['foo']['bar'] = [1, 2]
node.default['foo']['bar'] << 3
```

That means that any cached values for `node['unrelated']` would be blown away by that concatenation to 'foo'.

This is because [mutating methods in AttrArray aren't provided with `__path__`](https://github.com/chef/chef/blob/bed5613cf8f9b4f90c7b10c29196fa2e0150cfef/lib/chef/node/attribute_collections.rb#L34-L45).

On the face of it this might seem a minor problem, but this can rack up a lot of unnecessary full cache resets. In something like the [Facebook API model for Chef cookbooks](https://github.com/facebook/chef-utils/blob/main/Compile-Time-Run-Time.md#the-facebook-chef-api) it causes churn where an AttrArray is used as part of the API (where leaf cookbooks append arguments that are used at compile time). But this isn't specific to that model either, since it does these full cache resets [with include_recipe call](https://github.com/chef/chef/blob/main/lib/chef/node.rb#L288). It's possible there's other mutating methods that are `__path__`-safe, but this method is easy to reason about, I've tested this internally, and it would solve a problem that's already in the client.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
