### PR TITLE
Updating Fedora openssl libs

### DIFF
--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -9,6 +9,8 @@ echo "ruby version:"
 ruby -v
 echo "bundler version:"
 bundle -v
+echo "openssl version:"
+openssl version
 
 echo "--- Preparing Container..."
 

--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -9,11 +9,6 @@ echo "ruby version:"
 ruby -v
 echo "bundler version:"
 bundle -v
-echo "openssl version:"
-export PATH=$PATH:/usr/bin
-openssl version
-echo "chef-client version:"
-chef-client -v
 
 echo "--- Preparing Container..."
 

--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -11,6 +11,8 @@ echo "bundler version:"
 bundle -v
 echo "openssl version:"
 openssl version
+echo "chef-client version:"
+chef-client -v
 
 echo "--- Preparing Container..."
 

--- a/.expeditor/scripts/bk_container_prep.sh
+++ b/.expeditor/scripts/bk_container_prep.sh
@@ -10,6 +10,7 @@ ruby -v
 echo "bundler version:"
 bundle -v
 echo "openssl version:"
+export PATH=$PATH:/usr/bin
 openssl version
 echo "chef-client version:"
 chef-client -v

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -190,7 +190,7 @@ steps:
 - label: "Integration Fedora :ruby: 3.0"
   commands:
     - dnf install -y libxcrypt-compat
-    - dnf groupinstall -y development-tools rpm-development-tools c-development 
+    - dnf groupinstall -y development-tools rpm-development-tools c-development openssl1.1-devel openssl1.1
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -206,7 +206,7 @@ steps:
 - label: "Functional Fedora :ruby: 3.0"
   commands:
     - dnf install -y libxcrypt-compat
-    - dnf groupinstall -y development-tools rpm-development-tools c-development 
+    - dnf groupinstall -y development-tools rpm-development-tools c-development openssl1.1-devel openssl1.1
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -226,7 +226,7 @@ steps:
 - label: "Unit Fedora :ruby: 3.0"
   commands:
     - dnf install -y libxcrypt-compat
-    - dnf groupinstall -y development-tools rpm-development-tools c-development 
+    - dnf groupinstall -y development-tools rpm-development-tools c-development openssl1.1-devel openssl1.1
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -190,7 +190,9 @@ steps:
 - label: "Integration Fedora :ruby: 3.0"
   commands:
     - dnf install -y libxcrypt-compat
-    - dnf groupinstall -y development-tools rpm-development-tools c-development openssl1.1-devel openssl1.1
+    - dnf groupinstall -y development-tools rpm-development-tools c-development
+    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -206,7 +208,9 @@ steps:
 - label: "Functional Fedora :ruby: 3.0"
   commands:
     - dnf install -y libxcrypt-compat
-    - dnf groupinstall -y development-tools rpm-development-tools c-development openssl1.1-devel openssl1.1
+    - dnf groupinstall -y development-tools rpm-development-tools c-development
+    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -226,7 +230,9 @@ steps:
 - label: "Unit Fedora :ruby: 3.0"
   commands:
     - dnf install -y libxcrypt-compat
-    - dnf groupinstall -y development-tools rpm-development-tools c-development openssl1.1-devel openssl1.1
+    - dnf groupinstall -y development-tools rpm-development-tools c-development
+    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -191,8 +191,8 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-   # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - sudo /usr/share/bash-completion/completions/openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
@@ -211,7 +211,7 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - sudo /usr/share/bash-completion/completions/openssl version
@@ -235,7 +235,7 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - sudo /usr/share/bash-completion/completions/openssl version

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -189,7 +189,8 @@ steps:
 
 - label: "Integration Fedora :ruby: 3.0"
   commands:
-    - dnf install libxcrypt-compat -y
+    - dnf install -y libxcrypt-compat
+    - dnf groupinstall -y development-tools rpm-development-tools c-development 
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -204,7 +205,8 @@ steps:
 
 - label: "Functional Fedora :ruby: 3.0"
   commands:
-    - dnf install libxcrypt-compat -y
+    - dnf install -y libxcrypt-compat
+    - dnf groupinstall -y development-tools rpm-development-tools c-development 
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -223,7 +225,8 @@ steps:
 
 - label: "Unit Fedora :ruby: 3.0"
   commands:
