### PR TITLE
OpenSSL 3 bump for Chef 17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "cheffish", "~> 17.0.0"
 gem "ast", "~> 2.4.2"
 gem "rubocop-ast", ">= 1.31.0"
 
+gem "openssl", "= 3.2.0"
+
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,6 +285,7 @@ GEM
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.2.1)
     nori (2.6.0)
+    openssl (3.2.0)
     parallel (1.23.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -455,6 +456,7 @@ DEPENDENCIES
   fauxhai-ng
   inspec-core-bin (~> 5.22.40)
   ohai!
+  openssl (= 3.2.0)
   pry (>= 0.14.1)
   pry-byebug
   pry-stack_explorer

--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -103,10 +103,10 @@ class Chef
         unless config[:ssl_client_cert] && config[:ssl_client_key]
           raise Chef::Exceptions::ConfigurationError, "You must configure ssl_client_cert and ssl_client_key together"
         end
-        unless ::File.exists?(config[:ssl_client_cert])
+        unless ::File.exist?(config[:ssl_client_cert])
           raise Chef::Exceptions::ConfigurationError, "The configured ssl_client_cert #{config[:ssl_client_cert]} does not exist"
         end
-        unless ::File.exists?(config[:ssl_client_key])
+        unless ::File.exist?(config[:ssl_client_key])
           raise Chef::Exceptions::ConfigurationError, "The configured ssl_client_key #{config[:ssl_client_key]} does not exist"
         end
 
@@ -132,7 +132,7 @@ class Chef
       def add_trusted_cert(cert)
         http_client.cert_store.add_cert(cert)
       rescue OpenSSL::X509::StoreError => e
-        raise e unless e.message == "cert already in hash table"
+        raise e unless e.message =~ /cert already in hash table/
       end
 
     end

--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -157,7 +157,7 @@ class Chef
         raise TypeError, "curve must be a string" unless curve.is_a?(String)
         raise ArgumentError, "Specified curve is not available on this system" unless %w{prime256v1 secp384r1 secp521r1}.include?(curve)
 
-        ::OpenSSL::PKey::EC.new(curve).generate_key
+        ::OpenSSL::PKey::EC.generate(curve)
       end
 
       # generate pem format of the public key given a private key

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -6,6 +6,8 @@ gem "artifactory"
 
 gem "pedump"
 
+
+gem "ffi", "< 1.17.0"
 # Use Berkshelf for resolving cookbook dependencies
 # Using a branch here that calls out a berkshelf version for chef-17
 gem "berkshelf", git: "https://github.com/chef/berkshelf.git", branch: "jfm/chef-17-berkshelf"

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -6,7 +6,6 @@ gem "artifactory"
 
 gem "pedump"
 
-
 gem "ffi", "< 1.17.0"
 # Use Berkshelf for resolving cookbook dependencies
 # Using a branch here that calls out a berkshelf version for chef-17

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: b73b772fe13500f546cc992a963aeba71d68991a
+  revision: 412a236b4443fb872d2ee120099fc36481b1a5f9
   branch: main
   specs:
     omnibus-software (24.6.323)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -4,7 +4,7 @@ GIT
   branch: jfm/chef-17-berkshelf
   specs:
     berkshelf (8.0.7)
-      chef (~> 17.0)
+      chef (>= 15.7.32)
       chef-config
       cleanroom (~> 1.0)
       concurrent-ruby (~> 1.0)
@@ -19,11 +19,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 51d02fed12257bd713bf013e04da0135c4d0a327
+  revision: b73b772fe13500f546cc992a963aeba71d68991a
   branch: main
   specs:
     omnibus-software (24.6.323)
-      ffi (< 1.17.0)
       omnibus (>= 9.0.0)
 
 GIT
@@ -54,14 +53,14 @@ GEM
     artifactory (3.0.17)
     awesome_print (1.9.2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.901.0)
-    aws-sdk-core (3.191.5)
+    aws-partitions (1.937.0)
+    aws-sdk-core (3.196.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.78.0)
-      aws-sdk-core (~> 3, >= 3.191.0)
+    aws-sdk-kms (1.82.0)
+      aws-sdk-core (~> 3, >= 3.193.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.116.0)
       aws-sdk-core (~> 3, >= 3.127.0)
@@ -178,7 +177,7 @@ GEM
     citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.3)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.1)
     contracts (0.16.1)
     corefoundation (0.3.13)
       ffi (>= 1.15.0)
@@ -202,9 +201,6 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
-    ffi (1.16.3-x64-mingw32)
-    ffi (1.16.3-x86-mingw32)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -243,11 +239,11 @@ GEM
       train-core (~> 3.0)
       tty-prompt (~> 0.17)
       tty-table (~> 0.10)
-    iostruct (0.0.5)
+    iostruct (0.1.2)
     ipaddress (0.8.3)
     iso8601 (0.13.0)
     jmespath (1.6.2)
-    json (2.7.1)
+    json (2.7.2)
     kitchen-vagrant (2.0.0)
       test-kitchen (>= 1.4, < 4)
     libyajl2 (2.1.0)
@@ -286,20 +282,15 @@ GEM
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
-    mixlib-shellout (3.2.7-x64-mingw-ucrt)
-      chef-utils
-      ffi-win32-extensions (~> 1.0.3)
-      win32-process (~> 0.9)
-      wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
     molinillo (0.8.0)
     multi_json (1.15.0)
