### PR TITLE
Undoing PR that broke customers

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -146,7 +146,6 @@ class Chef
             if md = line.match(/^(\S*)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(.*)$/)
               (status, name, type, version, arch, repo) = [ md[1], md[2], md[3], md[4], md[5], md[6] ]
               next if version == "Version" # header
-              next if name != package_name
 
               # sometimes even though we request a specific version in the search string above and have match exact, we wind up
               # with other versions in the output, particularly getting the installed version when downgrading.

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -492,13 +492,4 @@ describe Chef::Provider::Package::Zypper do
     end
   end
 
-  describe "resolve_available_version" do
-    it "should return correct version if multiple packages are shown" do
-      status = double(stdout: "S  | Name                     | Type    | Version             | Arch   | Repository\n---+--------------------------+---------+---------------------+--------+-------------------------------------------------------------\n   | apache2-mod_wsgi         | package | 4.7.1-150400.3.3.1  | x86_64 | Update repository with updates from SUSE Linux Enterprise 15\n   | apache2-mod_wsgi         | package | 4.7.1-150400.1.52   | x86_64 | Main Repository\ni+ | apache2-mod_wsgi-python3 | package | 4.5.18-150000.4.6.1 | x86_64 | Update repository with updates from SUSE Linux Enterprise 15\nv  | apache2-mod_wsgi-python3 | package | 4.5.18-4.3.1        | x86_64 | Main Repository\n", exitstatus: 0)
-
-      allow(provider).to receive(:shell_out_compacted!).and_return(status)
-      result = provider.send(:resolve_available_version, "apache2-mod_wsgi-python3", nil)
-      expect(result).to eq("4.5.18-150000.4.6.1")
-    end
-  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We had taken an update from the [community ](https://github.com/chef/chef/pull/13691) to make zypper more idempotent. After releasing the update, we learned that this immediately broke SAP and had the exact opposite effect on customers as the PR intended - it made it impossible to install packages correctly. We're rolling this back here and will consider an update from the community in the future.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
