### PR TITLE
forcing win32-process

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -22,5 +22,5 @@ group :development do
 end
 
 if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
-  gem win32-process
+  gem "win32-process"
 end

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -23,4 +23,5 @@ end
 
 if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
   gem "win32-process"
+  gem 'ffi-win32-extensions', '~> 1.0', '>= 1.0.4'
 end

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -23,5 +23,5 @@ end
 
 if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
   gem "win32-process"
-  gem 'ffi-win32-extensions', '~> 1.0', '>= 1.0.4'
+  gem "ffi-win32-extensions", "~> 1.0", ">= 1.0.4"
 end

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -20,3 +20,7 @@ group :development do
   gem "kitchen-vagrant", ">= 1.3.1"
   gem "winrm-fs", "~> 1.0"
 end
+
+if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
+  gem win32-process
+end

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -286,11 +286,6 @@ GEM
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
-    mixlib-shellout (3.2.7-x64-mingw-ucrt)
-      chef-utils
-      ffi-win32-extensions (~> 1.0.3)
-      win32-process (~> 0.9)
-      wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -487,6 +482,7 @@ DEPENDENCIES
   omnibus-software!
   pedump
   test-kitchen (>= 1.23)
+  win32-process
   winrm-fs (~> 1.0)
 
 BUNDLED WITH

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -477,6 +477,7 @@ PLATFORMS
 DEPENDENCIES
   artifactory
   berkshelf!
+  ffi-win32-extensions (~> 1.0, >= 1.0.4)
   kitchen-vagrant (>= 1.3.1)
   omnibus!
   omnibus-software!


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Windows Builds in the Ad-Hoc pipeline keep breaking because they say they can't find the win32-process gem. Here I am explicitly loading it to get past that error message

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
