### PR TITLE
updating the code sign with digicerts HSM, also put some validation i…

### DIFF
--- a/.expeditor/scripts/omnibus_chef_build.ps1
+++ b/.expeditor/scripts/omnibus_chef_build.ps1
@@ -1,5 +1,9 @@
 $ScriptDir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 
+# to enable smctl debugging with digicert hsm signing un comment:
+#
+#$env:SM_LOG_LEVEL="TRACE"
+
 if ($env:BUILDKITE_ORGANIZATION_SLUG -eq "chef-oss" )
 {
   Write-Output "--- Generating self-signed Windows package signing certificate"
@@ -7,27 +11,81 @@ if ($env:BUILDKITE_ORGANIZATION_SLUG -eq "chef-oss" )
 }
 else
 {
-  Write-Output "--- Installing Windows package signing certificate"
-  $windows_certificate_json = "windows-package-signing-certificate.json"
-  $windows_certificate_pfx = "windows-package-signing-certificate.pfx"
+  try {
+    Write-Output "--- setting up auth for smctl"
+    $SM_CLIENT_CERT_FILE_JSON = "sm-client-cert-file.json"
+    aws ssm get-parameter --name "sm-client-cert-file" --with-decryption --region "us-west-1" --query Parameter.Value --output text | Set-Content -Path $SM_CLIENT_CERT_FILE_JSON
+    # this just grabs the secret as its a json object, converts it, then selects the cert_content_base64, then creates the file to c:\digicert\certificate_pkcs12.p12 while decoding the base64 #
+    $smClientCertJson = Get-Content $SM_CLIENT_CERT_FILE_JSON | ConvertFrom-Json | Select-Object -ExpandProperty cert_content_base64
+    $decodedFilePath = "c:\digicert\certificate_pkcs12.p12"
+    write-output "decoding CLIENT_CERT_FILE_CONTENT c:\digicert\certificate_pkcs12.p12"
+    [System.IO.File]::WriteAllBytes($decodedFilePath, [System.Convert]::FromBase64String($smClientCertJson))
+  } catch {
+      throw $_
+  }
+  try {
+      $file = Get-ChildItem -Path "c:\digicert\certificate_pkcs12.p12"
 
-  aws ssm get-parameter --name "windows-package-signing-cert" --with-decryption --region "us-west-1" --query Parameter.Value --output text | Set-Content -Path $windows_certificate_json
-  If ($lastexitcode -ne 0) { Throw $lastexitcode }
+      if ($file.Length -eq 2902) {
+          Write-Output "File attribute length is 2902. Which is correct"
+      }
+      else {
+          write-error "File attribute length is not 2902. Which means it likely failed the previous step at [System.IO.File]::WriteAllBytes!" -ErrorAction Stop
+      }
+  } catch {
+      throw $_
+  }
 
-  $cert_passphrase = Get-Content $windows_certificate_json | ConvertFrom-Json | Select-Object -ExpandProperty cert_passphrase | ConvertTo-SecureString -asplaintext -force
-  Get-Content $windows_certificate_json | ConvertFrom-Json | Select-Object -ExpandProperty cert_content_base64 | Set-Content -Path $windows_certificate_pfx
-  Remove-Item -Force $windows_certificate_json
-  Import-PfxCertificate $windows_certificate_pfx -CertStoreLocation Cert:\LocalMachine\My -Password $cert_passphrase
-  Remove-Item -Force $windows_certificate_pfx
-  $thumb = "13B510D1CF1B3467856A064F1BEA12D0884D2528"
+  Write-Output "--- smtcl env settings"
+  try {
+      $SM_API_KEY_VALUE = aws ssm get-parameter --name "sm-api-key" --with-decryption --region "us-west-1" --query Parameter.Value --output text
+      $SM_CLIENT_CERT_PASSWORD_VALUE = aws ssm get-parameter --name "sm-client-cert-password" --with-decryption --region "us-west-1" --query Parameter.Value --output text
+      $SM_HOST_VALUE = aws ssm get-parameter --name "sm-host" --with-decryption --region "us-west-1" --query Parameter.Value --output text
+      $env:SM_API_KEY_FILE=${SM_API_KEY_VALUE}
+      $env:SM_HOST=${SM_HOST_VALUE}
+      $env:SM_CLIENT_CERT_FILE="c:\digicert\certificate_pkcs12.p12"
+      $env:SM_CLIENT_CERT_PASSWORD_FILE=${SM_CLIENT_CERT_PASSWORD_VALUE}
+      smctl credentials save ${SM_API_KEY_VALUE} ${SM_CLIENT_CERT_PASSWORD_VALUE}
+  } catch {
+    throw $_
+  }
+
+####################################################################
+write-output "--- smksp_registrar sync certs before chef install"
+smksp_registrar.exe register
+certutil.exe -csp "DigiCert Software Trust Manager KSP" -key -user
+smksp_cert_sync.exe
+####################################################################
+
+  try {
+    $thumbprint = "769E6AF679126F184850AAC7C5C823A80DB3ADAA"
+
+    # Get the certificate from the Current User's Personal store by thumbprint, this case its ContainerAdministrator
+    $certificate = Get-ChildItem -Path Cert:\CurrentUser\My -Recurse | Where-Object { $_.Thumbprint -eq $thumbprint }
+
+    write-output "--- Display information about the retrieved certificate"
+    if ($certificate) {
+        Write-Output "Certificate Subject: $($certificate.Subject)"
+        Write-Output "Issuer: $($certificate.Issuer)"
+        Write-Output "Valid From: $($certificate.NotBefore)"
+        Write-Output "Valid To: $($certificate.NotAfter)"
+        Write-output "Has Private key: $($certificate.HasPrivateKey)"
+        $thumb = $thumbprint  # Set $thumb variable to $thumbprint
+    } else {
+        Write-Output "Certificate with thumbprint $thumbprint not found. Check SMCTL commands, check to see if the sm_client_cert file is valid, check if the SM_API_KEY hasnt expired, check if SM_CLIENT_CERT_PASSWORD is valid"
+    }
+    } catch {
+      Write-Error $_.Exception.Message
+      exit 1
+    }
 }
 
