### PR TITLE
Fix validation on locale-gen to account for the fact that Windows install does not have it on the path.

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -188,7 +188,6 @@ end
 
 locale "set system locale" do
   lang "en-us"
-  #only_if { debian? }
 end
 
 include_recipe "::_ohai_hint"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -187,7 +187,7 @@ include_recipe "git"
 end
 
 locale "set system locale" do
-  lang "en_US.UTF-8"
+  lang "en-us"
   #only_if { debian? }
 end
 

--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -188,7 +188,7 @@ end
 
 locale "set system locale" do
   lang "en_US.UTF-8"
-  only_if { debian? }
+  #only_if { debian? }
 end
 
 include_recipe "::_ohai_hint"

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -116,9 +116,23 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             # RHEL/CentOS type platforms don't have locale-gen
-            a.assertion { which("locale-gen") }
+            a.assertion { shell_out("locale-gen") }
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
           end
+
+          requirements.assert(:all_actions) do |a|
+            # RHEL/CentOS type platforms don't have locale-gen
+            a.assertion do
+              begin
+                which("locale-gen")
+              rescue NoMethodError => e
+                false
+              end
+              true
+            end
+            a.failure_message(Chef::Exceptions::ProviderNotFound, "Got a NoMethodError on which")
+          end
+
         end
 
         # Generates the localization files from templates using locale-gen.

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -113,17 +113,15 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             # RHEL/CentOS type platforms don't have locale-gen
-            a.assertion do
-              begin
-                which("locale-gen")
-              rescue => e
-                puts "EXCEPTIONEXCEPTION"
-                Chef::Log.error("EXCEPTIONEXCEPTION: #{e.inspect}")
-                p e
-                shell_out("locale-gen")
+            a.assertion { shell_out("locale-gen") }
               end
             end
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
+            begin
+              which("local-gen")
+            rescue => e
+              a.failure_message(e.class, e.inspect)
+            end
           end
         end
 

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -121,18 +121,16 @@ class Chef
           end
 
           requirements.assert(:all_actions) do |a|
-            # RHEL/CentOS type platforms don't have locale-gen
             a.assertion do
               begin
-                which("locale-gen")
-              rescue NoMethodError => e
-                false
+                @whichoutput=which("locale-gen").inspect
+              rescue => e
+                @whichoutput=e.inspect
               end
-              true
+              false
             end
-            a.failure_message(Chef::Exceptions::ProviderNotFound, "Got a NoMethodError on which")
+            a.failure_message(Chef::Exceptions::ProviderNotFound, "which returned #{@whichoutput}")
           end
-
         end
 
         # Generates the localization files from templates using locale-gen.

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -124,7 +124,7 @@ class Chef
             a.assertion do
               false
             end
-            a.failure_message(Chef::Exceptions::ProviderNotFound, "which returned #{which("locale-gen").class} #{which("locale_gen").inspect}")
+            a.failure_message(Chef::Exceptions::ProviderNotFound, "which returned #{which("locale-gen").class} #{which("locale_gen").inspect} vs. shell_out #{shell_out("locale-gen").inspect}")
           end
         end
 

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -115,17 +115,14 @@ class Chef
           end
 
           requirements.assert(:all_actions) do |a|
-            # RHEL/CentOS type platforms don't have locale-gen
-            a.assertion { shell_out("locale-gen") }
+            a.assertion do
+              # RHEL/CentOS type platforms don't have locale-gen
+              # Windows has locale-gen as part of the install, but not in the path
+              which("locale-gen") || windows?
+            end
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
           end
 
-          requirements.assert(:all_actions) do |a|
-            a.assertion do
-              false
-            end
-            a.failure_message(Chef::Exceptions::ProviderNotFound, "which returned #{which("locale-gen").class} #{which("locale_gen").inspect} vs. shell_out #{shell_out("locale-gen").inspect}")
-          end
         end
 
         # Generates the localization files from templates using locale-gen.

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -122,15 +122,9 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             a.assertion do
-              begin
-                a.instance_variable_set(:@whichoutput, which("locale-gen").inspect)
-
-              rescue => e
-                a.instance_variable_set(:@whichoutput, e.inspect)
-              end
               false
             end
