### PR TITLE
Revert "Update sudoer.erb (#14015)"

### DIFF
--- a/lib/chef/resource/support/sudoer.erb
+++ b/lib/chef/resource/support/sudoer.erb
@@ -1,7 +1,7 @@
 # This file is managed by <%= ChefUtils::Dist::Infra::PRODUCT %>. Changes will be overwritten.
 
 <% @command_aliases.each do |a| -%>
-Cmnd_Alias <%= a.upcase %> = <%= @commands.join(', ') %>
+Cmnd_Alias <%= a[:name].upcase %> = <%= a[:command_list].join(', ') %>
 <% end -%>
 <% @env_keep_add.each do |env_keep| -%>
 Defaults    env_keep += "<%= env_keep %>"
@@ -9,14 +9,9 @@ Defaults    env_keep += "<%= env_keep %>"
 <% @env_keep_subtract.each do |env_keep| -%>
 Defaults    env_keep -= "<%= env_keep %>"
 <% end -%>
-<% if @command_aliases.empty? %>
 <% @commands.each do |command| -%>
 <% unless @sudoer.empty? %><%= @sudoer %> <%= @host %>=(<%= @runas %>) <%= 'NOEXEC:' if @noexec %><%= 'NOPASSWD:' if @nopasswd.to_s == 'true' %><%= 'SETENV:' if @setenv.to_s == 'true' %><%= command %><% end -%>
 <% end -%>
-<% else %>
-<% unless @sudoer.empty? %><%= @sudoer %> <%= @host %>=(<%= @runas %>) <%= 'NOEXEC:' if @noexec %><%= 'NOPASSWD:' if @nopasswd.to_s == 'true' %><%= 'SETENV:' if @setenv.to_s == 'true' %> <%= @command_aliases.join(', ') %>
-<% end -%>
-<% end %>
 <% unless @defaults.empty? %>
 Defaults:<%= @sudoer %> <%= @defaults.join(',') %>
 <% end -%>


### PR DESCRIPTION
This reverts commit 44a2ae648c68911d6c2e1f13187bd471dae303bf.

<!--- Provide a short summary of your changes in the Title above -->

## Description
Kitchen tests broke without surfacing to the PR status and a fix appears to be more complicated than first anticipated. Reverting this PR for now.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
