### PR TITLE
Updating gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,13 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: af5657847b332bc4f227071aba6c8a5eee8994e4
+  revision: 929a523184482fbbf6bf753fbc6ce8ffbe1aed54
   branch: 17-stable
   specs:
-    ohai (17.9.5)
+    ohai (17.9.7)
       chef-config (>= 14.12, < 18)
       chef-utils (>= 16.0, < 18)
-      ffi (~> 1.9, < 1.16.0)
+      ffi
       ffi-yajl (~> 2.2)
       ipaddress
       mixlib-cli (>= 1.7.0)
@@ -46,7 +46,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (~> 1.15.5)
+      ffi (~> 1.16)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (>= 2.2, < 4.0)
       iniparse (~> 1.4)
@@ -58,7 +58,7 @@ PATH
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-sftp (>= 2.1.2, < 5.0)
-      ohai (~> 17.0)
+      ohai (~> 17.9)
       plist (~> 3.2)
       proxifier2 (~> 1.1)
       syslog-logger (~> 1.6)
@@ -78,7 +78,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (~> 1.15.5)
+      ffi (~> 1.16)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (>= 2.2, < 4.0)
       iniparse (~> 1.4)
@@ -91,7 +91,7 @@ PATH
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-sftp (>= 2.1.2, < 5.0)
-      ohai (~> 17.0)
+      ohai (~> 17.9)
       plist (~> 3.2)
       proxifier2 (~> 1.1)
       syslog-logger (~> 1.6)
@@ -202,9 +202,9 @@ GEM
     faraday-net_http (3.0.2)
     fauxhai-ng (9.3.0)
       net-ssh
-    ffi (1.15.5)
-    ffi (1.15.5-x64-mingw32)
-    ffi (1.15.5-x86-mingw32)
+    ffi (1.16.3)
+    ffi (1.16.3-x64-mingw32)
+    ffi (1.16.3-x86-mingw32)
     ffi-libarchive (1.1.3)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -35,10 +35,10 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
   s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
-  s.add_dependency "ohai", "~> 17.0"
+  s.add_dependency "ohai", "~> 17.9"
   s.add_dependency "inspec-core", "~> 5.22.40"
 
-  s.add_dependency "ffi", "~> 1.15.5"
+  s.add_dependency "ffi", "~> 1.16"
   s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "erubis", "~> 2.7" # template resource / cookbook syntax check

--- a/knife/knife.gemspec
+++ b/knife/knife.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
-  s.add_dependency "ohai", "~> 17.0"
-  s.add_dependency "ffi", "~> 1.15.5" # 1.14 versions are broken on i386 windows
+  s.add_dependency "ohai", "~> 17.9"
+  s.add_dependency "ffi", "~> 1.16" # 1.14 versions are broken on i386 windows
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", ">= 5.1", "< 8"
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Updating Ohai and FFI to pull in needed updates from them.

