### PR TITLE
Optimize chocolatey when doing large numbers of operations, by batching and caching

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -14,10 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# This uses class variables on purpose to maintain a state cache between resources,
+# since they work on shared state
+#
+# rubocop:disable Style/ClassVars
 
 require_relative "../package"
 require_relative "../../resource/chocolatey_package"
 require_relative "../../win32/api/command_line_helper" if ChefUtils.windows?
+require "zip" unless defined?(Zip)
 
 class Chef
   class Provider
@@ -38,6 +43,10 @@ class Chef
           '#{PATHFINDING_POWERSHELL_COMMAND}'.
         EOS
 
+        # initialize our cache on load
+        @@choco_available_packages = nil
+        @@choco_config = nil
+
         # Responsible for building the current_resource.
         #
         # @return [Chef::Resource::ChocolateyPackage] the current_resource
@@ -45,6 +54,10 @@ class Chef
           @current_resource = Chef::Resource::ChocolateyPackage.new(new_resource.name)
           current_resource.package_name(new_resource.package_name)
           current_resource.version(build_current_versions)
+          # Ensure that we have a working chocolatey executable - this used to be
+          # covered off by loading the resource, but since that's no longer required,
+          # we're going to put a quick check here to fail early!
+          choco_exe
           current_resource
         end
 
@@ -141,6 +154,39 @@ class Chef
           "search"
         end
 
+        # invalidate cache for testing purposes
+        def invalidate_cache
+          @@choco_config = nil
+        end
+
+        # This checks that the repo list has not changed between now and when we last checked
+        # the cache
+        def cache_is_valid?
+          return false if @@choco_config.nil? || (actual_config != @@choco_config)
+
+          true
+        end
+
+        # walk the collection to find peer resources to ensure that
+        # we get as much of the cache this run as possible.  Unified mode
+        # sub-resources will, of course, be incremental with this, since we can't
+        # grab them in advance, but even in that case we're still way, way
+        # more efficient with our queries...
+        #
+        # @return [Array] List of chocolatey packages referenced in the run list
+        def collect_package_requests(ignore_list: [])
+          return ["*"] if new_resource.bulk_query || Chef::Config[:always_use_bulk_chocolatey_package_list]
+
+          # Get to the root of the resource collection
+          rc = run_context.parent_run_context || run_context
+          rc = rc.parent_run_context while rc.parent_run_context
+
+          package_collection = package_name_array
+          package_collection += nested_package_resources(rc.resource_collection)
+          # downcase the array and uniq.  sorted for easier testing...
+          package_collection.uniq.sort.filter { |pkg| !ignore_list.include?(pkg) }
+        end
+
         private
 
         def version_compare(v1, v2)
@@ -152,6 +198,22 @@ class Chef
           gem_v2 = Gem::Version.new(v2)
 
           gem_v1 <=> gem_v2
+        end
+
+        # Cache the configuration in order to ensure that we can check our
+        # package cache is valid for a run
+        def actual_config
+          config_path = ::File.join("#{choco_install_path}", "config", "chocolatey.config")
+          if ::File.exist?(config_path)
+            return ::File.read(config_path)
+          end
+
+          nil
+        end
+
+        # update the validity of the package cache
+        def set_package_cache
+          @@choco_config = actual_config
         end
 
         # Magic to find where chocolatey is installed in the system, and to
@@ -171,9 +233,15 @@ class Chef
 
         # lets us mock out an incorrect value for testing.
         def choco_install_path
-          result = powershell_exec!(PATHFINDING_POWERSHELL_COMMAND).result
-          result = "" if result.empty?
-          result
+          @choco_install_path ||= begin
+            result = powershell_exec!(PATHFINDING_POWERSHELL_COMMAND).result
+            result = "" if result.empty?
+            result
+          end
+        end
+
+        def choco_lib_path
+          ::File.join(choco_install_path, "lib")
         end
 
         # Helper to dispatch a choco command through shell_out using the timeout
@@ -214,6 +282,17 @@ class Chef
           Hash[*lowercase_names(new_resource.package_name).zip(desired_versions).flatten]
         end
 
+        def nested_package_resources(res)
+          package_collection = []
+          res.each do |child_res|
+            package_collection += nested_package_resources(child_res.resources)
+            next unless child_res.is_a?(Chef::Resource::ChocolateyPackage)
+
+            package_collection += child_res.package_name.flatten
+          end
+          package_collection
+        end
+
         # Helper to construct optional args out of new_resource
         #
         # @param include_source [Boolean] should the source parameter be added
@@ -230,35 +309,125 @@ class Chef
         #
         # @return [Hash] name-to-version mapping of available packages
         def available_packages
