### PR TITLE
fixed message about duplicated fqdns

### DIFF
--- a/knife/lib/chef/knife/ssh.rb
+++ b/knife/lib/chef/knife/ssh.rb
@@ -194,7 +194,7 @@ class Chef
         if %i{warn fatal}.include?(config[:duplicated_fqdns])
           fqdns = list.map { |v| v[0] }
           if fqdns.count != fqdns.uniq.count
-            duplicated_fqdns = fqdns.uniq
+            duplicated_fqdns = fqdns.group_by{ |e| e }.select { |k, v| v.size > 1 }.map(&:first)
             ui.send(config[:duplicated_fqdns],
               "SSH #{duplicated_fqdns.count > 1 ? "nodes are" : "node is"} " +
               "duplicated: #{duplicated_fqdns.join(",")}")


### PR DESCRIPTION
fixed message about duplicated fqdns

## Description
Small fix to only show duplicated fqdns when running knife instead of all them


## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
