### PR TITLE
Update command aliases documentation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1561,7 +1561,10 @@
     "metaparameter",
     "igroups",
     "errorhandler",
-    "IPACK"
+    "IPACK",
+    "webteam",
+    "WEBTEAM",
+    "jbcs"
   ],
   // flagWords - list of words to be always considered incorrect
   // This is useful for offensive words and common spelling errors.

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
@@ -54,7 +54,7 @@ sudo "webteam" do
       "/usr/bin/systemctl --full edit eap7-standalone.service", \
       "/usr/bin/systemctl --full edit jbcs-httpd24-httpd.service", \
       "/usr/bin/systemctl daemon-reload",
-      ]
+      ],
     },
     {
       "name": "GENERIC_SYSTEMD",
@@ -63,12 +63,12 @@ sudo "webteam" do
         "/usr/sbin/systemctl list-timers", \
         "/usr/sbin/systemctl is-active *", \
         "/usr/sbin/systemctl is-enabled *",
-      ]
-    }
+      ],
+    },
   ]
   nopasswd               true
   users                  "%webteam"
-  commands %w(WEBTEAM_SYSTEMD_JBOSS GENERIC_SYSTEMD)
+  commands ['WEBTEAM_SYSTEMD_JBOSS', 'GENERIC_SYSTEMD']
 end
 
 sudo "git" do

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
@@ -40,6 +40,37 @@ sudo "alice" do
   commands ["STARTSSH"]
 end
 
+sudo "webteam" do
+  command_aliases [
+    {
+      "name": "WEBTEAM_SYSTEMD_JBOSS",
+      "command_list": [
+      "/usr/bin/systemctl start eap7-standalone.service",
+      "/usr/bin/systemctl start jbcs-httpd24-httpd.service", \
+      "/usr/bin/systemctl stop eap7-standalone.service", \
+      "/usr/bin/systemctl stop jbcs-httpd24-httpd.service", \
+      "/usr/bin/systemctl restart eap7-standalone.service", \
+      "/usr/bin/systemctl restart jbcs-httpd24-httpd.service", \
+      "/usr/bin/systemctl --full edit eap7-standalone.service", \
+      "/usr/bin/systemctl --full edit jbcs-httpd24-httpd.service", \
+      "/usr/bin/systemctl daemon-reload",
+      ]
+    },
+    {
+      "name": "GENERIC_SYSTEMD",
+      "command_list": [
+        "/usr/sbin/systemctl list-unit-files",
+        "/usr/sbin/systemctl list-timers", \
+        "/usr/sbin/systemctl is-active *", \
+        "/usr/sbin/systemctl is-enabled *",
+      ]
+    }
+  ]
+  nopasswd               true
+  users                  "%webteam"
+  commands %w(WEBTEAM_SYSTEMD_JBOSS GENERIC_SYSTEMD)
+end
+
 sudo "git" do
   user "git"
   runas "phabricator"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
@@ -68,7 +68,7 @@ sudo "webteam" do
   ]
   nopasswd               true
   users                  "%webteam"
-  commands %w(WEBTEAM_SYSTEMD_JBOSS GENERIC_SYSTEMD)
+  commands %w{WEBTEAM_SYSTEMD_JBOSS GENERIC_SYSTEMD}
 end
 
 sudo "git" do

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_sudo.rb
@@ -68,7 +68,7 @@ sudo "webteam" do
   ]
   nopasswd               true
   users                  "%webteam"
-  commands ['WEBTEAM_SYSTEMD_JBOSS', 'GENERIC_SYSTEMD']
+  commands %w(WEBTEAM_SYSTEMD_JBOSS GENERIC_SYSTEMD)
 end
 
 sudo "git" do

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -86,8 +86,8 @@ end
 
 # ssh_known_hosts_entry requires ssh-keyscan binary but that one
 # is not in the OpenSUSE Leap 15.5 dokken images by default
-package 'ssh-tools' do
-  only_if { platform_family?('suse') }
+package "ssh-tools" do
+  only_if { platform_family?("suse") }
 end
 
 ssh_known_hosts_entry "github.com"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -84,6 +84,12 @@ users_manage "sysadmin" do
   action [:create]
 end
 
