### PR TITLE
Support relative paths in `~/.chef/credentials` for knife `secret_file`

### DIFF
--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -167,7 +167,11 @@ module ChefConfig
         when "client_key"
           extract_key(value, :client_key, :client_key_contents)
         when "knife"
-          Config.knife.merge!(value.transform_keys(&:to_sym))
+          value = value.transform_keys(&:to_sym)
+          if value[:secret_file]
+            value[:secret_file] = Pathname.new(value[:secret_file]).expand_path(home_chef_dir)
+          end
+          Config.knife.merge!(value)
         else
           Config[key.to_sym] = value
         end

--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -499,6 +499,26 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
         end
       end
 
+      context "and uses relative paths for key files" do
+        let(:content) do
+          content = <<~EOH
+            [default]
+            client_key = "barney_rubble.pem"
+
+            [default.knife]
+            secret_file = "encrypted_data_bag_secret.pem"
+          EOH
+          content
+        end
+
+        it "applies the expected knife config" do
+          expect { config_loader.load_credentials }.not_to raise_error
+          expect(ChefConfig::Config.client_key.to_s).to eq("#{home}/.chef/barney_rubble.pem")
+          expect(ChefConfig::Config.knife[:secret_file].to_s).to eq("#{home}/.chef/encrypted_data_bag_secret.pem")
+          expect(ChefConfig::Config.profile.to_s).to eq("default")
+        end
+      end
+
       context "and has a profile containing a full key" do
         let(:content) do
           content = <<~EOH


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

This PR makes it possible to use relative file paths in `~/.chef/credentials` for the knife `secret_file` property, for example:

```toml
[default]
node_name = "drewhammond"
client_key = "drewhammond.pem" # ~/.chef/drewhammond.pem (already handled correctly)
chef_server_url = 'https://chef-server.example.com/organizations/example'

[default.knife]
secret_file = 'encrypted_data_bag_secret' # ~/.chef/encrypted_data_bag_secret
```

Based on [this documentation](https://docs.chef.io/workstation/knife_setup/), I think this is a bug fix. 
>File paths, such as `client_key` or `validator_key`, are relative to `~/.chef` unless you provide absolute path

## Related Issue

#14473

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
