### PR TITLE
Add Danger CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 ---
 name: lint
 
-"on":
+on:
   pull_request:
   push:
     branches:
@@ -13,23 +13,53 @@ jobs:
     env:
       BUNDLE_WITHOUT: ruby_shadow:omnibus_package
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.1
-        bundler-cache: false
-    - uses: r7kamura/rubocop-problem-matchers-action@v1  # this shows the failures in the PR
-    - run: |
-        gem install chefstyle
-        chefstyle -c .rubocop.yml
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: false
+      - uses: r7kamura/rubocop-problem-matchers-action@v1  # this shows the failures in the PR
+      - run: |
+          gem install chefstyle
+          chefstyle -c .rubocop.yml
 
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: carlosperate/download-file-action@v2.0.0
         id: download-custom-dictionary
         with:
           file-url: 'https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt'
           file-name: 'chef_dictionary.txt'
       - uses: streetsidesoftware/cspell-action@v2.12.0
+
+  danger:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      # Note this step not needed once we switch to the pre-canned action
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          # get weird post errors sometimes without this
+          bundler-cache: false
+      - run: gem install danger
+      - run: |
+          danger --verbose 2>&1 | tee danger.out || true
+          if grep -q 'Danger has failed this build' danger.out; then
+            exit 1
+          else
+            exit 0
+          fi
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# The pre-canned danger Action doesn't work on forks. Filed
+# https://github.com/danger/danger/issues/1462
+# against it
+#     - uses: danger/danger@master
+#       env:
+#         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,17 @@
+# Enforce our Gemfile update policy
+if git.modified_files.include?("Gemfile.lock") && !github.pr_authr == "dependabot"
+  if git.modified_files.include?("Gemfile")
+    message "PR updates Gemfile.lock, but it also updates Gemfile, so that" +
+      " is probably OK - but the reviewer should check updates are solely" +
+      " from the Gemfile update"
+  elsif !github.pr_body.include?("--conservative")
+    if github.pr_body.include?("#gemlock_major_upgrade")
+      message "PR updates Gemfile.lock, but output doesn't appear to be in" +
+        " the PR Description. However #gemlock_major_upgrade does, so allowing"
+    else
+      failure "Gem/Bundle changes were not documented in the Description. If" +
+        " this is a major update, add #gemlock_major_upgrade to the PR" +
+        " Description."
+    end
+  end
+end

--- a/cspell.json
+++ b/cspell.json
@@ -1578,6 +1578,7 @@
     "**/*.yml",
     "**/*.toml",
     "**/Berksfile",
+    "Dangerfile",
     "lib/chef/provider/package/yum/simplejson/**/*",
     "lib/chef/provider/package/yum/simplejson/*",
     "omnibus/resources/chef/**/*",


### PR DESCRIPTION
Add Danger CI

Summary:

OK this is a bit complicated. As of now this will work on branch-based PRs
all the time and will often fail on fork-based PRs (but not always). SOOO, what
we do is DETECT that failure and *NOT* fail the PR, but if there are real
issues detected, then we do fail the PR.

There's basically two problems going on here:

1. The GITHUB token given to PRs cannot comment on the PR, and while we
could make a token that does, it would have to have `public_repo` which gives
it full read/write access to the all public repos. Boo. Details throughout
https://github.com/danger/danger/issues/1103

2. There's some combination of bugs/race conditions that cause Danger to
not always see the PR commit, even though it has both remotes. This is discussed
here:
https://github.com/danger/danger/issues/1103#issuecomment-610055193

This works around and gives consistent feedback for internal users and
sometimes-feedback for external users. It's a step in the right direction.

Test Plan:

Signed-off-by: Phil Dibowitz <phil@ipom.com>
