### PR TITLE
Chef::Log.debug the puts debugs

### DIFF
--- a/lib/chef/monkey_patches/net-http.rb
+++ b/lib/chef/monkey_patches/net-http.rb
@@ -23,7 +23,7 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
           conn_port = port
         end
 
-        puts "opening connection to #{conn_addr}:#{conn_port}..."
+        Chef::Log.debug("opening connection to #{conn_addr}:#{conn_port}...")
         s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
           begin
             TCPSocket.open(conn_addr, conn_port, @local_host, @local_port)
@@ -33,7 +33,7 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
           end
         }
         s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
-        puts "opened"
+        Chef::Log.debug("opened")
         if use_ssl?
           if proxy?
             plain_sock = BufferedIO.new(s, read_timeout: @read_timeout,
@@ -92,7 +92,7 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
             ssl_host_address = @address
           end
 
-          puts "starting SSL for #{conn_addr}:#{conn_port}..."
+          Chef::Log.debug("starting SSL for #{conn_addr}:#{conn_port}...")
           s = OpenSSL::SSL::SSLSocket.new(s, @ssl_context)
           s.sync_close = true
           s.hostname = ssl_host_address if s.respond_to?(:hostname=) && ssl_host_address
@@ -105,7 +105,7 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
           if (@ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE) && verify_hostname
             s.post_connection_check(@address)
           end
-          puts "SSL established, protocol: #{s.ssl_version}, cipher: #{s.cipher[0]}"
+          Chef::Log.debug("SSL established, protocol: #{s.ssl_version}, cipher: #{s.cipher[0]}")
         end
         @socket = BufferedIO.new(s, read_timeout: @read_timeout,
                                 write_timeout: @write_timeout,
@@ -115,7 +115,7 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
         on_connect
       rescue => exception
         if s
-          puts "Conn close because of connect error #{exception}"
+          Chef::Log.debug("Conn close because of connect error #{exception}")
           s.close
         end
         raise


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The monkey patch for net/http issues pre-Ruby 3.2 added `puts` statements without converting them to `Chef::Log.debug`

## Related Issue
[About Monkey patch ruby for net/http added verbosity in #13745](https://github.com/chef/chef/issues/13936)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
