### PR TITLE
Removing (RH)EL6 Support to get a build out

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -19,8 +19,8 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  el-6-x86_64:
-    - el-6-x86_64
+  # el-6-x86_64:
+  #   - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -19,8 +19,8 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  el-6-x86_64:
-    - el-6-x86_64
+  # el-6-x86_64:
+  #   - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Removing support for EL6. Is is EOL except for paid extended support and the images are broken causing a delay in releasing chef-17 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
