### PR TITLE
Fix #6238 - handle link :delete action without `to`

### DIFF
--- a/lib/chef/provider/link.rb
+++ b/lib/chef/provider/link.rb
@@ -44,7 +44,7 @@ class Chef
         else
           current_resource.link_type(:hard)
           if ::File.exist?(current_resource.target_file)
-            if ::File.exist?(new_resource.to) &&
+            if new_resource.to && ::File.exist?(new_resource.to) &&
                 file_class.stat(current_resource.target_file).ino ==
                     file_class.stat(new_resource.to).ino
               current_resource.to(canonicalize(new_resource.to))
@@ -69,6 +69,17 @@ class Chef
           end
           a.failure_message Chef::Exceptions::Link, "Cannot delete #{new_resource} at #{new_resource.target_file}! Not a #{new_resource.link_type} link."
           a.whyrun("Would assume the link at #{new_resource.target_file} was previously created")
+        end
+        requirements.assert(:create) do |a|
+          a.assertion do
+            if new_resource.to && new_resource.to != ""
+              true
+            else
+              false
+            end
+          end
+          a.failure_message Chef::Exceptions::Link, "Cannot create #{new_resource} without specifying 'to'."
+          a.whyrun("Would create the link at #{new_resource.target_file} to #{new_resource.to}")
         end
       end
 

--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -46,7 +46,7 @@ class Chef
         description: "An optional property to set the target file if it differs from the resource block's name.",
         name_property: true
 
-      property :to, String,
+      property :to, [String, nil],
         description: "The actual file to which the link is to be created."
 
       property :link_type, [String, Symbol],


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
