### PR TITLE
Jfm/chef17 update omnibus software2

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -286,6 +286,11 @@ GEM
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
+    mixlib-shellout (3.2.7-x64-mingw-ucrt)
+      chef-utils
+      ffi-win32-extensions (~> 1.0.3)
+      win32-process (~> 0.9)
+      wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
     molinillo (0.8.0)
     multi_json (1.15.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -19,10 +19,11 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 4ea194c46d42899f95db963f38abb9347a3d4731
+  revision: 51d02fed12257bd713bf013e04da0135c4d0a327
   branch: main
   specs:
-    omnibus-software (24.3.315)
+    omnibus-software (24.6.323)
+      ffi (< 1.17.0)
       omnibus (>= 9.0.0)
 
 GIT
@@ -281,11 +282,6 @@ GEM
     mixlib-shellout (3.2.7)
       chef-utils
     mixlib-shellout (3.2.7-universal-mingw32)
-      chef-utils
-      ffi-win32-extensions (~> 1.0.3)
-      win32-process (~> 0.9)
-      wmi-lite (~> 1.0)
-    mixlib-shellout (3.2.7-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating omnibus-software to get the version constraint for FFI 1.17.

```
[Admin] PS C:\localrepo\chef2\omnibus (jfm/chef17-update-omnibus-software2 +0 ~1 -0 ~) bundle update --conservative omnibus-software
Fetching https://github.com/chef/omnibus-software.git
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies............
Using public_suffix 5.0.4
Using artifactory 3.0.17
Using awesome_print 1.9.2
Using aws-eventstream 1.3.0
Using aws-partitions 1.901.0
Using jmespath 1.6.2
Using bcrypt_pbkdf 1.1.0 (x64-mingw32)
Using concurrent-ruby 1.2.3
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using ffi 1.16.3 (x64-mingw32)
Using wmi-lite 1.0.7
Using libyajl2 2.1.0
Using chef-vault 4.1.11
Using hashie 4.1.0
Using mixlib-log 3.0.9
Using uuidtools 2.2.0
Using webrick 1.8.1
Using rack 2.2.9
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using iniparse 1.5.0
Using faraday-em_http 1.0.0
Using faraday-em_synchrony 1.0.0
Using faraday-excon 1.1.0
Using faraday-net_http 1.0.1
Using faraday-net_http_persistent 1.2.0
Using multipart-post 2.4.0
Using ruby2_keywords 0.0.5
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using unicode-display_width 2.5.0
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using tty-screen 0.8.2
Using wisper 2.0.1
Using method_source 1.0.0
Using parallel 1.24.0
Using parslet 1.8.2
Using coderay 1.1.3
Using rspec-support 3.11.1
Using rubyzip 2.3.2
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.3.1
Using json 2.7.1
Using net-ssh 7.2.1
Using iso8601 0.13.0
Using mixlib-authentication 3.0.10
Using mixlib-cli 2.1.8
Using ipaddress 0.8.3
Using plist 3.7.1
Using proxifier 1.0.3
Using syslog-logger 1.6.8
Using builder 3.2.4
Using erubi 1.12.0
Using rexml 3.2.6
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using bigdecimal 3.1.7
Using multi_json 1.15.0
Using rubyntlm 0.6.3
Using win32-api 1.5.3 (universal-mingw32)
Using structured_warnings 0.4.0
Using cleanroom 1.0.0
Using bundler 2.3.18
Using minitar 0.9
Using retryable 3.0.5
Using molinillo 0.8.0
Using chef-cleanroom 1.0.5
Using citrus 3.0.2
Using contracts 0.16.1
Using ed25519 1.3.0
Using iostruct 0.0.5
Using mixlib-versioning 1.2.12
Using rainbow 3.1.1
Using zhexdump 0.0.2
Using ruby-progressbar 1.13.0
Using addressable 2.8.6
Using aws-sigv4 1.8.0
Using chef-utils 17.10.0
Using mixlib-config 3.0.27
Using ffi-win32-extensions 1.0.4
Using win32-process 0.10.0
Using ffi-yajl 2.6.0
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.14
Using gssapi 1.3.1
Using win32-ipc 0.7.0
Using win32-eventlog 0.6.3
Using win32-mmap 0.4.2
Using mixlib-archive 1.1.7 (universal-mingw32)
Using faraday 1.4.3
Using pastel 0.8.0
Using strings 0.2.1
Using tty-reader 0.9.0
Using pry 0.14.2
Using rspec-core 3.11.0
Using rspec-expectations 3.11.1
Using rspec-mocks 3.11.2
Using gyoku 1.4.0
Using net-scp 4.0.0
Using net-sftp 2.1.2
Using net-ssh-gateway 2.0.0
Using logging 2.3.1
Using nori 2.7.0
Using win32-taskscheduler 2.0.4
Using solve 4.0.4
Using toml-rb 2.2.0
Using aws-sdk-core 3.191.5
Using vault 0.18.2
Using pedump 0.6.7
Using mixlib-shellout 3.2.7 (universal-mingw32)
Using win32-service 2.3.2
Using chef-powershell 1.0.13
Using chef-zero 15.0.11
Using win32-event 0.6.3
Using win32-mutex 0.4.3
Using faraday_middleware 1.2.0
Using tty-box 0.7.0
Using tty-prompt 0.23.1
Using tty-table 0.12.0
Using sawyer 0.9.2
Using rspec 3.11.0
Using rspec-its 1.3.0
Using winrm 2.3.6
Using aws-sdk-kms 1.78.0
Using aws-sdk-secretsmanager 1.90.0
Using chef-config 17.10.0
Using train-core 3.11.0
Using mixlib-install 3.12.30
Using license_scout 1.3.7
Using win32-certstore 0.6.16
Using license-acceptance 2.1.13
Using octokit 4.25.1
Using aws-sdk-s3 1.116.0
Using winrm-fs 1.3.5
Using chef-telemetry 1.1.1
Using ohai 17.9.4
Using inspec-core 4.56.20
Using omnibus 9.0.25 from https://github.com/chef/omnibus.git (at main@5c0122b)
Using winrm-elevated 1.2.3
Using train-winrm 0.2.13
Using test-kitchen 3.5.1
Using chef 17.10.0 (universal-mingw32)
Using kitchen-vagrant 2.0.0
Using berkshelf 8.0.7 from https://github.com/chef/berkshelf.git (at jfm/chef-17-berkshelf@dcdb969)
Using omnibus-software 24.6.323 (was 24.3.315) from https://github.com/chef/omnibus-software.git (at main@51d02fe)
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
