### PR TITLE
correct logic for `use_choco_list` in chocolatey_package provider

### DIFF
--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -36,9 +36,9 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
   # installed packages (ConEmu is upgradable)
   let(:local_list_stdout) do
     <<~EOF
-      Chocolatey v0.9.9.11
-      chocolatey|0.9.9.11
-      ConEmu|15.10.25.0
+      Chocolatey v0.9.9.10
+      chocolatey|0.9.9.12
+      ConEmu|15.10.25.2
     EOF
   end
 
@@ -50,7 +50,7 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
     allow(provider).to receive(:powershell_exec!).with("#{choco_exe} --version").and_return(double(result: "2.1.0"))
     # Mock the local file system choco queries
     allow(provider).to receive(:get_local_pkg_dirs).and_return(%w{chocolatey ConEmu})
-    allow(provider).to receive(:fetch_package_versions_local).and_return({ "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.0" })
+    allow(provider).to receive(:fetch_package_versions).and_return({ "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.0" })
   end
 
   after(:each) do
@@ -168,6 +168,7 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
 
     it "should load and downcase names in the installed_packages hash (with disk provider)" do
       new_resource.use_choco_list(false)
+      provider.invalidate_cache
       provider.load_current_resource
       expect(provider.send(:installed_packages)).to eql(
         { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.0" }
@@ -176,9 +177,10 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
 
     it "should load and downcase names in the installed_packages hash (with choco list provider)" do
       new_resource.use_choco_list(true)
+      provider.invalidate_cache
       provider.load_current_resource
       expect(provider.send(:installed_packages)).to eql(
-        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.0" }
+        { "chocolatey" => "0.9.9.12", "conemu" => "15.10.25.2" }
       )
     end
 


### PR DESCRIPTION
Make `use_choco_list` actually not use choco list when set to false

## Description
This fixes a regression that happened in a refactor, where the `use_choco_list` logic got flipped when changing how the global option worked.  Additionally, this fixes a bug that was introduced with multi-case package name compares not being downcased correctly.  The other half of the caching was the bigger win in my test environment, so i didn't catch the performance regression until I deployed the chef18 code more widely in our org.

Additionally, it didn't fail tests because the selection regression actually stopped the broken code from being hit at all.  This updates the tests to have the two mechanisms return different output, so the tests can tell that the correct one is being hit. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