-            a.failure_message(Chef::Exceptions::ProviderNotFound, "which returned #{a.instance_variable_get :@whichoutput}")
+            a.failure_message(Chef::Exceptions::ProviderNotFound, "which returned #{which("locale-gen").class} #{which("locale_gen").inspect}")
           end
         end
 

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -118,7 +118,7 @@ class Chef
                 which("locale-gen")
               rescue => e
                 puts "EXCEPTIONEXCEPTION"
-                Chef::Log.error("EXCEPTIONEXCEPTION: #{e.inspect}"
+                Chef::Log.error("EXCEPTIONEXCEPTION: #{e.inspect}")
                 p e
                 shell_out("locale-gen")
               end

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -113,7 +113,7 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             # RHEL/CentOS type platforms don't have locale-gen
-            a.assertion { which("locale-gen") }
+            a.assertion { shell_out("locale-gen") }
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
           end
         end

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -114,8 +114,6 @@ class Chef
           requirements.assert(:all_actions) do |a|
             # RHEL/CentOS type platforms don't have locale-gen
             a.assertion { shell_out("locale-gen") }
-              end
-            end
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
             begin
               which("local-gen")

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -119,7 +119,6 @@ class Chef
             end
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
           end
-
         end
 
         # Generates the localization files from templates using locale-gen.

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -123,13 +123,14 @@ class Chef
           requirements.assert(:all_actions) do |a|
             a.assertion do
               begin
-                @whichoutput=which("locale-gen").inspect
+                a.instance_variable_set(:@whichoutput, which("locale-gen").inspect)
+
               rescue => e
-                @whichoutput=e.inspect
+                a.instance_variable_set(:@whichoutput, e.inspect)
               end
               false
             end
-            a.failure_message(Chef::Exceptions::ProviderNotFound, "which returned #{@whichoutput}")
+            a.failure_message(Chef::Exceptions::ProviderNotFound, "which returned #{a.instance_variable_get :@whichoutput}")
           end
         end
 

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -113,7 +113,16 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             # RHEL/CentOS type platforms don't have locale-gen
-            a.assertion { shell_out("locale-gen") }
+            a.assertion do
+              begin
+                which("locale-gen")
+              rescue => e
+                puts "EXCEPTIONEXCEPTION"
+                Chef::Log.error("EXCEPTIONEXCEPTION: #{e.inspect}"
+                p e
+                shell_out("locale-gen")
+              end
+            end
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
           end
         end

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -16,11 +16,14 @@
 #
 
 require_relative "../resource"
+require_relative "../mixin/which"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 
 class Chef
   class Resource
     class Locale < Chef::Resource
+      extend Chef::Mixin::Which
+
       provides :locale
 
       description "Use the **locale** resource to set the system's locale on Debian and Windows systems. Windows support was added in Chef Infra Client 16.0"
@@ -113,13 +116,8 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             # RHEL/CentOS type platforms don't have locale-gen
-            a.assertion { shell_out("locale-gen") }
+            a.assertion { which("locale-gen") }
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
-            begin
-              which("local-gen")
-            rescue => e
-              a.failure_message(e.class, e.inspect)
-            end
           end
         end
 

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -16,14 +16,11 @@
 #
 
 require_relative "../resource"
-require_relative "../mixin/which"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 
 class Chef
   class Resource
     class Locale < Chef::Resource
-      extend Chef::Mixin::Which
-
       provides :locale
 
       description "Use the **locale** resource to set the system's locale on Debian and Windows systems. Windows support was added in Chef Infra Client 16.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
[chef#12833](https://github.com/chef/chef/pull/12833/files) broken locale code on Windows by trying to assert that `locale-gen` is in the path, which it won't likely be unless the Windows machine has bash for Windows or similar. The original `shell_out` invocation also errored but the result was non-`nil` so it validated fine for Windows.

```
<Mixlib::ShellOut::Windows::ThingThatLooksSortOfLikeAProcessStatus:0x00000120ff7ffaa0 @exitstatus=1> stdout: '' stderr: ''locale-gen' is not recognized as an internal or external command,

    operable program or batch file.' child_pid: 
 ```



## Related Issue
CHEF-3003

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