+# ssh_known_hosts_entry requires ssh-keyscan binary but that one
+# is not in the OpenSUSE Leap 15.5 dokken images by default
+package 'ssh-tools' do
+  only_if { platform_family?('suse') }
+end
+
 ssh_known_hosts_entry "github.com"
 
 include_recipe "openssh"

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -62,33 +62,36 @@ class Chef
 
       **Create Command Aliases and assign them to a group**
       ```ruby
-        sudo 'webteam' do
-          command_aliases   [{'name':'WEBTEAM_SYSTEMD_JBOSS',
-                              'command_list': [
-                                '/usr/bin/systemctl start eap7-standalone.service',
-                                '/usr/bin/systemctl start jbcs-httpd24-httpd.service', \
-                                '/usr/bin/systemctl stop eap7-standalone.service', \
-                                '/usr/bin/systemctl stop jbcs-httpd24-httpd.service', \
-                                '/usr/bin/systemctl restart eap7-standalone.service', \
-                                '/usr/bin/systemctl restart jbcs-httpd24-httpd.service', \
-                                '/usr/bin/systemctl --full edit eap7-standalone.service', \
-                                '/usr/bin/systemctl --full edit jbcs-httpd24-httpd.service', \
-                                '/usr/bin/systemctl daemon-reload',
-                              ]
-                             },
-                             {'name':'GENERIC_SYSTEMD',
-                              'command_list': [
-                                '/usr/sbin/systemctl list-unit-files',
-                                '/usr/sbin/systemctl list-timers', \
-                                '/usr/sbin/systemctl is-active *', \
-                                '/usr/sbin/systemctl is-enabled *',
-                              ]
-                             }
-                            ]
-          nopasswd          true
-          users             '%webteam'
-          commands          [ 'WEBTEAM_SYSTEMD_JBOSS', 'GENERIC_SYSTEMD' ]
-        end
+      sudo 'webteam' do
+        command_aliases [
+          {
+            'name': 'WEBTEAM_SYSTEMD_JBOSS',
+            'command_list': [
+              '/usr/bin/systemctl start eap7-standalone.service',
+              '/usr/bin/systemctl start jbcs-httpd24-httpd.service', \
+              '/usr/bin/systemctl stop eap7-standalone.service', \
+              '/usr/bin/systemctl stop jbcs-httpd24-httpd.service', \
+              '/usr/bin/systemctl restart eap7-standalone.service', \
+              '/usr/bin/systemctl restart jbcs-httpd24-httpd.service', \
+              '/usr/bin/systemctl --full edit eap7-standalone.service', \
+              '/usr/bin/systemctl --full edit jbcs-httpd24-httpd.service', \
+              '/usr/bin/systemctl daemon-reload',
+            ]
+          },
+          {
+            'name': 'GENERIC_SYSTEMD',
+            'command_list': [
+              '/usr/sbin/systemctl list-unit-files',
+              '/usr/sbin/systemctl list-timers', \
+              '/usr/sbin/systemctl is-active *', \
+              '/usr/sbin/systemctl is-enabled *',
+              ]
+          }
+        ]
+        nopasswd true
+        users '%webteam'
+        commands [ 'WEBTEAM_SYSTEMD_JBOSS', 'GENERIC_SYSTEMD' ]
+      end
       ```
       DOC
 

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -59,6 +59,37 @@ class Chef
         nopasswd true
       end
       ```
+
+      **Create Command Aliases and assign them to a group**
+      ```ruby
+        sudo 'webteam' do
+          command_aliases   [{'name':'WEBTEAM_SYSTEMD_JBOSS',
+                              'command_list': [
+                                '/usr/bin/systemctl start eap7-standalone.service',
+                                '/usr/bin/systemctl start jbcs-httpd24-httpd.service', \
+                                '/usr/bin/systemctl stop eap7-standalone.service', \
+                                '/usr/bin/systemctl stop jbcs-httpd24-httpd.service', \
+                                '/usr/bin/systemctl restart eap7-standalone.service', \
+                                '/usr/bin/systemctl restart jbcs-httpd24-httpd.service', \
+                                '/usr/bin/systemctl --full edit eap7-standalone.service', \
+                                '/usr/bin/systemctl --full edit jbcs-httpd24-httpd.service', \
+                                '/usr/bin/systemctl daemon-reload',
+                              ]
+                             },
+                             {'name':'GENERIC_SYSTEMD',
+                              'command_list': [
+                                '/usr/sbin/systemctl list-unit-files',
+                                '/usr/sbin/systemctl list-timers', \
+                                '/usr/sbin/systemctl is-active *', \
+                                '/usr/sbin/systemctl is-enabled *',
+                              ]
+                             }
+                            ]
+          nopasswd          true
+          users             '%webteam'
+          commands          [ 'WEBTEAM_SYSTEMD_JBOSS', 'GENERIC_SYSTEMD' ]
+        end
+      ```
       DOC
 
       # According to the sudo man pages sudo will ignore files in an include dir that have a `.` or `~`
@@ -79,7 +110,7 @@ class Chef
         coerce: proc { |x| coerce_groups(x) }
 
       property :commands, Array,
-        description: "An array of full paths to commands this sudoer can execute.",
+        description: "An array of full paths to commands and/or Cmnd_Aliases this sudoer can execute.",
         default: ["ALL"]
 
       property :host, String,
@@ -110,7 +141,7 @@ class Chef
         default: []
 
       property :command_aliases, Array,
-        description: "Command aliases that can be used as allowed commands later in the configuration.",
+        description: "Command aliases that can be used as allowed commands later in the configuration.The object represents an array of hashes in the following format: `[{'name':'ALIAS1','command_list': [ 'command1', 'command2' ] }, {'name':'Alias2','command_list: [ 'command3', 'command4 arg1 arg2' ]}]`",
         default: []
 
       property :setenv, [TrueClass, FalseClass],


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Main points with CHEF-2186 are:

The sudo resource documentation is misleading (managed to fool even the support team - nobody found out that I was using the resource wrongly)
The 'commands' option doesn't defaults to the the Cmnd_Aliases' names.
The second one we cannot fix it without breaking someone's code, but the first one can be safely fixed. Can you help with the Spec tests ? I can't make them work, while the suse stuff is "fixed".
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
