### PR TITLE
Updating to properly load URI for Fedora

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -62,6 +62,11 @@ Gem::Specification.new do |s|
   s.bindir       = "bin"
   s.executables  = %w{ }
 
+  if RUBY_VERSION.match?("3.0.0")
+    # Ruby 3.0.0 on Fedora specifically makes trouble
+    s.add_dependency "uri", "= 0.10.1"
+  end
+
   s.require_paths = %w{ lib }
   s.files = %w{Gemfile Rakefile LICENSE README.md} +
     Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } +


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
fedora tests are failing again on the uri gem. This happens in Chef now (instead of just Knife) because of a pending update for Inspec that pulls in a new version of uri. That PR is pending

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
