### PR TITLE
modifying this setting for the release

### DIFF
--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -57,7 +57,7 @@ for platform in ${win_test_platforms[@]}; do
   echo "      propagate-environment: true"
   echo "  commands:"
   echo "    - .\.expeditor\scripts\prep_and_run_tests.ps1 {{matrix}}"
-  echo "  timeout_in_minutes: 60"
+  echo "  timeout_in_minutes: 120"
 
 done
 
@@ -73,7 +73,7 @@ for platform in ${win_test_platforms[@]}; do
   echo "  env:"
   echo "  - CHEF_FOUNDATION_VERSION"
   echo "    - .\.expeditor\scripts\prep_and_run_tests.ps1 {{matrix}}"
-  echo "  timeout_in_minutes: 60"
+  echo "  timeout_in_minutes: 120"
 done
 
 external_gems=("chef-zero" "cheffish" "chefspec" "knife-windows" "berkshelf")

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -106,19 +106,19 @@ subscriptions:
   # the omnibus/docker/gem chain
   - workload: artifact_published:unstable:chef:{{version_constraint}}
     actions:
-      - trigger_pipeline:docker/build
+      # - trigger_pipeline:docker/build
       - trigger_pipeline:macos_universal_package
-  - workload: artifact_published:current:chef:{{version_constraint}}
-    actions:
-      - bash:.expeditor/promote-docker-images.sh
+  # - workload: artifact_published:current:chef:{{version_constraint}}
+  #   actions:
+  #     - bash:.expeditor/promote-docker-images.sh
   - workload: project_promoted:{{agent_id}}:*
     actions:
       - built_in:promote_artifactory_artifact
   - workload: artifact_published:stable:chef:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
-      - bash:.expeditor/update_dockerfile.sh
-      - bash:.expeditor/promote-docker-images.sh
+      # - bash:.expeditor/update_dockerfile.sh
+      # - bash:.expeditor/promote-docker-images.sh
       - bash:.expeditor/publish-release-notes.sh
       - bash:.expeditor/announce-release.sh
       - built_in:publish_rubygems


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Removing this docker build from the subscriptions to get around the `/promote` command in expeditor cli. 

We dont even pull from the stable branch on the docker file, and produces an image that isnt being used.

using skip all here, to re-load the expeditor config, then we can do the 'expeditor promote' command. 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
