### PR TITLE
Put chefstyle gem back in chefstyle group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,11 +55,10 @@ group(:development, :test) do
   gem "fauxhai-ng" # for chef-utils gem
 end
 
-gem "chefstyle"
-# group(:chefstyle) do
-#   # for testing new chefstyle rules
-#   gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "main"
-# end
+group(:chefstyle) do
+  # for testing new chefstyle rules
+  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "main"
+end
 
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/chef/chefstyle.git
+  revision: 71ae97744713ffd91ac8277d7a1385dabb6d570b
+  branch: main
+  specs:
+    chefstyle (2.2.2)
+      rubocop (= 1.25.1)
+
+GIT
   remote: https://github.com/chef/ohai.git
   revision: c63a8dca74db3fd542a082c7b6626ff497904290
   branch: main
@@ -198,8 +206,6 @@ GEM
       chef-utils (>= 17.0)
       chef-zero (>= 14.0)
       net-ssh
-    chefstyle (2.2.2)
-      rubocop (= 1.25.1)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     corefoundation (0.3.13)


### PR DESCRIPTION
## Description
The chefstyle group had been inadvertently [commented out in the Ruby 3.1 effort](https://github.com/chef/chef/commit/2f5dbd1ee69c970fc06870477dbbca6c5c3555c4#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR61)

This means that chefstyle (and the rest of the RuboCop toolchain) has been in infra client RPMs since it hasn't been [properly excluded from omnibus](https://github.com/chef/chef/blob/d493cfa966903f8bb03973cee4a96e1d69197352/omnibus/config/software/chef-local-source.rb#L70). This has lead to a significant amount of on-disk install size (at least 10MB, didn't bother to dig into exact numbers since 10MB is enough for me).

I've not modified Gemfile.lock yet since there's not yet a policy for that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
