### PR TITLE
Fix invalid CPUQuota value

### DIFF
--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -176,7 +176,7 @@ class Chef
           }
 
           unit["Service"]["ConditionACPower"] = "true" unless new_resource.run_on_battery
-          unit["Service"]["CPUQuota"] = new_resource.cpu_quota if new_resource.cpu_quota
+          unit["Service"]["CPUQuota"] = "#{new_resource.cpu_quota}%" if new_resource.cpu_quota
           unit["Service"]["Environment"] = new_resource.environment.collect { |k, v| "\"#{k}=#{v}\"" } unless new_resource.environment.empty?
           unit
         end

--- a/spec/unit/resource/chef_client_systemd_timer_spec.rb
+++ b/spec/unit/resource/chef_client_systemd_timer_spec.rb
@@ -102,7 +102,7 @@ describe Chef::Resource::ChefClientSystemdTimer do
 
     it "sets CPUQuota if cpu_quota property is set" do
       resource.cpu_quota 50
-      expect(provider.service_content["Service"]["CPUQuota"]).to eq(50)
+      expect(provider.service_content["Service"]["CPUQuota"]).to eq("50%")
     end
   end
 end


### PR DESCRIPTION
Added percent sign to the CPUQuota value.

## Description

systemd does not accept integer values for a unit's CPU quota. The value must be defined as a percentage.

## Related Issue

https://github.com/chef/chef/issues/14009

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
