### PR TITLE
try fixing kitchen tests for macOS

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -1,4 +1,4 @@
----
+
 name: kitchen
 
 "on":
@@ -107,15 +107,7 @@ jobs:
         /opt/chef/bin/ohai -v
     - name: 'Run end_to_end::default recipe'
       id: run
-      run: |
-        cd kitchen-tests
-        sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
-        sudo /opt/chef/embedded/bin/bundle config set --local path 'vendor/bundle'
-        sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3
-        sudo rm -f /opt/chef/embedded/bin/{htmldiff,ldiff}
-        sudo /opt/chef/embedded/bin/gem install berkshelf --no-doc
-        sudo /opt/chef/embedded/bin/berks vendor cookbooks
-        sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist
+      run: .github/workflows/prep_and_run_macos_kitchen_tests.sh
 
   linux:
     strategy:

--- a/.github/workflows/prep_and_run_macos_kitchen_tests.sh
+++ b/.github/workflows/prep_and_run_macos_kitchen_tests.sh
@@ -1,4 +1,6 @@
 ## this somehow prevents ffi signature issues with macOS on kitchen tests
+# related to https://github.com/ffi/ffi/issues/836 issue with code signature
+
 cd kitchen-tests
 
 sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
@@ -6,6 +8,11 @@ sudo /opt/chef/embedded/bin/bundle config set --local path 'vendor/bundle'
 sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3
 sudo rm -f /opt/chef/embedded/bin/{htmldiff,ldiff}
 
+# gem installing berkshelf from rubygems picks up the newest ffi ~> 1.9
+# match which conflicts with what's installed chef current. gem build and
+# gem install from the cached gemspec appears to behave equivalent to bundler
+# in using the ffi already installed (1.15.5 at the time of this writing) instead
+# of installng the latest (1.16.3 at this moment)
 export BERKSHELF_GEMSPEC=$(find . -name 'berkshelf.gemspec')
 pushd $(dirname $BERKSHELF_GEMSPEC)
 sudo /opt/chef/embedded/bin/gem build berkshelf.gemspec

--- a/.github/workflows/prep_and_run_macos_kitchen_tests.sh
+++ b/.github/workflows/prep_and_run_macos_kitchen_tests.sh
@@ -1,4 +1,6 @@
 ## this somehow prevents ffi signature issues with macOS on kitchen tests
+cd kitchen-tests
+
 sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
 sudo /opt/chef/embedded/bin/bundle config set --local path 'vendor/bundle'
 sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3

--- a/.github/workflows/prep_and_run_macos_kitchen_tests.sh
+++ b/.github/workflows/prep_and_run_macos_kitchen_tests.sh
@@ -1,0 +1,17 @@
+## this somehow prevents ffi signature issues with macOS on kitchen tests
+sudo /opt/chef/embedded/bin/bundle config set --local without 'omnibus_package'
+sudo /opt/chef/embedded/bin/bundle config set --local path 'vendor/bundle'
+sudo /opt/chef/embedded/bin/bundle install --jobs=3 --retry=3
+sudo rm -f /opt/chef/embedded/bin/{htmldiff,ldiff}
+
+export BERKSHELF_GEMSPEC=$(find . -name 'berkshelf.gemspec')
+pushd $(dirname $BERKSHELF_GEMSPEC)
+sudo /opt/chef/embedded/bin/gem build berkshelf.gemspec
+
+export BERKSHELF_GEM=$(find . -name 'berkshelf*gem')
+sudo /opt/chef/embedded/bin/gem install $BERKSHELF_GEM --no-doc
+
+popd
+
+sudo /opt/chef/embedded/bin/berks vendor cookbooks
+sudo /opt/chef/bin/chef-client -z -o end_to_end --chef-license accept-no-persist


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This somehow prevents ffi signature issues with macOS on kitchen tests 

Ohai and other Chef 17 dependencies have ffi < 1.16.0 added but the `gem install berkshelf` in `.github/workflows/kitchen.yml` was installing berkshelf from rubygems which picks up the newest ffi ~> 1.9
match which conflicts with what's installed chef current. `gem build` and
`gem install` from the cached gemspec appears to behave equivalent to bundler
 in using the ffi already installed (1.15.5 at the time of this writing) instead of installng the latest (1.16.3 at this moment)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
[ffi/ffi#836](https://github.com/ffi/ffi/issues/836)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
