### PR TITLE
update kitchen-tests platforms

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -35,8 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
           - macos-13
+          - macos-12
     runs-on: ${{ matrix.os }}
     env:
       CHEF_LICENSE: accept-no-persist
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-14
+          - macos-latest
     runs-on: ${{ matrix.os }}
     env:
       CHEF_LICENSE: accept-no-persist
@@ -90,6 +90,7 @@ jobs:
           - rockylinux-9
           - ubuntu-2004
           - ubuntu-2204
+          - ubuntu-2404
     runs-on: ubuntu-latest
     env:
       FORCE_FFI_YAJL: ext
@@ -113,6 +114,7 @@ jobs:
         os:
           - amazonlinux-2
           - oraclelinux-7
+          - ubuntu-1804
     runs-on: ubuntu-20.04
     env:
       FORCE_FFI_YAJL: ext
@@ -135,12 +137,12 @@ jobs:
           - amazonlinux-2023
           - almalinux-8
           - almalinux-9
-          # - centos-7 Need to troubleshoot slow and hanging behaviour on lifecycle hook run
+          - centos-7 # Need to troubleshoot slow and hanging behaviour on lifecycle hook run
           - debian-11
           - debian-12
           - fedora-latest
-          # - freebsd-13 # Need to troubleshoot shell invalid issue
-          # - freebsd-14 # Need to troubleshoot bad bento box issue
+          - freebsd-13 # Need to troubleshoot shell invalid issue
+          - freebsd-14 # Need to troubleshoot bad bento box issue
           - opensuse-leap-15
           - oracle-7
           - oracle-8
@@ -150,6 +152,7 @@ jobs:
           - ubuntu-1804
           - ubuntu-2004
           - ubuntu-2204
+          - ubuntu-2404
     runs-on: ubuntu-latest
     env:
       CHEF_LICENSE: accept-no-persist

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -85,7 +85,7 @@ jobs:
           - opensuse-leap-15
           - oraclelinux-8
           - oraclelinux-9
-          - rockylinux-8 # Need to troubleshoot issue with container startup
+          - rockylinux-8
           - rockylinux-9
           - ubuntu-2004
           - ubuntu-2204

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -79,14 +79,13 @@ jobs:
           - amazonlinux-2023
           - almalinux-8
           - almalinux-9
-          - centos-7
           - debian-11
           - debian-12
           - fedora-latest
           - opensuse-leap-15
           - oraclelinux-8
           - oraclelinux-9
-          # - rockylinux-8 # Need to troubleshoot issue with container startup
+          - rockylinux-8 # Need to troubleshoot issue with container startup
           - rockylinux-9
           - ubuntu-2004
           - ubuntu-2204
@@ -113,8 +112,8 @@ jobs:
       matrix:
         os:
           - amazonlinux-2
+          - centos-7
           - oraclelinux-7
-          - ubuntu-1804
     runs-on: ubuntu-20.04
     env:
       FORCE_FFI_YAJL: ext
@@ -137,12 +136,12 @@ jobs:
           - amazonlinux-2023
           - almalinux-8
           - almalinux-9
-          - centos-7 # Need to troubleshoot slow and hanging behaviour on lifecycle hook run
+          # - centos-7 # Need to troubleshoot slow and hanging behaviour on lifecycle hook run
           - debian-11
           - debian-12
           - fedora-latest
-          - freebsd-13 # Need to troubleshoot shell invalid issue
-          - freebsd-14 # Need to troubleshoot bad bento box issue
+          # - freebsd-13 # Need to troubleshoot shell invalid issue
+          # - freebsd-14 # Need to troubleshoot bad bento box issue
           - opensuse-leap-15
           - oracle-7
           - oracle-8

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -106,7 +106,7 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
-        - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
+        - RUN mkdir -p /etc/sysconfig/network-scripts # missing from the alma image
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
   - name: rockylinux-9

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -106,7 +106,7 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
-        - RUN mkdir -p /etc/sysconfig/network-scripts # missing from the alma image
+        - RUN mkdir -p /etc/sysconfig/network-scripts
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
   - name: rockylinux-9
@@ -115,7 +115,7 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
-        - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
+        - RUN mkdir -p /etc/sysconfig/network-scripts
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
   - name: oraclelinux-7

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -42,148 +42,148 @@ lifecycle:
     - remote: /opt/chef/bin/ohai -v
 
 platforms:
-- name: amazonlinux-2
-  driver:
-    image: dokken/amazonlinux-2
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: amazonlinux-2
+    driver:
+      image: dokken/amazonlinux-2
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: amazonlinux-2023
-  driver:
-    image: dokken/amazonlinux-2023
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: amazonlinux-2023
+    driver:
+      image: dokken/amazonlinux-2023
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: debian-12
-  driver:
-    image: dokken/debian-12
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update -y
-      - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
+  - name: debian-12
+    driver:
+      image: dokken/debian-12
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -y
+        - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
 
-- name: debian-11
-  driver:
-    image: dokken/debian-11
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update -y
-      - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -y
+        - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
 
-- name: centos-7
-  driver:
-    image: dokken/centos-7
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN yum -y install e2fsprogs
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
-      - RUN yum install -y centos-release-scl
-      - RUN yum install -y devtoolset-7
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN yum -y install e2fsprogs
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+        - RUN yum install -y centos-release-scl
+        - RUN yum install -y devtoolset-7
 
