### PR TITLE
Revert "Put chefstyle gem back in chefstyle group"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,10 +55,11 @@ group(:development, :test) do
   gem "fauxhai-ng" # for chef-utils gem
 end
 
-group(:chefstyle) do
-  # for testing new chefstyle rules
-  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "main"
-end
+gem "chefstyle"
+# group(:chefstyle) do
+#   # for testing new chefstyle rules
+#   gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "main"
+# end
 
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/chef/chefstyle.git
-  revision: 71ae97744713ffd91ac8277d7a1385dabb6d570b
-  branch: main
-  specs:
-    chefstyle (2.2.2)
-      rubocop (= 1.25.1)
-
-GIT
   remote: https://github.com/chef/ohai.git
   revision: d5d03240e6ee1130ef38441c1d25a7ca08df0cab
   branch: main
@@ -206,6 +198,8 @@ GEM
       chef-utils (>= 17.0)
       chef-zero (>= 14.0)
       net-ssh
+    chefstyle (2.2.2)
+      rubocop (= 1.25.1)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     corefoundation (0.3.13)


### PR DESCRIPTION
Reverts chef/chef#13927

Windows plan on the verify pipeline is failing from the addition of `chefstyle` that was not noticed prior to merging the above PR
 
```
chef-infra-client:  ** 'rake install' any gem sourced as a git reference so they'll look like regular gems.
--
  | chef-infra-client:  -- installing C:\hab\studios\bk018b4871551a20e31bff\hab\pkgs\ci\chef-infra-client\18.3.39\20231019150510\vendor\bundler\gems\chefstyle-71ae97744713
  | rake aborted!
  | Gem::MissingSpecError: Could not find 'rubocop' (>= 0) among 220 total gem(s)
  | Checked in 'GEM_PATH=C:/hab/studios/bk018b4871551a20e31bff/hab/pkgs/ci/chef-infra-client/18.3.39/20231019150510/vendor;C:/hab/studios/bk018b4871551a20e31bff/hab/pkgs/chef/ruby31-plus-devkit/3.1.2/20220715234242/lib/ruby/gems/3.1.0' , execute `gem env` for more information
```