### PR TITLE
uninstall libyajl2 to avoid kitchen-tests base image conflict (Chef 17's Version)

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -38,6 +38,11 @@ jobs:
         $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
         Move-Item -Path $output.FullName -Destination $target_path
 
+        # if a different version of ffi-yajl is installed, then libyajl2 needs to be reinstalled
+        # so that libyajldll.a is present in the intermediate build step. bundler seems to skip
+        # libyajl2 build if already present. gem install seems to build anyway.
+        gem uninstall -I libyajl2
+
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
         appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -38,11 +38,6 @@ jobs:
         $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
         Move-Item -Path $output.FullName -Destination $target_path
 
-        # if a different version of ffi-yajl is installed, then libyajl2 needs to be reinstalled
-        # so that libyajldll.a is present in the intermediate build step. bundler seems to skip
-        # libyajl2 build if already present. gem install seems to build anyway.
-        gem uninstall -I libyajl2
-
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
         appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY
@@ -64,6 +59,11 @@ jobs:
             Remove-Item -Path C:\opscode\chef\embedded\bin\htmldiff
             Remove-Item -Path C:\opscode\chef\embedded\bin\ldiff
         }
+
+        # if a different version of ffi-yajl is installed, then libyajl2 needs to be reinstalled
+        # so that libyajldll.a is present in the intermediate build step. bundler seems to skip
+        # libyajl2 build if already present. gem install seems to build anyway.
+        gem uninstall -I libyajl2
 
         bundle install --jobs=3 --retry=3
         # If ($lastexitcode -ne 0) { Exit $lastexitcode }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Similar to #13847 but actually *before* the `bundle install` in the kitchen test phase instead

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
