### PR TITLE
Add `start_after_enable` property to `systemd_unit` resource

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -43,6 +43,7 @@ class Chef
         current_resource.static(static?)
         current_resource.indirect(indirect?)
         current_resource.triggers_reload(new_resource.triggers_reload)
+        current_resource.start_after_enable(new_resource.start_after_enable)
 
         current_resource
       end
@@ -118,6 +119,10 @@ class Chef
           converge_by("enabling unit: #{new_resource.unit_name}") do
             systemctl_execute!(:enable, new_resource.unit_name)
             logger.info("#{new_resource} enabled")
+            if new_resource.start_after_enable
+              systemctl_execute!(:start, new_resource.unit_name)
+              logger.info("#{new_resource} started (after enable)")
+            end
           end
         end
       end

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -98,6 +98,10 @@ class Chef
         description: "Specifies whether to trigger a daemon reload when creating or deleting a unit.",
         default: true, desired_state: false
 
+      property :start_after_enable, [TrueClass, FalseClass],
+        description: "Specifies whether to start the unit after it is enabled.",
+        default: false, desired_state: false
+
       property :verify, [TrueClass, FalseClass],
         default: true, desired_state: false,
         description: "Specifies if the unit will be verified before installation. Systemd can be overly strict when verifying units, so in certain cases it is preferable not to verify the unit."

--- a/spec/unit/provider/systemd_unit_spec.rb
+++ b/spec/unit/provider/systemd_unit_spec.rb
@@ -531,6 +531,17 @@ describe Chef::Provider::SystemdUnit, :linux_only do
             provider.action_enable
           end
 
+          it "starts the unit after enabling it when start_after_enable" do
+            current_resource.enabled(false)
+            current_resource.start_after_enable(true)
+            %w{enable start}.each do |action|
+              expect(provider).to receive(:shell_out_compacted!)
+                .with(systemctl_path, "--system", action, unit_name)
+                .and_return(shell_out_success)
+            end
+            provider.action_enable
+          end
+
           it "does not enable the unit when it is enabled" do
             current_resource.enabled(true)
             expect(provider).not_to receive(:shell_out_compacted!)


### PR DESCRIPTION
## Description

A common operational task is to start a service after enabling it. systemd has a flag for this (--now). I didn't see a way to cleanly add that flag in the implementation so I added an explicit start.

Note this feature is different than the `:start` action which always starts a service.

A `stop_after_disable` property may also be useful.

## Related Issue

https://github.com/chef/chef/issues/14187

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
