### PR TITLE
Add hook to service resource for non-enable-able services

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -331,6 +331,7 @@
     "EMBEDDEDNT",
     "EMBEDDEDSERVER",
     "ENABLEDELAYEDEXPANSION",
+    "enableable",
     "enablegroups",
     "enablement",
     "enablerepo",

--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -80,7 +80,19 @@ class Chef
         end
       end
 
+      # This is a hook for subclasses to be able to tell the super class that a
+      # service is or is not enable-able. For example, on systemd, static and
+      # indirect units are not enable-able.
+      #
+      # In addition, this method offloads the messaging to the user. If the
+      # method returns `false`, it should say why `action` couldn't be taken
+      def enableable?(action)
+        true
+      end
+
       action :enable do
+        return unless enableable?(:enable)
+
         if current_resource.enabled
           logger.debug("#{new_resource} already enabled - nothing to do")
         else
@@ -94,6 +106,8 @@ class Chef
       end
 
       action :disable do
+        return unless enableable?(:disable)
+
         if current_resource.enabled
           converge_by("disable service #{new_resource}") do
             disable_service

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -93,6 +93,9 @@ class Chef
       # if the service is masked or not
       property :masked, [ TrueClass, FalseClass ], skip_docs: true
 
+      # if the service is static or not
+      property :static, [ TrueClass, FalseClass ], skip_docs: true
+
       # if the service is indirect or not
       property :indirect, [ TrueClass, FalseClass ], skip_docs: true
 

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -56,6 +56,7 @@ describe Chef::Provider::Service::Systemd do
       allow(provider).to receive(:is_active?).and_return(false)
       allow(provider).to receive(:is_enabled?).and_return(false)
       allow(provider).to receive(:is_masked?).and_return(false)
+      allow(provider).to receive(:is_static?).and_return(false)
       allow(provider).to receive(:is_indirect?).and_return(false)
     end
 


### PR DESCRIPTION
Add hook to service resource for non-enable-able services

Summary:

There are many hacks in `system_service` around non-enable-able services (such as `masked` or `static` services). While this allows for the right underlying behavior, the parent class having no understanding that this can happen means you get weird output like:

```
[2020-06-02T16:56:33-07:00] TRACE: service[gdm] cannot be disabled: it is static
[2020-06-02T16:56:33-07:00] INFO: service[gdm] disabled
```

So this adds a small hook into the service parent class called `enableable?` which subclasses can use to denote (and log why) a service is or isn't enable-able.

This replaces #9949.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

Test Plan:

So far, tests all pass, but more testing to come
