### PR TITLE
Search for choco 1.4, chef-powershell bundle fix, and resolv registry patch fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ PATH
       unf_ext (~> 0.0.8.2)
       uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.18.2)
-    chef (19.0.10-x64-mingw-ucrt)
+    chef (19.0.10-universal-mingw-ucrt)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
@@ -444,8 +444,8 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     win32-api (1.10.1-universal-mingw32)
-    win32-certstore (0.6.15)
-      chef-powershell (>= 1.0.12)
+    win32-certstore (0.6.16)
+      chef-powershell
       ffi
     win32-event (0.6.3)
       win32-ipc (>= 0.6.0)

--- a/chef-universal-mingw-ucrt.gemspec
+++ b/chef-universal-mingw-ucrt.gemspec
@@ -1,6 +1,6 @@
 gemspec = instance_eval(File.read(File.expand_path("chef.gemspec", __dir__)))
 
-gemspec.platform = Gem::Platform.new(%w{x64-mingw-ucrt})
+gemspec.platform = Gem::Platform.new(%w{universal mingw-ucrt})
 
 gemspec.add_dependency "win32-api", "~> 1.10.0"
 gemspec.add_dependency "win32-event", "~> 0.6.1"

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -153,7 +153,7 @@ class Chef
 
         # Choco V2 uses 'Search' for remote repositories and 'List' for local packages
         def query_command
-          return "list" if get_choco_version.match?(/^1/)
+          return "list" if Gem::Dependency.new("", "< 1.4.0").match?("", get_choco_version)
 
           "search"
         end
@@ -240,7 +240,7 @@ class Chef
           @choco_exe ||= begin
               # if this check is in #define_resource_requirements, it won't get
               # run before choco.exe gets called from #load_current_resource.
-              exe_path = ::File.join(choco_install_path, "bin", "choco.exe")
+              exe_path = ::File.join(choco_install_path, "choco.exe")
               raise Chef::Exceptions::MissingLibrary, CHOCO_MISSING_MSG unless ::File.exist?(exe_path)
 
               exe_path

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -26,6 +26,11 @@ if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
     autoload :Registry, File.expand_path("../monkey_patches/win32/registry", __dir__)
   end
   require_relative "api/registry"
+
+  require "win32/resolv"
+  ::Win32::Registry.define_method :export_string do |str, enc = (Encoding.default_internal || "utf-8")|
+    str.encode(enc)
+  end
 end
 
 class Chef
@@ -190,7 +195,9 @@ class Chef
         key_exists!(key_path)
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
-          reg.each_key { |current_key| subkeys << current_key }
+          reg.each_key do |current_key|
+            subkeys << current_key
+          end
         end
         subkeys
       end

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -92,7 +92,7 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
 
   describe "choco searches change with the version" do
     it "Choco V1 uses List" do
-      allow(provider).to receive(:powershell_exec!).with("Get-ItemProperty #{choco_exe} | select-object -expandproperty versioninfo | select-object -expandproperty productversion").and_return(double(result: "1.4.0"))
+      allow(provider).to receive(:powershell_exec!).with("Get-ItemProperty #{choco_exe} | select-object -expandproperty versioninfo | select-object -expandproperty productversion").and_return(double(result: "1.3.0"))
       expect(provider.query_command).to eql("list")
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chocolatey dumps a deprecation warning for `list` command if you're on *1.4* in addition to the deprecation in version 2.

Use `search` if on 1.4 or later.

`bundle update --conservative` is not necessary, as the chef (windows) gem spec is the reason for the `Gemfile.lock` update. Use `universal` for the Windows `gemspec` to prevent losing the Windows section on `bundle install`

Proactively include `win32/resolv` so that it's loaded prior to forcing a monkey patch on the `export_string` method.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
