### PR TITLE
Add helper, filter, and tags to prevent s390x ipv6 tests from running

### DIFF
--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -84,7 +84,7 @@ describe "chef-client" do
 
   # Some Solaris test platforms are too old for IPv6. These tests should not
   # otherwise be platform dependent, so exclude solaris
-  when_the_chef_server "is running on IPv6", :not_supported_on_solaris, :not_supported_on_gce, :not_supported_on_aix do
+  when_the_chef_server "is running on IPv6", :not_supported_on_solaris, :not_supported_on_gce, :not_supported_on_aix, :not_supported_on_s390x do
 
     when_the_repository "has a cookbook with a no-op recipe" do
       before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -180,6 +180,7 @@ RSpec.configure do |config|
   config.filter_run_excluding aes_256_gcm_only: true unless aes_256_gcm?
   config.filter_run_excluding broken: true
   config.filter_run_excluding not_wpar: true unless wpar?
+  config.filter_run_excluding not_supported_on_s390x: true unless s390x?
   config.filter_run_excluding not_supported_under_fips: true if fips?
   config.filter_run_excluding rhel: true unless rhel?
   config.filter_run_excluding rhel6: true unless rhel6?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -175,6 +175,10 @@ def wpar?
   !((ohai[:virtualization] || {})[:wpar_no].nil?)
 end
 
+def s390x?
+  RUBY_PLATFORM.include?("s390x")
+end
+
 def supports_cloexec?
   Fcntl.const_defined?(:F_SETFD) && Fcntl.const_defined?(:FD_CLOEXEC)
 end


### PR DESCRIPTION
## Description
ipv6 is disabled on the builder hosts for s390x hosts due to connection stability errors in the environment.
- add a platform helper to flag when `RUBY_PLATFORM` contains `s390x`
- add a filter tag `:not_supported_on_s390x`
- add tags to the ipv6 tests of concern

[internal adhoc build to validate](https://buildkite.com/chef/chef-chef-main-validate-adhoc/builds/1624)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
