### PR TITLE
[StateTracking] Do in-place compact

### DIFF
--- a/lib/chef/node/mixin/state_tracking.rb
+++ b/lib/chef/node/mixin/state_tracking.rb
@@ -37,7 +37,8 @@ class Chef
         def [](*args)
           ret = super
           key = args.first
-          next_path = [ __path__, convert_key(key) ].flatten.compact
+          next_path = [ __path__, convert_key(key) ].flatten
+          next_path.compact!
           copy_state_to(ret, next_path)
         end
 
@@ -45,7 +46,8 @@ class Chef
           ret = super
           key = args.first
           value = args.last
-          next_path = [ __path__, convert_key(key) ].flatten.compact
+          next_path = [ __path__, convert_key(key) ].flatten
+          next_path.compact!
           send_attribute_changed_event(next_path, value)
           copy_state_to(ret, next_path)
         end
@@ -77,7 +79,8 @@ class Chef
         end
 
         def send_reset_cache(path = nil, key = nil)
-          next_path = [ path, key ].flatten.compact
+          next_path = [ path, key ].flatten
+          next_path.compact!
           __root__.reset_cache(next_path.first) if !__root__.nil? && __root__.respond_to?(:reset_cache)
         end
 


### PR DESCRIPTION
## Description
`compact` creates a new Array object, which is unnecessary here. Use `compact!` instead

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
