### PR TITLE
feat: Support Signed-By option for apt repository

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -614,6 +614,7 @@
     "keygen",
     "keyid",
     "keyivgen",
+    "keyrings",
     "KEYNAME",
     "keyname",
     "keypair",

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -164,6 +164,10 @@ class Chef
       property :key_proxy, [String, nil, FalseClass],
         description: "If set, a specified proxy is passed to GPG via `http-proxy=`."
 
+      property :signed_by, [String, true, false, nil],
+        description: "If a string, specify the file and/or fingerprint the repo is signed with. If true, set Signed-With to use the specified key",
+        default: true
+
       property :cookbook, [String, nil, FalseClass],
         description: "If key should be a cookbook_file, specify a cookbook where the key is located for files/default. Default value is nil, so it will use the cookbook where the resource is used.",
         desired_state: false
@@ -233,6 +237,17 @@ class Chef
           valid
         end
 
+        # validate the key against the a gpg keyring to see if that version is expired
+        # @param [String] key
+        #
+        # @return [Boolean] is the key valid or not
+        def keyring_key_is_valid?(keyring, key)
+          valid = shell_out("gpg", "--no-default-keyring", "--keyring", keyring, "--list-public-keys", key).stdout.each_line.none?(/\[(expired|revoked):/)
+
+          logger.debug "key #{key} #{valid ? "is valid" : "is not valid"}"
+          valid
+        end
+
         # return the specified cookbook name or the cookbook containing the
         # resource.
         #
@@ -279,6 +294,10 @@ class Chef
           end
         end
 
+        def keyring_path
+          "/etc/apt/keyrings/#{new_resource.repo_name}.gpg"
+        end
+
         # Fetch the key using either cookbook_file or remote_file, validate it,
         # and install it with apt-key add
         # @param [String] key the key to install
@@ -288,11 +307,19 @@ class Chef
         # @return [void]
         def install_key_from_uri(key)
           key_name = key.gsub(/[^0-9A-Za-z\-]/, "_")
-          cached_keyfile = ::File.join(Chef::Config[:file_cache_path], key_name)
+          keyfile_path = ::File.join(Chef::Config[:file_cache_path], key_name)
           tmp_dir = TargetIO::Dir.mktmpdir(".gpg")
           at_exit { TargetIO::FileUtils.remove_entry(tmp_dir) }
 
-          declare_resource(key_type(key), cached_keyfile) do
+          if new_resource.signed_by
+            keyfile_path = keyring_path
+
+            directory "/etc/apt/keyrings" do
+              mode "0755"
+            end
+          end
+
+          declare_resource(key_type(key), keyfile_path) do
             source key
             mode "0644"
             sensitive new_resource.sensitive
@@ -300,13 +327,17 @@ class Chef
             verify "gpg --homedir #{tmp_dir} %{path}"
           end
 
-          execute "apt-key add #{cached_keyfile}" do
-            command [ "apt-key", "add", cached_keyfile ]
-            default_env true
-            sensitive new_resource.sensitive
-            action :run
-            not_if { no_new_keys?(cached_keyfile) }
-            notifies :run, "execute[apt-cache gencaches]", :immediately
+          # If signed by is true, then we don't need to
+          # add to the default keyring
+          unless new_resource.signed_by
+            execute "apt-key add #{keyfile_path}" do
+              command [ "apt-key", "add", keyfile_path ]
+              default_env true
+              sensitive new_resource.sensitive
+              action :run
+              not_if { no_new_keys?(keyfile_path) }
+              notifies :run, "execute[apt-cache gencaches]", :immediately
+            end
           end
         end
 
@@ -336,6 +367,10 @@ class Chef
         #
         # @return [void]
         def install_key_from_keyserver(key, keyserver = new_resource.keyserver)
+          if new_resource.signed_by
+            install_key_from_keyserver_to_keyring(key, keyserver, keyring_path)
+            return
+          end
           execute "install-key #{key}" do
             command keyserver_install_cmd(key, keyserver)
             default_env true
@@ -350,6 +385,31 @@ class Chef
           end
 
           raise "The key #{key} is invalid and cannot be used to verify an apt repository." unless key_is_valid?(key.upcase)
+        end
+
+        # @param [String] key
+        # @param [String] keyserver
+        # @param [String] keyring
+        def install_key_from_keyserver_to_keyring(key, keyserver, keyring)
+          keyserver = "hkp://#{keyserver}:80" unless keyserver.start_with?("hkp://")
+
+          cmd = "gpg --no-default-keyring --keyring #{keyring}"
+          cmd << " --keyserver-options http-proxy=#{new_resource.key_proxy}" if new_resource.key_proxy
+          cmd << " --keyserver #{keyserver}"
+          cmd << " --recv #{key}"
+
+          execute "install-key #{key}" do
+            command cmd
+            default_env true
+            sensitive new_resource.sensitive
+            not_if do
+              present = shell_out(*%W{gpg --no-default-keyring --keyring #{keyring} --list-public-keys --with-fingerprint --with-colons #{key}}).exitstatus != 0
+              present && keyring_key_is_valid?(keyring, key.upcase)
+            end
+            notifies :run, "execute[apt-cache gencaches]", :immediately
+          end
+
+          raise "The key #{key} is invalid and cannot be used to verify an apt repository." unless keyring_key_is_valid?(keyring, key.upcase)
         end
 
         # @param [String] owner
@@ -405,11 +465,12 @@ class Chef
         # @param [Array] components
         # @param [Boolean] trusted
         # @param [String] arch
+        # @param [String] signed_by
         # @param [Array] options
         # @param [Boolean] add_src
         #
         # @return [String] complete repo config text
-        def build_repo(uri, distribution, components, trusted, arch, options, add_src = false)
+        def build_repo(uri, distribution, components, trusted, arch, signed_by, options, add_src = false)
           uri = make_ppa_url(uri) if is_ppa_url?(uri)
 
           uri = Addressable::URI.parse(uri)
@@ -417,6 +478,7 @@ class Chef
           options_list = []
           options_list << "arch=#{arch}" if arch
           options_list << "trusted=yes" if trusted
+          options_list << "signed-by=#{signed_by}" if signed_by
           options_list += options
           optstr = unless options_list.empty?
                      "[" + options_list.join(" ") + "]"
@@ -474,12 +536,18 @@ class Chef
 
         cleanup_legacy_file!
 
+        signed_by = new_resource.signed_by
+        if signed_by == true
+          signed_by = keyring_path
+        end
+
         repo = build_repo(
           new_resource.uri,
           new_resource.distribution,
           repo_components,
           new_resource.trusted,
           new_resource.arch,
+          signed_by,
           new_resource.options,
           new_resource.deb_src
         )
@@ -505,6 +573,11 @@ class Chef
             apt_update new_resource.name do
               ignore_failure true
               action :nothing
+            end
+
+            file keyring_path do
+              sensitive new_resource.sensitive
+              action :delete
             end
 
             file "/etc/apt/sources.list.d/#{new_resource.repo_name}.list" do

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -246,43 +246,48 @@ C5986B4F1257FFA86632CBA746181433FBB75451
   describe "#build_repo" do
     it "creates a repository string" do
       target = "deb      http://test/uri unstable main\n"
-      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, [])).to eql(target)
+      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, nil, [])).to eql(target)
     end
 
     it "creates a repository string with spaces" do
       target = "deb      http://test/uri%20with%20spaces unstable main\n"
