### PR TITLE
Fixed the issue with log level on the chef config

### DIFF
--- a/knife/lib/chef/knife.rb
+++ b/knife/lib/chef/knife.rb
@@ -423,7 +423,8 @@ class Chef
                                  when 2
                                    :debug
                                  when nil
-                                   Chef::Config[:log_level] || :warn
+                                   # The default log_level is auto and that is not a valid log_level.
+                                   Chef::Config[:log_level] == :auto ? :warn : Chef::Config[:log_level]
                                  else
                                    :trace
                                  end

--- a/knife/lib/chef/knife.rb
+++ b/knife/lib/chef/knife.rb
@@ -414,16 +414,19 @@ class Chef
     def apply_computed_config
       Chef::Config[:color] = config[:color]
 
-      case Chef::Config[:verbosity]
-      when 0, nil
-        Chef::Config[:log_level] = :warn
-      when 1
-        Chef::Config[:log_level] = :info
-      when 2
-        Chef::Config[:log_level] = :debug
-      else
-        Chef::Config[:log_level] = :trace
-      end
+      # If the verbosity is not set, use what is already present on the log_level config.
+      Chef::Config[:log_level] = case Chef::Config[:verbosity]
+                                 when 0
+                                   :warn
+                                 when 1
+                                   :info
+                                 when 2
+                                   :debug
+                                 when nil
+                                   Chef::Config[:log_level] || :warn
+                                 else
+                                   :trace
+                                 end
 
       Chef::Config[:log_level] = :trace if ENV["KNIFE_DEBUG"]
 

--- a/knife/spec/unit/knife_spec.rb
+++ b/knife/spec/unit/knife_spec.rb
@@ -320,6 +320,9 @@ describe Chef::Knife do
       end
 
       it "sets the default log_level to warn so we can issue Chef::Log.warn" do
+        # Reset the log level to the default value
+        Chef::Config[:log_level] = :auto
+
         knife_command = KnifeSpecs::TestYourself.new([])
         knife_command.configure_chef
         expect(Chef::Config[:log_level]).to eql(:warn)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
In the chef config, there are two different options to set the log level. One is the `log_level` and the other is the `verbose`. The verbose has more preference, meaning that if it is set, it will overwrite the log_level based on the verbosity level. 

Currently, If the verbosity is not set, the code will default the log_level to `warn` even if the user specifies a different log_level on the config.rb or the credentials file.

This PR will update that flow so that, if the verbosity is not set, it will use whatever value is already set on the log_level and if that is `:auto`(the default value), it will default to `warn`. 


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