-    - dnf install libxcrypt-compat -y
+    - dnf install -y libxcrypt-compat
+    - dnf groupinstall -y development-tools rpm-development-tools c-development 
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -192,7 +192,7 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -210,7 +210,7 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -232,7 +232,7 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -191,10 +191,12 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - yum install openssl1.1.x86_64
+    # - yum install openssl1.1.x86_64
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
+    - echo "yum repo list:"
+    - yum repolist
     - echo "which openssl:"
     - which openssl
     - /workdir/.expeditor/scripts/bk_container_prep.sh
@@ -213,10 +215,12 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - yum install openssl1.1.x86_64
+    # - yum install openssl1.1.x86_64
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
+    - echo "yum repo list:"
+    - yum repolist
     - echo "which openssl:"
     - which openssl
     - /workdir/.expeditor/scripts/bk_container_prep.sh
@@ -239,10 +243,12 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - yum install openssl1.1.x86_64
+    # - yum install openssl1.1.x86_64
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
+    - echo "yum repo list:"
+    - yum repolist
     - echo "which openssl:"
     - which openssl
     - /workdir/.expeditor/scripts/bk_container_prep.sh

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -199,8 +199,9 @@ steps:
     - yum list openssl
     - echo "yum repo list:"
     - yum repolist
-    - echo "which openssl:"
-    - which openssl
+    - echo "cleaning yum:"
+    - yum cleanall
+    - yum update -y
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -225,8 +226,9 @@ steps:
     - yum list openssl
     - echo "yum repo list:"
     - yum repolist
-    - echo "which openssl:"
-    - which openssl
+    - echo "cleaning yum:"
+    - yum cleanall
+    - yum update -y
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -255,8 +257,9 @@ steps:
     - yum list openssl
     - echo "yum repo list:"
     - yum repolist
-    - echo "which openssl:"
-    - which openssl
+    - echo "cleaning yum:"
+    - yum cleanall
+    - yum update -y
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -219,6 +219,8 @@ steps:
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
+    - echo "yum list openssl:"
+    - yum list openssl
     - echo "yum repo list:"
     - yum repolist
     - echo "which openssl:"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -193,6 +193,9 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - echo "openssl version:"
+    - export PATH=$PATH:/usr/bin
+    - openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -211,6 +214,9 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - echo "openssl version:"
+    - export PATH=$PATH:/usr/bin
+    - openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -233,6 +239,9 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - echo "openssl version:"
+    - export PATH=$PATH:/usr/bin
+    - openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -189,6 +189,7 @@ steps:
 
 - label: "Integration Fedora :ruby: 3.0"
   commands:
+    - dnf install libxcrypt-compat
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -203,6 +204,7 @@ steps:
 
 - label: "Functional Fedora :ruby: 3.0"
   commands:
+    - dnf install libxcrypt-compat
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -221,6 +223,7 @@ steps:
 
 - label: "Unit Fedora :ruby: 3.0"
   commands:
+    - dnf install libxcrypt-compat
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -192,9 +192,9 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - /usr/share/bash-completion/completions/openssl version
    # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
+    - sudo /usr/share/bash-completion/completions/openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -212,9 +212,9 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - /usr/share/bash-completion/completions/openssl version
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
+    - sudo /usr/share/bash-completion/completions/openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -236,9 +236,9 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - /usr/share/bash-completion/completions/openssl version
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
+    - sudo /usr/share/bash-completion/completions/openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -194,7 +194,8 @@ steps:
     # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
-    - sudo /usr/share/bash-completion/completions/openssl version
+    - cd /usr/share/bash-completion/completions/
+    - openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -214,7 +215,8 @@ steps:
     # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
-    - sudo /usr/share/bash-completion/completions/openssl version
+    - cd /usr/share/bash-completion/completions/
+    - openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -238,7 +240,8 @@ steps:
     # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
-    - sudo /usr/share/bash-completion/completions/openssl version
+    - cd /usr/share/bash-completion/completions/
+    - openssl version
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -189,7 +189,7 @@ steps:
 
 - label: "Integration Fedora :ruby: 3.0"
   commands:
-    - dnf install libxcrypt-compat
+    - dnf install libxcrypt-compat -y
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -204,7 +204,7 @@ steps:
 
 - label: "Functional Fedora :ruby: 3.0"
   commands:
