### PR TITLE
Do not use untaint

### DIFF
--- a/knife/lib/chef/knife/core/gem_glob_loader.rb
+++ b/knife/lib/chef/knife/core/gem_glob_loader.rb
@@ -78,7 +78,7 @@ class Chef
           if check_load_path
             files = $LOAD_PATH.map do |load_path|
               Dir["#{File.expand_path glob, ChefConfig::PathHelper.escape_glob_dir(load_path)}#{Gem.suffix_pattern}"]
-            end.flatten.select { |file| File.file? file.untaint }
+            end.flatten.select { |file| File.file? file }
 
           end
 
@@ -114,7 +114,7 @@ class Chef
 
           glob = File.join(ChefConfig::PathHelper.escape_glob_dir(spec.full_gem_path, dirs), glob)
 
-          Dir[glob].map(&:untaint)
+          Dir[glob]
         end
 
         def from_different_chef_version?(path)


### PR DESCRIPTION
Method untaint does not exist anymore https://bugs.ruby-lang.org/issues/16131

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Removed the call to untaint as it can cause crash

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
While trying to launch a simple command, eg.
`bundle exec knife update roles` I faced the following issue
```
bundle exec knife upload roles
bundler: failed to load command: knife (/xxx/.rbenv/versions/3.2.2/bin/knife)
/xxx/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/knife-18.3.0/lib/chef/knife/core/gem_glob_loader.rb:81:in `block in find_files_latest_gems': undefined method `untaint' for "/xxx/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/knife-18.3.0/lib/chef/knife/acl_add.rb":String (NoMethodError)

            end.flatten.select { |file| File.file? file.untaint }
```
This methods seems [not to exist anymore](https://bugs.ruby-lang.org/issues/16131)
I just removed the filter which solved the issue on my side. We can maybe propose something else. 
There is [another occurrence](https://github.com/chef/chef/blob/9c124baf772896d9e732b4fc5fd93638bcd7c30e/knife/lib/chef/knife/core/gem_glob_loader.rb#L117) in the code and I don't know if we should change it and how.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass. 
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