-          return @available_packages if @available_packages
+          return @available_packages unless @available_packages.nil?
 
-          @available_packages = {}
-          package_name_array.each do |pkg|
+          # @available_packages is per object - each resource is an object, meaning if you
+          # have a LOT of chocolatey package installs, then this quickly gets very slow.
+          # So we use @@choco_available_packages instead - BUT it's important to ensure that
+          # the cache is valid before you do this.  There are two cache items that can change:
+          # a) the sources - we check this with cache_is_valid?
+          if cache_is_valid? && @@choco_available_packages.is_a?(Hash) &&
+              @@choco_available_packages[new_resource.list_options]
+
+            # Ensure we have the package names, or else double check...
+            need_redo = false
+            package_name_array.each do |pkg|
+              need_redo = true unless @@choco_available_packages[new_resource.list_options][pkg.downcase]
+            end
+            return @@choco_available_packages[new_resource.list_options] unless need_redo
+          end
+          if new_resource.list_options
+            Chef::Log.info("Fetching chocolatey package list with options #{new_resource.list_options.inspect}")
+          else
+            Chef::Log.info("Fetching chocolatey package list")
+          end
+
+          # Only reset the array if the cache is invalid - if we're just augmenting it, don't
+          # clear it
+          @@choco_available_packages = {} if @@choco_available_packages.nil? || !cache_is_valid?
+          if @@choco_available_packages[new_resource.list_options].nil?
+            @@choco_available_packages[new_resource.list_options] = {}
+          end
+
+          # Attempt to get everything we need in a single query.
+          # Grab 25 packages at a time at most, to avoid hurting servers too badly
+          #
+          # For v1 we actually used to grab the entire list of packages, but we found
+          # that it could cause undue load on really large package lists
+          collect_package_requests(
+            ignore_list: @@choco_available_packages[new_resource.list_options].keys
+          ).each_slice(25) do |pkg_set|
             available_versions =
               begin
-                cmd = [ query_command, "-r", pkg ]
-                cmd += common_options
-                cmd.push( new_resource.list_options ) if new_resource.list_options
+              cmd = [ query_command, "-r" ]
 
-                raw = parse_list_output(*cmd)
-                raw.keys.each_with_object({}) do |name, available|
-                  available[name] = desired_name_versions[name] || raw[name]
-                end
+              # Chocolatey doesn't actually take a wildcard for this query, however
+              # it will return all packages when using '*' as a query
+              unless pkg_set == ["*"]
+                cmd += pkg_set
               end
-            @available_packages.merge! available_versions
+              cmd += common_options
+              cmd.push( new_resource.list_options ) if new_resource.list_options
+
+              Chef::Log.debug("Choco List Command: #{cmd}")
+
+              raw = parse_list_output(*cmd)
+              raw.keys.each_with_object({}) do |name, available|
+                available[name] = desired_name_versions[name] || raw[name]
+              end
+            end
+            @@choco_available_packages[new_resource.list_options].merge!(available_versions)
           end
-          @available_packages
+          # Mark the cache as valid, with the required metadata
+          set_package_cache
+          # Why both?  So when we fail to find a package once, we don't try on every
+          # retry, even though it would be reasonable to do so if queried in another
+          # resource (because the chocolatey configuration may well have changed!)
+          @available_packages = @@choco_available_packages[new_resource.list_options]
         end
 
         # Installed packages in chocolatey as a Hash of names mapped to versions
-        # (names are downcased for case-insensitive matching)
-        #
-        # Beginning with Choco 2.0, "list" returns local packages only while "search" returns packages from external package sources
+        # (names are downcased for case-insensitive matching).  Depending on the user
+        # preference, we get these either from the local database, or from the choco
+        # list command
         #
         # @return [Hash] name-to-version mapping of installed packages
         def installed_packages
+          if new_resource.use_choco_list == false || !Chef::Config[:always_use_choco_list]
+            installed_packages_via_choco
+          else
+            installed_packages_via_disk
+          end
+        end
+
+        # Beginning with Choco 2.0, "list" returns local packages only while "search" returns packages from external package sources
+        #
+        # @return [Hash] name-to-version mapping of installed packages
+        def installed_packages_via_choco
           @installed_packages ||= Hash[*parse_list_output("list", "-l", "-r").flatten]
           @installed_packages
