### PR TITLE
Correcting security issue

### DIFF
--- a/lib/chef/file_access_control/windows.rb
+++ b/lib/chef/file_access_control/windows.rb
@@ -324,7 +324,7 @@ class Chef
           acls += mode_ace(SID.Everyone, (mode & 07))
         end
 
-        acls.nil? ? nil : Chef::ReservedNames::Win32::Security::ACL.create(acls)
+        (acls.nil? || acls.empty?) ? nil : Chef::ReservedNames::Win32::Security::ACL.create(acls)
       end
 
       def target_group

--- a/lib/chef/file_access_control/windows.rb
+++ b/lib/chef/file_access_control/windows.rb
@@ -324,7 +324,9 @@ class Chef
           acls += mode_ace(SID.Everyone, (mode & 07))
         end
 
-        # acls can be [] in addition to nil
+        # 'acls.nil?'' will evaulate to false when it is actually null. It is an empty array and Ruby
+        # still considers it not nil even though it's empty. Verifying it is indeed empty as well
+        # solves the dilemma. 'acls' can be [] in addition to nil
         (acls.nil? || acls.empty?) ? nil : Chef::ReservedNames::Win32::Security::ACL.create(acls)
       end
 

--- a/lib/chef/file_access_control/windows.rb
+++ b/lib/chef/file_access_control/windows.rb
@@ -324,7 +324,7 @@ class Chef
           acls += mode_ace(SID.Everyone, (mode & 07))
         end
 
-        # 'acls.nil?'' will evaulate to false when it is actually null. It is an empty array and Ruby
+        # 'acls.nil?'' will evaluate to false when it is actually null. It is an empty array and Ruby
         # still considers it not nil even though it's empty. Verifying it is indeed empty as well
         # solves the dilemma. 'acls' can be [] in addition to nil
         (acls.nil? || acls.empty?) ? nil : Chef::ReservedNames::Win32::Security::ACL.create(acls)

--- a/lib/chef/file_access_control/windows.rb
+++ b/lib/chef/file_access_control/windows.rb
@@ -324,9 +324,9 @@ class Chef
           acls += mode_ace(SID.Everyone, (mode & 07))
         end
 
-        # 'acls.nil?'' will evaluate to false when it is actually null. It is an empty array and Ruby
-        # still considers it not nil even though it's empty. Verifying it is indeed empty as well
-        # solves the dilemma. 'acls' can be [] in addition to nil
+        # 'acls.nil?' is true if uninitialized, but false if the initial empty array value.
+        # 'acls.empty?' cannot be called if acls is nil but successfully guards against using the empty array value.
+        # either case should return nil from this method.
         (acls.nil? || acls.empty?) ? nil : Chef::ReservedNames::Win32::Security::ACL.create(acls)
       end
 

--- a/lib/chef/file_access_control/windows.rb
+++ b/lib/chef/file_access_control/windows.rb
@@ -324,6 +324,7 @@ class Chef
           acls += mode_ace(SID.Everyone, (mode & 07))
         end
 
+        # acls can be [] in addition to nil
         (acls.nil? || acls.empty?) ? nil : Chef::ReservedNames::Win32::Security::ACL.create(acls)
       end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR corrects issues in Chef-18 only where executing the chef_client_config resource results in permissions on the \chef folder being removed or otherwise borked. Please see the following issues:
[Github](https://github.com/chef/chef/issues/14170)
[Jira](https://chefio.atlassian.net/jira/software/c/projects/CHEF/boards/492?selectedIssue=CHEF-3839)

The `file_access_control\windows.rb` file has a bug in it. It appears to be a Ruby issue. On line 327 when checking to see if permissions need to be updated, the acls object is nil entering this statement:
`acls.nil? ? nil : Chef::ReservedNames::Win32::Security::ACL.create(acls)`
When the clause acls.nil? executes, it returns false which is incorrect because the damned thing IS empty. That causes the secondary part of the ternary to execute which itself is DOA since the acls object is null at that point. That results in a Windows error 87 - trying to apply a busted ACL - that results in the downstream effect of resetting the permissions on the \chef folder

The fix was to verify if the object was null OR empty which then allows for the code to execute correctly and maintain permissions

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
