### PR TITLE
Re-add solaris i386 because it exists in 18

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -55,6 +55,8 @@ builder-to-testers-map:
     - sles-15-x86_64
   sles-15-aarch64:
     - sles-15-aarch64
+  solaris2-5.11-i386:
+    - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Looks like [this commit](https://github.com/chef/chef/commit/2827202a5013491d97ecc6d3cbe2ff519efd9fd8) accidentally removed i386 Solaris builds whereas they are [still built in `main`](https://github.com/chef/chef/blob/main/.expeditor/release.omnibus.yml#L75-L76)


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