[Admin] PS C:\localrepo\chef2 (jfm/chef17-update-gems) bundle update --conservative ohai ffi
I am (re)loading the Resolv Class
Loading The Base Win32/Registry class
I am in the win32/Resolv class
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies.......
Using rake 13.1.0
Using public_suffix 5.0.4
Using mixlib-cli 2.1.8
Using concurrent-ruby 1.2.2
Using ffi 1.16.3 (x64-mingw32)
Using wmi-lite 1.0.7
Using ast 2.4.2
Using aws-eventstream 1.2.0
Using aws-partitions 1.809.0
Using jmespath 1.6.2
Using bundler 2.3.18
Using debug_inspector 1.1.0
Using builder 3.2.4
Using byebug 11.1.3
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using libyajl2 2.1.0
Using chef-vault 4.1.11
Using hashie 4.1.0
Using mixlib-log 3.0.9
Using rack 2.2.7
Using uuidtools 2.2.0
Using webrick 1.8.1
Using diff-lcs 1.5.0
Using erubis 2.7.0
Using iniparse 1.5.0
Using faraday-net_http 3.0.2
Using ruby2_keywords 0.0.5
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using unicode-display_width 2.4.2
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using tty-screen 0.8.2
Using wisper 2.0.1
Using method_source 1.0.0
Using multipart-post 2.3.0
Using parallel 1.23.0
Using parslet 1.8.2
Using coderay 1.1.3
Using rspec-support 3.11.1
Using rubyzip 2.3.2
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.2.2
Using json 2.6.3
Using net-ssh 7.2.1
Using iso8601 0.13.0
Using mixlib-authentication 3.0.10
Using ipaddress 0.8.3
Using plist 3.7.1
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using erubi 1.12.0
Using rexml 3.2.5
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using multi_json 1.15.0
Using nori 2.6.0
Using rubyntlm 0.6.3
Using win32-api 1.5.3 (universal-mingw32)
Using structured_warnings 0.4.0
Using racc 1.7.1
Using rainbow 3.1.1
Using regexp_parser 2.8.1
Using ruby-progressbar 1.13.0
Using ed25519 1.3.0
Using hashdiff 1.0.1
Using chef-utils 17.10.134 from source at `chef-utils`
Using rb-readline 0.5.5
Using addressable 2.8.6
Using ffi-win32-extensions 1.0.4
Using win32-process 0.10.0
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.3
Using gssapi 1.3.1
Using win32-ipc 0.7.0
Using win32-eventlog 0.6.3
Using win32-mmap 0.4.2
Using aws-sigv4 1.6.0
Using binding_of_caller 1.0.0
Using mixlib-config 3.0.27
Using ffi-yajl 2.4.0
Using mixlib-archive 1.1.7 (universal-mingw32)
Using faraday 2.7.7
Using pastel 0.8.0
Using strings 0.2.1
Using pry 0.14.2
Using tty-reader 0.9.0
Using rspec-core 3.11.0
Using rspec-expectations 3.11.1
Using rspec-mocks 3.11.2
Using net-scp 4.0.0
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using gyoku 1.4.0
Using crack 0.4.5
Using logging 2.3.1
Using win32-taskscheduler 2.0.4
Using parser 3.3.0.5
Using win32-service 2.3.2
Using win32-event 0.6.3
Using win32-mutex 0.4.3
Using aws-sdk-core 3.181.0
Using vault 0.17.0
Using chef-powershell 18.1.0
Using chef-zero 15.0.11
Using faraday-follow_redirects 0.3.0
Using tty-box 0.7.0
Using tty-table 0.12.0
Using tty-prompt 0.23.1
Using pry-byebug 3.10.1
Using pry-stack_explorer 0.6.1
Using rspec-its 1.3.0
Using rspec 3.11.0
Using webmock 3.19.1
Using winrm 2.3.6
Using rubocop-ast 1.31.1
Using aws-sdk-kms 1.71.0
Using aws-sdk-secretsmanager 1.82.0
Using win32-certstore 0.6.15
Using license-acceptance 2.1.13
Using winrm-fs 1.3.5
Using aws-sdk-s3 1.133.0
Using rubocop 1.25.1
Using winrm-elevated 1.2.3
Using chefstyle 2.2.3 from https://github.com/chef/chefstyle.git (at main@1293442)
Using train-winrm 0.2.13
Using mixlib-shellout 3.2.7 (universal-mingw32)
Using cheffish 17.0.0
Using chef-config 17.10.134 from source at `chef-config`
Using appbundler 0.13.4
Using train-core 3.10.8
Using chef-telemetry 1.1.1
Using ohai 17.9.7 (was 17.9.5) from https://github.com/chef/ohai.git (at 17-stable@929a523)
Using inspec-core 5.22.40
Using inspec-core-bin 5.22.40
Using chef 17.10.134 (universal-mingw32) from source at `.`
Using chef-bin 17.10.134 from source at `chef-bin` and installing its executables
Bundle updated!

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
