### PR TITLE
Safeguard for undefined and fix reference to CHEF_FOUNDATION_VERSION

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -10,13 +10,13 @@ docker ps || true
 # Get chef foundation version from the json file
 CHEF_FOUNDATION_VERSION=$(cat .buildkite-platform.json | jq -r '.chef_foundation')
 export CHEF_FOUNDATION_VERSION
-echo "Chef Foundation Version: $CHEF_FOUNDATION_VERSION" 
+echo "Chef Foundation Version: $CHEF_FOUNDATION_VERSION"
 
 OMNIBUS_TOOLCHAIN_VERSION=$(cat .buildkite-platform.json | jq -r '.omnibus_toolchain')
 export OMNIBUS_TOOLCHAIN_VERSION
 echo "Omnibus Toolchain Version: $OMNIBUS_TOOLCHAIN_VERSION"
 
-if [ $BUILDKITE_STEP_KEY == "build-windows-2019" ] && [[ "$BUILDKITE_ORGANIZATION_SLUG" =~ chef(-canary)?$ ]]
+if [[ "$BUILDKITE_STEP_KEY" == "build-windows-2019" ]] && [[ "$BUILDKITE_ORGANIZATION_SLUG" =~ chef(-canary)?$ ]]
 then
   TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
   ROLE=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/iam/security-credentials/)

--- a/.expeditor/scripts/omnibus_chef_build.ps1
+++ b/.expeditor/scripts/omnibus_chef_build.ps1
@@ -88,7 +88,7 @@ $env:ARTIFACTORY_ENDPOINT="https://artifactory-internal.ps.chef.co/artifactory"
 $env:ARTIFACTORY_USERNAME="buildkite"
 
 Write-Output "--- Installing Chef Foundation ${env:CHEF_FOUNDATION_VERSION}"
-. { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v ${env:CHEF_FOUNDATION_VERSION}
+. { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v $env:CHEF_FOUNDATION_VERSION
 
 $env:PROJECT_NAME="chef"
 $env:OMNIBUS_PIPELINE_DEFINITION_PATH="${ScriptDir}/../release.omnibus.yml"
@@ -138,7 +138,7 @@ try {
 
     # Assign the full path to a variable ($fullPath) for later use
     $fullPathVariable = $fullPath
-    write-output "--- verify signed file smctl sign verify --input ${fullPathVariable}" 
+    write-output "--- verify signed file smctl sign verify --input ${fullPathVariable}"
     smctl sign verify --input ${fullPathVariable}
   } else {
     Write-Output "No .msi files found in the directory: $directoryPath or its not signed"

--- a/.expeditor/scripts/prep_and_run_tests.ps1
+++ b/.expeditor/scripts/prep_and_run_tests.ps1
@@ -3,7 +3,7 @@ param(
     [Parameter(Position=0)][String]$TestType
 )
 
-. { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v ${env:CHEF_FOUNDATION_VERSION}
+. { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v $env:CHEF_FOUNDATION_VERSION
 
 $env:Path = 'C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\ProgramData\chocolatey\bin;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Program Files\Git\cmd;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin'
 

--- a/.expeditor/scripts/prep_and_run_tests.ps1
+++ b/.expeditor/scripts/prep_and_run_tests.ps1
@@ -3,7 +3,8 @@ param(
     [Parameter(Position=0)][String]$TestType
 )
 
-. { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v $CHEF_FOUNDATION_VERSION
+. { Invoke-WebRequest -useb https://omnitruck.chef.io/chef/install.ps1 } | Invoke-Expression; install -channel "current" -project "chef-foundation" -v ${env:CHEF_FOUNDATION_VERSION}
+
 $env:Path = 'C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\ProgramData\chocolatey\bin;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Program Files\Git\cmd;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\opscode\chef\bin;C:\opscode\chef\embedded\bin'
 
 if ($TestType -eq 'Functional') {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Change to `pre-command` is to prevent:

```
C:/bk018dc96f97171dc5b89d/.buildkite/hooks/pre-command: line 19: [: ==: unary operator expected
```

The change in `prep_and_run_tests.ps1` is to match `omnibus_chef_build.ps1` in using `${env:CHEF_FOUNDATION_VERSION}` instead of `$CHEF_FOUNDATION_VERSION`. The environment variable `CHEF_FOUNDATION_VERSION` gets forwarded via `--env CHEF_FOUNDATION_VERSION` in the `docker` invocation, but that will population the `$env:` variable inside the container.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
