### PR TITLE
Move untag to the node to match tag

### DIFF
--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -401,9 +401,31 @@ class Chef
       normal[:tags]
     end
 
+    # Add the list of tags to the node.
+    #
+    # === Parameters
+    # tags<Array>:: A list of tags
+    #
+    # === Returns
+    # tags<Array>:: The current list of run_context.node.tags
     def tag(*args)
       args.each do |tag|
         tags.push(tag.to_s) unless tags.include? tag.to_s
+      end
+
+      tags
+    end
+
+    # Removes the list of tags from the node.
+    #
+    # === Parameters
+    # tags<Array>:: A list of tags
+    #
+    # === Returns
+    # tags<Array>:: The current list of run_context.node.tags
+    def untag(*args)
+      args.each do |tag|
+        tags.delete(tag.to_s)
       end
 
       tags

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -70,12 +70,12 @@ class Chef
 
     # This was moved to Chef::Node#tag, redirecting here for compatibility
     def tag(*tags)
-      run_context.node.tag(*tags)
+      node.tag(*tags)
     end
 
     # This was moved to Chef::Node#untag, redirecting here for compatibility
     def untag(*tags)
-      run_context.node.untag(*tags)
+      node.untag(*tags)
     end
 
     def from_yaml_file(filename)

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -73,17 +73,9 @@ class Chef
       run_context.node.tag(*tags)
     end
 
-    # Removes the list of tags from the node.
-    #
-    # === Parameters
-    # tags<Array>:: A list of tags
-    #
-    # === Returns
-    # tags<Array>:: The current list of run_context.node.tags
+    # This was moved to Chef::Node#untag, redirecting here for compatibility
     def untag(*tags)
-      tags.each do |tag|
-        run_context.node.tags.delete(tag)
-      end
+      run_context.node.untag(*tags)
     end
 
     def from_yaml_file(filename)

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -304,7 +304,7 @@ describe Chef::Node do
       end
 
       it "should let you use untag as a convince method for the tags attribute" do
-        node.normal["tags"] = %w{one two thre four}
+        node.normal["tags"] = %w{one two three four}
         node.untag("three", "four")
         expect(node["tags"]).to eq(%w{one two})
       end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -303,6 +303,12 @@ describe Chef::Node do
         expect(node["tags"]).to eq(%w{one two three four})
       end
 
+      it "should let you use untag as a convince method for the tags attribute" do
+        node.normal["tags"] = %w{one two thre four}
+        node.untag("three", "four")
+        expect(node["tags"]).to eq(%w{one two})
+      end
+
       it "normal_unless sets a value even if default or override attrs are set" do
         node.default[:decontamination] = true
         node.override[:decontamination] = false


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Moving the `untag` method the same way `tag` was moved from recipe to node in this commit https://github.com/chef/chef/commit/9e954aeb26e83bb77a645c76a184df5a265161d6

## Related Issue
https://github.com/chef/chef/issues/13993

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
