### PR TITLE
chocolatey: fix regression in calling `choco --version`

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -130,19 +130,15 @@ class Chef
         # install from, but like the rubygem provider's sources which are more like repos.
         def check_resource_semantics!; end
 
-        def self.get_choco_version
-          @get_choco_version ||= powershell_exec!("choco --version").result
+        def get_choco_version
+          @get_choco_version ||= powershell_exec!("#{choco_exe} --version").result
         end
 
         # Choco V2 uses 'Search' for remote repositories and 'List' for local packages
-        def self.query_command
+        def query_command
           return "list" if get_choco_version.match?(/^1/)
 
           "search"
-        end
-
-        def query_command
-          self.class.query_command
         end
 
         private

--- a/spec/functional/resource/chocolatey_package_spec.rb
+++ b/spec/functional/resource/chocolatey_package_spec.rb
@@ -24,7 +24,7 @@ describe Chef::Resource::ChocolateyPackage, :windows_only, :choco_installed do
   let(:package_name) { "test-A" }
   let(:package_source) { File.join(CHEF_SPEC_ASSETS, "chocolatey_feed") }
   let(:package_list) do
-    if Chef::Provider::Package::Chocolatey.query_command == "list"
+    if provider.query_command == "list"
       # using result of query_command because that indicates which "search" command to use
       # which coincides with the package list output
       proc { shell_out!("choco search -lo #{Array(package_name).join(" ")}").stdout.chomp }
@@ -63,7 +63,7 @@ describe Chef::Resource::ChocolateyPackage, :windows_only, :choco_installed do
   end
 
   after(:each) do
-    described_class.instance_variable_set(:@get_choco_version, nil)
+    provider.instance_variable_set(:@get_choco_version, nil)
   end
 
   context "installing a package" do

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -47,10 +47,11 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
     allow(provider).to receive(:choco_exe).and_return(choco_exe)
     local_list_obj = double(stdout: local_list_stdout)
     allow(provider).to receive(:shell_out_compacted!).with(choco_exe, "list", "-l", "-r", { returns: [0, 2], timeout: timeout }).and_return(local_list_obj)
+    allow(provider).to receive(:powershell_exec!).with("#{choco_exe} --version").and_return(double(result: "2.1.0"))
   end
 
   after(:each) do
-    described_class.instance_variable_set(:@get_choco_version, nil)
+    provider.instance_variable_set(:@get_choco_version, nil)
   end
 
   def allow_remote_list(package_names, args = nil)
@@ -65,9 +66,9 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
     remote_list_obj = double(stdout: remote_list_stdout)
     package_names.each do |pkg|
       if args
-        allow(provider).to receive(:shell_out_compacted!).with(choco_exe, described_class.query_command, "-r", pkg, *args, { returns: [0, 2], timeout: timeout }).and_return(remote_list_obj)
+        allow(provider).to receive(:shell_out_compacted!).with(choco_exe, provider.query_command, "-r", pkg, *args, { returns: [0, 2], timeout: timeout }).and_return(remote_list_obj)
       else
-        allow(provider).to receive(:shell_out_compacted!).with(choco_exe, described_class.query_command, "-r", pkg, { returns: [0, 2], timeout: timeout }).and_return(remote_list_obj)
+        allow(provider).to receive(:shell_out_compacted!).with(choco_exe, provider.query_command, "-r", pkg, { returns: [0, 2], timeout: timeout }).and_return(remote_list_obj)
       end
     end
   end
@@ -84,12 +85,12 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
 
   describe "choco searches change with the version" do
     it "Choco V1 uses List" do
-      allow(described_class).to receive(:get_choco_version).and_return("1.4.0")
+      allow(provider).to receive(:powershell_exec!).with("#{choco_exe} --version").and_return(double(result: "1.4.0"))
       expect(provider.query_command).to eql("list")
     end
 
     it "Choco V2 uses Search" do
-      allow(described_class).to receive(:get_choco_version).and_return("2.1.0")
+      allow(provider).to receive(:powershell_exec!).with("#{choco_exe} --version").and_return(double(result: "2.1.0"))
       expect(provider.query_command).to eql("search")
     end
   end
@@ -166,7 +167,7 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
       new_resource.package_name("package-does-not-exist")
       new_resource.returns([0])
       allow(provider).to receive(:shell_out_compacted!)
-        .with(choco_exe, described_class.query_command, "-r", new_resource.package_name.first, { returns: new_resource.returns, timeout: timeout })
+        .with(choco_exe, provider.query_command, "-r", new_resource.package_name.first, { returns: new_resource.returns, timeout: timeout })
         .and_raise(Mixlib::ShellOut::ShellCommandFailed, "Expected process to exit with [0], but received '2'")
       expect { provider.send(:available_packages) }.to raise_error(Mixlib::ShellOut::ShellCommandFailed, "Expected process to exit with [0], but received '2'")
     end


### PR DESCRIPTION
https://github.com/chef/chef/pull/13833 added `choco --version`, but this binary may not be in the path.

Fix this by using `choco_exe` and promoting the calls to instance methods.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