+$thumb = ${thumbprint}
 Write-Output "THUMB=$thumb"
 
 $env:ARTIFACTORY_BASE_PATH="com/getchef"
 $env:ARTIFACTORY_ENDPOINT="https://artifactory-internal.ps.chef.co/artifactory"
 $env:ARTIFACTORY_USERNAME="buildkite"
-
 
 Write-Output "--- Installing Chef Foundation ${env:CHEF_FOUNDATION_VERSION}"
 . { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v ${env:CHEF_FOUNDATION_VERSION}
@@ -47,9 +105,12 @@ $omnibus_toolchain_msystem = & "${env:OMNIBUS_TOOLCHAIN_INSTALL_DIR}\embedded\bi
 If ($omnibus_toolchain_msystem -eq "x64-mingw-ucrt") {
   $env:MSYSTEM = "UCRT64"
 }
+
+write-output "--- setting critical must have paths for omnibus-toolchain to work"
 $original_path = $env:PATH
-$env:PATH = "${env:MSYS2_INSTALL_DIR}\$env:MSYSTEM\bin;${env:MSYS2_INSTALL_DIR}\usr\bin;${env:OMNIBUS_TOOLCHAIN_INSTALL_DIR}\embedded\bin;C:\wix;C:\Program Files (x86)\Windows Kits\8.1\bin\x64;${original_path}"
+$env:PATH = "${env:MSYS2_INSTALL_DIR}\$env:MSYSTEM\bin;${env:MSYS2_INSTALL_DIR}\usr\bin;${env:OMNIBUS_TOOLCHAIN_INSTALL_DIR}\embedded\bin;C:\wix;${original_path}"
 Write-Output "env:PATH = $env:PATH"
+$env:Path -split ';' | ForEach-Object { $_ }
 
 Write-Output "--- Removing libyajl2 for reinstall to get libyajldll.a"
 gem uninstall -I libyajl2
@@ -63,6 +124,39 @@ if ( -not $? ) { throw "Running bundle install failed" }
 Write-Output "--- Building Chef"
 bundle exec omnibus build chef -l internal --override append_timestamp:false
 if ( -not $? ) { throw "omnibus build chef failed" }
+
+#confirm file is signed
+try {
+  write-output "--- signing with powershell smctl"
+  $directoryPath = "C:\omnibus-ruby\pkg\"
+  $msiFile = Get-ChildItem -Path $directoryPath -Filter *.msi | Select-Object -First 1
+  write-output "--- test msi path"
+  # Check if an .msi file was found
+  if ($msiFile -ne $null) {
+    # Display the full path of the found .msi file
+    $fullPath = $msiFile.FullName
+    Write-Output "Found .msi file: $fullPath"
+
+    # Assign the full path to a variable ($fullPath) for later use
+    $fullPathVariable = $fullPath
+    write-output "--- verify signed file smctl sign verify --input ${fullPathVariable}" 
+    smctl sign verify --input ${fullPathVariable}
+  } else {
+    Write-Output "No .msi files found in the directory: $directoryPath or its not signed"
+  }
+} catch {
+  Write-Output "An error occurred: $_"
+  exit 1
+}
+
+write-output "--- smctl credentials delete just to clean up"
+smctl windows certdesync
+
+#uncomment these as well for logs#
+# Write-output "--- grabbing smctl logs"
+# gc $home\.signingmanager\logs\smctl.log
+# gc $home\.signinmanager\logs\smksp.log
+# gc $home\.signingmanager\logs\smksp_cert_sync.log
 
 Write-Output "--- Uploading package to BuildKite"
 C:\buildkite-agent\bin\buildkite-agent.exe artifact upload "pkg/*.msi*"

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -117,7 +117,7 @@ winrm quickconfig -quiet
 If ($lastexitcode -ne 0) { Throw $lastexitcode }
 
 # temp fix until we figure out whats going on with this gem #
-gem install unf_ext -v 0.0.8.2 --source https://artifactory-internal.ps.chef.co/artifactory/api/gems/rubygems-proxy
+gem install unf_ext -v 0.0.8.2 --source https://rubygems.org/gems/unf_ext
 bundle
 If ($lastexitcode -ne 0) { Throw $lastexitcode }
 

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -116,8 +116,6 @@ $Env:CHEF_LICENSE = "accept-no-persist"
 winrm quickconfig -quiet
 If ($lastexitcode -ne 0) { Throw $lastexitcode }
 
-# temp fix until we figure out whats going on with this gem #
-gem install unf_ext -v 0.0.8.2 --source https://rubygems.org/gems/unf_ext
 bundle
 If ($lastexitcode -ne 0) { Throw $lastexitcode }
 

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -116,6 +116,8 @@ $Env:CHEF_LICENSE = "accept-no-persist"
 winrm quickconfig -quiet
 If ($lastexitcode -ne 0) { Throw $lastexitcode }
 
+# temp fix until we figure out whats going on with this gem #
+gem install unf_ext -v 0.0.8.2 --source https://artifactory-internal.ps.chef.co/artifactory/api/gems/rubygems-proxy
 bundle
 If ($lastexitcode -ne 0) { Throw $lastexitcode }
 


### PR DESCRIPTION
…n the script

also putting in a temp fix for omnibus tests until we can figure out why Artifactory is not caching this folder correctly

<!--- Provide a short summary of your changes in the Title above -->

## Description
This solves the issue with windows code singing certs and integrates with digicerts HSM. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