-    - dnf install libxcrypt-compat
+    - dnf install libxcrypt-compat -y
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -223,7 +223,7 @@ steps:
 
 - label: "Unit Fedora :ruby: 3.0"
   commands:
-    - dnf install libxcrypt-compat
+    - dnf install libxcrypt-compat -y
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -191,7 +191,7 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - cd /usr/share/bash-completion/completions/
@@ -212,7 +212,7 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - cd /usr/share/bash-completion/completions/
@@ -237,7 +237,7 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    # - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - cd /usr/share/bash-completion/completions/

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -193,9 +193,9 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
-    - find / -name openssl -type f
-    - cd /usr/share/bash-completion/completions/
-    - openssl version
+    # - find / -name openssl -type f
+    - echo "which openssl:"
+    - which openssl
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -214,9 +214,9 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
-    - find / -name openssl -type f
-    - cd /usr/share/bash-completion/completions/
-    - openssl version
+    # - find / -name openssl -type f
+    - echo "which openssl:"
+    - which openssl
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -239,9 +239,9 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
-    - find / -name openssl -type f
-    - cd /usr/share/bash-completion/completions/
-    - openssl version
+    # - find / -name openssl -type f
+    - echo "which openssl:"
+    - which openssl
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -191,7 +191,8 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - yum install openssl1.1.x86_64
+    # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
     - echo "which openssl:"
@@ -212,7 +213,8 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - yum install openssl1.1.x86_64
+    # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
     - echo "which openssl:"
@@ -237,7 +239,8 @@ steps:
   commands:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
-    - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
+    - yum install openssl1.1.x86_64
+    # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
     - echo "which openssl:"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -192,7 +192,8 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - /usr/share/bash-completion/completions/openssl version
+   # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
@@ -211,7 +212,8 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - /usr/share/bash-completion/completions/openssl version
+    # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
@@ -234,7 +236,8 @@ steps:
     - dnf install -y libxcrypt-compat
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
-    - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
+    - /usr/share/bash-completion/completions/openssl version
+    # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     - find / -name openssl -type f
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -195,6 +195,8 @@ steps:
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
+    - echo "yum list openssl:"
+    - yum list openssl
     - echo "yum repo list:"
     - yum repolist
     - echo "which openssl:"
@@ -249,6 +251,8 @@ steps:
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl/3.2.1/2.fc40/x86_64/openssl-3.2.1-2.fc40.x86_64.rpm
     # - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
     # - find / -name openssl -type f
+    - echo "yum list openssl:"
+    - yum list openssl
     - echo "yum repo list:"
     - yum repolist
     - echo "which openssl:"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -193,9 +193,7 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     - dnf install -y --allowerasing  https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
-    - echo "openssl version:"
-    - export PATH=$PATH:/usr/bin
-    - openssl version
+    - find / -name openssl -type f
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - cd /workdir; bundle config set --local without omnibus_package
     - bundle config set --local path 'vendor/bundle'
@@ -214,9 +212,7 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
-    - echo "openssl version:"
-    - export PATH=$PATH:/usr/bin
-    - openssl version
+    - find / -name openssl -type f
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y crontabs e2fsprogs
     - cd /workdir; bundle config set --local without omnibus_package
@@ -239,9 +235,7 @@ steps:
     - dnf groupinstall -y development-tools rpm-development-tools c-development
     - dnf install -y https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-1.1.1q-7.fc40.x86_64.rpm
     - dnf install -y --allowerasing https://kojipkgs.fedoraproject.org//packages/openssl1.1/1.1.1q/7.fc40/x86_64/openssl1.1-devel-1.1.1q-7.fc40.x86_64.rpm
-    - echo "openssl version:"
-    - export PATH=$PATH:/usr/bin
-    - openssl version
+    - find / -name openssl -type f
     - /workdir/.expeditor/scripts/bk_container_prep.sh
     - dnf install -y libarchive-devel
     - bundle config set --local without omnibus_package


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Fedora testers in the verify pipeline are all throwing openssl errors. In investigating this I discovered that libcrypt.so.1 was missing. (install Chef client on a bare fedora 40 node, run "chef-client -v, get the error) That file is installed via the libxcrypt-compat package. This update ensures that this package is installed prior to starting any testing so we don't get weirdo openssl failures.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
