### PR TITLE
[PathHelper#relative_path_from] Reduce number of cleanpath calls

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -197,7 +197,15 @@ module ChefConfig
     end
 
     def self.relative_path_from(from, to, windows: ChefUtils.windows?)
-      Pathname.new(cleanpath(to, windows: windows)).relative_path_from(Pathname.new(cleanpath(from, windows: windows)))
+      path = Pathname.new(to).relative_path_from(Pathname.new(from)).to_s
+      if windows
+        # ensure all forward slashes are backslashes
+        path.gsub!(File::SEPARATOR, path_separator(windows: windows))
+      else
+        # ensure all backslashes are forward slashes
+        path.gsub!(BACKSLASH, File::SEPARATOR)
+      end
+      Pathname.new(path)
     end
 
     # Set the project-specific home directory environment variable.


### PR DESCRIPTION
Halves the number of calls to Pathname#cleanpath when doing `knife cookbook upload`. Pathname#cleanpath can be expensive in deeply nested directories.

- [relative_path_from already runs `cleanpath`](https://github.com/ruby/pathname/blob/master/lib/pathname.rb#L517-L520)
- call to PathHelper#cleanpath creates more cleanpath calls, and appeared to only be used for the slashes cleanup
- continues to return Pathname object

Note: This has not yet been tested on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
