### PR TITLE
[ChefConfig] Add memoization to var_root_dir and var_chef_dir methods

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -97,8 +97,11 @@ module ChefConfig
     # @return [String] the platform-specific path
     #
     def self.var_chef_dir(windows: ChefUtils.windows?)
-      path = windows ? c_chef_dir : PathHelper.join("/var", ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
-      PathHelper.cleanpath(path, windows: windows)
+      @var_chef_dir ||= {}
+      @var_chef_dir[windows] ||= begin
+        path = windows ? c_chef_dir : PathHelper.join("/var", ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
+        PathHelper.cleanpath(path, windows: windows)
+      end
     end
 
     # On *nix, /var, on Windows C:\
@@ -107,8 +110,11 @@ module ChefConfig
     # @return [String] the platform-specific path
     #
     def self.var_root_dir(windows: ChefUtils.windows?)
-      path = windows ? "C:\\" : "/var"
-      PathHelper.cleanpath(path, windows: windows)
+      @var_root_dir ||= {}
+      @var_root_dir[windows] ||= begin
+        path = windows ? "C:\\" : "/var"
+        PathHelper.cleanpath(path, windows: windows)
+      end
     end
 
     # On windows, C:/chef/


### PR DESCRIPTION
## Description

These two methods get hit with each call to [cache_path](https://github.com/dafyddcrosby/chef/blob/f52a96dafa46968fd5ca21db35b83f649acb387f/chef-config/lib/chef-config/config.rb#L374-L375), and are essentially constant values.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