-      expect(provider.build_repo("http://test/uri with spaces", "unstable", "main", false, nil, [])).to eql(target)
+      expect(provider.build_repo("http://test/uri with spaces", "unstable", "main", false, nil, nil, [])).to eql(target)
     end
 
     it "creates a repository string with no distribution" do
       target = "deb      http://test/uri main\n"
-      expect(provider.build_repo("http://test/uri", nil, "main", false, nil, [])).to eql(target)
+      expect(provider.build_repo("http://test/uri", nil, "main", false, nil, nil, [])).to eql(target)
     end
 
     it "creates a repository string with source" do
       target = "deb      http://test/uri unstable main\ndeb-src  http://test/uri unstable main\n"
-      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, [], true)).to eql(target)
+      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, nil, [], true)).to eql(target)
     end
 
     it "creates a repository string with trusted" do
       target = "deb      [trusted=yes] http://test/uri unstable main\n"
-      expect(provider.build_repo("http://test/uri", "unstable", "main", true, nil, [])).to eql(target)
+      expect(provider.build_repo("http://test/uri", "unstable", "main", true, nil, nil, [])).to eql(target)
+    end
+
+    it "creates a repository string with signed-by" do
+      target = "deb      [signed-by=/etc/apt/keyrings/test.gpg] http://test/uri unstable main\n"
+      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, "/etc/apt/keyrings/test.gpg", [])).to eql(target)
     end
 
     it "creates a repository string with custom options" do
       target = "deb      [by-hash=no] http://test/uri unstable main\n"
-      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, ["by-hash=no"])).to eql(target)
+      expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, nil, ["by-hash=no"])).to eql(target)
     end
 
     it "creates a repository string with trusted, arch, and custom options" do
       target = "deb      [arch=amd64 trusted=yes by-hash=no] http://test/uri unstable main\n"
-      expect(provider.build_repo("http://test/uri", "unstable", "main", true, "amd64", ["by-hash=no"])).to eql(target)
+      expect(provider.build_repo("http://test/uri", "unstable", "main", true, "amd64", nil, ["by-hash=no"])).to eql(target)
     end
 
     it "handles a ppa repo" do
       target = "deb      http://ppa.launchpad.net/chef/main/ubuntu unstable main\n"
       expect(provider).to receive(:make_ppa_url).with("ppa:chef/main").and_return("http://ppa.launchpad.net/chef/main/ubuntu")
-      expect(provider.build_repo("ppa:chef/main", "unstable", "main", false, nil, [])).to eql(target)
+      expect(provider.build_repo("ppa:chef/main", "unstable", "main", false, nil, nil, [])).to eql(target)
     end
   end
 end


### PR DESCRIPTION
If it is used, it will avoid using the deprecated apt-key command.

Fixes: #13168

<!--- Provide a short summary of your changes in the Title above -->

## Description
Add support for a `signed_by` property for apt_repository. 

If true, and a key is supplied, it will install the key in a repo-specific keyring, and reference that in the Signed-By option. 
If a string, it will pass that string to the Signed-By option. 

I'm not sure what the behavior should be if signed_by is a string, and a key is also supplied. Currently it will install the key in a repo-specific location, but use the value of the string in the signed-by field. 

Other options for the case where key and signed-by are both specified could be:
1. install the key in /etc/apt/trusted.gpg.d, and use signed-by as is
2. try to interpret the first entry (comma seprated) as a file path, and install the key at that location
3. prepend the generated location to the list of signed-by values if it isn't already included

This still needs testing and documentation. But I wanted to see if this was a good approach before polishing it.

## Related Issue
#13168 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
