### PR TITLE
Cleaning up the installer

### DIFF
--- a/lib/chef/resource/habitat_install.rb
+++ b/lib/chef/resource/habitat_install.rb
@@ -127,6 +127,7 @@ class Chef
           remote_file ::File.join(Chef::Config[:file_cache_path], "hab-install.sh") do
             source new_resource.install_url
             sensitive true
+            mode 0755
           end
 
           execute "installing with hab-install.sh" do
@@ -235,7 +236,7 @@ class Chef
         end
 
         def hab_command
-          cmd = "bash #{Chef::Config[:file_cache_path]}/hab-install.sh"
+          cmd = "#{Chef::Config[:file_cache_path]}/hab-install.sh"
           cmd << " -v #{new_resource.hab_version} " if new_resource.hab_version
           cmd << " -t x86_64-linux-kernel2" if node["kernel"]["release"].to_i < 3
           cmd


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We have a bug against the hab installer here [Bug](https://chefio.atlassian.net/browse/CHEF-627). In a nutshell, the installer is calling a random bash executable. One problem is that we explicitly call bash from our script. Here we update the bash script (per comments from Marc Paradise in the bug) to remove the call to bash and let the hab_installer.sh figure it out. Then we set the downloaded script to mode 0755 so it's executable. That will be easier for customers to use and solve for which bash shell gets called. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
