### PR TITLE
Chef::CookbookSynchronizer#remove_deleted_files: Use Array instead of Set

### DIFF
--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -18,7 +18,6 @@ require_relative "../util/threaded_job_queue"
 require_relative "../server_api"
 require "singleton" unless defined?(Singleton)
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
-require "set" unless defined?(Set)
 
 class Chef
 
@@ -240,8 +239,8 @@ class Chef
       @cookbooks_by_name.each_key do |cookbook_name|
         cache_file_hash[cookbook_name].each_key do |segment|
           manifest_segment = cookbook_segment(cookbook_name, segment)
-          manifest_record_paths = manifest_segment.map { |manifest_record| manifest_record["path"] }.to_set
-          to_be_removed = cache_file_hash[cookbook_name][segment].keys.to_set - manifest_record_paths
+          manifest_record_paths = manifest_segment.map { |manifest_record| manifest_record["path"] }
+          to_be_removed = cache_file_hash[cookbook_name][segment].keys - manifest_record_paths
           to_be_removed.each do |path|
             cache_file = cache_file_hash[cookbook_name][segment][path]
 


### PR DESCRIPTION
## Description

Should address #13940. The usage of Sets over Arrays was only a minor speedup IIRC, and we can take another pass it once we've figured out why `.to_set` wasn't working with the earlier `require`. `Set` became a built-in in [Ruby 3.2](https://docs.ruby-lang.org/en/3.2/NEWS_md.html), so could also wait until that's the running version before using that `Set` more extensively in the client

## Related Issue
#13940 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
