### PR TITLE
Chef 18.5: OpenSSL 3 / chef-foundation split version

### DIFF
--- a/.buildkite-platform.json
+++ b/.buildkite-platform.json
@@ -1,4 +1,4 @@
 {
-    "chef_foundation": "3.2.7",
+    "chef_foundation": "3.2.8",
     "omnibus_toolchain": "3.0.28"
 }

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -164,13 +164,7 @@ then
     echo "  plugins:"
     echo "  - chef/omnibus#v0.2.88:"
     echo "      build: chef"
-    # temporary fix to make sure AIX builds
-    if [[ $platform == *"aix"* ]]
-    then
-      echo "      chef-foundation-version: 3.1.20"
-    else
-      echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
-    fi
+    echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
     echo "      config: omnibus/omnibus.rb"
     echo "      install-dir: \"/opt/chef\""
     if [ $build_key == "mac_os_x-11-x86_64" ]

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -164,7 +164,13 @@ then
     echo "  plugins:"
     echo "  - chef/omnibus#v0.2.88:"
     echo "      build: chef"
-    echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
+    # temporary fix to make sure AIX builds
+    if [[ $platform == *"aix"* ]]
+    then
+      echo "      chef-foundation-version: 3.1.20"
+    else
+      echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
+    fi
     echo "      config: omnibus/omnibus.rb"
     echo "      install-dir: \"/opt/chef\""
     if [ $build_key == "mac_os_x-11-x86_64" ]
@@ -235,7 +241,7 @@ then
         echo "    queue: docker-linux-arm64"
       else
         echo "    queue: default-privileged"
-      fi      
+      fi
       echo "  plugins:"
       echo "  - docker#v3.5.0:"
       echo "      image: chefes/omnibus-toolchain-${platform%:*}:$OMNIBUS_TOOLCHAIN_VERSION" | sed 's/-arm//'

--- a/.expeditor/scripts/download_built_omnibus_pkgs.sh
+++ b/.expeditor/scripts/download_built_omnibus_pkgs.sh
@@ -1,11 +1,11 @@
 #! /bin/bash
 set -eu -o pipefail
 
-if [[ "$BUILDKITE_LABEL" =~ "el-.*-x86_64" || \
-      "$BUILDKITE_LABEL" =~ "el-.*-ppc64" || \
-      "$BUILDKITE_LABEL" =~ "el-.*aarch" || \
-      "$BUILDKITE_LABEL" =~ "ubuntu-" || \
-      "$BUILDKITE_LABEL" =~ "amazon-2023" ]]
+if [[ "${BUILDKITE_LABEL:-}" =~ "el-.*-x86_64" || \
+      "${BUILDKITE_LABEL:-}" =~ "el-.*-ppc64" || \
+      "${BUILDKITE_LABEL:-}" =~ "el-.*aarch" || \
+      "${BUILDKITE_LABEL:-}" =~ "ubuntu-" || \
+      "${BUILDKITE_LABEL:-}" =~ "amazon-2023" ]]
 then
   echo "%% Installing with OPENSSL_FIPS=1 %%"
   export OPENSSL_FIPS=1

--- a/.expeditor/scripts/download_built_omnibus_pkgs.sh
+++ b/.expeditor/scripts/download_built_omnibus_pkgs.sh
@@ -1,6 +1,16 @@
 #! /bin/bash
 set -eu -o pipefail
 
+if [[ "$BUILDKITE_LABEL" =~ "el-.*-x86_64" || \
+      "$BUILDKITE_LABEL" =~ "el-.*-ppc64" || \
+      "$BUILDKITE_LABEL" =~ "el-.*aarch" || \
+      "$BUILDKITE_LABEL" =~ "ubuntu-" || \
+      "$BUILDKITE_LABEL" =~ "amazon-2023" ]]
+then
+  echo "%% Installing with OPENSSL_FIPS=1 %%"
+  export OPENSSL_FIPS=1
+fi
+
 echo "--- Installing package from BuildKite"
 
 if [[ $OSTYPE == "msys" ]]; then

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt
 gem "ffi", ">= 1.15.5"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
+# required for FIPS or bundler will pick up default openssl
+gem "openssl", "= 3.2.0" unless Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" }
 
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,14 +297,14 @@ GEM
     mixlib-config (3.0.27)
       tomlrb
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.7)
+    mixlib-shellout (3.2.8)
       chef-utils
