### PR TITLE
Attempt to make Gemfile.lock stable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5)
+      ffi (~> 1.15.5)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
@@ -90,7 +90,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5)
+      ffi (~> 1.15.5)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
@@ -222,8 +222,10 @@ GEM
     faraday-net_http (3.0.2)
     fauxhai-ng (9.3.0)
       net-ssh
-    ffi (1.16.2)
-    ffi (1.16.2-x64-mingw-ucrt)
+    ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
+    ffi (1.15.5-x64-mingw32)
+    ffi (1.15.5-x86-mingw32)
     ffi-libarchive (1.1.3)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -297,6 +299,11 @@ GEM
     mixlib-log (3.0.9)
     mixlib-shellout (3.2.7)
       chef-utils
+    mixlib-shellout (3.2.7-universal-mingw32)
+      chef-utils
+      ffi-win32-extensions (~> 1.0.3)
+      win32-process (~> 0.9)
+      wmi-lite (~> 1.0)
     mixlib-shellout (3.2.7-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
@@ -421,7 +428,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.4.2)
     unicode_utils (1.4.0)
     uuidtools (2.2.0)
@@ -432,7 +438,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    win32-api (1.10.1-universal-mingw32)
+    win32-api (1.10.1)
     win32-certstore (0.6.15)
       chef-powershell (>= 1.0.12)
       ffi
@@ -476,8 +482,11 @@ GEM
     wmi-lite (1.0.7)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
   x64-mingw-ucrt
+  x64-mingw32
+  x86-mingw32
 
 DEPENDENCIES
   appbundler
@@ -490,7 +499,7 @@ DEPENDENCIES
   chefstyle
   ed25519 (~> 1.2)
   fauxhai-ng
-  ffi (>= 1.15.5)
+  ffi (~> 1.15.5)
   inspec-core-bin (>= 5)
   ohai!
   pry (= 0.13.0)


### PR DESCRIPTION
Attempt to make Gemfile.lock stable

Summary:

As it stands today doing a `bundle install` will change `Gemfile.lock`
because the `PLATFORMS` section doesn't list all the platforms.

Used CLIs to fix this:

```shell
[phil@rider RBENV(3.1.1) chef]$ bundle lock --add-platform x64-mingw32
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies....^[[A...
Writing lockfile to /home/phil/src/git/chef/Gemfile.lock
[phil@rider RBENV(3.1.1) chef]$ bundle lock --add-platform x86-mingw32
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies.........
Writing lockfile to /home/phil/src/git/chef/Gemfile.lock
[phil@rider RBENV(3.1.1) chef]$ bundle lock --add-platform arm64-darwin-21
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies............
Writing lockfile to /home/phil/src/git/chef/Gemfile.lock
```

Note that one should not add `universal-mingw` as a platform, as it is
not a valid platform to support, but some gems which have builds that work
on all mingw platforms are marked as such and will satisfy any $arch-mingw
requirements

All the changes look correct, except for two I worry about: `win32-api` and `unf_ext` both drop their universal versions for the base version. Given
these are Windows by default, that may be OK, but the Windows tests
will tell us for sure.

Test Plan:

The actions and buildkite tests should be sufficient.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
