### PR TITLE
Add support for use_inline_powershell for powershell_script

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -71,6 +71,23 @@ powershell_script "sleep 1 second" do
   live_stream true
 end
 
+powershell_script "sleep 1 second inline" do
+  code "Start-Sleep -s 1"
+  use_inline_powershell true
+end
+
+powershell_script "ensure inline only_if guards work" do
+  code "Start-Sleep -s 1"
+  only_if "$True"
+  use_inline_powershell true
+end
+
+powershell_script "ensure inline not_if guards work" do
+  code "Start-Sleep -s 1"
+  not_if "$False"
+  use_inline_powershell true
+end
+
 powershell_script "sensitive sleep" do
   code "Start-Sleep -s 1"
   sensitive true

--- a/lib/chef/guard_interpreter/resource_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/resource_guard_interpreter.rb
@@ -77,6 +77,8 @@ class Chef
           @resource.updated
         rescue Mixlib::ShellOut::ShellCommandFailed
           nil
+        rescue ChefPowerShell::PowerShellExceptions::PowerShellCommandFailed
+          nil
         end
       end
 

--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -21,7 +21,7 @@ class Chef
   class Resource
     class PowershellScript < Chef::Resource::WindowsScript
 
-      set_guard_inherited_attributes(:interpreter)
+      set_guard_inherited_attributes(:interpreter, :use_inline_powershell)
 
       provides :powershell_script, os: "windows"
 
@@ -38,6 +38,10 @@ class Chef
         default: "powershell",
         equal_to: %w{powershell pwsh},
         description: "The interpreter type, `powershell` or `pwsh` (PowerShell Core)"
+
+      property :use_inline_powershell, [true, false],
+        default: false,
+        description: "Use inline powershell.dll rather than shelling out - this is faster, but could have different semantics to the traditional method.  In particular, it does not allow for streaming output, nor does it allow for passing custom parameters to the interpreter"
 
       property :convert_boolean_return, [true, false],
         default: false,

--- a/spec/unit/provider/powershell_script_spec.rb
+++ b/spec/unit/provider/powershell_script_spec.rb
@@ -17,10 +17,14 @@
 #
 
 require "spec_helper"
-describe Chef::Provider::PowershellScript, "action_run" do
+describe Chef::Provider::PowershellScript, "action_run", windows_only: true do
   let(:events) { Chef::EventDispatch::Dispatcher.new }
 
-  let(:run_context) { Chef::RunContext.new(Chef::Node.new, {}, events) }
+  let(:run_context) {
+    @node = Chef::Node.new
+    @node.consume_external_attrs(OHAI_SYSTEM.data.dup, {})
+    Chef::RunContext.new(@node, {}, events)
+  }
 
   let(:new_resource) do
     Chef::Resource::PowershellScript.new("run some powershell code", run_context)
@@ -44,7 +48,7 @@ describe Chef::Provider::PowershellScript, "action_run" do
         "C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None -InputFormat Fabulous -File "C:\\Temp\\Script.ps1"
       CMD
 
-      expect(provider.command).to eq(expected)
+      expect(provider.send(:command)).to eq(expected)
     end
 
     it "uses pwsh when given the pwsh interpreter" do
@@ -55,7 +59,99 @@ describe Chef::Provider::PowershellScript, "action_run" do
         "pwsh" -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None  -File "C:\\Temp\\Script.ps1"
       CMD
 
