### PR TITLE
[Immutablize#convert_value] return already frozen String objects

### DIFF
--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -49,7 +49,9 @@ class Chef
             ImmutableArray.new(value, __root__, __node__, __precedence__)
           end
         else
-          safe_dup(value).freeze
+          # We return any already frozen strings, since that's common over the course of a run.
+          # Check `frozen?` first since that's faster than a Class comparison
+          value.frozen? && String === value ? value : safe_dup(value).freeze
         end
       end
 


### PR DESCRIPTION
## Description
One of the reasons DeepMergeCache flaps are so bad for performance is that we `dup` new objects that aren't Hashes/Arrays during the creation of the cache, but we also freeze the new objects well. Freezing an Object makes further modification of the object result in RuntimeError, which means they are already immutable.

Given the expectation that the objects aren't able to be further modified, creating duplicate objects (which are then also frozen) appears to be needless, since we can instead pass the frozen object during ImmutableMash/ImmutableArray creation.

This *significantly* cuts the number of `Kernel#dup` calls in a run.

References:
- https://docs.ruby-lang.org/en/master/Object.html#method-i-freeze
- https://docs.chef.io/release_notes_client/#13.0.113-freezing-immutable-merged-attributes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
