### PR TITLE
Fix bigdecimal error with webmock / crack in macOS and AIX builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group(:development, :test) do
   gem "rake"
   gem "rspec"
   gem "webmock", "~> 3.19.1"
+  gem "bigdecimal", "= 3.1.5"
   gem "fauxhai-ng" # for chef-utils gem
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,8 @@ end
 group(:development, :test) do
   gem "rake"
   gem "rspec"
-  gem "webmock", "~> 3.19.1"
+  gem "webmock"
+  gem "crack", "< 1.0"
   gem "fauxhai-ng" # for chef-utils gem
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group(:development, :test) do
   gem "rake"
   gem "rspec"
   gem "webmock", "~> 3.19.1"
-  gem "bigdecimal", "= 3.1.5"
+  gem "bigdecimal", "= 3.1.1"
   gem "fauxhai-ng" # for chef-utils gem
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ end
 group(:development, :test) do
   gem "rake"
   gem "rspec"
-  gem "webmock"
+  gem "webmock", "~> 3.19.1"
   gem "fauxhai-ng" # for chef-utils gem
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group(:development, :test) do
   gem "rake"
   gem "rspec"
   gem "webmock"
-  gem "crack", "< 1.0"
+  gem "crack", "< 0.4.6" # due to https://github.com/jnunemaker/crack/pull/75
   gem "fauxhai-ng" # for chef-utils gem
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group(:development, :test) do
   gem "rake"
   gem "rspec"
   gem "webmock", "~> 3.19.1"
-  gem "bigdecimal", "= 3.1.1"
   gem "fauxhai-ng" # for chef-utils gem
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    bigdecimal (3.1.5)
+    bigdecimal (3.1.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -491,7 +491,7 @@ PLATFORMS
 
 DEPENDENCIES
   appbundler
-  bigdecimal (= 3.1.5)
+  bigdecimal (= 3.1.1)
   chef!
   chef-bin!
   chef-config!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,6 +497,7 @@ DEPENDENCIES
   chef-vault
   cheffish (>= 17)
   chefstyle
+  crack (< 1.0)
   ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5)
@@ -510,7 +511,7 @@ DEPENDENCIES
   rest-client!
   rspec
   ruby-shadow!
-  webmock (~> 3.19.1)
+  webmock
 
 BUNDLED WITH
    2.3.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,7 +497,7 @@ DEPENDENCIES
   chef-vault
   cheffish (>= 17)
   chefstyle
-  crack (< 1.0)
+  crack (< 0.4.6)
   ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,6 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    bigdecimal (3.1.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -491,7 +490,6 @@ PLATFORMS
 
 DEPENDENCIES
   appbundler
-  bigdecimal (= 3.1.1)
   chef!
   chef-bin!
   chef-config!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    bigdecimal (3.1.5)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -490,6 +491,7 @@ PLATFORMS
 
 DEPENDENCIES
   appbundler
+  bigdecimal (= 3.1.5)
   chef!
   chef-bin!
   chef-config!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,7 @@ DEPENDENCIES
   rest-client!
   rspec
   ruby-shadow!
-  webmock
+  webmock (~> 3.19.1)
 
 BUNDLED WITH
    2.3.7

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -4,7 +4,7 @@ gem "knife", path: "."
 
 group(:development, :test) do
   gem "cheffish", ">= 14" # testing only , but why didn't this need to explicit in chef?
-  gem "webmock" # testing only
+  gem "webmock", "~> 3.19.1" # testing only
   gem "rake"
   gem "rspec"
   gem "chef-bin", path: "../chef-bin"

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -4,7 +4,8 @@ gem "knife", path: "."
 
 group(:development, :test) do
   gem "cheffish", ">= 14" # testing only , but why didn't this need to explicit in chef?
-  gem "webmock", "~> 3.19.1" # testing only
+  gem "webmock"
+  gem "crack", "< 0.4.6" # due to https://github.com/jnunemaker/crack/pull/75
   gem "rake"
   gem "rspec"
   gem "chef-bin", path: "../chef-bin"

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -125,7 +125,6 @@ sudo_path="$(command -v sudo)"
 # cspell:disable-next-line
 rhel_sudo="/opt/rh/devtoolset-7/root/usr/bin/sudo"
 sudo_args=""
-gem uninstall --force bigdecimal
 if [[ "$sudo_path" != "$rhel_sudo" ]]; then
   echo "HERE"
   sudo -E bundle install --jobs=3 --retry=3

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -125,6 +125,7 @@ sudo_path="$(command -v sudo)"
 # cspell:disable-next-line
 rhel_sudo="/opt/rh/devtoolset-7/root/usr/bin/sudo"
 sudo_args=""
+gem uninstall --force bigdecimal
 if [[ "$sudo_path" != "$rhel_sudo" ]]; then
   echo "HERE"
   sudo -E bundle install --jobs=3 --retry=3


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
AIX and macOS (ARM only?) builds are failing on attempting to bundle `bigdecimal`. AIX is due to the bundle requiring `bigdecimal` on a test environment without a compiler to build the native extension and macOS ARM is failing with a code signature error:

```txt
Failure/Error: require "webmock/rspec"
--
  |  
  | LoadError:
  | dlopen(/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/bigdecimal-3.1.5/lib/bigdecimal.bundle, 9): no suitable image found.  Did find:
  | /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/bigdecimal-3.1.5/lib/bigdecimal.bundle: code signature in (/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/bigdecimal-3.1.5/lib/bigdecimal.bundle) not valid for use in process using Library Validation: mapped file has no Team ID and is not a platform binary (signed with custom identity or adhoc?) - /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/bigdecimal-3.1.5/lib/bigdecimal.bundle
```


Looks like `bigdecimal` was added as a dependency to `crack` `0.4.6` in [crack#75](https://github.com/jnunemaker/crack/pull/75), due to `bigdecimal` being [removed from default gems for 3.4.0](https://github.com/ruby/ruby/pull/9573)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
