### PR TITLE
Updating default version of Ruby to get past 2 CVE's

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   if RUBY_PLATFORM =~ /aix/
     s.required_ruby_version = ">= 3.0.3"
   else
-    s.required_ruby_version = ">= 3.1.0"
+    s.required_ruby_version = ">= 3.1.4"
   end
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating default Ruby versions to get past https://chefio.atlassian.net/browse/CHEF-11425 and https://chefio.atlassian.net/browse/CHEF-11598

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
