### PR TITLE
add umask to chef_client_systemd_timer

### DIFF
--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -103,6 +103,10 @@ class Chef
         coerce: proc { |x| Integer(x) },
         callbacks: { "should be a positive Integer" => proc { |v| v > 0 } }
 
+      property :service_umask, [Integer, String],
+        descritpion: "Fix umask for hardended systems that have a changed default umask. This changes the chef-client umask so any files or folders are created with new umask. Recommend setting to stand install default of 0022.",
+        introduced: "18.5"
+
       action :add, description: "Add a systemd timer that runs #{ChefUtils::Dist::Infra::PRODUCT}." do
         systemd_unit "#{new_resource.job_name}.service" do
           content service_content
@@ -175,6 +179,7 @@ class Chef
             "Install" => { "WantedBy" => "multi-user.target" },
           }
 
+          unit["Service"]["UMask"] = new_resource.service_umask if new_resource.service_umask
           unit["Service"]["ConditionACPower"] = "true" unless new_resource.run_on_battery
           unit["Service"]["CPUQuota"] = "#{new_resource.cpu_quota}%" if new_resource.cpu_quota
           unit["Service"]["Environment"] = new_resource.environment.collect { |k, v| "\"#{k}=#{v}\"" } unless new_resource.environment.empty?

--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -104,7 +104,7 @@ class Chef
         callbacks: { "should be a positive Integer" => proc { |v| v > 0 } }
 
       property :service_umask, [Integer, String],
-        descritpion: "Fix umask for hardended systems that have a changed default umask. This changes the chef-client umask so any files or folders are created with new umask. Recommend setting to stand install default of 0022.",
+        description: "Fix umask for hardened systems that have a changed default umask. This changes the chef-client umask so any files or folders are created with new umask. Recommend setting to stand install default of 0022.",
         introduced: "18.5"
 
       action :add, description: "Add a systemd timer that runs #{ChefUtils::Dist::Infra::PRODUCT}." do


### PR DESCRIPTION
## Description
Add property to modify the Service UMask directive in the SystemD unit content. This allows fixing of the chef-client umask for files and directories created by chef-client. Hardened systems change the system default which then breaks chef-client package installs and file creations for configuration management.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
