### PR TITLE
Move Ubuntu 18.04 kitchen test to Virtualbox + Vagrant 

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -88,7 +88,6 @@ jobs:
           - oraclelinux-9
           # - rockylinux-8 # Need to troubleshoot issue with container startup
           - rockylinux-9
-          - ubuntu-1804
           - ubuntu-2004
           - ubuntu-2204
     runs-on: ubuntu-latest
@@ -112,6 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-1804
           - amazonlinux-2
           - oraclelinux-7
     runs-on: ubuntu-20.04
@@ -148,7 +148,6 @@ jobs:
           - oracle-9
           - rockylinux-8
           - rockylinux-9
-          - ubuntu-1804
           - ubuntu-2004
           - ubuntu-2204
     runs-on: ubuntu-latest

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -111,7 +111,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-1804
           - amazonlinux-2
           - oraclelinux-7
     runs-on: ubuntu-20.04
@@ -148,6 +147,7 @@ jobs:
           - oracle-9
           - rockylinux-8
           - rockylinux-9
+          - ubuntu-1804
           - ubuntu-2004
           - ubuntu-2204
     runs-on: ubuntu-latest

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -196,6 +196,10 @@ class Chef
                   next
                 end
               end
+              Chef::Log.warn("<=> #{__FILE__} #{__LINE__}<=>")
+              Chef::Log.warn(body.inspect)
+              Chef::Log.warn("<=> #{__FILE__} #{__LINE__}<=>")
+              Chef::Log.warn(result.inspect)
               result
             end
           end

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -181,7 +181,7 @@ class Chef
               )
               result = nil
               body = ""
-              last_parser_error_length=0
+              json_error_last = false
               socket.each_char do |c|
                 body << c
                 # we know we're not done if we don't have a char that
@@ -192,15 +192,19 @@ class Chef
                   result = JSON.parse(body)
                   # if we get here, we were able to parse the json so we
                   # are done reading
+                  json_error_last = false
                   break
                 rescue JSON::ParserError
-                  last_parser_error_length=body.length
+                  json_error_last = true
                   next
                 end
               end
-              if last_parser_error_length == body.length
+              if json_error_last
                 Chef::Log.warn("<=> never successfully parsed <=>")
                 Chef::Log.warn(result.inspect)
+              else
+                Chef::Log.warn("<=> successfully parsed <=>")
+                Chef::Log.warn(result.class.to_s)
               end
               result
             end

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -181,6 +181,7 @@ class Chef
               )
               result = nil
               body = ""
+              last_parser_error_length=0
               socket.each_char do |c|
                 body << c
                 # we know we're not done if we don't have a char that
@@ -193,13 +194,14 @@ class Chef
                   # are done reading
                   break
                 rescue JSON::ParserError
+                  last_parser_error_length=result.length
                   next
                 end
               end
-              Chef::Log.warn("<=> #{__FILE__} #{__LINE__}<=>")
-              Chef::Log.warn(body.inspect)
-              Chef::Log.warn("<=> #{__FILE__} #{__LINE__}<=>")
-              Chef::Log.warn(result.inspect)
+              if last_parser_error_length == result.length
+                Chef::Log.warn("<=> never successfully parsed <=>")
+                Chef::Log.warn(result.inspect)
+              end
               result
             end
           end

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -221,6 +221,14 @@ class Chef
           waiting = true
           while waiting
             result = get_change_id(id)
+
+            if result["result"]["summary"] == "Install \"hello\" snap"
+              Chef::Log.warn("<=> get_change_id(#{id}) <=>")
+              Chef::Log.warn(result["result"]["status"])
+              Chef::Log.warn(result.class)
+              Chef::Log.warn(result.inspect)
+            end
+
             case result["result"]["status"]
             when "Do", "Doing", "Undoing", "Undo"
               # Continue

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -199,13 +199,6 @@ class Chef
                   next
                 end
               end
-              if json_error_last
-                Chef::Log.warn("<=> never successfully parsed <=>")
-                Chef::Log.warn(result.inspect)
-              else
-                Chef::Log.warn("<=> successfully parsed <=>")
-                Chef::Log.warn(result.class.to_s)
-              end
               result
             end
           end
@@ -232,6 +225,8 @@ class Chef
             when "Do", "Doing", "Undoing", "Undo"
               # Continue
             when "Abort", "Hold", "Error"
+              Chef::Log.warn("<=> broken? <=>")
+              Chef::Log.warn(result.inspect)
               raise result
             when "Done"
               waiting = false

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -192,10 +192,8 @@ class Chef
                   result = JSON.parse(body)
                   # if we get here, we were able to parse the json so we
                   # are done reading
-                  json_error_last = false
                   break
                 rescue JSON::ParserError
-                  json_error_last = true
                   next
                 end
               end
@@ -222,21 +220,10 @@ class Chef
           while waiting
             result = get_change_id(id)
 
-            if result["result"]["summary"] == "Install \"hello\" snap"
-              Chef::Log.warn("<=> get_change_id(#{id}) <=>")
-              Chef::Log.warn(result["result"]["status"])
-              Chef::Log.warn(result.class)
-              Chef::Log.warn(result.inspect)
-            end
-
             case result["result"]["status"]
             when "Do", "Doing", "Undoing", "Undo"
               # Continue
             when "Abort", "Hold", "Error"
-              Chef::Log.warn("<=> broken? <=>")
-              Chef::Log.warn(result["result"]["status"])
-              Chef::Log.warn(result.class)
-              Chef::Log.warn(result.inspect)
               raise result
             when "Done"
               waiting = false

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -226,6 +226,8 @@ class Chef
               # Continue
             when "Abort", "Hold", "Error"
               Chef::Log.warn("<=> broken? <=>")
+              Chef::Log.warn(result["result"]["status"])
+              Chef::Log.warn(result.class)
               Chef::Log.warn(result.inspect)
               raise result
             when "Done"

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -193,8 +193,6 @@ class Chef
                   # are done reading
                   break
                 rescue JSON::ParserError
-                  Chef::Log.warn("<=> JSON::ParserError <=>")
-                  Chef::Log.warn(body)
                   next
                 end
               end

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -181,7 +181,6 @@ class Chef
               )
               result = nil
               body = ""
-              json_error_last = false
               socket.each_char do |c|
                 body << c
                 # we know we're not done if we don't have a char that

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -194,7 +194,7 @@ class Chef
                   break
                 rescue JSON::ParserError
                   Chef::Log.warn("<=> JSON::ParserError <=>")
-                  Chef::Log.warn(body.inspect)
+                  Chef::Log.warn(body)
                   next
                 end
               end

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -194,11 +194,11 @@ class Chef
                   # are done reading
                   break
                 rescue JSON::ParserError
-                  last_parser_error_length=result.length
+                  last_parser_error_length=body.length
                   next
                 end
               end
-              if last_parser_error_length == result.length
+              if last_parser_error_length == body.length
                 Chef::Log.warn("<=> never successfully parsed <=>")
                 Chef::Log.warn(result.inspect)
               end

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -193,6 +193,8 @@ class Chef
                   # are done reading
                   break
                 rescue JSON::ParserError
+                  Chef::Log.warn("<=> JSON::ParserError <=>")
+                  Chef::Log.warn(body.inspect)
                   next
                 end
               end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Snap has been erroring for 18.04 in kitchen-test with the following error in API body that is being parsed:

`ERROR cannot reload udev rules: exit status 2\nudev output:` 

Moving to the vagrant + virtualbox section (`vm_lnx_x86_64`)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