-      expect(provider.command).to eq(expected)
+      expect(provider.send(:command)).to eq(expected)
+    end
+
+    it "returns the script specific to the inline interpreter when using use_inline_interpreter" do
+      new_resource.code = "test script"
+      new_resource.use_inline_powershell = true
+      # This is a string that is ONLY in the use_inline_interpreter version of this
+      expect(provider.send(:powershell_wrapper_script)).to include("$interpolatedexitcode = $")
+    end
+
+    it "returns the script specific to the normal interpreter when not using use_inline_interpreter" do
+      new_resource.code = "test script"
+      new_resource.use_inline_powershell = false
+      # This is a string that is ONLY in the non use_inline_interpreter version of this
+      expect(provider.send(:powershell_wrapper_script)).to include("new-variable -name interpolatedexitcode -visibility private")
+    end
+
+    it "Correctly returns for $True for regular powershell" do
+      new_resource.code = "$True"
+      new_resource.use_inline_powershell = false
+      new_resource.convert_boolean_return = true
+      expect(provider.run_action(:run)).to eq(nil)
+    end
+
+    it "Correctly returns for $True for inline powershell with convert_boolean_return" do
+      new_resource.code = "$True"
+      new_resource.use_inline_powershell = true
+      new_resource.convert_boolean_return = true
+      expect(provider.run_action(:run)).to eq(nil)
+    end
+
+    it "Correctly throws exception for $False for regular powershell" do
+      new_resource.code = "$False"
+      new_resource.use_inline_powershell = false
+      new_resource.convert_boolean_return = true
+      expect { provider.run_action(:run) }.to raise_error(an_instance_of(Mixlib::ShellOut::ShellCommandFailed))
+    end
+
+    it "Correctly throws exception for $False for inline powershell" do
+      new_resource.code = "$False"
+      new_resource.use_inline_powershell = true
+      new_resource.convert_boolean_return = true
+      expect { provider.run_action(:run) }.to raise_error(an_instance_of(ChefPowerShell::PowerShellExceptions::PowerShellCommandFailed))
+    end
+
+    it "return 1 fails correctly for non-inline" do
+      new_resource.code = "return 1"
+      new_resource.use_inline_powershell = false
+      expect { provider.run_action(:run) }.to raise_error(an_instance_of(Mixlib::ShellOut::ShellCommandFailed))
+    end
+
+    it "return 1 fails correctly for inline" do
+      new_resource.code = "return 1"
+      new_resource.use_inline_powershell = true
+      expect { provider.run_action(:run) }.to raise_error(an_instance_of(ChefPowerShell::PowerShellExceptions::PowerShellCommandFailed))
+    end
+
+    it "return 1 is valid when returns includes 1 for non-inline" do
+      new_resource.code = "return 1"
+      new_resource.use_inline_powershell = false
+      new_resource.returns = [1]
+      expect(provider.run_action(:run)).to eq(nil)
+    end
+    it "return 1 is valid when returns includes 1 for inline" do
+      new_resource.code = "return 1"
+      new_resource.use_inline_powershell = true
+      new_resource.returns = [1]
+      expect(provider.run_action(:run)).to eq(nil)
+    end
+
+    it "bad powershell exceptions for non-inline" do
+      new_resource.code = "xyzzy"
+      new_resource.use_inline_powershell = false
+      expect { provider.run_action(:run) }.to raise_error(an_instance_of(Mixlib::ShellOut::ShellCommandFailed))
+    end
+
+    it "bad powershell exceptions for inline" do
+      new_resource.code = "xyzzy"
+      new_resource.use_inline_powershell = true
+      expect { provider.run_action(:run) }.to raise_error(an_instance_of(ChefPowerShell::PowerShellExceptions::PowerShellCommandFailed))
+    end
+
+    it "uses powershell for inline by default" do
+      new_resource.code = "$host.version.major -lt 7"
+      new_resource.use_inline_powershell = true
+      expect(provider.run_action(:run)).to eq(nil)
+    end
+
+    it "uses pwsh for inline when asked" do
+      new_resource.code = "$host.version.major -ge 7"
+      new_resource.use_inline_powershell = true
+      new_resource.interpreter = "pwsh"
+      expect(provider.run_action(:run)).to eq(nil)
     end
   end
 end

--- a/spec/unit/resource/powershell_script_spec.rb
+++ b/spec/unit/resource/powershell_script_spec.rb
@@ -47,9 +47,9 @@ describe Chef::Resource::PowershellScript do
     expect(resource.convert_boolean_return).to eq(false)
   end
 
-  it "inherits exactly the :cwd, :domain, :environment, :group, :password, :path, :user, :umask, :architecture, :elevated, :interpreter, :login properties from a parent resource class" do
+  it "inherits exactly the :cwd, :domain, :environment, :group, :password, :path, :user, :umask, :architecture, :elevated, :interpreter, :login, :use_inline_powershell properties from a parent resource class" do
     inherited_difference = Chef::Resource::PowershellScript.guard_inherited_attributes -
-      %i{cwd domain environment group password path user umask architecture elevated interpreter login}
+      %i{cwd domain environment group password path user umask architecture elevated interpreter login use_inline_powershell}
 
     expect(inherited_difference).to eq([])
   end


### PR DESCRIPTION
## Description

This adds support for the powershell_script resource to use powershell.dll directly instead of going through the powershell_out process - this is _significantly_ faster if you're doing a lot of small powershell changes.  For our environment, doing things this way instead of via powershell_out yields a 28% reducition in chef run time.

It is not, and should not be, default behaviour because there are a bunch of semantic differences - most notably, you can't stream output, and you can't switch user.  But for a significant number of powershell use cases, the large performance improvement makes this worth the compromise.  This is particularly true for idempotent runs, where executing guards can be a significant user of cycles from constantly starting powershell.exe/pwsh.exe

It can be seen to work with the following chef-apply script:

```
powershell_script 'guardme - should not run' do
  code <<-EOH
Write-Output "hi"
EOH
  use_inline_powershell true
  only_if '$False'
end

powershell_script 'guardme2 - should run' do
  code <<-EOH
Write-Output "hi"
EOH
  use_inline_powershell true
  only_if '$True'
end

powershell_script 'guardme3 - should not run' do
  code <<-EOH
Write-Output "hi"
EOH
  use_inline_powershell true
  only_if 'throw_exception'
end

powershell_script 'using creates' do
  code <<-EOH
Write-Output "hi"
EOH
  use_inline_powershell true
  creates "c:/windows"
end

powershell_script "fail on pourpose" do
  code "return 1"
  ignore_failure true
end
```

which outputs
```
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * powershell_script[guardme - should not run] action run (skipped due to only_if)
  * powershell_script[guardme2 - should run] action run
    - execute direct powershell guardme2 - should run
  * powershell_script[guardme3 - should not run] action run (skipped due to only_if)
  * powershell_script[using creates] action run (up to date)
  * powershell_script[fail on pourpose] action run

    ================================================================================
    Error executing action `run` on resource 'powershell_script[fail on pourpose]'
    ================================================================================
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
