### PR TITLE
Add not_rhel6 to EL6 yum resource tests to disable

### DIFF
--- a/spec/functional/resource/yum_package_spec.rb
+++ b/spec/functional/resource/yum_package_spec.rb
@@ -20,7 +20,7 @@ require "chef/mixin/shell_out"
 
 # run this test only for following platforms.
 exclude_test = !(%w{rhel fedora amazon}.include?(OHAI_SYSTEM[:platform_family]) && !File.exist?("/usr/bin/dnf"))
-describe Chef::Resource::YumPackage, :requires_root, external: exclude_test do
+describe Chef::Resource::YumPackage, :requires_root, external: exclude_test, not_rhel6: true do
   include RecipeDSLHelper
   include Chef::Mixin::ShellOut
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
@sean-simmons-progress and I looked at an EL6 instant and it appears that the repo that is the default for EL6 is no more.
I suspect there is an extended LTS repo that requires authentication or other arrangement. EL6 still builds and is tested, but yum package tests are skipped for EL6 specifically. They still get validated for other yum package using environments, including EL7 and 8.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
