### PR TITLE
Forcing bundle update to get the URI gem to load properly

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -192,6 +192,7 @@ steps:
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
+    - bundle update # Force the correct URI version to update the gemfile.lock
     - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:integration
   expeditor:
@@ -206,6 +207,7 @@ steps:
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
+    - bundle update # Force the correct URI version to update the gemfile.lock
     - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:functional
   expeditor:
@@ -223,6 +225,7 @@ steps:
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
+    - bundle update # Force the correct URI version to update the gemfile.lock
     - bundle install --jobs=3 --retry=3
     - bundle exec rake spec:unit
     - bundle exec rake component_specs


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
As part of the update for the new Ohai, we pull in a new inspec build as well. That tool relies on the uri gem which will fail to load if we don't force an update first.

The failure in the fedora builds is because we need to merge this update: https://github.com/chef/chef/pull/14271

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
