### PR TITLE
Sean simmons progress/chef 11286 freebsd13 fix

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -68,9 +68,6 @@ fi
 
 if [[ ! "$BUILDKITE_STEP_KEY" =~ ^test.* ]] && [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]]; then
 
-  # export VAULT_ADDR="https://vault.ps.chef.co"
-  # export VAULT_TOKEN=$(vault login -method=aws -path=aws/private-cd -token-only header_value=vault.ps.chef.co role=ci)
-
   if [[ ! $BUILDKITE_LABEL =~ macOS|mac_os_x ]]; then
     lita_password=$(aws ssm get-parameter --name "artifactory-lita-password" --with-decryption --query Parameter.Value --output text --region ${AWS_REGION})
     export ARTIFACTORY_API_KEY=$(echo -n "lita:${lita_password}" | base64)

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -65,7 +65,7 @@ if [[ ! "$BUILDKITE_STEP_KEY" =~ ^test.* ]] && [[ $BUILDKITE_ORGANIZATION_SLUG !
   export VAULT_TOKEN=$(vault login -method=aws -path=aws/private-cd -token-only header_value=vault.ps.chef.co role=ci)
 
   if [[ ! $BUILDKITE_LABEL =~ macOS|mac_os_x ]]; then
-    lita_password=$(aws ssm get-parameter --name "artifactory-lita-password" --with-decryption --query Parameter.Value --output text --region "us-west-2")
+    lita_password=$(aws ssm get-parameter --name "artifactory-lita-password" --with-decryption --query Parameter.Value --output text --region ${AWS_REGION})
     export ARTIFACTORY_API_KEY=$(echo -n "lita:${lita_password}" | base64)
   fi
   export ARTIFACTORY_PASSWORD=$(vault kv get -field password account/static/artifactory/buildkite)

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -58,6 +58,13 @@ if [[ "$BUILDKITE_BRANCH" != "main" ]]; then
   fi
 fi
 
+# force regions on omnibus queues
+[[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]] && if [[ $BUILDKITE_ORGANIZATION_SLUG = "chef" ]]; then
+  export AWS_REGION="us-west-2"
+else
+  export AWS_REGION="us-west-1"
+fi
+
 # Only if on chef-canary or chef org
 if [[ ! "$BUILDKITE_STEP_KEY" =~ ^test.* ]] && [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]]; then
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -58,6 +58,7 @@ if [[ "$BUILDKITE_BRANCH" != "main" ]]; then
   fi
 fi
 
+# Only if on chef-canary or chef org
 # force regions on omnibus queues
 [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]] && if [[ $BUILDKITE_ORGANIZATION_SLUG = "chef" ]]; then
   export AWS_REGION="us-west-2"
@@ -65,20 +66,19 @@ else
   export AWS_REGION="us-west-1"
 fi
 
-# Only if on chef-canary or chef org
 if [[ ! "$BUILDKITE_STEP_KEY" =~ ^test.* ]] && [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]]; then
 
-  export VAULT_ADDR="https://vault.ps.chef.co"
-  export VAULT_TOKEN=$(vault login -method=aws -path=aws/private-cd -token-only header_value=vault.ps.chef.co role=ci)
+  # export VAULT_ADDR="https://vault.ps.chef.co"
+  # export VAULT_TOKEN=$(vault login -method=aws -path=aws/private-cd -token-only header_value=vault.ps.chef.co role=ci)
 
   if [[ ! $BUILDKITE_LABEL =~ macOS|mac_os_x ]]; then
     lita_password=$(aws ssm get-parameter --name "artifactory-lita-password" --with-decryption --query Parameter.Value --output text --region ${AWS_REGION})
     export ARTIFACTORY_API_KEY=$(echo -n "lita:${lita_password}" | base64)
   fi
-  export ARTIFACTORY_PASSWORD=$(vault kv get -field password account/static/artifactory/buildkite)
+  export ARTIFACTORY_PASSWORD=$(aws ssm get-parameter --name "buildkite-artifactory-docker-full-access-token" --query Parameter.Value --with-decryption --output text --region ${AWS_REGION})
 
   # Only if on RPM-based Linux distros
   if [[ "$BUILDKITE_LABEL" =~ rhel|rocky|sles|centos|amazon ]]; then
-    export RPM_SIGNING_KEY=$(vault kv get -field packages_at_chef_io account/static/packages/signing_certs)
+    export RPM_SIGNING_KEY=$(aws ssm get-parameter --name "packages-at-chef-io-signing-cert" --with-decryption --query Parameter.Value --output text --region ${AWS_REGION})
   fi
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -65,7 +65,7 @@ if [[ ! "$BUILDKITE_STEP_KEY" =~ ^test.* ]] && [[ $BUILDKITE_ORGANIZATION_SLUG !
   export VAULT_TOKEN=$(vault login -method=aws -path=aws/private-cd -token-only header_value=vault.ps.chef.co role=ci)
 
   if [[ ! $BUILDKITE_LABEL =~ macOS|mac_os_x ]]; then
-    lita_password=$(aws ssm get-parameter --name "artifactory-lita-password" --with-decryption --query Parameter.Value --output text)
+    lita_password=$(aws ssm get-parameter --name "artifactory-lita-password" --with-decryption --query Parameter.Value --output text --region "us-west-2")
     export ARTIFACTORY_API_KEY=$(echo -n "lita:${lita_password}" | base64)
   fi
   export ARTIFACTORY_PASSWORD=$(vault kv get -field password account/static/artifactory/buildkite)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

The freebsd 13 image was not working with the aws calls. It was missing a region ENV. This is to address that. 

We also dont want to have to rely on connections back to vault. I updated those to pull directly from parameter store as well. 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