-- name: almalinux-8
-  driver:
-    image: dokken/almalinux-8
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install e2fsprogs
-      - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN dnf -y install e2fsprogs
+        - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: almalinux-9
-  driver:
-    image: dokken/almalinux-9
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install e2fsprogs
-      - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: almalinux-9
+    driver:
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN dnf -y install e2fsprogs
+        - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: rockylinux-8
-  driver:
-    image: dokken/rockylinux-8
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install e2fsprogs
-      - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN dnf -y install e2fsprogs
+        - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: rockylinux-9
-  driver:
-    image: dokken/rockylinux-9
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install e2fsprogs
-      - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: rockylinux-9
+    driver:
+      image: dokken/rockylinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN dnf -y install e2fsprogs
+        - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: oraclelinux-7
-  driver:
-    image: dokken/oraclelinux-7
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN yum -y install e2fsprogs
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
-      - RUN wget --no-check-certificate -O /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo
-      - RUN printf "[centos-sclo-rh]\nname=CentOS-7 - SCLo rh\nbaseurl=https://archive.kernel.org/centos-vault/7.8.2003/sclo/x86_64/rh/\ngpgcheck=1\nenabled=1\ngpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo" > /etc/yum.repos.d/CentOS-SCLo-rh.repo
-      - RUN yum install -y devtoolset-7
+  - name: oraclelinux-7
+    driver:
+      image: dokken/oraclelinux-7
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN yum -y install e2fsprogs
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+        - RUN wget --no-check-certificate -O /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo
+        - RUN printf "[centos-sclo-rh]\nname=CentOS-7 - SCLo rh\nbaseurl=https://archive.kernel.org/centos-vault/7.8.2003/sclo/x86_64/rh/\ngpgcheck=1\nenabled=1\ngpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo" > /etc/yum.repos.d/CentOS-SCLo-rh.repo
+        - RUN yum install -y devtoolset-7
 
-- name: oraclelinux-8
-  driver:
-    image: dokken/oraclelinux-8
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install e2fsprogs
-      - RUN dnf -y reinstall systemd
-      - RUN mkdir /etc/sysconfig/network-scripts # missing from the oracle image
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: oraclelinux-8
+    driver:
+      image: dokken/oraclelinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN dnf -y install e2fsprogs
+        - RUN dnf -y reinstall systemd
+        - RUN mkdir /etc/sysconfig/network-scripts # missing from the oracle image
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: oraclelinux-9
-  driver:
-    image: dokken/oraclelinux-9
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install e2fsprogs
-      - RUN dnf -y reinstall systemd
-      - RUN mkdir /etc/sysconfig/network-scripts # missing from the oracle image
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: oraclelinux-9
+    driver:
+      image: dokken/oraclelinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN dnf -y install e2fsprogs
+        - RUN dnf -y reinstall systemd
+        - RUN mkdir /etc/sysconfig/network-scripts # missing from the oracle image
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: fedora-latest
-  driver:
-    image: dokken/fedora-latest
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+  - name: fedora-latest
+    driver:
+      image: dokken/fedora-latest
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: ubuntu-18.04
-  driver:
-    image: dokken/ubuntu-18.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update -y
-      - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
+  - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -y
+        - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
 
-- name: ubuntu-20.04
-  driver:
-    image: dokken/ubuntu-20.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update -y
-      - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-20.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -y
+        - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
 
-- name: ubuntu-22.04
-  driver:
-    image: dokken/ubuntu-22.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update -y
-      - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
+  - name: ubuntu-22.04
+    driver:
+      image: dokken/ubuntu-22.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -y
+        - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
 
-- name: opensuse-leap-15
-  driver:
-    image: dokken/opensuse-leap-15
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/zypper --non-interactive update
-      - RUN /usr/bin/zypper --non-interactive install net-tools-deprecated # we need this for /etc/network/interfaces & ifconfig resource testing
+  - name: opensuse-leap-15
+    driver:
+      image: dokken/opensuse-leap-15
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/zypper --non-interactive update
+        - RUN /usr/bin/zypper --non-interactive install net-tools-deprecated # we need this for /etc/network/interfaces & ifconfig resource testing

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -180,6 +180,14 @@ platforms:
         - RUN /usr/bin/apt-get update -y
         - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
 
+  - name: ubuntu-24.04
+    driver:
+      image: dokken/ubuntu-24.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -y
+        - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
+
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15

--- a/kitchen-tests/kitchen.exec.macos.yml
+++ b/kitchen-tests/kitchen.exec.macos.yml
@@ -26,7 +26,8 @@ lifecycle:
     - remote: /opt/chef/bin/ohai -v
 
 platforms:
-  - name: macos-latest # x86_64 MacOS 12 on 3/11/2024
+  - name: macos-latest # arm64
   - name: macos-14 # arm64
   - name: macos-14-large # x86_64
   - name: macos-13 # x86_64
+  - name: macos-12 # x86_64

--- a/kitchen-tests/kitchen.linux.ci.yml
+++ b/kitchen-tests/kitchen.linux.ci.yml
@@ -73,6 +73,7 @@ platforms:
   - name: ubuntu-18.04
   - name: ubuntu-20.04
   - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
   - name: end-to-end

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -42,6 +42,7 @@ platforms:
   - name: ubuntu-18.04
   - name: ubuntu-20.04
   - name: ubuntu-22.04
+  - name: ubuntu-24.04
   - name: windows-10
     driver:
       box: stromweld/windows-10


### PR DESCRIPTION
## Description

Add ubuntu 24.04 to tests and fix macos-latest is now run on apple silicon vs x86 in github actions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