-    mixlib-shellout (3.2.7-universal-mingw32)
+    mixlib-shellout (3.2.8-universal-mingw32)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
-    mixlib-shellout (3.2.7-x64-mingw-ucrt)
+    mixlib-shellout (3.2.8-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
@@ -323,6 +323,7 @@ GEM
     net-ssh (7.1.0)
     netrc (0.11.0)
     nori (2.6.0)
+    openssl (3.2.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -503,6 +504,7 @@ DEPENDENCIES
   ffi (>= 1.15.5)
   inspec-core-bin (>= 5, < 6)
   ohai!
+  openssl (= 3.2.0)
   pry (= 0.13.0)
   pry-byebug
   pry-stack_explorer

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -8,6 +8,8 @@ gem "artifactory"
 
 gem "pedump"
 
+gem "ffi", "< 1.17"
+
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
 # the Test Kitchen-based build lab. You can skip these unnecessary dependencies

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.3)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.3)
     contracts (0.16.1)
     corefoundation (0.3.13)
       ffi (>= 1.15.0)
@@ -193,7 +193,6 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
     ffi-libarchive (1.1.3)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -274,14 +273,14 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.2.7)
+    mixlib-shellout (3.2.8)
       chef-utils
-    mixlib-shellout (3.2.7-universal-mingw32)
+    mixlib-shellout (3.2.8-universal-mingw32)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
-    mixlib-shellout (3.2.7-x64-mingw-ucrt)
+    mixlib-shellout (3.2.8-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
@@ -450,7 +449,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
     uuidtools (2.2.0)
@@ -511,6 +509,7 @@ PLATFORMS
 DEPENDENCIES
   artifactory
   berkshelf (>= 8.0)
+  ffi (< 1.17)
   kitchen-vagrant (>= 1.3.1)
   omnibus!
   omnibus-software!

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -ueo pipefail
 
+if [[ "$BUILDKITE_LABEL" =~ "el-.*-x86_64" || \
+      "$BUILDKITE_LABEL" =~ "el-.*-ppc64" || \
+      "$BUILDKITE_LABEL" =~ "el-.*aarch" || \
+      "$BUILDKITE_LABEL" =~ "ubuntu-" || \
+      "$BUILDKITE_LABEL" =~ "amazon-2023" ]]
+then
+  export OPENSSL_FIPS=1
+fi
+
 # Our tests hammer YUM pretty hard and the EL6 testers get corrupted
 # after some period of time. Rebuilding the RPM database clears
 # up the underlying corruption. We'll do this each test run just to
@@ -126,7 +135,6 @@ sudo_path="$(command -v sudo)"
 rhel_sudo="/opt/rh/devtoolset-7/root/usr/bin/sudo"
 sudo_args=""
 if [[ "$sudo_path" != "$rhel_sudo" ]]; then
-  echo "HERE"
   sudo -E bundle install --jobs=3 --retry=3
   sudo -E bundle exec rspec --profile -f progress
 else

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -ueo pipefail
 
-if [[ "$BUILDKITE_LABEL" =~ "el-.*-x86_64" || \
-      "$BUILDKITE_LABEL" =~ "el-.*-ppc64" || \
-      "$BUILDKITE_LABEL" =~ "el-.*aarch" || \
-      "$BUILDKITE_LABEL" =~ "ubuntu-" || \
-      "$BUILDKITE_LABEL" =~ "amazon-2023" ]]
+if [[ "${BUILDKITE_LABEL:-}" =~ "el-.*-x86_64" || \
+      "${BUILDKITE_LABEL:-}" =~ "el-.*-ppc64" || \
+      "${BUILDKITE_LABEL:-}" =~ "el-.*aarch" || \
+      "${BUILDKITE_LABEL:-}" =~ "ubuntu-" || \
+      "${BUILDKITE_LABEL:-}" =~ "amazon-2023" ]]
 then
   export OPENSSL_FIPS=1
 fi

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -22,7 +22,7 @@ describe "chef-client fips" do
     expect { enable_fips }.not_to raise_error
   end
 
-  example "Error on MD5 if fips_mode", :fips_mode_test
+  example "Error on MD5 if fips_mode", :fips_mode_test do
     enable_fips
     expect { OpenSSL::Digest.new("MD5", "test string for digesting") }.to raise_error(OpenSSL::Digest::DigestError)
   end

--- a/spec/integration/client/fips_spec.rb
+++ b/spec/integration/client/fips_spec.rb
@@ -9,20 +9,20 @@ describe "chef-client fips" do
   after { OpenSSL.fips_mode = false }
 
   # For non-FIPS OSes/builds of Ruby, enabling FIPS should error
-  example "Error enabling fips_mode if FIPS not linked", fips_mode: false do
+  example "Error enabling fips_mode if FIPS not linked", :fips_mode_negative_test do
     expect { enable_fips }.to raise_error(OpenSSL::OpenSSLError)
   end
 
-  example "Do not error on MD5 if not fips_mode", fips_mode: false do
+  example "Do not error on MD5 if not fips_mode", :fips_mode_negative_test do
     expect { OpenSSL::Digest.new("MD5", "test string for digesting") }.not_to raise_error
   end
 
   # For FIPS OSes/builds of Ruby, enabling FIPS should not error
-  example "Do not error enabling fips_mode if FIPS linked", fips_mode: true do
+  example "Do not error enabling fips_mode if FIPS linked", :fips_mode_test do
     expect { enable_fips }.not_to raise_error
   end
 
-  example "Error on MD5 if fips_mode", fips_mode: true do
+  example "Error on MD5 if fips_mode", :fips_mode_test
     enable_fips
     expect { OpenSSL::Digest.new("MD5", "test string for digesting") }.to raise_error(OpenSSL::Digest::DigestError)
   end

--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -84,7 +84,7 @@ describe "chef-client" do
 
   # Some Solaris test platforms are too old for IPv6. These tests should not
   # otherwise be platform dependent, so exclude solaris
-  when_the_chef_server "is running on IPv6", :not_supported_on_solaris, :not_supported_on_gce, :not_supported_on_aix, :not_supported_on_s390x do
+  when_the_chef_server "is running on IPv6", :not_supported_on_solaris, :not_supported_on_gce, :not_supported_on_aix do
 
     when_the_repository "has a cookbook with a no-op recipe" do
       before do

--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -84,7 +84,7 @@ describe "chef-client" do
 
   # Some Solaris test platforms are too old for IPv6. These tests should not
   # otherwise be platform dependent, so exclude solaris
-  when_the_chef_server "is running on IPv6", :not_supported_on_solaris, :not_supported_on_gce, :not_supported_on_aix do
+  when_the_chef_server "is running on IPv6", :not_supported_on_solaris, :not_supported_on_gce, :not_supported_on_aix, :not_supported_on_s390x do
 
     when_the_repository "has a cookbook with a no-op recipe" do
       before do

--- a/spec/integration/client/open_ssl_spec.rb
+++ b/spec/integration/client/open_ssl_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe "openssl checks" do
+  let(:openssl_version_default) do
+    if windows? || aix?
+      "1.0.2zi"
+    elsif macos?
+      "1.1.1m"
+    else
+      "3.0.9"
+    end
+  end
+
+  %w{version library_version}.each do |method|
+    # macOS just picks up its own for some reason, maybe it circumvents a build step
+    example "check #{method}", not_supported_on_macos: true do
+      expect(OpenSSL.const_get("OPENSSL_#{method.upcase}")).to match(openssl_version_default), "OpenSSL doesn't match omnibus_overrides.rb"
+    end
+  end
+end

--- a/spec/integration/client/open_ssl_spec.rb
+++ b/spec/integration/client/open_ssl_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "openssl checks" do
   let(:openssl_version_default) do
-    if windows? || aix?
+    if windows?
       "1.0.2zi"
     elsif macos?
       "1.1.1m"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -181,6 +181,7 @@ RSpec.configure do |config|
   config.filter_run_excluding aes_256_gcm_only: true unless aes_256_gcm?
   config.filter_run_excluding broken: true
   config.filter_run_excluding not_wpar: true unless wpar?
+  config.filter_run_excluding not_supported_on_s390x: true unless s390x?
   config.filter_run_excluding not_supported_under_fips: true if fips?
   config.filter_run_excluding rhel: true unless rhel?
   config.filter_run_excluding rhel6: true unless rhel6?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,7 +138,8 @@ RSpec.configure do |config|
 
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
-  config.filter_run_excluding fips_mode: !fips_mode_build?
+  config.filter_run_excluding fips_mode: true unless fips_mode_build?
+  config.filter_run_excluding fips_mode: false # disable all fips_mode negative tests
   # Skip fips on windows
   # config.filter_run_excluding :fips_mode if windows?
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,8 +138,8 @@ RSpec.configure do |config|
 
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
-  config.filter_run_excluding fips_mode: true unless fips_mode_build?
-  config.filter_run_excluding fips_mode: false # disable all fips_mode negative tests
+  config.filter_run_excluding fips_mode_test: true unless fips_mode_build?
+  config.filter_run_excluding fips_mode_negative_test: true # disable all fips_mode negative tests
   # Skip fips on windows
   # config.filter_run_excluding :fips_mode if windows?
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -175,6 +175,10 @@ def wpar?
   !((ohai[:virtualization] || {})[:wpar_no].nil?)
 end
 
+def s390x?
+  RUBY_PLATFORM.include?("s390x")
+end
+
 def supports_cloexec?
   Fcntl.const_defined?(:F_SETFD) && Fcntl.const_defined?(:FD_CLOEXEC)
 end

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -67,10 +67,10 @@ end
 
 def win32_os_version
   @win32_os_version ||= begin
-    wmi = WmiLite::Wmi.new
-    host = wmi.first_of("Win32_OperatingSystem")
-    host["version"]
-  end
+                          wmi = WmiLite::Wmi.new
+                          host = wmi.first_of("Win32_OperatingSystem")
+                          host["version"]
+                        end
 end
 
 def windows_powershell_dsc?
@@ -80,7 +80,7 @@ def windows_powershell_dsc?
   begin
     wmi = WmiLite::Wmi.new("root/microsoft/windows/desiredstateconfiguration")
     lcm = wmi.query("SELECT * FROM meta_class WHERE __this ISA 'MSFT_DSCLocalConfigurationManager'")
-    supports_dsc = !! lcm
+    supports_dsc = !!lcm
   rescue WmiLite::WmiException
   end
   supports_dsc
@@ -95,7 +95,7 @@ end
 
 # detects if the hardware is 64-bit (evaluates to true in "WOW64" mode in a 32-bit app on a 64-bit system)
 def windows64?
-  windows? && ( ENV["PROCESSOR_ARCHITECTURE"] == "AMD64" || ENV["PROCESSOR_ARCHITEW6432"] == "AMD64" )
+  windows? && (ENV["PROCESSOR_ARCHITECTURE"] == "AMD64" || ENV["PROCESSOR_ARCHITEW6432"] == "AMD64")
 end
 
 # detects if the hardware is 32-bit
@@ -224,7 +224,15 @@ def aes_256_gcm?
 end
 
 def fips_mode_build?
-  OpenSSL::OPENSSL_FIPS
+  if ENV.include?("BUILDKITE_LABEL") # try keying directly off Buildkite environments
+    # regex version of chef/chef-foundation:.expeditor/release.omnibus.yml:fips-platforms
+    [/el-.*-x86_64/, /el-.*-ppc64/, /el-.*aarch/, /ubuntu-/, /windows-/, /amazon-2/].any? do |os_arch|
+      ENV["BUILDKITE_LABEL"].match?(os_arch)
+    end
+  else
+    # if you're testing your local build
+    OpenSSL::OPENSSL_FIPS
+  end
 end
 
 def fips?
@@ -233,6 +241,7 @@ end
 
 class HttpHelper
   extend Ohai::Mixin::HttpHelper
+
   def self.logger
     Chef::Log
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
`chef-foundation` bump to `3.2.8` for build and environment fixes.

Leave AIX on `chef-foundation` version `3.1.20`

Force `OPENSSL_FIPS` before installation and build of anything that builds `openssl` gem.

Include `openssl` gem in `Gemfile` to ensure that a FIPS enabled version of `openssl` is used, versus the default for the ruby install.

Determine whether to do `fips_mode` tests by a list of platforms carried from the `chef-foundation` `release.omnibus.yml` `fips-platforms` and mapped to associated testers.

`mixlib-shellout` version `bundle update` for fixes to build.

```bash
❯ bundle update --conservative mixlib-shellout
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using rake 13.0.6
Using public_suffix 5.0.1
Using mixlib-cli 2.1.8
Using concurrent-ruby 1.2.2
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using aws-partitions 1.739.0
Using ast 2.4.2
Using hashie 4.1.0
Using mixlib-log 3.0.9
Using aws-eventstream 1.2.0
Using webrick 1.8.1
Using ffi 1.16.3
Using diff-lcs 1.5.0
Using erubis 2.7.0
Using rack 2.2.6.4
Using bundler 2.3.26
Using ruby2_keywords 0.0.5
Using tty-color 0.6.0
Using byebug 11.1.3
Using unicode-display_width 2.4.2
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using tty-screen 0.8.1
Using fuzzyurl 0.9.0
Using faraday-net_http 3.0.2
Using builder 3.2.4
Using parallel 1.22.1
Using parslet 1.8.2
Using coderay 1.1.3
Using rspec-support 3.11.1
Using rubyzip 2.3.2
Using strings-ansi 0.2.0
Using sslshake 1.3.1
Using thor 1.2.1
Using json 2.6.3
Using net-ssh 7.1.0
Using mixlib-authentication 3.0.10
Using multipart-post 2.3.0
Using jmespath 1.6.2
Using uuidtools 2.2.0
Using iniparse 1.5.0
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using semverse 3.0.2
Using syslog-logger 1.6.8
Using unf_ext 0.0.8.2
Using mime-types-data 3.2023.0218.1
Using netrc 0.11.0
Using erubi 1.12.0
Using rexml 3.2.5
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using multi_json 1.15.0
Using nori 2.6.0
Using rubyntlm 0.6.3
Using libyajl2 2.1.0
Using http-accept 1.7.0
Using date 3.3.3
Using timeout 0.3.2
Using ruby-progressbar 1.13.0
Using openssl 3.2.0
Using ipaddress 0.8.3
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using hashdiff 1.0.1
Using addressable 2.8.2
Using chef-utils 18.4.56 from source at `chef-utils`
Using wisper 2.0.1
Using rb-readline 0.5.5
Using mixlib-config 3.0.27
Using mixlib-archive 1.1.7
Using parser 3.2.2.0
Using method_source 1.0.0
Using gssapi 1.3.1
Using faraday 2.7.4
Using rspec-core 3.11.0
Using rspec-expectations 3.11.1
Using corefoundation 0.3.13
Using regexp_parser 2.7.0
Using net-scp 4.0.0
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using unf 0.1.4
Using ffi-libarchive 1.1.3
Using gyoku 1.4.0
Using logging 2.3.1
Using crack 0.4.5
Using ffi-yajl 2.6.0
Using time 0.2.2
Using net-protocol 0.2.1
Using plist 3.7.0
Using pastel 0.8.0
Using tty-reader 0.9.0
Using mime-types 3.4.1
Using faraday-follow_redirects 0.3.0
Using rspec-its 1.3.0
Using chef-zero 15.0.11
Fetching mixlib-shellout 3.2.8 (was 3.2.7)
Using strings 0.2.1
Using debug_inspector 1.1.0
Using domain_name 0.5.20190701
Using winrm 2.3.6
Using webmock 3.19.1
Using tty-box 0.7.0
Using tty-prompt 0.23.1
Using tty-table 0.12.0
Using cheffish 17.1.5
Using rubocop-ast 1.28.0
Using pry 0.13.0
Using rainbow 3.1.1
Using pry-byebug 3.10.1
Using ed25519 1.3.0
Using rspec-mocks 3.11.2
Using aws-sigv4 1.5.2
Using rspec 3.11.0
Using http-cookie 1.0.5
Using aws-sdk-core 3.171.0
Using vault 0.18.2
Using license-acceptance 2.1.13
Using winrm-fs 1.3.5
Using rubocop 1.25.1
Using net-ftp 0.2.0
Using aws-sdk-secretsmanager 1.73.0
Using chefstyle 2.2.2
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using aws-sdk-kms 1.63.0
Using winrm-elevated 1.2.3
Using binding_of_caller 1.0.0
Using aws-sdk-s3 1.120.0
Using train-winrm 0.2.13
Using pry-stack_explorer 0.6.1
Installing mixlib-shellout 3.2.8 (was 3.2.7)
Using chef-config 18.4.56 from source at `chef-config`
Using train-core 3.10.7
Using chef-telemetry 1.1.1
Using appbundler 0.13.4
Using ohai 18.1.11 from https://github.com/chef/ohai.git (at main@d5d0324)
Using train-rest 0.5.0
Using inspec-core 5.22.40
Using inspec-core-bin 5.22.40
Using chef 18.4.56 from source at `.`
Using chef-bin 18.4.56 from source at `chef-bin` and installing its executables
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
