### PR TITLE
Fix bigdecimal error with webmock / crack in macOS and AIX builds 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group(:development, :test) do
   gem "rake"
   gem "rspec"
   gem "webmock"
+  gem "crack", "< 0.4.6" # due to https://github.com/jnunemaker/crack/pull/75
   gem "fauxhai-ng" # for chef-utils gem
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,6 +450,7 @@ DEPENDENCIES
   chef-vault
   cheffish (~> 17.0.0)
   chefstyle!
+  crack (< 0.4.6)
   ed25519 (~> 1.2)
   fauxhai-ng
   inspec-core-bin (~> 5.22.36)

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -4,7 +4,8 @@ gem "knife", path: "."
 
 group(:development, :test) do
   gem "cheffish", ">= 14" # testing only , but why didn't this need to explicit in chef?
-  gem "webmock" # testing only
+  gem "webmock"
+  gem "crack", "< 0.4.6" # due to https://github.com/jnunemaker/crack/pull/75
   gem "rake"
   gem "rspec"
   gem "chef-bin", path: "../chef-bin"


### PR DESCRIPTION
Cherry-pick backport of (#14243) from `main`

* restrict crack (dependency of webmock) to < 0.4.6 due to update for bigdecimal being extracted from ruby 3.4.0 as default gem.

---------

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