+        end
+
+        # Return packages sourced from the local disk - because this doesn't have
+        # shell out overhead, this ends up being a significant performance win
+        # vs calling choco list
+        #
+        # @return [Hash] name-to-version mapping of installed packages
+        def installed_packages_via_disk
+          @installed_packages ||= begin
+            targets = new_resource.name
+            target_dirs = []
+            # If we're using a single package name, have it at the head of the list
+            # so we can get more performance.  In either case, the
+            # array is filled by the call to `get_local_pkg_dirs` below - but
+            # that contains all possible package folders, and so we push our
+            # guess to the front as an optimization.
+            target_dirs << targets.first.downcase if targets.length == 1
+            if targets.downcase is_a?(String)
+              target_dirs << targets
+            end
+            target_dirs += get_local_pkg_dirs(choco_lib_path)
+            fetch_package_versions(choco_lib_path, target_dirs, targets)
+          end
+        end
+
+        # Grab the nupkg folder list
+        def get_local_pkg_dirs(base_dir)
+          return [] unless Dir.exist?(base_dir)
+
+          Dir.entries(base_dir).select do |dir|
+            ::File.directory?(::File.join(base_dir, dir)) && !dir.start_with?(".")
+          end
         end
 
         # Helper to convert choco.exe list output to a Hash
@@ -292,7 +461,46 @@ class Chef
           args.push( [ "--password", new_resource.password ]) if new_resource.password
           args
         end
+
+        # Fetch the local package versions from chocolatey
+        def fetch_package_versions(base_dir, target_dirs, targets)
+          pkg_versions = {}
+          target_dirs.each do |dir|
+            pkg_versions.merge!(get_pkg_data(::File.join(base_dir, dir)))
+            # return early if we found the single package version we were looking for
+            return pkg_versions if targets.length == 1 && pkg_versions[targets.first]
+          end
+          pkg_versions
+        end
+
+        # Grab the locally installed packages from the nupkg list
+        # rather than shelling out to chocolatey
+        def get_pkg_data(path)
+          t = ::File.join(path, "*.nupkg").gsub("\\", "/")
+          targets = Dir.glob(t)
+
+          # Extract package version from the first nuspec file in this nupkg
+          targets.each do |target|
+            Zip::File.open(target) do |zip_file|
+              zip_file.each do |entry|
+                next unless entry.name.end_with?(".nuspec")
+
+                f = entry.get_input_stream
+                doc = REXML::Document.new(f.read.to_s)
+                f.close
+                id = doc.elements["package/metadata/id"]
+                version = doc.elements["package/metadata/version"]
+                return { id.text.to_s.downcase => version.text } if id && version
+              end
+            end
+          end
+          {}
+        rescue StandardError => e
+          Chef::Log.warn("Failed to get package info for #{path}: #{e}")
+          {}
+        end
       end
     end
   end
 end
+# rubocop:enable Style/ClassVars

--- a/lib/chef/resource/chocolatey_package.rb
+++ b/lib/chef/resource/chocolatey_package.rb
@@ -67,6 +67,14 @@ class Chef
         description: "The name of the package. Default value: the name of the resource block.",
         coerce: proc { |x| [x].flatten }
 
+      property :bulk_query, [TrueClass, FalseClass],
+        description: "Bulk query the chocolatey server?  This will cause the provider to list all packages instead of doing individual queries.",
+        default: false
+
+      property :use_choco_list, [TrueClass, FalseClass],
+        description: "Use choco list for getting the locally installed packages, rather than reading the nupkg database directly?  This defaults to false, since reading the package data is faster.",
+        default: false
+
       property :version, [String, Array],
         description: "The version of a package to be installed or upgraded.",
         coerce: proc { |x| [x].flatten }


### PR DESCRIPTION
## Description

When we instrumented, chocolatey resources were a major (>30% run time) contibutor to our idempotent run time.  This reduces that to around 2%, via the following optimizations:

 * Cache choco list/search command output in order to reduce queries to the nuget servers.  This saves significant wall clock time when installing >50 packages

 * Attempt to batch queries as much as possible, either by walking the resource tree, or with a non-default resource property of "bulk_query".  This also significantly reduces load on upstream package servers, since queries are expensive.  Note that on _some_ nuget implementations, bulk_query gets a bad result from the server on v2.x - this is reproducable outside of chef, however.  The public repositories work for this, but it should always be non-default there since it's going to return a large list!

 * Grab package data from the disk rather than shelling out to chocolatey list, avoiding shell outs saving significant cycles on an idempotent runs

In our environment, this saves around 30% of the time of a chef run.

This is tested on chocolatey 1.2.1, 2.0.0, and 2.2.2

Note that this does NOT fix the existing rubocop issues - it doesn't add a pile of new ones, and it _does_ command and suppress the new one it introduces.  It might be worth another PR to generally clean this up for style...


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
