### PR TITLE
Backport: Chef-17 - Remove EOL warning

### DIFF
--- a/docs/dev/policy/release_and_support_schedule.md
+++ b/docs/dev/policy/release_and_support_schedule.md
@@ -59,8 +59,8 @@ This stage indicates a previously deprecated release version, which is no longer
 
 ### Generally Available Release Schedule
 
-  - **Minor releases**: 2nd week of each month
-  - **Major releases**: Once a year in April
+  - **Minor releases**: As needed
+  - **Major releases**: To be announced
 
 ### Deprecated Release Schedule
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -292,8 +292,6 @@ class Chef
         # keep this inside the main loop to get exception backtraces
         end_profiling
 
-        warn_if_eol
-
         # rebooting has to be the last thing we do, no exceptions.
         Chef::Platform::Rebooter.reboot_if_needed!(node)
       rescue Exception => run_error

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -323,35 +323,6 @@ class Chef
     #
 
     # @api private
-    def warn_if_eol
-      require_relative "version"
-
-      # New Date format is YYYY-MM-DD or false
-      new_date = eol_override
-
-      # We make a release every year so take the version you're on + 2006 and you get
-      # the year it goes EOL. 1/8/2024 - EOL for Chef-17 is now November 1, 2024
-      # eol_year = 2006 + Gem::Version.new(Chef::VERSION).segments.first
-      eol_year = "2024"
-      cut_off_date = !!new_date ? Time.parse(new_date) : Time.new(eol_year, 11, 30)
-
-      return if Time.now < cut_off_date
-
-      logger.warn("This release of #{ChefUtils::Dist::Infra::PRODUCT} became end of life (EOL) on #{cut_off_date.strftime("%b %d, %Y")}. Please update to a supported release to receive new features, bug fixes, and security updates.")
-    end
-
-    def eol_override
-      # If you want to override the existing EOL date, add a file in the root of Chef
-      # put a date in it in the form of YYYY-DD-MM.
-      override_file = "EOL_override"
-      if File.exist?(override_file)
-        File.read(File.expand_path(override_file)).strip
-      else
-        false
-      end
-    end
-
-    # @api private
     def configure_formatters
       formatters_for_run.map do |formatter_name, output_path|
         if output_path.nil?

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -308,25 +308,6 @@ describe Chef::Client do
     end
   end
 
-  describe "eol release warning" do
-    it "warns when running an EOL release" do
-      stub_const("Chef::VERSION", 15)
-      # added a call to client because Time.now gets invoked multiple times during instantiation. Don't mock Time until after client initialized
-      client
-      expect(Time).to receive(:now).and_return(Time.new(2024, 12, 1, 5))
-      allow(client).to receive(:eol_override).and_return(false)
-      expect(logger).to receive(:warn).with("This release of Chef Infra Client became end of life (EOL) on Nov 30, 2024. Please update to a supported release to receive new features, bug fixes, and security updates.")
-      client.warn_if_eol
-    end
-
-    it "does not warn when running an non-EOL release" do
-      stub_const("Chef::VERSION", 15)
-      allow(Time).to receive(:now).and_return(Time.new(2021, 4, 30))
-      expect(logger).to_not receive(:warn).with(/became end of life/)
-      client.warn_if_eol
-    end
-  end
-
   describe "authentication protocol selection" do
     context "when FIPS is disabled" do
       before do


### PR DESCRIPTION


## Description
Since there is no specific schedule for major releases having an eol message is irrelevant. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
