### PR TITLE
Don't try to run SonarQube on forked-based PRs

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -12,9 +12,11 @@ on:
  
 jobs:
   sonarqube:
+    # this only works on branch-based PRs
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ip-range-controlled
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0


### PR DESCRIPTION
Don't try to run SonarQube on forked-based PRs

Summary:

It fails anyway, no point in running it

Test Plan:

this is the test!!

Signed-off-by: Phil Dibowitz <phil@ipom.com>
