### PR TITLE
Enable state tracking on mutating Array operations

### DIFF
--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -18,6 +18,7 @@
 
 require_relative "common_api"
 require_relative "mixin/state_tracking"
+require_relative "mixin/state_tracking_array"
 require_relative "mixin/immutablize_array"
 require_relative "mixin/immutablize_hash"
 require_relative "mixin/mashy_array"
@@ -97,7 +98,7 @@ class Chef
         key
       end
 
-      prepend Chef::Node::Mixin::StateTracking
+      prepend Chef::Node::Mixin::StateTrackingArray
     end
 
     # == VividMash

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -17,6 +17,7 @@
 
 require_relative "common_api"
 require_relative "mixin/state_tracking"
+require_relative "mixin/state_tracking_array"
 require_relative "mixin/immutablize_array"
 require_relative "mixin/immutablize_hash"
 require_relative "../delayed_evaluator"
@@ -119,7 +120,7 @@ class Chef
         value
       end
 
-      prepend Chef::Node::Mixin::StateTracking
+      prepend Chef::Node::Mixin::StateTrackingArray
       prepend Chef::Node::Mixin::ImmutablizeArray
     end
 

--- a/lib/chef/node/mixin/state_tracking_array.rb
+++ b/lib/chef/node/mixin/state_tracking_array.rb
@@ -1,0 +1,41 @@
+#--
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "immutablize_array"
+require_relative "state_tracking"
+
+class Chef
+  class Node
+    module Mixin
+      module StateTrackingArray
+        include ::Chef::Node::Mixin::StateTracking
+
+        MUTATOR_METHODS = Chef::Node::Mixin::ImmutablizeArray::DISALLOWED_MUTATOR_METHODS
+
+        # For all of the methods that may mutate an Array, we override them to
+        # also track the state and trigger attribute_changed event.
+        MUTATOR_METHODS.each do |mutator|
+          define_method(mutator) do |*args, &block|
+            ret = super(*args, &block)
+            send_attribute_changed_event(__path__, self)
+            ret
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
The State tracking feature is nice, especially as it allows to get an event when an attribute is updated.

However, mutating operations on Arrays were not properly tracked, at least for the "attribute_changed" event.
For instance, `default['array'] << 1` was not triggering an event.

The new code, ensure that all identified mutating methods are properly implementing the State Tracking feature.
To do it, it leverages existing DISALLOWED_MUTATOR_METHODS constant.

## Related Issue
#13995

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
