### PR TITLE
hyperv added to virtualization helper

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/virtualization.rb
+++ b/chef-utils/lib/chef-utils/dsl/virtualization.rb
@@ -184,6 +184,17 @@ module ChefUtils
         node.dig("virtualization", "system") == "openvz" && node.dig("virtualization", "role") == "host"
       end
 
+      # Determine if the current node is running under Microsoft Hyper-v.
+      #
+      # @param [Chef::Node] node
+      # @since 18.5
+      #
+      # @return [Boolean]
+      #
+      def hyperv?(node = __getnode)
+        node.dig("virtualization", "system") == "hyperv" && node.dig("virtualization", "role") == "guest"
+      end
+
       # Determine if the current node is running under any virtualization environment
       #
       # @param [Chef::Node] node

--- a/chef-utils/spec/unit/dsl/virtualization_spec.rb
+++ b/chef-utils/spec/unit/dsl/virtualization_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe ChefUtils::DSL::Virtualization do
     end
   end
 
+  context "on hyperv" do
+    virtualization_reports_true_for(:guest?, :virtual?, :hyperv?, node: { "virtualization" => { "system" => "hyperv", "role" => "guest" } })
+  end
   context "on kvm" do
     virtualization_reports_true_for(:guest?, :virtual?, :kvm?, node: { "virtualization" => { "system" => "kvm",  "role" => "guest" } })
     virtualization_reports_true_for(:hypervisor?, :physical?, :kvm_host?, node: { "virtualization" => { "system" => "kvm", "role" => "host" } })


### PR DESCRIPTION
Signed-off-by: Mike Butler <michael.butler@progress.com>

## Description

hyperv was missing from the virtualization helpers. There is no host, only guest.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
