### PR TITLE
adding the built in ruby gem to build the gems and push them to artif…

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -153,7 +153,7 @@ subscriptions:
             - "Expeditor: Skip Omnibus"
             - "Expeditor: Skip All"
           only_if: built_in:bump_version
-      - built_in:build_gem
+      - built_in:build_gem:
           only_if: built_in:bump_version
 
   # the habitat chain

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -153,6 +153,8 @@ subscriptions:
             - "Expeditor: Skip Omnibus"
             - "Expeditor: Skip All"
           only_if: built_in:bump_version
+      - built_in:build_gem
+          only_if: built_in:bump_version
 
   # the habitat chain
   - workload: buildkite_hab_build_group_published:{{agent_id}}:*


### PR DESCRIPTION
…actory on every merge to main

only on artifact_published:stable:chef:{{version_constraint}} is when they will get promoted to rubygems.org

<!--- Provide a short summary of your changes in the Title above -->

## Description
We noticed that the knife gem was not built automatically on the last release. This should address the building of the gem. 

https://expeditor.chef.io/docs/reference/actions/#built_inbuild_gem

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
