### PR TITLE
Fix requiring of chef-utils/version_string.

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,14 +1,12 @@
 $:.unshift(File.dirname(__FILE__) + "/lib")
+$:.unshift(File.dirname(__FILE__) + "/chef-utils/lib")
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
 
 
 if File.exist?(vs_path)
-  puts "eval(IO.read(#{vs_path}))"
-  puts IO.read(vs_path)
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard
   eval(IO.read(vs_path))
 else
-  puts "require \"chef-utils/version_string\""
   # if the path doesn't exist then we're just in the wild gem and not in the git repo
   require "chef-utils/version_string"
 end

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -4,6 +4,7 @@ vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir_
 
 if File.exist?(vs_path)
   puts "eval(IO.read(#{vs_path}))"
+  puts IO.read(vs_path)
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard
   eval(IO.read(vs_path))
 else

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,4 +1,5 @@
 $:.unshift(File.expand_path(File.dirname(__FILE__)) + "/lib")
+$:.unshift(File.expand_path(File.dirname(__FILE__)))
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
 
 if File.exist?(vs_path)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -4,7 +4,7 @@ vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir_
 if File.exist?(vs_path)
   # include chef-utils/lib in the path if we're inside of chef vs. chef-utils gem
   # but add it to the end of the search path
-  $:<< (File.dirname(__FILE__) + "/chef-utils/lib")
+  $: << (File.dirname(__FILE__) + "/chef-utils/lib")
 end
 # if the path doesn't exist then we're just in the wild gem and not in the git repo
 require "chef-utils/version_string"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,9 +1,7 @@
 $:.unshift(File.dirname(__FILE__) + "/lib")
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
 
-
 if File.exist?(vs_path)
-  # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard
   # include chef-utils/lib in the path if we're inside of chef vs. chef-utils gem
   $:.unshift(File.dirname(__FILE__) + "/chef-utils/lib")
 end

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -4,7 +4,6 @@ vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir_
 
 if File.exist?(vs_path)
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard
-  #eval(IO.read(vs_path))
   # include chef-utils/lib in the path if we're inside of chef vs. chef-utils gem
   $:.unshift(File.dirname(__FILE__) + "/chef-utils/lib")
 end

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,4 +1,4 @@
-$:.unshift(File.dirname(__FILE__) + "/lib")
+$:.unshift(File.expand_path(File.dirname(__FILE__)) + "/lib")
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
 
 if File.exist?(vs_path)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,9 +1,5 @@
 $:.unshift(File.dirname(__FILE__) + "/lib")
-puts "__dir__"
-p __dir__
-puts "File.dirname(__FILE__)"
-p File.dirname(__FILE__)
-vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", File.dirname(__FILE__))
+vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
 p vs_path
 
 
@@ -11,6 +7,7 @@ if File.exist?(vs_path)
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard
   eval(IO.read(vs_path))
 else
+  $:.unshift(File.dirname(__FILE__) + "/chef-utils/lib")
   # if the path doesn't exist then we're just in the wild gem and not in the git repo
   require "chef-utils/version_string"
 end

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,7 +1,11 @@
 $:.unshift(File.dirname(__FILE__) + "/lib")
+puts "__dir__"
 p __dir__
+puts "File.dirname(__FILE__)"
 p File.dirname(__FILE__)
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", File.dirname(__FILE__))
+p vs_path
+
 
 if File.exist?(vs_path)
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,5 +1,5 @@
 $:.unshift(File.expand_path(File.dirname(__FILE__)) + "/lib")
-$:.unshift(File.expand_path(File.dirname(__FILE__)))
+$:.unshift(File.expand_path(File.dirname(__FILE__)) + "/chef-utils/lib" )
 
 p $:
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,15 +1,15 @@
 $:.unshift(File.dirname(__FILE__) + "/lib")
-$:.unshift(File.dirname(__FILE__) + "/chef-utils/lib")
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
 
 
 if File.exist?(vs_path)
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard
-  eval(IO.read(vs_path))
-else
-  # if the path doesn't exist then we're just in the wild gem and not in the git repo
-  require "chef-utils/version_string"
+  #eval(IO.read(vs_path))
+  # include chef-utils/lib in the path if we're inside of chef vs. chef-utils gem
+  $:.unshift(File.dirname(__FILE__) + "/chef-utils/lib")
 end
