### PR TITLE
WIP: Append command_aliases to commands

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
@@ -58,6 +58,33 @@ sudo "rbenv" do
   env_keep_add %w{PATH RBENV_ROOT RBENV_VERSION}
 end
 
+sudo 'webteam' do
+  command_aliases        [{'name':'WEBTEAM_SYSTEMD_JBOSS',
+                           'command_list': [
+                             '/usr/bin/systemctl start eap7-standalone.service',
+                             '/usr/bin/systemctl start jbcs-httpd24-httpd.service', \
+                             '/usr/bin/systemctl stop eap7-standalone.service', \
+                             '/usr/bin/systemctl stop jbcs-httpd24-httpd.service', \
+                             '/usr/bin/systemctl restart eap7-standalone.service', \
+                             '/usr/bin/systemctl restart jbcs-httpd24-httpd.service', \
+                             '/usr/bin/systemctl --full edit eap7-standalone.service', \
+                             '/usr/bin/systemctl --full edit jbcs-httpd24-httpd.service', \
+                             '/usr/bin/systemctl daemon-reload',
+                            ]
+                          },
+                          {'name':'GENERIC_SYSTEMD',
+                           'command_list': [
+                             '/usr/sbin/systemctl list-unit-files',
+                             '/usr/sbin/systemctl list-timers', \
+                             '/usr/sbin/systemctl is-active *', \
+                             '/usr/sbin/systemctl is-enabled *',
+                            ]
+                          }
+                         ]
+  nopasswd               true
+  users                  '%webteam'
+end
+
 sudo "java_home" do
   env_keep_subtract ["JAVA_HOME"]
 end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -84,6 +84,12 @@ users_manage "sysadmin" do
   action [:create]
 end
 
