### PR TITLE
Fix validation on locale-gen to account for the fact that Windows ins…

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -182,8 +182,7 @@ include_recipe "git"
 end
 
 locale "set system locale" do
-  lang "en_US.UTF-8"
-  only_if { debian? }
+  lang "en-us"
 end
 
 include_recipe "::_ohai_hint"

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -113,8 +113,11 @@ class Chef
           end
 
           requirements.assert(:all_actions) do |a|
-            # RHEL/CentOS type platforms don't have locale-gen
-            a.assertion { which("locale-gen") }
+            a.assertion do
+              # RHEL/CentOS type platforms don't have locale-gen
+              # Windows has locale-gen as part of the install, but not in the path
+              which("locale-gen") || windows?
+            end
             a.failure_message(Chef::Exceptions::ProviderNotFound, "The locale resource requires the locale-gen tool")
           end
         end


### PR DESCRIPTION
…tall does not have it on the path. (#14014)

* use `which` unless Windows is involved. In that case, the check doesn't matter, anyway.

---------

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
