### PR TITLE
Added the databag_fallback attribute

### DIFF
--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -132,6 +132,9 @@ class Chef
 
         node.consume_external_attrs(ohai_data, json_attribs)
 
+        # Preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item.
+        set_databag_fallback
+
         setup_run_list_override
 
         expand_run_list
@@ -189,6 +192,11 @@ class Chef
 
         setup_chef_class(run_context)
         run_context
+      end
+
+      #Preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item.
+      def set_databag_fallback
+        node.default["chef-vault"]["databag_fallback"] = true
       end
 
       # Sets `run_list` on the node from the policy, sets `roles` and `recipes`

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -133,7 +133,7 @@ class Chef
         node.consume_external_attrs(ohai_data, json_attribs)
 
         # Preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item.
-        set_databag_fallback
+        set_databag_fallback if ChefUtils.kitchen?(node)
 
         setup_run_list_override
 

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -194,7 +194,7 @@ class Chef
         run_context
       end
 
-      #Preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item.
+      # Preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item.
       def set_databag_fallback
         node.default["chef-vault"]["databag_fallback"] = true
       end

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -133,7 +133,7 @@ class Chef
         node.consume_external_attrs(ohai_data, json_attribs)
 
         # Preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item.
-        set_databag_fallback if ChefUtils.kitchen?(node)
+        set_databag_fallback
 
         setup_run_list_override
 
@@ -196,7 +196,7 @@ class Chef
 
       # Preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item.
       def set_databag_fallback
-        node.default["chef-vault"]["databag_fallback"] = true
+        node.default["chef-vault"]["databag_fallback"] = ChefUtils.kitchen?(node)
       end
 
       # Sets `run_list` on the node from the policy, sets `roles` and `recipes`


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
When chef_vault_item was moved into chef client in #9477  the node attributes chef-vault and databag_fallback were never set. Any call to chef_vault_item in test kitchen will result in undefined method '[]' for nil:NilClass for node["chef-vault"]["databag_fallback"].

Setting this attribute to the node `node.default["chef-vault"]["databag_fallback"] = true`, this will fixed the undefined method '[]' for nil:NilClass for node["chef-vault"] and will also preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item

## Related Issue
Fixes : 
https://github.com/chef/customer-bugs/issues/761
https://github.com/chef/chef/issues/13084

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
