### PR TITLE
Bumping inspec-core minimum version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "rubocop-ast", ">= 1.31.0"
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec-core-bin", "~> 5.22.36" # need to provide the binaries for inspec
+  gem "inspec-core-bin", "~> 5.22.40" # need to provide the binaries for inspec
   gem "chef-vault"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ PATH
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (>= 2.2, < 4.0)
       iniparse (~> 1.4)
-      inspec-core (~> 5.22.36)
+      inspec-core (~> 5.22.40)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
@@ -82,7 +82,7 @@ PATH
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (>= 2.2, < 4.0)
       iniparse (~> 1.4)
-      inspec-core (~> 5.22.36)
+      inspec-core (~> 5.22.40)
       iso8601 (>= 0.12.1, < 0.14)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
@@ -453,7 +453,7 @@ DEPENDENCIES
   crack (< 0.4.6)
   ed25519 (~> 1.2)
   fauxhai-ng
-  inspec-core-bin (~> 5.22.36)
+  inspec-core-bin (~> 5.22.40)
   ohai!
   pry (>= 0.14.1)
   pry-byebug

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 17.0"
-  s.add_dependency "inspec-core", "~> 5.22.36"
+  s.add_dependency "inspec-core", "~> 5.22.40"
 
   s.add_dependency "ffi", "~> 1.15.5"
   s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating inspec version requirements to ensure that CVE and ActiveSupport dependency fix from 5.22.40 are the minimum version requirements for Chef 17.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