+# ssh_known_hosts_entry requires ssh-keyscan binary but that one
+# is not in the OpenSUSE Leap 15.5 dokken images by default
+zypper_package 'ssh-tools' do
+  only_if { platform_family?('suse') }
+end
+
 ssh_known_hosts_entry "github.com"
 
 include_recipe "openssh"

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -163,7 +163,7 @@ platforms:
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN /usr/bin/zypper --non-interactive update
-      - RUN /usr/bin/zypper --non-interactive install net-tools-deprecated openssh-server # we need this for /etc/network/interfaces & ifconfig resource testing
+      - RUN /usr/bin/zypper --non-interactive install net-tools-deprecated ssh-tools # we need this for /etc/network/interfaces & ifconfig resource testing
 
 suites:
   - name: end-to-end

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -163,7 +163,7 @@ platforms:
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN /usr/bin/zypper --non-interactive update
-      - RUN /usr/bin/zypper --non-interactive install net-tools-deprecated # we need this for /etc/network/interfaces & ifconfig resource testing
+      - RUN /usr/bin/zypper --non-interactive install net-tools-deprecated openssh-server # we need this for /etc/network/interfaces & ifconfig resource testing
 
 suites:
   - name: end-to-end

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -50,6 +50,35 @@ class Chef
         groups 'sysadmins, superusers'
       end
       ```
+      **Create Command Aliases and assign them to a group**
+      ```ruby
+        sudo 'webteam' do
+          command_aliases        [{'name':'WEBTEAM_SYSTEMD_JBOSS',
+                                   'command_list': [
+                                     '/usr/bin/systemctl start eap7-standalone.service',
+                                     '/usr/bin/systemctl start jbcs-httpd24-httpd.service', \
+                                     '/usr/bin/systemctl stop eap7-standalone.service', \
+                                     '/usr/bin/systemctl stop jbcs-httpd24-httpd.service', \
+                                     '/usr/bin/systemctl restart eap7-standalone.service', \
+                                     '/usr/bin/systemctl restart jbcs-httpd24-httpd.service', \
+                                     '/usr/bin/systemctl --full edit eap7-standalone.service', \
+                                     '/usr/bin/systemctl --full edit jbcs-httpd24-httpd.service', \
+                                     '/usr/bin/systemctl daemon-reload',
+                                    ]
+                                  },
+                                  {'name':'GENERIC_SYSTEMD',
+                                   'command_list': [
+                                     '/usr/sbin/systemctl list-unit-files',
+                                     '/usr/sbin/systemctl list-timers', \
+                                     '/usr/sbin/systemctl is-active *', \
+                                     '/usr/sbin/systemctl is-enabled *',
+                                    ]
+                                  }
+                                 ]
+          nopasswd               true
+          users                  '%webteam'
+        end
+      ```
 
       **Grant passwordless sudo privileges for specific commands**
 

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -139,10 +139,12 @@ class Chef
         default: []
 
       property :command_aliases, Array,
-        description "Command aliases that can be used as allowed commands later in the configuration." \
-                    "The object represents an array of hashes in the following format:" \
-                    "[{'name':'ALIAS1','command_list': [ 'command1', 'command2' ] }," \
-                    " {'name':'Alias2','command_list: [ 'command3', 'command4 arg1 arg2' ]}]",
+        description do
+          "Command aliases that can be used as allowed commands later in the configuration." \
+           "The object represents an array of hashes in the following format:" \
+           "[{'name':'ALIAS1','command_list': [ 'command1', 'command2' ] }," \
+           " {'name':'Alias2','command_list: [ 'command3', 'command4 arg1 arg2' ]}]"
+        end,
         default: []
 
       property :setenv, [TrueClass, FalseClass],

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -144,7 +144,7 @@ class Chef
            "The object represents an array of hashes in the following format:" \
            "[{'name':'ALIAS1','command_list': [ 'command1', 'command2' ] }," \
            " {'name':'Alias2','command_list: [ 'command3', 'command4 arg1 arg2' ]}]"
-        end,
+        end
         default: []
 
       property :setenv, [TrueClass, FalseClass],

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -139,12 +139,7 @@ class Chef
         default: []
 
       property :command_aliases, Array,
-        description do
-          "Command aliases that can be used as allowed commands later in the configuration." \
-           "The object represents an array of hashes in the following format:" \
-           "[{'name':'ALIAS1','command_list': [ 'command1', 'command2' ] }," \
-           " {'name':'Alias2','command_list: [ 'command3', 'command4 arg1 arg2' ]}]"
-        end
+        description: "Command aliases that can be used as allowed commands later in the configuration.The object represents an array of hashes in the following format: `[{'name':'ALIAS1','command_list': [ 'command1', 'command2' ] }, {'name':'Alias2','command_list: [ 'command3', 'command4 arg1 arg2' ]}]`",
         default: []
 
       property :setenv, [TrueClass, FalseClass],

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -139,7 +139,10 @@ class Chef
         default: []
 
       property :command_aliases, Array,
-        description: "Command aliases that can be used as allowed commands later in the configuration.",
+        description "Command aliases that can be used as allowed commands later in the configuration." \
+                    "The object represents an array of hashes in the following format:" \
+                    "[{'name':'ALIAS1','command_list': [ 'command1', 'command2' ] }," \
+                    " {'name':'Alias2','command_list: [ 'command3', 'command4 arg1 arg2' ]}]",
         default: []
 
       property :setenv, [TrueClass, FalseClass],

--- a/lib/chef/resource/support/sudoer.erb
+++ b/lib/chef/resource/support/sudoer.erb
@@ -2,6 +2,7 @@
 
 <% @command_aliases.each do |a| -%>
 Cmnd_Alias <%= a[:name].upcase %> = <%= a[:command_list].join(', ') %>
+<% @commands.append(a[:name]) %>
 <% end -%>
 <% @env_keep_add.each do |env_keep| -%>
 Defaults    env_keep += "<%= env_keep %>"
@@ -9,8 +10,12 @@ Defaults    env_keep += "<%= env_keep %>"
 <% @env_keep_subtract.each do |env_keep| -%>
 Defaults    env_keep -= "<%= env_keep %>"
 <% end -%>
-<% @commands.each do |command| -%>
-<% unless @sudoer.empty? %><%= @sudoer %> <%= @host %>=(<%= @runas %>) <%= 'NOEXEC:' if @noexec %><%= 'NOPASSWD:' if @nopasswd.to_s == 'true' %><%= 'SETENV:' if @setenv.to_s == 'true' %><%= command %><% end -%>
+<%# Remove default value from commands %>
+<% unless @command_aliases.empty? %>
+<% @commands.delete("ALL") %>
+<%end%>
+<% @commands = @commands.uniq.join(', ') %>
+<% unless @sudoer.empty? %><%= @sudoer %> <%= @host %>=(<%= @runas %>) <%= 'NOEXEC:' if @noexec %><%= 'NOPASSWD:' if @nopasswd.to_s == 'true' %><%= 'SETENV:' if @setenv.to_s == 'true' %><%= @commands %>
 <% end -%>
 <% unless @defaults.empty? %>
 Defaults:<%= @sudoer %> <%= @defaults.join(',') %>


### PR DESCRIPTION
The changes append the command_aliases to commands and a single rule is created

## Description
The changes allow the user to skip definition of 'commands'.

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
