### PR TITLE
Avoid DeepMergeCache flap in Chef::Node#loaded_recipe

### DIFF
--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -285,7 +285,7 @@ class Chef
     def loaded_recipe(cookbook, recipe)
       fully_qualified_recipe = "#{cookbook}::#{recipe}"
 
-      automatic_attrs[:recipes] << fully_qualified_recipe unless Array(self[:recipes]).include?(fully_qualified_recipe)
+      automatic_attrs[:recipes] << fully_qualified_recipe unless Array(automatic_attrs[:recipes]).include?(fully_qualified_recipe)
     end
 
     # Returns true if this Node expects a given role, false if not.


### PR DESCRIPTION
## Description
Using `self` does a DeepMergeCache build on `:recipes`, which worsens as the array grows with included recipes since appending the recipe to the array causes the DeepMergeCache to drop for `:recipes`. `loaded_recipe` uses the `:recipes` array as a an ordered set, and doing writes to `:recipes` outside of automatic precedence doesn't make sense. Avoid reads from the other precedence levels entirely and read directly from the automatic precedence.

Potentially worth discussing - should we also change the `#recipe?` method?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
