### PR TITLE
Update input validation for openssl_x509_certificate.

### DIFF
--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -212,13 +212,18 @@ class Chef
         end
 
         def subject
+          if new_resource.common_name.nil? && new_resource.subject_alt_name.empty?
+            Chef::Log.fatal("Neither common_name nor subject_alt_name specified, one is required.")
+            raise "Neither common_name nor subject_alt_name specified, one is required."
+          end
+
           OpenSSL::X509::Name.new.tap do |csr_subject|
             csr_subject.add_entry("C", new_resource.country) unless new_resource.country.nil?
             csr_subject.add_entry("ST", new_resource.state) unless new_resource.state.nil?
             csr_subject.add_entry("L", new_resource.city) unless new_resource.city.nil?
             csr_subject.add_entry("O", new_resource.org) unless new_resource.org.nil?
             csr_subject.add_entry("OU", new_resource.org_unit) unless new_resource.org_unit.nil?
-            csr_subject.add_entry("CN", new_resource.common_name)
+            csr_subject.add_entry("CN", new_resource.common_name) unless new_resource.common_name.nil?
             csr_subject.add_entry("emailAddress", new_resource.email) unless new_resource.email.nil?
           end
         end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Fixes https://github.com/chef/chef/issues/14079.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
TL;DR, as I understand it, you must have one of common_name or a subject_alt_name entry. If you have a common_name entry, it must match the subject_alt_name entry. But common_name is not required.

Currently, the resource implicitly requires common_name to be specified: https://github.com/chef/chef/blob/main/lib/chef/resource/openssl_x509_certificate.rb#L221. Implicit because common_name isn't marked as required: https://github.com/chef/chef/blob/main/lib/chef/resource/openssl_x509_certificate.rb#L101.

I believe the correct solution is to leave the common_name and subject_alt_name property definitions as-is, add an unless check on the nilness of common_name, and require that one of subject_alt_name or common_name be set.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/14079
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
