### PR TITLE
Pulling in updated Omnibus and Omnibus-Software

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -4,7 +4,7 @@ GIT
   branch: jfm/chef-17-berkshelf
   specs:
     berkshelf (8.0.7)
-      chef (>= 15.7.32)
+      chef (~> 17.0)
       chef-config
       cleanroom (~> 1.0)
       concurrent-ruby (~> 1.0)
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 8a87f3b2b842abe80bc997de9da3e43696ea5c36
+  revision: 763ae8b0f5c60b90ee0451b61d4dca2022229315
   branch: main
   specs:
     omnibus-software (24.3.314)
@@ -27,10 +27,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 16e27f648f5be10b5895b46c109f194ff93c9f63
+  revision: 5c0122b185a65af3e93856cba6c394a68343818a
   branch: main
   specs:
-    omnibus (9.0.24)
+    omnibus (9.0.25)
       aws-sdk-s3 (~> 1.116.0)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)
@@ -53,8 +53,8 @@ GEM
     artifactory (3.0.17)
     awesome_print (1.9.2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.900.0)
-    aws-sdk-core (3.191.4)
+    aws-partitions (1.901.0)
+    aws-sdk-core (3.191.5)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
@@ -66,14 +66,15 @@ GEM
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sdk-secretsmanager (1.77.0)
-      aws-sdk-core (~> 3, >= 3.174.0)
+    aws-sdk-secretsmanager (1.90.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt_pbkdf (1.1.0)
     bcrypt_pbkdf (1.1.0-x64-mingw32)
     bcrypt_pbkdf (1.1.0-x86-mingw32)
+    bigdecimal (3.1.7)
     builder (3.2.4)
     chef (17.10.0)
       addressable
@@ -180,7 +181,7 @@ GEM
     contracts (0.16.1)
     corefoundation (0.3.13)
       ffi (>= 1.15.0)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     ed25519 (1.3.0)
     erubi (1.12.0)
     erubis (2.7.0)
@@ -201,7 +202,7 @@ GEM
       faraday (~> 1.0)
     ffi (1.16.3)
     ffi (1.16.3-x64-mingw-ucrt)
-    ffi-libarchive (1.1.3)
+    ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
@@ -244,7 +245,7 @@ GEM
     iso8601 (0.13.0)
     jmespath (1.6.2)
     json (2.7.1)
-    kitchen-vagrant (1.14.1)
+    kitchen-vagrant (2.0.0)
       test-kitchen (>= 1.4, < 4)
     libyajl2 (2.1.0)
     license-acceptance (2.1.13)
@@ -270,7 +271,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-install (3.12.27)
+    mixlib-install (3.12.30)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -298,7 +299,8 @@ GEM
     net-ssh (7.2.1)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
-    nori (2.6.0)
+    nori (2.7.0)
+      bigdecimal
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -315,11 +317,11 @@ GEM
       plist (~> 3.1)
       train-core
       wmi-lite (~> 1.0)
-    parallel (1.23.0)
+    parallel (1.24.0)
     parslet (1.8.2)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pedump (0.6.6)
+    pedump (0.6.7)
       awesome_print
       iostruct (>= 0.0.4)
       multipart-post (>= 2.0.0)
@@ -331,7 +333,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.4)
-    rack (2.2.7)
+    rack (2.2.9)
     rainbow (3.1.1)
     retryable (3.0.5)
     rexml (3.2.6)
@@ -370,7 +372,7 @@ GEM
     strings-ansi (0.2.0)
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
-    test-kitchen (3.5.0)
+    test-kitchen (3.5.1)
       bcrypt_pbkdf (~> 1.0)
       chef-utils (>= 16.4.35)
       ed25519 (~> 1.2)
@@ -412,20 +414,20 @@ GEM
       tty-cursor (~> 0.7)
       tty-screen (~> 0.8)
       wisper (~> 2.0)
-    tty-screen (0.8.1)
+    tty-screen (0.8.2)
     tty-table (0.12.0)
       pastel (~> 0.8)
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
     uuidtools (2.2.0)
-    vault (0.17.0)
+    vault (0.18.2)
       aws-sigv4
     webrick (1.8.1)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.6.15)
-      chef-powershell (>= 1.0.12)
+    win32-certstore (0.6.16)
+      chef-powershell
       ffi
     win32-event (0.6.3)
       win32-ipc (>= 0.6.0)
@@ -485,4 +487,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   2.3.7
+   2.3.18


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We have an issue with an update to Ohai. A correction to windows fqdn name resolution required use of the 'Resolv' class which in turn (re)loaded the Win32/Registry class. That PR is [here](https://github.com/chef/ohai/pull/1816). That action - reloading the Win32/Registry class, stepped all over the Win32/Registry monkey patch we have in place to get data out of the Registry encoded in UTF-8. That was fixed in [omnibus-software](https://github.com/chef/omnibus-software/compare/8a87f3b2b842abe80bc997de9da3e43696ea5c36...763ae8b0f5c60b90ee0451b61d4dca2022229315#diff-67082374705e880301df0ba02632f9467cf1be3b7aaf484c4e3ecf33f821b806R2) via a patch to `ext/win32/lib/win32/resolv.rb`

This update pulls that patch in for testing and ultimately a release. 


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
