### PR TITLE
Move attribute merge NIL checks into inject 

### DIFF
--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -628,10 +628,6 @@ class Chef
         elsif merge_onto.is_a?(Array) && merge_with.is_a?(Array)
           merge_onto |= merge_with
 
-        # If merge_with is NIL, don't replace merge_onto
-        elsif merge_with == NIL
-          merge_onto
-
         # In all other cases, replace merge_onto with merge_with
         else
           if merge_with.is_a?(Hash)
@@ -659,10 +655,6 @@ class Chef
             # internal_set bypasses converting keys, does convert values and allows writing to immutable mashes
             merge_onto.internal_set(key, value)
           end
-          merge_onto
-
-        # If merge_with is NIL, don't replace merge_onto
-        elsif merge_with == NIL
           merge_onto
 
         # In all other cases, replace merge_onto with merge_with

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -570,7 +570,7 @@ class Chef
         ]
 
         ret = components.inject(NIL) do |merged, component|
-          hash_only_merge!(merged, component)
+          component == NIL ? merged : hash_only_merge!(merged, component)
         end
         ret == NIL ? nil : ret
       end
@@ -584,7 +584,7 @@ class Chef
       def merge_defaults(path)
         DEFAULT_COMPONENTS.inject(NIL) do |merged, component_ivar|
           component_value = apply_path(instance_variable_get(component_ivar), path)
-          deep_merge!(merged, component_value)
+          component_value == NIL ? merged : deep_merge!(merged, component_value)
         end
       end
 
@@ -597,7 +597,7 @@ class Chef
       def merge_overrides(path)
         OVERRIDE_COMPONENTS.inject(NIL) do |merged, component_ivar|
           component_value = apply_path(instance_variable_get(component_ivar), path)
-          deep_merge!(merged, component_value)
+          component_value == NIL ? merged : deep_merge!(merged, component_value)
         end
       end
 


### PR DESCRIPTION
## Description

Saw this while doing some profiling of attributes reads/writes. By moving the `merge_with == NIL` conditional out of the `deep_merge!` and `hash_only_merge!` methods, there's less method overhead over the course of a run since attribute keys generally aren't set on every attribute type (ie default/force_default/normal/override/force_override/automatic).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