+# if the path doesn't exist then we're just in the wild gem and not in the git repo
+require "chef-utils/version_string"
 require "chef/version"
 
 Gem::Specification.new do |s|

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,13 +1,14 @@
 $:.unshift(File.dirname(__FILE__) + "/lib")
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
-p vs_path
 
 
 if File.exist?(vs_path)
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard
   eval(IO.read(vs_path))
 else
-  $:.unshift(File.dirname(__FILE__) + "/chef-utils/lib")
+  # for some reason, __dir__ is nil in some circumstances coming from the chef-universal-mingw-ucrt.gemspec
+  # instance_eval (Ruby 3.1.4)
+  $:.unshift(File.expand_path(File.dirname(__FILE__)) + "/chef-utils/lib")
   # if the path doesn't exist then we're just in the wild gem and not in the git repo
   require "chef-utils/version_string"
 end

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -3,7 +3,8 @@ vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir_
 
 if File.exist?(vs_path)
   # include chef-utils/lib in the path if we're inside of chef vs. chef-utils gem
-  $:.unshift(File.dirname(__FILE__) + "/chef-utils/lib")
+  # but add it to the end of the search path
+  $:<< (File.dirname(__FILE__) + "/chef-utils/lib")
 end
 # if the path doesn't exist then we're just in the wild gem and not in the git repo
 require "chef-utils/version_string"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,5 +1,7 @@
 $:.unshift(File.expand_path(File.dirname(__FILE__)) + "/lib")
 $:.unshift(File.expand_path(File.dirname(__FILE__)))
+
+p $:
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
 
 if File.exist?(vs_path)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -3,12 +3,11 @@ vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir_
 
 
 if File.exist?(vs_path)
+  puts "eval(IO.read(#{vs_path}))"
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard
   eval(IO.read(vs_path))
 else
-  # for some reason, __dir__ is nil in some circumstances coming from the chef-universal-mingw-ucrt.gemspec
-  # instance_eval (Ruby 3.1.4)
-  $:.unshift(File.expand_path(File.dirname(__FILE__)) + "/chef-utils/lib")
+  puts "require \"chef-utils/version_string\""
   # if the path doesn't exist then we're just in the wild gem and not in the git repo
   require "chef-utils/version_string"
 end

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,8 +1,5 @@
-$:.unshift(File.expand_path(File.dirname(__FILE__)) + "/lib")
-$:.unshift(File.expand_path(File.dirname(__FILE__)) + "/chef-utils/lib" )
-
-p $:
-vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", __dir__)
+$:.unshift(File.dirname(__FILE__) + "/lib")
+vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", File.dirname(__FILE__))
 
 if File.exist?(vs_path)
   # this is the moral equivalent of a require_relative since bundler makes require_relative here fail hard

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -1,4 +1,6 @@
 $:.unshift(File.dirname(__FILE__) + "/lib")
+p __dir__
+p File.dirname(__FILE__)
 vs_path = File.expand_path("chef-utils/lib/chef-utils/version_string.rb", File.dirname(__FILE__))
 
 if File.exist?(vs_path)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Fixes a problem that most recently manifested in a `bundle install` in `chef/cheffish` but we've since other manifestations elsewhere. The problem is that the `eval(IO.read("chef-utils/lib/chef-utils/version_string.rb"))` doesn't fix the fact that `chef-utils/version_string` isn't in the load path for the later `require "chef-utils/version_string"` another solution might be to just `eval` or `require "chef-utils/version_string"` but the `eval` feels like unnecessary messiness.

Example error:
```
[!] There was an error while loading `chef-universal-mingw-ucrt.gemspec`: cannot load such file -- chef-utils/version_string. Bundler cannot continue.

 #  from /home/runner/work/cheffish/cheffish/vendor/bundle/ruby/3.1.0/bundler/gems/chef-718b2ef032da/chef-universal-mingw-ucrt.gemspec:1
 #  -------------------------------------------
 >  gemspec = instance_eval(File.read(File.expand_path("chef.gemspec", __dir__)))
 #  
 #  -------------------------------------------
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
