### PR TITLE
Deprecate osx_profile resource.

### DIFF
--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -31,6 +31,7 @@ class Chef
 
       description "Use the **osx_profile** resource to manage configuration profiles (`.mobileconfig` files) on macOS nodes. The **osx_profile** resource generates a unique `ProfileUUID` using the uuidgen library and then uses the `profiles` command to install the profile on the system. Warning: Profile installation is not available on macOS 11.0 or later due to Apple's removal of support for CLI profile installation."
       introduced "12.7"
+      deprecated "This resource will be removed in #{ChefUtils::Dist::Infra::PRODUCT} 19.0, as macOS 11 and later no longer support this functionality."
       examples <<~DOC
       **Install a profile from a cookbook file**
 

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -29,7 +29,7 @@ class Chef
       provides :osx_profile
       provides :osx_config_profile
 
-      description "Use the **osx_profile** resource to manage configuration profiles (`.mobileconfig` files) on the macOS platform. The **osx_profile** resource installs profiles by using the uuidgen library to generate a unique `ProfileUUID`, and then using the `profiles` command to install the profile on the system."
+      description "Use the **osx_profile** resource to manage configuration profiles (`.mobileconfig` files) on macOS nodes. The **osx_profile** resource generates a unique `ProfileUUID` using the uuidgen library and then uses the `profiles` command to install the profile on the system. Warning: Profile installation is not available on macOS 11.0 or later due to Apple's removal of support for CLI profile installation."
       introduced "12.7"
       examples <<~DOC
       **Install a profile from a cookbook file**

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -31,7 +31,7 @@ class Chef
 
       description "Use the **osx_profile** resource to manage configuration profiles (`.mobileconfig` files) on macOS nodes. The **osx_profile** resource generates a unique `ProfileUUID` using the uuidgen library and then uses the `profiles` command to install the profile on the system. Warning: Profile installation is not available on macOS 11.0 or later due to Apple's removal of support for CLI profile installation."
       introduced "12.7"
-      deprecated "This resource will be removed in #{ChefUtils::Dist::Infra::PRODUCT} 19.0, as macOS 11 and later no longer support this functionality."
+      Chef.deprecated :generic, "This resource will be removed in #{ChefUtils::Dist::Infra::PRODUCT} 19.0, as macOS 11 and later no longer support this functionality."
       examples <<~DOC
       **Install a profile from a cookbook file**
 


### PR DESCRIPTION
Basically #10471

## Description
In 2020, Apple dropped support for non-interactively installing configuration profiles. This commit more prominently documents that change.

## Related Issue
https://github.com/chef/chef/issues/10075

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
