### PR TITLE
Fix tests and code to prep for OpenSSL 3.x

### DIFF
--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -157,9 +157,7 @@ class Chef
         raise TypeError, "curve must be a string" unless curve.is_a?(String)
         raise ArgumentError, "Specified curve is not available on this system" unless %w{prime256v1 secp384r1 secp521r1}.include?(curve)
 
-        # https://stackoverflow.com/questions/76252414/pkeys-are-immutable-on-openssl-3-0-e0m-opensslpkeypkeyerror
-        # ::OpenSSL::PKey::EC.new(curve).generate_key
-        key = OpenSSL::PKey::EC.generate(curve)
+        ::OpenSSL::PKey::EC.generate(curve)
       end
 
       # generate pem format of the public key given a private key

--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -157,7 +157,9 @@ class Chef
         raise TypeError, "curve must be a string" unless curve.is_a?(String)
         raise ArgumentError, "Specified curve is not available on this system" unless %w{prime256v1 secp384r1 secp521r1}.include?(curve)
 
-        ::OpenSSL::PKey::EC.new(curve).generate_key
+        # https://stackoverflow.com/questions/76252414/pkeys-are-immutable-on-openssl-3-0-e0m-opensslpkeypkeyerror
+        # ::OpenSSL::PKey::EC.new(curve).generate_key
+        key = OpenSSL::PKey::EC.generate(curve)
       end
 
       # generate pem format of the public key given a private key

--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -92,7 +92,12 @@ describe Chef::Mixin::OpenSSLHelper do
 
     context "When the dhparam.pem file does exist, and does contain a vaild dhparam key" do
       it "returns true" do
-        @dhparam_file.puts(::OpenSSL::PKey::DH.new(256).to_pem) # this is 256 to speed up specs
+        # bumped this from 256 to 1024 because OpenSSL 3.x will enforce
+        # size
+        #      OpenSSL::PKey::PKeyError:
+        #       EVP_PKEY_paramgen: modulus too small
+        # need to double check that the mixin itself doesn't allow smaller
+        @dhparam_file.puts(::OpenSSL::PKey::DH.new(1024).to_pem)
         @dhparam_file.close
         expect(instance.dhparam_pem_valid?(@dhparam_file.path)).to be_truthy
       end


### PR DESCRIPTION

## Description

### Test performance revert

Part of this change is reverting the performance improvement in #10438 

Before
```ruby
        @dhparam_file.puts(::OpenSSL::PKey::DH.new(256).to_pem) # this is 256 to speed up specs
```

After
```ruby
        @dhparam_file.puts(::OpenSSL::PKey::DH.new(1024).to_pem)
```

due to OpenSSL 3.x erroring on a length <1024 with the following

```

              OpenSSL::PKey::PKeyError:
               EVP_PKEY_paramgen: modulus too small
```

### Change private key call

Old call of [`::OpenSSL::PKey::EC.new(curve).generate_key`](https://ruby-doc.org/stdlib-3.1.0/libdoc/openssl/rdoc/OpenSSL/PKey/EC.html#method-i-generate_key) generates a new random private and public key on the `EC` instance just created with `::OpenSSL::PKey::EC.new(curve)`, which triggers "pkeys are immutable on OpenSSL 3.0" once we upgrade to OpenSSL >=3, due to the attempt to mutate the existing key.

New call of [`::OpenSSL::PKey::EC.generate(curve)`](https://ruby-doc.org/stdlib-3.1.0/libdoc/openssl/rdoc/OpenSSL/PKey/EC.html#method-i-generate_key)
 creates a new EC instance with a new random private and public key instead of trying to mutate the existing instance.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
