### PR TITLE
Fix pagination for supermarket list

### DIFF
--- a/knife/lib/chef/knife/supermarket_list.rb
+++ b/knife/lib/chef/knife/supermarket_list.rb
@@ -64,7 +64,7 @@ class Chef
         cr["items"].each do |cookbook|
           cookbook_collection[cookbook["cookbook_name"]] = cookbook["cookbook"]
         end
-        new_start = start + items
+        new_start = start + cr["items"].length
         if new_start < cr["total"]
           get_cookbook_list(items, new_start, cookbook_collection)
         else


### PR DESCRIPTION
## Description
As per the issue, the API limits on the supermarket end have been changed from unlimited to a maximum of 100.

This fix is in accordance with how it is done in `supermarket_show.rb` 

## Related Issue
#14360

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
