### PR TITLE
Add note about adding account rights not taking immediate effect.

### DIFF
--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -442,10 +442,9 @@ class Chef
         NetworkService have this right when running as a service. This is necessary
         even if the user is an Administrator.
 
-        This right can be added and checked in a recipe using this example:
+        This right can be added and checked in a recipe using this example (will not take effect in the same Chef run):
 
         ```ruby
-        # note: this will not take place in the same connection
         windows_user_privilege 'add assign token privilege' do
           principal '<user>'
           privilege 'SeAssignPrimaryTokenPrivilege'

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -449,7 +449,7 @@ class Chef
           principal '<user>'
           privilege 'SeAssignPrimaryTokenPrivilege'
           action :add
-        end 
+        end
         ```
 
         The following example shows how to run `mkdir test_dir` from a Chef Infra Client

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -445,39 +445,12 @@ class Chef
         This right can be added and checked in a recipe using this example:
 
         ```ruby
-        # Add 'SeAssignPrimaryTokenPrivilege' for the user
-        Chef::ReservedNames::Win32::Security.add_account_right('<user>', 'SeAssignPrimaryTokenPrivilege')
-
-        # Check if the user has 'SeAssignPrimaryTokenPrivilege' rights
-        Chef::ReservedNames::Win32::Security.get_account_right('<user>').include?('SeAssignPrimaryTokenPrivilege')
-        ```
-
-        If you do have to add the user using `add_account_right` then the permissions will require logging out and
-        back in to the system. This can be accomplished via the `reboot` resource.
-
-        ```ruby
-        USER_RUNNING_CHEF = 'Administrator' # if running vagrant + kitchen-tests, this should be 'vagrant'
-
-        ruby_block 'set privileges' do
-          not_if { Chef::ReservedNames::Win32::Security.get_account_right(USER_RUNNING_CHEF).include?('SeAssignPrimaryTokenPrivilege') }
-          not_if { Chef::ReservedNames::Win32::Security.get_account_right(USER_RUNNING_CHEF).include?('SeIncreaseQuotaPrivilege') }
-
-          block do
-            # Setting privileges
-            Chef::ReservedNames::Win32::Security.add_account_right(USER_RUNNING_CHEF, 'SeAssignPrimaryTokenPrivilege')
-            Chef::ReservedNames::Win32::Security.add_account_right(USER_RUNNING_CHEF, 'SeIncreaseQuotaPrivilege')
-          end
-          notifies :reboot_now, 'reboot[now]', :immediately
-        end
-
-        # Reboot
-        reboot 'now' do
-          # https://docs.chef.io/resources/reboot/#actions
-          # action :nothing will only run if notified by another action
-          action :nothing
-          reason 'Cannot continue Chef run without a reboot.'
-          delay_mins 1
-        end
+        # note: this will not take place in the same connection
+        windows_user_privilege 'add assign token privilege' do
+          principal '<user>'
+          privilege 'SeAssignPrimaryTokenPrivilege'
+          action :add
+        end 
         ```
 
         The following example shows how to run `mkdir test_dir` from a Chef Infra Client


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
There is some confusion about `add_account_right` and whether it can take immediate effect in Windows in the same Chef run. Also updated the example for setting rights to use `windows_privilege_resource`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
