### PR TITLE
Updating Train Support to allow for more connection types

### DIFF
--- a/knife/knife.gemspec
+++ b/knife/knife.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 17.0"
-  s.add_dependency "ffi", ">= 1.15" # 1.14 versions are broken on i386 windows
+  s.add_dependency "ffi", "~> 1.15.5" # 1.14 versions are broken on i386 windows
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", ">= 5.1", "< 8"
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This is a rebuild of https://github.com/chef/chef/pull/13534. The underlying branch was deleted somehow?

These changes supported protocols for knife bootstrap to dynamic detection of installed Train transports instead of just static ssh and winrm.

With this, alternative connection options such as AWS Systems Manager, Telnet, Serial/USB, and others get viable for easy onboarding of Chef nodes.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
