### PR TITLE
EC and modulo length update for OpenSSL 3 compatibility

### DIFF
--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -111,7 +111,7 @@ class Chef
         raise ArgumentError, "Key length must be a power of 2 greater than or equal to 1024" unless key_length_valid?(key_length)
         raise TypeError, "Generator must be an integer" unless generator.is_a?(Integer)
 
-        ::OpenSSL::PKey::DH.new(key_length, generator)
+        ::OpenSSL::PKey::EC.generate(curve)
       end
 
       # generate an RSA private key given key length

--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -111,7 +111,7 @@ class Chef
         raise ArgumentError, "Key length must be a power of 2 greater than or equal to 1024" unless key_length_valid?(key_length)
         raise TypeError, "Generator must be an integer" unless generator.is_a?(Integer)
 
-        ::OpenSSL::PKey::EC.generate(curve)
+        ::OpenSSL::PKey::DH.new(key_length, generator)
       end
 
       # generate an RSA private key given key length
@@ -157,7 +157,7 @@ class Chef
         raise TypeError, "curve must be a string" unless curve.is_a?(String)
         raise ArgumentError, "Specified curve is not available on this system" unless %w{prime256v1 secp384r1 secp521r1}.include?(curve)
 
-        ::OpenSSL::PKey::EC.new(curve).generate_key
+        ::OpenSSL::PKey::EC.generate(curve)
       end
 
       # generate pem format of the public key given a private key

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = "Stop"
 # install chocolatey
 function installChoco {
 
-  if (!(Test-Path "$($env:ProgramData)\chocolatey\choco.exe")) {
-      Write-Output "Chocolatey is not installed, proceeding to install"
+  #if (!(Test-Path "$($env:ProgramData)\chocolatey\choco.exe")) {
+  #    Write-Output "Chocolatey is not installed, proceeding to install"
           try {
               write-output "installing in 3..2..1.."
               Set-ExecutionPolicy Bypass -Scope Process -Force
@@ -16,11 +16,11 @@ function installChoco {
           catch {
                 Write-Error $_.Exception.Message
           }
-  }
+  #}
 
-  else {
-      Write-Output "Chocolatey is already installed"
-  }
+  #else {
+  #    Write-Output "Chocolatey is already installed"
+  #}
 }
 
 installChoco

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = "Stop"
 # install chocolatey
 function installChoco {
 
-  #if (!(Test-Path "$($env:ProgramData)\chocolatey\choco.exe")) {
-  #    Write-Output "Chocolatey is not installed, proceeding to install"
+  if (!(Test-Path "$($env:ProgramData)\chocolatey\choco.exe")) {
+      Write-Output "Chocolatey is not installed, proceeding to install"
           try {
               write-output "installing in 3..2..1.."
               Set-ExecutionPolicy Bypass -Scope Process -Force
@@ -16,11 +16,12 @@ function installChoco {
           catch {
                 Write-Error $_.Exception.Message
           }
-  #}
+  }
 
-  #else {
-  #    Write-Output "Chocolatey is already installed"
-  #}
+  else {
+      Write-Output "Chocolatey is already installed, upgrading"
+      choco upgrade chocolatey
+  }
 }
 
 installChoco

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -20,6 +20,7 @@ function installChoco {
 
   else {
       Write-Output "Chocolatey is already installed, upgrading"
+      choco feature enable -n=allowGlobalConfirmation
       choco upgrade chocolatey
   }
 }

--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -92,7 +92,12 @@ describe Chef::Mixin::OpenSSLHelper do
 
     context "When the dhparam.pem file does exist, and does contain a vaild dhparam key" do
       it "returns true" do
-        @dhparam_file.puts(::OpenSSL::PKey::DH.new(256).to_pem) # this is 256 to speed up specs
+         # bumped this from 256 to 1024 because OpenSSL 3.x will enforce
+         # size
+         #      OpenSSL::PKey::PKeyError:
+         #       EVP_PKEY_paramgen: modulus too small
+         # need to double check that the mixin itself doesn't allow smaller
+        @dhparam_file.puts(::OpenSSL::PKey::DH.new(1024).to_pem)
         @dhparam_file.close
         expect(instance.dhparam_pem_valid?(@dhparam_file.path)).to be_truthy
       end

--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -92,11 +92,11 @@ describe Chef::Mixin::OpenSSLHelper do
 
     context "When the dhparam.pem file does exist, and does contain a vaild dhparam key" do
       it "returns true" do
-         # bumped this from 256 to 1024 because OpenSSL 3.x will enforce
-         # size
-         #      OpenSSL::PKey::PKeyError:
-         #       EVP_PKEY_paramgen: modulus too small
-         # need to double check that the mixin itself doesn't allow smaller
+        # bumped this from 256 to 1024 because OpenSSL 3.x will enforce
+        # size
+        #      OpenSSL::PKey::PKeyError:
+        #       EVP_PKEY_paramgen: modulus too small
+        # need to double check that the mixin itself doesn't allow smaller
         @dhparam_file.puts(::OpenSSL::PKey::DH.new(1024).to_pem)
         @dhparam_file.close
         expect(instance.dhparam_pem_valid?(@dhparam_file.path)).to be_truthy


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Extracting fixes for EC syntax and modulo length that will generate errors in OpenSSL 3.0. Gem installs of chef on 3.1 (see: unit tests in GitHub Actions) are already flagging this due to the update of `macOS@latest` runners to use ARM which has OpenSSL 3 installed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
