### PR TITLE
Test FIPS MD5

### DIFF
--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -13,8 +13,17 @@ describe "chef-client fips" do
     expect { enable_fips }.to raise_error(OpenSSL::OpenSSLError)
   end
 
+  example "Do not error on MD5 if not fips_mode", fips_mode: false do
+    expect { OpenSSL::Digest::MD5.new("abcdefghijklmnop") }.not_to raise_error
+  end
+
   # For FIPS OSes/builds of Ruby, enabling FIPS should not error
   example "Do not error enabling fips_mode if FIPS linked", fips_mode: true do
     expect { enable_fips }.not_to raise_error
+  end
+
+  example "Error on MD5 if fips_mode", fips_mode: true do
+    enable_fips
+    expect { OpenSSL::Digest::MD5.new("abcdefghijklmnop") }.to raise_error(OpenSSL::Digest::DigestError)
   end
 end

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -14,7 +14,7 @@ describe "chef-client fips" do
   end
 
   example "Do not error on MD5 if not fips_mode", fips_mode: false do
-    expect { OpenSSL::Digest::MD5.new("abcdefghijklmnop") }.not_to raise_error
+    expect { OpenSSL::Digest.new("MD5", "test string for digesting") }.not_to raise_error
   end
 
   # For FIPS OSes/builds of Ruby, enabling FIPS should not error
@@ -24,6 +24,6 @@ describe "chef-client fips" do
 
   example "Error on MD5 if fips_mode", fips_mode: true do
     enable_fips
-    expect { OpenSSL::Digest::MD5.new("abcdefghijklmnop") }.to raise_error(OpenSSL::Digest::DigestError)
+    expect { OpenSSL::Digest.new("MD5", "test string for digesting") }.to raise_error(OpenSSL::Digest::DigestError)
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Add a test to validate FIPS' invalidation of MD5 hashes from the OpenSSL library.

Integration on CentOS, RHEL, Ubuntu, and Windows should show the following in the [Chef OSS Verify Pipeline](https://buildkite.com/chef-oss/chef-chef-main-verify/) (FIPS enabled/linked)

```
chef-client fips
  Do not error enabling fips_mode if FIPS linked
  Error on MD5 if fips_mode
```

Debian and SLES integration tests should show the FIPS disabled results
```
chef-client fips
  Error enabling fips_mode if FIPS not linked
  Do not error on MD5 if not fips_mode
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
