### PR TITLE
Revert "[chef-17] backport pr14064"

### DIFF
--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -74,7 +74,6 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
       current_resource.run_as_user(config_info.service_start_name)    if config_info.service_start_name
       current_resource.display_name(config_info.display_name)         if config_info.display_name
       current_resource.delayed_start(current_delayed_start)           if current_delayed_start
-      current_resource.description(config_info.description)           if new_resource.description
     end
 
     current_resource


### PR DESCRIPTION
Reverts chef/chef#14151


`Struct::ServiceConfigInfo` doesn't have `description` and `win32-service` is in a state in which it can't be rolled out at the moment.

```ruby
NoMethodError
undefined method "description' for #<struct Struct::ServiceConfigInfo service_type="own process"
```
