### PR TITLE
Fix the latin-1 hex value for ü to \xFC

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_tests.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_tests.rb
@@ -17,7 +17,7 @@ end
 # ran it in lamont-ci, so added the test here so everyone else other than
 # me gets coverage for this as well.
 # cspell:disable-next-line
-file "/tmp/chef-test-\xFDmlaut" do
+file "/tmp/chef-test-\xFCmlaut" do
   content "testing illegal UTF-8 char in the filename"
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
In troubleshooting an end-to-end test failure, I noticed the "umlaut u" code in the "wrong encoding Latin-1" test (added with [#5335](https://github.com/chef/chef/pull/5335/files)) is `\xFD` which is `ý` and not `ü` if you force encoding to latin 1 (`.force_encoding(Encoding::ISO_8859_1)`) and then `.encode('utf-8')`

```ruby
# this caught a regression in 12.14.70 before it was released when i
 # ran it in lamont-ci, so added the test here so everyone else other than
 # me gets coverage for this as well.
 file "/tmp/chef-test-\xFDmlaut" do
   content "testing illegal UTF-8 char in the filename"
 end
```

The proper code in ISO-8859/Latin-1 is `\xFC`, which is a trivial detail unless you happen to break graceful handling and you're trying to find a way to match the "bad" Latin-1 string to the UTF-8 string in the case above it.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
