### PR TITLE
Use constant for ChefFS::PathUtils regexp_path_separator

### DIFF
--- a/lib/chef/chef_fs/file_pattern.rb
+++ b/lib/chef/chef_fs/file_pattern.rb
@@ -238,7 +238,7 @@ class Chef
             end
           end
 
-          @regexp = Regexp.new("^#{full_regexp_parts.join(Chef::ChefFS::PathUtils.regexp_path_separator)}$")
+          @regexp = Regexp.new("^#{full_regexp_parts.join(Chef::ChefFS::PathUtils::REGEXP_PATH_SEPARATOR)}$")
           @normalized_pattern = Chef::ChefFS::PathUtils.join(*normalized_parts)
           @normalized_pattern = Chef::ChefFS::PathUtils.join("", @normalized_pattern) if @is_absolute
         end

--- a/lib/chef/chef_fs/path_utils.rb
+++ b/lib/chef/chef_fs/path_utils.rb
@@ -40,13 +40,15 @@ class Chef
       # path to discover the Chef-FS root path) are handled in accordance to the rules
       # of the local file-system and OS.
 
+      REGEXP_PATH_SEPARATOR = ChefUtils.windows? ? "[\\/\\\\]" : "/"
+
       def self.join(*parts)
         return "" if parts.length == 0
 
         # Determine if it started with a slash
-        absolute = parts[0].length == 0 || parts[0].length > 0 && parts[0] =~ /^#{regexp_path_separator}/
+        absolute = parts[0].length == 0 || parts[0].length > 0 && parts[0] =~ /^#{REGEXP_PATH_SEPARATOR}/
         # Remove leading and trailing slashes from each part so that the join will work (and the slash at the end will go away)
-        parts = parts.map { |part| part.gsub(/^#{regexp_path_separator}+|#{regexp_path_separator}+$/, "") }
+        parts = parts.map { |part| part.gsub(/^#{REGEXP_PATH_SEPARATOR}+|#{REGEXP_PATH_SEPARATOR}+$/, "") }
         # Don't join empty bits
         result = parts.select { |part| part != "" }.join("/")
         # Put the / back on
@@ -54,16 +56,12 @@ class Chef
       end
 
       def self.split(path)
-        path.split(Regexp.new(regexp_path_separator))
-      end
-
-      def self.regexp_path_separator
-        ChefUtils.windows? ? "[\\/\\\\]" : "/"
+        path.split(Regexp.new(REGEXP_PATH_SEPARATOR))
       end
 
       # Given a server path, determines if it is absolute.
       def self.is_absolute?(path)
-        !!(path =~ /^#{regexp_path_separator}/)
+        !!(path =~ /^#{REGEXP_PATH_SEPARATOR}/)
       end
 
       # Given a path which may only be partly real (i.e. /x/y/z when only /x exists,
@@ -118,7 +116,7 @@ class Chef
 
         if ancestor.length == path.length
           ""
-        elsif /#{PathUtils.regexp_path_separator}/.match?(path[ancestor.length, 1])
+        elsif /#{PathUtils::REGEXP_PATH_SEPARATOR}/.match?(path[ancestor.length, 1])
           path[ancestor.length + 1..-1]
         else
           nil


### PR DESCRIPTION
## Description
Found while profiling the cookbook resolution code.

In #join alone there are three references. This leads to a ton of calls to `windows?`, which shouldn't change during the course of a run.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
