### PR TITLE
Adding train support

### DIFF
--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -32,7 +32,7 @@ class Chef
       include DataBagSecretOptions
       include LicenseAcceptance::CLIFlags::MixlibCLI
 
-      SUPPORTED_CONNECTION_PROTOCOLS ||= %w{ssh winrm}.freeze
+      TRANSPORTS_BLACKLIST ||= %w{train-core train-aws train-azure train-habitat train-rest}.freeze
       WINRM_AUTH_PROTOCOL_LIST ||= %w{plaintext kerberos ssl negotiate}.freeze
 
       # Common connectivity options
@@ -54,8 +54,7 @@ class Chef
       option :connection_protocol,
         short: "-o PROTOCOL",
         long: "--connection-protocol PROTOCOL",
-        description: "The protocol to use to connect to the target node.",
-        in: SUPPORTED_CONNECTION_PROTOCOLS
+        description: "The protocol to use to connect to the target node. Examples: ssh, winrm"
 
       option :max_wait,
         short: "-W SECONDS",
@@ -810,11 +809,11 @@ class Chef
           exit 1
         end
 
-        unless SUPPORTED_CONNECTION_PROTOCOLS.include?(connection_protocol)
+        unless supported_connection_protocols.include?(connection_protocol)
           ui.error <<~EOM
             Unsupported protocol '#{connection_protocol}'.
 
-            Supported protocols are: #{SUPPORTED_CONNECTION_PROTOCOLS.join(" ")}
+            Supported protocols are: #{supported_connection_protocols.join(" ")}
           EOM
           exit 1
         end
@@ -1187,6 +1186,24 @@ class Chef
         return unless opts.is_a?(Hash) || !opts.empty?
 
         connection&.connection&.transport_options&.merge! opts
+      end
+      
+      # List Train transports available (but not loaded) on system.
+      #
+      # Will filter out train-core, API transports, and other incompatible ones.
+      #
+      # @return [Array] transport_names which can be used for command execution
+      def transports_available
+        train_gems = Gem::Specification.select { |spec| spec.name.start_with? "train-" }
+        train_gems.delete_if { |spec| TRANSPORTS_BLACKLIST.include? spec.name }
+        train_gems.map { |spec| spec.name.delete_prefix "train-" }
+      end
+      
+      # Return all supported connection types, classical and Train-based
+      #
+      # @return [Array] connection types supported
+      def supported_connection_protocols
+        %w{ssh winrm} | transports_available
       end
     end
   end

--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -1187,7 +1187,7 @@ class Chef
 
         connection&.connection&.transport_options&.merge! opts
       end
-      
+
       # List Train transports available (but not loaded) on system.
       #
       # Will filter out train-core, API transports, and other incompatible ones.
@@ -1198,7 +1198,7 @@ class Chef
         train_gems.delete_if { |spec| TRANSPORTS_BLACKLIST.include? spec.name }
         train_gems.map { |spec| spec.name.delete_prefix "train-" }
       end
-      
+
       # Return all supported connection types, classical and Train-based
       #
       # @return [Array] connection types supported

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -697,7 +697,7 @@ describe Chef::Knife::Bootstrap do
         expect { knife.validate_protocol! }.to raise_error SystemExit
       end
     end
-    
+
     context "when additional Train transports are present" do
       before do
         Gem::Specification.new do |spec|
@@ -708,7 +708,7 @@ describe Chef::Knife::Bootstrap do
 
         Gem.refresh
       end
-      
+
       context "and their usage is supported" do
         let(:connection_protocol) { "rfc2549" }
         it "accepts the transport as protocol" do

--- a/knife/spec/unit/knife/bootstrap_spec.rb
+++ b/knife/spec/unit/knife/bootstrap_spec.rb
@@ -682,7 +682,7 @@ describe Chef::Knife::Bootstrap do
 
     context "and the protocol is supported" do
 
-      Chef::Knife::Bootstrap::SUPPORTED_CONNECTION_PROTOCOLS.each do |proto|
+      %w{winrm ssh}.each do |proto|
         let(:connection_protocol) { proto }
         it "returns true for #{proto}" do
           expect(knife.validate_protocol!).to eq true
@@ -695,6 +695,45 @@ describe Chef::Knife::Bootstrap do
       it "outputs an error and exits" do
         expect(knife.ui).to receive(:error).with(/Unsupported protocol '#{connection_protocol}'/)
         expect { knife.validate_protocol! }.to raise_error SystemExit
+      end
+    end
+    
+    context "when additional Train transports are present" do
+      before do
+        Gem::Specification.new do |spec|
+          spec.name = "train-rfc2549"
+          spec.version = "0.0.1"
+          spec.summary = "Train transport to use IPoAC"
+        end.activate
+
+        Gem.refresh
+      end
+      
+      context "and their usage is supported" do
+        let(:connection_protocol) { "rfc2549" }
+        it "accepts the transport as protocol" do
+          # While the Gem mocking above will work in native RSpec, it will
+          # fail when executed as part of the test suite via Bundler.
+          #
+          # Reason for this is, that Bundler effectively replaces the whole
+          # gem loading architecture. Mocking the Gem inside of Bundler will
+          # have to reach deep into its internal implementation and make
+          # the test tighly-coupled and brittle.
+          #
+          # During the discussion on PR 13534, it was decided to skip the
+          # test as a result and add this explanation for future reference.
+
+          # expect(knife.validate_protocol!).to eq true
+          skip
+        end
+      end
+
+      context "and invalid proctocols are still refused" do
+        let(:connection_protocol) { "rfc6216" }
+        it "accepts the transport as protocol" do
+          expect(knife.ui).to receive(:error).with(/Unsupported protocol '#{connection_protocol}'/)
+          expect { knife.validate_protocol! }.to raise_error SystemExit
+        end
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This is a rebuild of [PR13534](https://github.com/chef/chef/pull/13534). The underlying branch was deleted somehow?

These changes supported protocols for `knife bootstrap` to dynamic detection of installed Train transports instead of just static `ssh `and `winrm`.

With this, alternative connection options such as AWS Systems Manager, Telnet, Serial/USB, and others get viable for easy onboarding of Chef nodes.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
