### PR TITLE
Account for multiple ansidecl.h files found

### DIFF
--- a/.github/workflows/fips-validation.yml
+++ b/.github/workflows/fips-validation.yml
@@ -1,12 +1,12 @@
 ---
     name: fips-validation
-    
+
     "on":
       pull_request:
       push:
         branches:
           - chef-17
-    
+
     jobs:
       windows:
         strategy:
@@ -31,14 +31,21 @@
           run: |
             $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
             $env:OHAI_VERSION = ( Select-String -Path .\Gemfile.lock -Pattern '(?<=ohai \()\d.*(?=\))' | ForEach-Object { $_.Matches[0].Value } )
-    
+
             # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
             # This leads to failures during testing. Moving that file to its correct position here.
             # Another example of 'bad' that needs to be corrected
             $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
+
+            # Grabbing the first (and shortest) path found is a bit of a :fingers-crossed: but
+            # making the leap that ansidecl.h isn't going to vary in a way that will fail
+            # subtly.
+            if ($output -is [Array]) { $output = $output[0] }
+
             $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-            Move-Item -Path $output.FullName -Destination $target_path
-    
+            # silently continue if the ruby distro has the file there
+            Move-Item -Path $output.FullName -Destination $target_path -ErrorAction SilentlyContinue
+
             gem install appbundler appbundle-updater --no-doc
             If ($lastexitcode -ne 0) { Exit $lastexitcode }
             appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -35,6 +35,14 @@ jobs:
         # This leads to failures during testing. Moving that file to its correct position here.
         # Another example of 'bad' that needs to be corrected
         $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
+
+
+        # As of Ruby 3.1, there are 3 ansidecl.h files found in the opscode path
+        # Grabbing the first (and shortest) path found is a bit of a :fingers-crossed: but
+        # making the leap that ansidecl.h isn't going to vary in a way that will fail
+        # subtly.
+        if ($output -is [Array]) { $output = $output[0] }
+
         $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
         Move-Item -Path $output.FullName -Destination $target_path
 

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -44,7 +44,7 @@ jobs:
         if ($output -is [Array]) { $output = $output[0] }
 
         $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-        Move-Item -Path $output.FullName -Destination $target_path
+        #Move-Item -Path $output.FullName -Destination $target_path -ErrorAction SilentlyContinue
 
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -44,7 +44,7 @@ jobs:
         if ($output -is [Array]) { $output = $output[0] }
 
         $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-        #Move-Item -Path $output.FullName -Destination $target_path -ErrorAction SilentlyContinue
+        Move-Item -Path $output.FullName -Destination $target_path -ErrorAction SilentlyContinue
 
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -44,6 +44,7 @@ jobs:
         if ($output -is [Array]) { $output = $output[0] }
 
         $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
+        # silently continue if the ruby distro has the file there
         Move-Item -Path $output.FullName -Destination $target_path -ErrorAction SilentlyContinue
 
         gem install appbundler appbundle-updater --no-doc


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
It appears (as evidenced by a rerun of [kitchen run for 17.10.94 bump](https://github.com/chef/chef/actions/runs/6669026848/job/18125907355)) that the underlying Ruby on the Chef 17 branch GitHub Actions runners now has multiple `ansidecl.h` files as well. Backport the `[0]` selection if it's an Array.

It also appears likely that the file we're trying to copy will actually be in place already, so `SilentlyContinue` the `Move-Item` call.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
