### PR TITLE
chefspec verify needs to point to chef/chefspec

### DIFF
--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -90,7 +90,7 @@ for gem in ${external_gems[@]}; do
   echo "      image: chefes/omnibus-toolchain-ubuntu-1804:$OMNIBUS_TOOLCHAIN_VERSION"
   echo "      environment:"
   echo "        - CHEF_FOUNDATION_VERSION"
-  if [ $gem == "chef-zero" ] 
+  if [ $gem == "chef-zero" ]
   then
     echo "        - PEDANT_OPTS=--skip-oc_id"
     echo "        - CHEF_FS=true"
@@ -116,7 +116,7 @@ for gem in ${external_gems[@]}; do
     echo "    - bundle config set --local path 'vendor/bundle'"
   fi
   echo "    - bundle install --jobs=3 --retry=3"
-  case $gem in 
+  case $gem in
     "chef-zero")
       echo "    - bundle exec tasks/bin/run_external_test chef/chef-zero main rake pedant"
       ;;
@@ -124,7 +124,7 @@ for gem in ${external_gems[@]}; do
       echo "    - bundle exec tasks/bin/run_external_test chef/cheffish main rake spec"
       ;;
     "chefspec")
-      echo "    - bundle exec tasks/bin/run_external_test chefspec/chefspec main rake"
+      echo "    - bundle exec tasks/bin/run_external_test chef/chefspec main rake"
       ;;
     "knife-windows")
       echo "    - bundle exec tasks/bin/run_external_test chef/knife-windows main rake spec"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
[chefspec#6](https://github.com/chef/chefspec/pull/6) has fixed the rspec private API change issue temporarily, but the chefspec step was pointing at `chefspec/chefspec` instead of `chef/chefspec`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
