### PR TITLE
Amending URU to be more version specific

### DIFF
--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -34,9 +34,9 @@ if(-not($old_version -match "3.0")){
     Remove-Item $package_destination -Force;
 }
   
-Write-Output "Register Installed Ruby Version 3.0 With Uru"
+Write-Output "Register Installed Ruby Version 3.0.3 With Uru"
 Start-Process "uru_rt.exe" -ArgumentList 'admin add C:\ruby30\bin' -Wait
-uru 30
+uru 303
 if (-not $?) { throw "Can't Activate Ruby. Did Uru Registration Succeed?" }
 ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The Windows images on buildkite have 2 discrete installs of Ruby on them. One is version 3.0.0 and the other is 3.0.3p157 - the URU option is set to choice option '30' which brings up a screen prompt to choose the version. Here I am forcing the version.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