-    multipart-post (2.4.0)
+    multipart-post (2.4.1)
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (7.2.1)
+    net-ssh (7.2.3)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     nori (2.7.0)
@@ -324,7 +315,7 @@ GEM
     parslet (1.8.2)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pedump (0.6.7)
+    pedump (0.6.10)
       awesome_print
       iostruct (>= 0.0.4)
       multipart-post (>= 2.0.0)
@@ -335,11 +326,12 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.4)
+    public_suffix (5.0.5)
     rack (2.2.9)
     rainbow (3.1.1)
     retryable (3.0.5)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -373,6 +365,7 @@ GEM
       unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
+    strscan (3.1.0)
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
     test-kitchen (3.5.1)
@@ -393,7 +386,7 @@ GEM
     toml-rb (2.2.0)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.3.0)
-    train-core (3.11.0)
+    train-core (3.12.3)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)
@@ -470,7 +463,7 @@ GEM
       winrm (~> 2.0)
     wisper (2.0.1)
     wmi-lite (1.0.7)
-    zhexdump (0.0.2)
+    zhexdump (0.1.1)
 
 PLATFORMS
   ruby
@@ -482,6 +475,7 @@ PLATFORMS
 DEPENDENCIES
   artifactory
   berkshelf!
+  ffi (< 1.17.0)
   kitchen-vagrant (>= 1.3.1)
   omnibus!
   omnibus-software!

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -13,9 +13,21 @@ override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "6.3"
 override "nokogiri", version: "1.13.1"
-override "openssl", version: mac_os_x? ? "1.1.1m" : "1.0.2zi"
+# if you need to calculate openssl environment
+openssl_version_default =
+  case
+  when windows?, aix?
+    "1.0.2zi"
+  when macos?
+    "1.1.1m"
+  else
+    "3.0.9"
+  end
+# set OPENSSL_OVERRIDE variable to a different openssl version to test
+# builds for other versions in omnibus_software
+override "openssl", version: ENV.fetch("OPENSSL_OVERRIDE", openssl_version_default)
 override "pkg-config-lite", version: "0.28-1"
-override "ruby", version: "3.0.3"
+override "ruby", version: "3.0.3", openssl_gem: "3.2.0"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe "chef-client fips" do
+  def enable_fips
+    OpenSSL.fips_mode = true
+  end
+
+  # All tests assume fips mode is off at present
+  after { OpenSSL.fips_mode = false }
+
+  # For non-FIPS OSes/builds of Ruby, enabling FIPS should error
+  example "Error enabling fips_mode if FIPS not linked", fips_mode: false do
+    expect { enable_fips }.to raise_error(OpenSSL::OpenSSLError)
+  end
+
+  example "Do not error on MD5 if not fips_mode", fips_mode: false do
+    expect { OpenSSL::Digest.new("MD5", "test string for digesting") }.not_to raise_error
+  end
+
+  # For FIPS OSes/builds of Ruby, enabling FIPS should not error
+  example "Do not error enabling fips_mode if FIPS linked", fips_mode: true do
+    expect { enable_fips }.not_to raise_error
+  end
+
+  example "Error on MD5 if fips_mode", fips_mode: true do
+    enable_fips
+    expect { OpenSSL::Digest.new("MD5", "test string for digesting") }.to raise_error(OpenSSL::Digest::DigestError)
+  end
+end

--- a/spec/integration/client/open_ssl_spec.rb
+++ b/spec/integration/client/open_ssl_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe "openssl checks" do
+  let(:openssl_version_default) do
+    if windows? || aix?
+      "1.0.2zi"
+    elsif macos?
+      "1.1.1m"
+    else
+      "3.0.9"
+    end
+  end
+
+  %w{version library_version}.each do |method|
+    # macOS just picks up its own for some reason, maybe it circumvents a build step
+    example "check #{method}", not_supported_on_macos: true do
+      expect(OpenSSL.const_get("OPENSSL_#{method.upcase}")).to match(openssl_version_default), "OpenSSL doesn't match omnibus_overrides.rb"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,6 +138,8 @@ RSpec.configure do |config|
 
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
+  config.filter_run_excluding fips_mode: !fips_mode_build?
+
   config.filter_run_excluding windows_only: true unless windows?
   config.filter_run_excluding not_supported_on_windows: true if windows?
   config.filter_run_excluding not_supported_on_macos: true if macos?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -219,6 +219,10 @@ def aes_256_gcm?
   OpenSSL::Cipher.ciphers.include?("aes-256-gcm")
 end
 
+def fips_mode_build?
+  OpenSSL::OPENSSL_FIPS
+end
+
 def fips?
   ENV["CHEF_FIPS"] == "1"
 end

--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -92,7 +92,7 @@ describe Chef::Mixin::OpenSSLHelper do
 
     context "When the dhparam.pem file does exist, and does contain a vaild dhparam key" do
       it "returns true" do
-        @dhparam_file.puts(::OpenSSL::PKey::DH.new(256).to_pem) # this is 256 to speed up specs
+        @dhparam_file.puts(::OpenSSL::PKey::DH.new(1024).to_pem)
         @dhparam_file.close
         expect(instance.dhparam_pem_valid?(@dhparam_file.path)).to be_truthy
       end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
* install openssl 3.2.0 to backfill for custom openssl
* Set OpenSSL version to 1.0.2zi for Windows due to FIPS challenges and 3.0.9 for others.
* `::File.exists?` -> `::File.exist?` for `ssl_policies.rb` 
* Fix `EC` and modulus length for OpenSSL 3 compatibility
* OpenSSL validation checks

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
