### PR TITLE
Bump buildkite-platform and omnibus for solaris issue

### DIFF
--- a/.buildkite-platform.json
+++ b/.buildkite-platform.json
@@ -1,4 +1,4 @@
 {
-    "chef_foundation": "3.1.15",
+    "chef_foundation": "3.1.18",
     "omnibus_toolchain": "3.0.0"
 }

--- a/.buildkite-platform.json
+++ b/.buildkite-platform.json
@@ -1,4 +1,4 @@
 {
-    "chef_foundation": "3.1.18",
+    "chef_foundation": "3.1.20",
     "omnibus_toolchain": "3.0.0"
 }

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 82dae896a066542f1b66dc866186f856f37e518e
+  revision: 16e27f648f5be10b5895b46c109f194ff93c9f63
   branch: main
   specs:
-    omnibus (9.0.23)
+    omnibus (9.0.24)
       aws-sdk-s3 (~> 1.116.0)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)
@@ -453,7 +453,7 @@ GEM
     vault (0.17.0)
       aws-sigv4
     webrick (1.8.1)
-    win32-api (1.10.1-universal-mingw32)
+    win32-api (1.10.1)
     win32-certstore (0.6.15)
       chef-powershell (>= 1.0.12)
       ffi


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Bump `chef-foundation` and `omnibus` to pick up [Truncate depend fmri version specifiers to allow Solaris install flexibility](https://github.com/chef/omnibus/pull/1144)

`bundle update --conservative omnibus` in `/omnibus`:

```
❯ bundle update --conservative omnibus
Fetching https://github.com/chef/omnibus-software.git
Fetching https://github.com/chef/omnibus.git
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies..................
Using public_suffix 5.0.3
Using fuzzyurl 0.9.0
Using artifactory 3.0.15
Using awesome_print 1.9.2
Using mixlib-log 3.0.9
Using rack 2.2.6.4
Using uuidtools 2.2.0
Using webrick 1.8.1
Using ffi 1.16.3
Using diff-lcs 1.5.0
Using erubis 2.7.0
Using iniparse 1.5.0
Using faraday-net_http 3.0.2
Using ruby2_keywords 0.0.5
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using unicode-display_width 2.4.2
Using unicode_utils 1.4.0
Using aws-eventstream 1.2.0
Using tty-cursor 0.7.1
Using wisper 2.0.1
Using method_source 1.0.0
Using multipart-post 2.3.0
Using parallel 1.22.1
Using parslet 1.8.2
Using coderay 1.1.3
Using rspec-support 3.11.1
Using rubyzip 2.3.2
Using semverse 3.0.2
Using tty-screen 0.8.1
Using thor 1.2.2
Using json 2.6.3
Using net-ssh 7.2.0
Using mixlib-authentication 3.0.10
Using mixlib-cli 2.1.8
Using timeout 0.3.2
Using date 3.3.3
Using hashie 4.1.0
Using plist 3.7.0
Using ipaddress 0.8.3
Using aws-partitions 1.837.0
Using syslog-logger 1.6.8
Using http-accept 1.7.0
Using jmespath 1.6.2
Using mime-types-data 3.2023.0218.1
Using netrc 0.11.0
Using builder 3.2.4
Using erubi 1.12.0
Using rexml 3.2.6
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using chef-vault 4.1.11
Using nori 2.6.0
Using rubyntlm 0.6.3
Using cleanroom 1.0.0
Using sslshake 1.3.1
Using retryable 3.0.5
Using molinillo 0.8.0
Using bundler 2.3.7
Using chef-cleanroom 1.0.5
Using citrus 3.0.2
Using contracts 0.16.1
Using ed25519 1.3.0
Using iostruct 0.0.5
Using wmi-lite 1.0.7
Using bcrypt_pbkdf 1.1.0
Using zhexdump 0.0.2
Using rainbow 3.1.1
Using addressable 2.8.5
Using concurrent-ruby 1.2.2
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.3
Using faraday 2.7.4
Using pastel 0.8.0
Using strings 0.2.1
Using mixlib-archive 1.1.7
Using aws-sigv4 1.6.0
Using pry 0.14.2
Using rspec-core 3.11.0
Using rspec-expectations 3.11.1
Using rspec-mocks 3.11.2
Using tty-reader 0.9.0
Using multi_json 1.15.0
Using net-protocol 0.2.1
Using time 0.2.2
Using net-sftp 4.0.0
Using net-ssh-gateway 2.0.0
Using mime-types 3.4.1
Using gyoku 1.4.0
Using solve 4.0.4
Using toml-rb 2.2.0
Using pedump 0.6.6
Using tomlrb 1.3.0
Using aws-sdk-core 3.185.1
Using chef-utils 18.1.29
Using faraday-follow_redirects 0.3.0
Using tty-box 0.7.0
Using tty-prompt 0.23.1
Using rspec 3.11.0
Using rspec-its 1.3.0
Using tty-table 0.12.0
Using net-ftp 0.2.0
Using logging 2.3.1
Using vault 0.17.0
Using sawyer 0.9.2
Using libyajl2 2.1.0
Using minitar 0.9
Using mixlib-versioning 1.2.12
Using gssapi 1.3.1
Using ruby-progressbar 1.13.0
Using proxifier2 1.1.0
Using unf_ext 0.0.8.2
Using net-scp 4.0.0
Using aws-sdk-kms 1.72.0
Using aws-sdk-secretsmanager 1.73.0
Using mixlib-config 3.0.27
Using mixlib-shellout 3.2.7
Using ffi-yajl 2.6.0
Using license-acceptance 2.1.13
Using unf 0.1.4
Using winrm 2.3.6
Using octokit 4.25.1
Using chef-config 18.1.29
Using chef-zero 15.0.11
Using winrm-fs 1.3.5
Using domain_name 0.5.20190701
Using mixlib-install 3.12.27
Using winrm-elevated 1.2.3
Using aws-sdk-s3 1.116.0
Using chef-telemetry 1.1.1
Using license_scout 1.3.6
Using http-cookie 1.0.5
Using train-core 3.10.8
Using train-winrm 0.2.13
Using inspec-core 5.21.29
Using ohai 18.1.3
Using rest-client 2.1.0
Using test-kitchen 3.5.0
Using train-rest 0.5.0
Using kitchen-vagrant 1.14.1
Using omnibus 9.0.24 (was 9.0.23) from https://github.com/chef/omnibus.git (at main@16e27f6)
Using chef 18.1.29
Using berkshelf 8.0.9
Using omnibus-software 23.12.308 from https://github.com/chef/omnibus-software.git (at main@f50a2ad)
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
