### PR TITLE
Replace Chef trademark with distro name in deprecation warnings.

### DIFF
--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -57,7 +57,7 @@ class Chef
         # Print out deprecations.
         unless deprecations.empty?
           puts_line ""
-          puts_line "Deprecation warnings that must be addressed before upgrading to Chef Infra #{Chef::VERSION.to_i + 1}:"
+          puts_line "Deprecation warnings that must be addressed before upgrading to #{ChefUtils::Dist::Infra::PRODUCT} #{Chef::VERSION.to_i + 1}:"
           puts_line ""
           deprecations.each do |message, details|
             locations = details[:locations]


### PR DESCRIPTION
## Description

Deprecation warnings currently use a hardcoded product name, which could instead use the distro-specific product string.

```
Deprecation warnings that must be addressed before upgrading to Chef Infra 19:

  The resource in the cookbook should declare `unified_mode true` at 1 location:
    - /Users/foo/.cinc/local-mode-cache/cache/cookbooks/example/resources/test.rb:34:in `block in class_from_file'
   See https://docs.chef.io/deprecations_unified_mode/ for further details.
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
