### PR TITLE
Capture a '104' return from zypper info

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -132,10 +132,11 @@ class Chef
           end
           current_version ||= latest_version if is_installed
           current_version
-        rescue Mixlib::ShellOut::ShellCommandFailed => e
+#        rescue Mixlib::ShellOut::ShellCommandFailed => e
           # zypper returns a '104' code if info is called for a non-existent package
-          return nil if e.message =~ /'104'/
-          raise
+#          return nil if e.message =~ /'104'/
+
+#          raise
         end
 
         def resolve_available_version(package_name, new_version)

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -132,6 +132,10 @@ class Chef
           end
           current_version ||= latest_version if is_installed
           current_version
+        rescue Mixlib::ShellOut::ShellCommandFailed => e
+          # zypper returns a '104' code if info is called for a non-existent package
+          return nil if e.message =~ /'104'/
+          raise
         end
 
         def resolve_available_version(package_name, new_version)

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -132,11 +132,11 @@ class Chef
           end
           current_version ||= latest_version if is_installed
           current_version
-#        rescue Mixlib::ShellOut::ShellCommandFailed => e
+        rescue Mixlib::ShellOut::ShellCommandFailed => e
           # zypper returns a '104' code if info is called for a non-existent package
-#          return nil if e.message =~ /'104'/
+          return nil if e.message =~ /'104'/
 
-#          raise
+          raise
         end
 
         def resolve_available_version(package_name, new_version)

--- a/spec/functional/resource/zypper_package_spec.rb
+++ b/spec/functional/resource/zypper_package_spec.rb
@@ -189,6 +189,15 @@ describe Chef::Resource::ZypperPackage, :requires_root, :suse_only do
         expect(zypper_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
       end
+
+      context "Package doesn't exist" do
+        let(:package_name) { "nonexistent_repo" }
+        it "does nothing if the package is not installed" do
+          zypper_package.run_action(:remove)
+          expect(zypper_package.updated_by_last_action?).to be false
+        end
+
+      end
     end
 
     context "with no available version" do
@@ -259,6 +268,7 @@ describe Chef::Resource::ZypperPackage, :requires_root, :suse_only do
       expect(shell_out("zypper locks | grep chef_rpm_provides").stdout.chomp).not_to match("chef_rpm_provides")
     end
   end
+
   def remove_package
     pkg_to_remove = Chef::Resource::ZypperPackage.new(package_name, run_context)
     pkg_to_remove.run_action(:remove)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The latest version of zypper in SLES 15 SP5 returns a 104 return code when querying or removing packages that do not exist in the repository. As a result, listing packages that should not exist on a system in the 'zypper' resource of chef results in the chef recipe failing due to a non-zero exit code.

Note, you may need to update packages first to trigger the error:

```sh
sudo zypper ref
sudo zypper update
```

Running `chef-apply recipe.rb` on the following recipe.rb should trigger the error on latest SLES 15 zypper:
```ruby
# any package or array of packages not in the package database will work:
package "bork" do
  action :remove
end
```


## Related Issue
[package resource sub item zypper_package cannot handle removing non-present packages
](https://chefio.atlassian.net/browse/CHEF-8848) (internal issue)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
