### PR TITLE
chefspec verify needs to point to chef/chefspec

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -334,7 +334,7 @@ steps:
     - bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
     - bundle install --jobs=3 --retry=3
-    - bundle exec tasks/bin/run_external_test chefspec/chefspec main rake
+    - bundle exec tasks/bin/run_external_test chef/chefspec main rake
   expeditor:
     executor:
       docker:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Manual backport of #14230 (due to chef-foundation retooling of verify pipeline)

https://github.com/chef/chefspec/pull/6 has fixed the rspec private API change issue temporarily, but the chefspec step was pointing at chefspec/chefspec instead of chef/chefspec

Second attempt, accidentally created #14246 pointing to `main` initially.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
