### PR TITLE
Try to bound logger to < 1.6 for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "ffi", ">= 1.15.5"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 # required for FIPS or bundler will pick up default openssl
-gem "openssl", "= 3.2.0" unless Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" }
+gem "openssl", "= 3.2.0" unless (%w(which rbenv) && $? != 0) && Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" }
 
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "chef", path: "."
 
+gem "logger", "< 1.6.0"
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "main"
 
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "ffi", ">= 1.15.5"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 # required for FIPS or bundler will pick up default openssl
-gem "openssl", "= 3.2.0" unless (%w(which rbenv) && $? != 0) && Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" }
+gem "openssl", "= 3.2.0" unless (%x(which rbenv) && $? != 0) && Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" }
 
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gem "chef", path: "."
 
-gem "logger", "< 1.6.0"
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "main"
 
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt
 gem "ffi", ">= 1.15.5"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
-# required for FIPS or bundler will pick up default openssl
-gem "openssl", "= 3.2.0" unless (%x(which rbenv) && $? != 0) && Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" }
+# required for FIPS or bundler will pick up default openssl... set LOCAL_DEV env var to prevent openssl from unbundling
+gem "openssl", "= 3.2.0" unless ENV["LOCAL_DEV"].nil? && Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" }
 
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,9 +196,10 @@ GEM
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
       webrick
-    cheffish (17.1.5)
+    cheffish (17.1.7)
       chef-utils (>= 17.0)
       chef-zero (>= 14.0)
+      logger (< 1.6.0)
       net-ssh
     chefstyle (2.2.2)
       rubocop (= 1.25.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,8 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.0.9)
+    mixlib-log (3.1.1)
+      ffi (< 1.17.0)
     mixlib-shellout (3.2.8)
       chef-utils
     mixlib-shellout (3.2.8-universal-mingw32)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,8 +508,8 @@ DEPENDENCIES
   fauxhai-ng
   ffi (>= 1.15.5)
   inspec-core-bin (>= 5, < 6)
+  logger (< 1.6.0)
   ohai!
-  openssl (= 3.2.0)
   pry (= 0.13.0)
   pry-byebug
   pry-stack_explorer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,7 @@ GEM
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
     little-plugger (1.1.4)
+    logger (1.5.3)
     logging (2.4.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
@@ -511,6 +512,7 @@ DEPENDENCIES
   ffi (>= 1.15.5)
   inspec-core-bin (>= 5, < 6)
   ohai!
+  openssl (= 3.2.0)
   pry (= 0.13.0)
   pry-byebug
   pry-stack_explorer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,6 @@ DEPENDENCIES
   fauxhai-ng
   ffi (>= 1.15.5)
   inspec-core-bin (>= 5, < 6)
-  logger (< 1.6.0)
   ohai!
   pry (= 0.13.0)
   pry-byebug

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gem "knife", path: "."
 
+gem "logger", "< 1.6.0"
+
 group(:development, :test) do
   gem "cheffish", ">= 14" # testing only , but why didn't this need to explicit in chef?
   gem "webmock"

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 gem "knife", path: "."
 
-gem "logger", "< 1.6.0"
-
 group(:development, :test) do
   gem "cheffish", ">= 14" # testing only , but why didn't this need to explicit in chef?
   gem "webmock"

--- a/knife/Gemfile.lock
+++ b/knife/Gemfile.lock
@@ -8,12 +8,12 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 7f3f45a8aeddcee34f3945da78946513982cc6c9
+  revision: a235eacc7cb8ee9dbc7fce6bbc7cb311177b8282
   branch: main
   specs:
-    ohai (18.2.0)
-      chef-config (>= 14.12, < 19)
-      chef-utils (>= 16.0, < 19)
+    ohai (19.0.0)
+      chef-config (>= 14.12, < 20)
+      chef-utils (>= 16.0, < 20)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
@@ -28,18 +28,18 @@ GIT
 PATH
   remote: ../chef-bin
   specs:
-    chef-bin (18.5.1)
-      chef (= 18.5.1)
+    chef-bin (19.0.2)
+      chef (= 19.0.2)
 
 PATH
   remote: ..
   specs:
-    chef (18.5.1)
+    chef (19.0.2)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
-      chef-config (= 18.5.1)
-      chef-utils (= 18.5.1)
+      chef-config (= 19.0.2)
+      chef-utils (= 19.0.2)
       chef-vault
       chef-zero (>= 14.0.11)
       corefoundation (~> 0.3.4)
@@ -58,7 +58,7 @@ PATH
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
-      ohai (~> 18.0)
+      ohai (~> 19.0)
       plist (~> 3.2)
       proxifier2 (~> 1.1)
       syslog-logger (~> 1.6)
@@ -68,61 +68,15 @@ PATH
       unf_ext (~> 0.0.8.2)
       uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.18.2)
-    chef (18.5.1-x64-mingw-ucrt)
-      addressable
-      aws-sdk-s3 (~> 1.91)
-      aws-sdk-secretsmanager (~> 1.46)
-      chef-config (= 18.5.1)
-      chef-powershell (~> 18.1.0)
-      chef-utils (= 18.5.1)
-      chef-vault
-      chef-zero (>= 14.0.11)
-      corefoundation (~> 0.3.4)
-      diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
-      erubis (~> 2.7)
-      ffi (>= 1.15.5)
-      ffi-libarchive (~> 1.0, >= 1.0.3)
-      ffi-yajl (~> 2.2)
-      iniparse (~> 1.4)
-      inspec-core (>= 5, < 6)
-      iso8601 (>= 0.12.1, < 0.14)
-      license-acceptance (>= 1.0.5, < 3)
-      mixlib-archive (>= 0.4, < 2.0)
-      mixlib-authentication (>= 2.1, < 4)
-      mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 3.1.1, < 4.0)
-      net-ftp
-      net-sftp (>= 2.1.2, < 5.0)
-      ohai (~> 18.0)
-      plist (~> 3.2)
-      proxifier2 (~> 1.1)
-      syslog-logger (~> 1.6)
-      train-core (~> 3.10)
-      train-rest (>= 0.4.1)
-      train-winrm (>= 0.2.5)
-      unf_ext (~> 0.0.8.2)
-      uuidtools (>= 2.1.5, < 3.0)
-      vault (~> 0.18.2)
-      win32-api (~> 1.10.0)
-      win32-certstore (~> 0.6.15)
-      win32-event (~> 0.6.1)
-      win32-eventlog (= 0.6.3)
-      win32-mmap (~> 0.4.1)
-      win32-mutex (~> 0.4.2)
-      win32-process (~> 0.9)
-      win32-service (>= 2.1.5, < 3.0)
-      win32-taskscheduler (~> 2.0)
-      wmi-lite (~> 1.0)
 
 PATH
   remote: .
   specs:
-    knife (18.5.1)
+    knife (19.0.2)
       bcrypt_pbkdf (~> 1.1)
-      chef (>= 18)
-      chef-config (>= 18)
-      chef-utils (>= 18)
+      chef (>= 19)
+      chef-config (>= 19)
+      chef-utils (>= 19)
       chef-vault
       erubis (~> 2.7)
       ffi (>= 1.15)
@@ -133,7 +87,7 @@ PATH
       mixlib-cli (>= 2.1.1, < 3.0)
       net-ssh (>= 5.1, < 8)
       net-ssh-multi (~> 1.2, >= 1.2.1)
-      ohai (~> 18.0)
+      ohai (~> 19.0)
       pastel
       proxifier2 (~> 1.1)
       train-core (~> 3.10)
@@ -145,9 +99,9 @@ PATH
 PATH
   remote: /Users/powell/projects/chef/chef-config
   specs:
-    chef-config (18.5.1)
+    chef-config (19.0.2)
       addressable
-      chef-utils (= 18.5.1)
+      chef-utils (= 19.0.2)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -156,7 +110,7 @@ PATH
 PATH
   remote: /Users/powell/projects/chef/chef-utils
   specs:
-    chef-utils (18.5.1)
+    chef-utils (19.0.2)
       concurrent-ruby
 
 GEM
@@ -166,8 +120,8 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.955.0)
-    aws-sdk-core (3.201.1)
+    aws-partitions (1.959.0)
+    aws-sdk-core (3.201.3)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
@@ -179,10 +133,10 @@ GEM
       aws-sdk-core (~> 3, >= 3.201.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
-    aws-sdk-secretsmanager (1.101.0)
+    aws-sdk-secretsmanager (1.102.0)
       aws-sdk-core (~> 3, >= 3.201.0)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.8.0)
+    aws-sigv4 (1.9.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
@@ -192,9 +146,6 @@ GEM
       debug_inspector (>= 1.2.0)
     builder (3.3.0)
     byebug (11.1.3)
-    chef-powershell (18.1.0)
-      ffi (~> 1.15)
-      ffi-yajl (~> 2.4)
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
@@ -229,10 +180,10 @@ GEM
       logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.1.0)
+    faraday-net_http (3.1.1)
       net-http
-    ffi (1.17.0)
-    ffi (1.17.0-x64-mingw-ucrt)
+    ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -278,7 +229,6 @@ GEM
       tty-prompt (~> 0.17)
       tty-table (~> 0.10)
     ipaddress (0.8.3)
-    iso8601 (0.13.0)
     jmespath (1.6.2)
     json (2.7.2)
     libyajl2 (2.1.0)
@@ -288,7 +238,7 @@ GEM
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
     little-plugger (1.1.4)
-    logger (1.5.3)
+    logger (1.6.0)
     logging (2.4.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
@@ -305,6 +255,7 @@ GEM
     mixlib-config (3.0.27)
       tomlrb
     mixlib-log (3.1.1)
+      ffi (< 1.17.0)
     mixlib-shellout (3.2.8)
       chef-utils
     mixlib-shellout (3.2.8-x64-mingw-ucrt)
@@ -332,7 +283,7 @@ GEM
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
-    nori (2.7.0)
+    nori (2.7.1)
       bigdecimal
     parallel (1.25.1)
     parser (3.3.4.0)
@@ -404,7 +355,6 @@ GEM
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
     strscan (3.1.0)
-    structured_warnings (0.4.0)
     syslog-logger (1.6.8)
     thor (1.2.2)
     time (0.3.0)
@@ -457,28 +407,8 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    win32-api (1.10.1-universal-mingw32)
-    win32-certstore (0.6.16)
-      chef-powershell
-      ffi
-    win32-event (0.6.3)
-      win32-ipc (>= 0.6.0)
-    win32-eventlog (0.6.3)
-      ffi
-    win32-ipc (0.7.0)
-      ffi
-    win32-mmap (0.4.2)
-      ffi
-    win32-mutex (0.4.3)
-      win32-ipc (>= 0.6.0)
     win32-process (0.10.0)
       ffi (>= 1.0.0)
-    win32-service (2.3.2)
-      ffi
-      ffi-win32-extensions
-    win32-taskscheduler (2.0.4)
-      ffi
-      structured_warnings
     winrm (2.3.8)
       builder (>= 2.1.2)
       erubi (~> 1.8)

--- a/knife/Gemfile.lock
+++ b/knife/Gemfile.lock
@@ -1,35 +1,526 @@
+GIT
+  remote: https://github.com/chef/chefstyle.git
+  revision: c1fed9c045622992bf9e84ad3c374448b0c1134b
+  branch: main
+  specs:
+    chefstyle (2.2.3)
+      rubocop (= 1.25.1)
+
+GIT
+  remote: https://github.com/chef/ohai.git
+  revision: 7f3f45a8aeddcee34f3945da78946513982cc6c9
+  branch: main
+  specs:
+    ohai (18.2.0)
+      chef-config (>= 14.12, < 19)
+      chef-utils (>= 16.0, < 19)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli (>= 1.7.0)
+      mixlib-config (>= 2.0, < 4.0)
+      mixlib-log (>= 2.0.1, < 4.0)
+      mixlib-shellout (~> 3.2, >= 3.2.5)
+      plist (~> 3.1)
+      train-core
+      wmi-lite (~> 1.0)
+
+PATH
+  remote: ../chef-bin
+  specs:
+    chef-bin (18.5.1)
+      chef (= 18.5.1)
+
 PATH
   remote: ..
   specs:
     chef (18.5.1)
+      addressable
+      aws-sdk-s3 (~> 1.91)
+      aws-sdk-secretsmanager (~> 1.46)
+      chef-config (= 18.5.1)
+      chef-utils (= 18.5.1)
+      chef-vault
+      chef-zero (>= 14.0.11)
+      corefoundation (~> 0.3.4)
+      diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
+      erubis (~> 2.7)
+      ffi (>= 1.15.5)
+      ffi-libarchive (~> 1.0, >= 1.0.3)
+      ffi-yajl (~> 2.2)
+      iniparse (~> 1.4)
+      inspec-core (>= 5, < 6)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-authentication (>= 2.1, < 4)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      mixlib-log (>= 2.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
+      net-ftp
+      net-sftp (>= 2.1.2, < 5.0)
+      ohai (~> 18.0)
+      plist (~> 3.2)
+      proxifier2 (~> 1.1)
+      syslog-logger (~> 1.6)
+      train-core (~> 3.10)
+      train-rest (>= 0.4.1)
+      train-winrm (>= 0.2.5)
+      unf_ext (~> 0.0.8.2)
+      uuidtools (>= 2.1.5, < 3.0)
+      vault (~> 0.18.2)
     chef (18.5.1-x64-mingw-ucrt)
+      addressable
+      aws-sdk-s3 (~> 1.91)
+      aws-sdk-secretsmanager (~> 1.46)
+      chef-config (= 18.5.1)
+      chef-powershell (~> 18.1.0)
+      chef-utils (= 18.5.1)
+      chef-vault
+      chef-zero (>= 14.0.11)
+      corefoundation (~> 0.3.4)
+      diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
+      erubis (~> 2.7)
+      ffi (>= 1.15.5)
+      ffi-libarchive (~> 1.0, >= 1.0.3)
+      ffi-yajl (~> 2.2)
+      iniparse (~> 1.4)
+      inspec-core (>= 5, < 6)
+      iso8601 (>= 0.12.1, < 0.14)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-authentication (>= 2.1, < 4)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      mixlib-log (>= 2.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
+      net-ftp
+      net-sftp (>= 2.1.2, < 5.0)
+      ohai (~> 18.0)
+      plist (~> 3.2)
+      proxifier2 (~> 1.1)
+      syslog-logger (~> 1.6)
+      train-core (~> 3.10)
+      train-rest (>= 0.4.1)
+      train-winrm (>= 0.2.5)
+      unf_ext (~> 0.0.8.2)
+      uuidtools (>= 2.1.5, < 3.0)
+      vault (~> 0.18.2)
+      win32-api (~> 1.10.0)
+      win32-certstore (~> 0.6.15)
+      win32-event (~> 0.6.1)
+      win32-eventlog (= 0.6.3)
+      win32-mmap (~> 0.4.1)
+      win32-mutex (~> 0.4.2)
+      win32-process (~> 0.9)
+      win32-service (>= 2.1.5, < 3.0)
+      win32-taskscheduler (~> 2.0)
+      wmi-lite (~> 1.0)
+
+PATH
+  remote: .
+  specs:
+    knife (18.5.1)
+      bcrypt_pbkdf (~> 1.1)
+      chef (>= 18)
+      chef-config (>= 18)
+      chef-utils (>= 18)
+      chef-vault
+      erubis (~> 2.7)
+      ffi (>= 1.15)
+      ffi-yajl (~> 2.2)
+      highline (>= 1.6.9, < 3)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      net-ssh (>= 5.1, < 8)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (~> 18.0)
+      pastel
+      proxifier2 (~> 1.1)
+      train-core (~> 3.10)
+      train-winrm (>= 0.2.5)
+      tty-prompt (~> 0.21)
+      tty-screen (~> 0.6)
+      tty-table (~> 0.11)
+
+PATH
+  remote: /Users/powell/projects/chef/chef-config
+  specs:
+    chef-config (18.5.1)
+      addressable
+      chef-utils (= 18.5.1)
+      fuzzyurl
+      mixlib-config (>= 2.2.12, < 4.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      tomlrb (~> 1.2)
+
+PATH
+  remote: /Users/powell/projects/chef/chef-utils
+  specs:
+    chef-utils (18.5.1)
+      concurrent-ruby
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.955.0)
+    aws-sdk-core (3.201.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.88.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.156.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-secretsmanager (1.101.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.2.0)
+    bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-x64-mingw-ucrt)
+    bigdecimal (3.1.8)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
+    builder (3.3.0)
+    byebug (11.1.3)
+    chef-powershell (18.1.0)
+      ffi (~> 1.15)
+      ffi-yajl (~> 2.4)
+    chef-telemetry (1.1.1)
+      chef-config
+      concurrent-ruby (~> 1.0)
+    chef-vault (4.1.11)
+    chef-zero (15.0.11)
+      ffi-yajl (~> 2.2)
+      hashie (>= 2.0, < 5.0)
+      mixlib-log (>= 2.0, < 4.0)
+      rack (~> 2.0, >= 2.0.6)
+      uuidtools (~> 2.1)
+      webrick
+    cheffish (17.1.5)
+      chef-utils (>= 17.0)
+      chef-zero (>= 14.0)
+      net-ssh
+    coderay (1.1.3)
+    concurrent-ruby (1.3.3)
+    cookstyle (7.32.8)
+      rubocop (= 1.25.1)
+    corefoundation (0.3.13)
+      ffi (>= 1.15.0)
+    crack (0.4.5)
+      rexml
+    date (3.3.4)
+    debug_inspector (1.2.0)
+    diff-lcs (1.5.1)
+    domain_name (0.6.20240107)
+    erubi (1.13.0)
+    erubis (2.7.0)
+    faraday (2.10.0)
+      faraday-net_http (>= 2.0, < 3.2)
+      logger
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.1.0)
+      net-http
+    ffi (1.17.0)
+    ffi (1.17.0-x64-mingw-ucrt)
+    ffi-libarchive (1.1.14)
+      ffi (~> 1.0)
+    ffi-win32-extensions (1.0.4)
+      ffi
+    ffi-yajl (2.6.0)
+      libyajl2 (>= 1.2)
+    fuzzyurl (0.9.0)
+    gssapi (1.3.1)
+      ffi (>= 1.0.1)
+    gyoku (1.4.0)
+      builder (>= 2.1.2)
+      rexml (~> 3.0)
+    hashdiff (1.1.0)
+    hashie (4.1.0)
+    highline (2.1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.6)
+      domain_name (~> 0.5)
+    httpclient (2.8.3)
+    iniparse (1.5.0)
+    inspec-core (5.22.50)
+      addressable (~> 2.4)
+      chef-telemetry (~> 1.0, >= 1.0.8)
+      cookstyle
+      faraday (>= 1, < 3)
+      faraday-follow_redirects (~> 0.3)
+      hashie (>= 3.4, < 6.0)
+      license-acceptance (>= 0.2.13, < 3.0)
+      method_source (>= 0.8, < 2.0)
+      mixlib-log (~> 3.0)
+      multipart-post (~> 2.0)
+      parallel (~> 1.9)
+      parslet (>= 1.5, < 3.0)
+      pry (~> 0.13)
+      rspec (>= 3.9, <= 3.12)
+      rspec-its (~> 1.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      semverse (~> 3.0)
+      sslshake (~> 1.2)
+      thor (>= 0.20, < 1.3.0)
+      tomlrb (>= 1.2, < 2.1)
+      train-core (~> 3.10)
+      tty-prompt (~> 0.17)
+      tty-table (~> 0.10)
+    ipaddress (0.8.3)
+    iso8601 (0.13.0)
+    jmespath (1.6.2)
+    json (2.7.2)
+    libyajl2 (2.1.0)
+    license-acceptance (2.1.13)
+      pastel (~> 0.7)
+      tomlrb (>= 1.2, < 3.0)
+      tty-box (~> 0.6)
+      tty-prompt (~> 0.20)
+    little-plugger (1.1.4)
+    logger (1.5.3)
+    logging (2.4.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.14)
+    method_source (1.1.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0702)
+    mixlib-archive (1.1.7)
+      mixlib-log
+    mixlib-archive (1.1.7-universal-mingw32)
+      mixlib-log
+    mixlib-authentication (3.0.10)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
+      tomlrb
+    mixlib-log (3.0.9)
+    mixlib-shellout (3.2.8)
+      chef-utils
+    mixlib-shellout (3.2.8-x64-mingw-ucrt)
+      chef-utils
+      ffi-win32-extensions (~> 1.0.3)
+      win32-process (~> 0.9)
+      wmi-lite (~> 1.0)
+    multi_json (1.15.0)
+    multipart-post (2.4.1)
+    net-ftp (0.3.7)
+      net-protocol
+      time
+    net-http (0.4.1)
+      uri
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-ssh (7.2.3)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
+    net-ssh-multi (1.2.1)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
+    netrc (0.11.0)
+    nori (2.7.0)
+      bigdecimal
+    parallel (1.25.1)
+    parser (3.3.4.0)
+      ast (~> 2.4.1)
+      racc
+    parslet (2.0.0)
+    pastel (0.8.0)
+      tty-color (~> 0.5)
+    plist (3.7.1)
+    proxifier2 (1.1.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    pry-stack_explorer (0.6.1)
+      binding_of_caller (~> 1.0)
+      pry (~> 0.13)
+    public_suffix (6.0.0)
+    racc (1.8.0)
+    rack (2.2.9)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rexml (3.3.1)
+      strscan
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.3)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.12.7)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.2)
+    rubocop (1.25.1)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.15.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    rubyntlm (0.6.5)
+      base64
+    rubyzip (2.3.2)
+    semverse (3.0.2)
+    sslshake (1.3.1)
+    strings (0.2.1)
+      strings-ansi (~> 0.2)
+      unicode-display_width (>= 1.5, < 3.0)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.2.0)
+    strscan (3.1.0)
+    structured_warnings (0.4.0)
+    syslog-logger (1.6.8)
+    thor (1.2.2)
+    time (0.3.0)
+      date
+    timeout (0.4.1)
+    tomlrb (1.3.0)
+    train-core (3.12.5)
+      addressable (~> 2.5)
+      ffi (!= 1.13.0)
+      json (>= 1.8, < 3.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      net-scp (>= 1.2, < 5.0)
+      net-ssh (>= 2.9, < 8.0)
+    train-rest (0.5.0)
+      aws-sigv4 (~> 1.5)
+      rest-client (~> 2.1)
+      train-core (~> 3.0)
+    train-winrm (0.2.13)
+      winrm (>= 2.3.6, < 3.0)
+      winrm-elevated (~> 1.2.2)
+      winrm-fs (~> 1.0)
+    tty-box (0.7.0)
+      pastel (~> 0.8)
+      strings (~> 0.2.0)
+      tty-cursor (~> 0.7)
+    tty-color (0.6.0)
+    tty-cursor (0.7.1)
+    tty-prompt (0.23.1)
+      pastel (~> 0.8)
+      tty-reader (~> 0.8)
+    tty-reader (0.9.0)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      wisper (~> 2.0)
+    tty-screen (0.8.2)
+    tty-table (0.12.0)
+      pastel (~> 0.8)
+      strings (~> 0.2.0)
+      tty-screen (~> 0.8)
+    unf_ext (0.0.8.2)
+    unf_ext (0.0.8.2-x64-mingw-ucrt)
+    unicode-display_width (2.5.0)
+    unicode_utils (1.4.0)
+    uri (0.13.0)
+    uuidtools (2.2.0)
+    vault (0.18.2)
+      aws-sigv4
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.8.1)
+    win32-api (1.10.1-universal-mingw32)
+    win32-certstore (0.6.16)
+      chef-powershell
+      ffi
+    win32-event (0.6.3)
+      win32-ipc (>= 0.6.0)
+    win32-eventlog (0.6.3)
+      ffi
+    win32-ipc (0.7.0)
+      ffi
+    win32-mmap (0.4.2)
+      ffi
+    win32-mutex (0.4.3)
+      win32-ipc (>= 0.6.0)
+    win32-process (0.10.0)
+      ffi (>= 1.0.0)
+    win32-service (2.3.2)
+      ffi
+      ffi-win32-extensions
+    win32-taskscheduler (2.0.4)
+      ffi
+      structured_warnings
+    winrm (2.3.8)
+      builder (>= 2.1.2)
+      erubi (~> 1.8)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rexml (~> 3.0)
+      rubyntlm (~> 0.6.0, >= 0.6.3)
+    winrm-elevated (1.2.3)
+      erubi (~> 1.8)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
+    winrm-fs (1.3.5)
+      erubi (~> 1.8)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 2.0)
+      winrm (~> 2.0)
+    wisper (2.0.1)
+    wmi-lite (1.0.7)
 
 PLATFORMS
   ruby
   x64-mingw-ucrt
 
 DEPENDENCIES
-  appbundler
   chef!
   chef-bin!
   chef-config!
   chef-utils!
-  chef-vault
-  cheffish (>= 17.1.5)
-  chefstyle
-  ed25519 (~> 1.2)
-  fauxhai-ng
-  ffi (>= 1.15.5)
-  inspec-core-bin (>= 5)
+  cheffish (>= 14)
+  chefstyle!
+  crack (< 0.4.6)
+  knife!
+  logger (< 1.6.0)
   ohai!
-  pry (= 0.13.0)
+  pry
   pry-byebug
   pry-stack_explorer
   rake
-  rb-readline
-  rest-client!
   rspec
-  ruby-shadow!
   webmock
 
 BUNDLED WITH

--- a/knife/Gemfile.lock
+++ b/knife/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.0.9)
+    mixlib-log (3.1.1)
     mixlib-shellout (3.2.8)
       chef-utils
     mixlib-shellout (3.2.8-x64-mingw-ucrt)
@@ -514,7 +514,6 @@ DEPENDENCIES
   chefstyle!
   crack (< 0.4.6)
   knife!
-  logger (< 1.6.0)
   ohai!
   pry
   pry-byebug

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -275,7 +275,8 @@ GEM
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (3.0.9)
+    mixlib-log (3.1.1)
+      ffi (< 1.17.0)
     mixlib-shellout (3.2.8)
       chef-utils
     mixlib-shellout (3.2.8-universal-mingw32)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
<details>
<summary>`bundle update --conservative cheffish`</summary>
```sh
❯ bundle update --conservative cheffish
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies......
Using rake 13.0.6
Using public_suffix 5.0.1
Using mixlib-cli 2.1.8
Using fuzzyurl 0.9.0
Using ast 2.4.2
Using concurrent-ruby 1.2.2
Using aws-eventstream 1.2.0
Using hashie 4.1.0
Using aws-partitions 1.739.0
Using rack 2.2.6.4
Using bundler 2.3.7
Using uuidtools 2.2.0
Using ffi 1.16.3
Using diff-lcs 1.5.0
Using erubis 2.7.0
Using debug_inspector 1.1.0
Using faraday-net_http 3.0.2
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using jmespath 1.6.2
Using unicode-display_width 2.4.2
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using iniparse 1.5.0
Using wisper 2.0.1
Using method_source 1.0.0
Using mixlib-log 3.0.9
Using multipart-post 2.3.0
Using parslet 1.8.2
Using ruby2_keywords 0.0.5
Using coderay 1.1.3
Using rspec-support 3.11.1
Using rubyzip 2.3.2
Using semverse 3.0.2
Using libyajl2 2.1.0
Using tty-screen 0.8.1
Using net-ssh 7.1.0
Using json 2.6.3
Using timeout 0.3.2
Using date 3.3.3
Using mixlib-authentication 3.0.10
Using plist 3.7.0
Using wmi-lite 1.0.7
Using sslshake 1.3.1
Using parallel 1.22.1
Using builder 3.2.4
Using syslog-logger 1.6.8
Using unf_ext 0.0.8.2
Using tty-color 0.6.0
Using http-accept 1.7.0
Using rexml 3.2.5
Using httpclient 2.8.3
Using proxifier2 1.1.0
Using multi_json 1.15.0
Using nori 2.6.0
Using rubyntlm 0.6.3
Using logger 1.5.3
Using rainbow 3.1.1
Using regexp_parser 2.7.0
Using ruby-progressbar 1.13.0
Using ed25519 1.3.0
Using mime-types-data 3.2023.0218.1
Using ipaddress 0.8.3
Using rb-readline 0.5.5
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using hashdiff 1.0.1
Using netrc 0.11.0
Using chef-utils 18.5.1 from source at `chef-utils`
Using erubi 1.12.0
Using aws-sigv4 1.5.2
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.3
Using gssapi 1.3.1
Using binding_of_caller 1.0.0
Using mixlib-config 3.0.27
Using mixlib-archive 1.1.7
Using faraday 2.7.4
Using thor 1.2.1
Using strings-ansi 0.2.0
Using ffi-yajl 2.6.0
Using tty-reader 0.9.0
Using net-scp 4.0.0
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using net-protocol 0.2.1
Using time 0.2.2
Using parser 3.2.2.0
Using addressable 2.8.2
Using pry 0.13.0
Using crack 0.4.5
Using little-plugger 1.1.4
Using pastel 0.8.0
Using mime-types 3.4.1
Using rspec-expectations 3.11.1
Using mixlib-shellout 3.2.8
Using strings 0.2.1
Using net-ftp 0.2.0
Using rubocop-ast 1.28.0
Using pry-stack_explorer 0.6.1
Using tty-prompt 0.23.1
Using logging 2.3.1
Using faraday-follow_redirects 0.3.0
Using appbundler 0.13.4
Using chef-config 18.5.1 from source at `chef-config`
Using tty-box 0.7.0
Using train-core 3.10.7
Using tty-table 0.12.0
Using rubocop 1.25.1
Using webrick 1.8.1
Using unf 0.1.4
Using rspec-mocks 3.11.2
Using gyoku 1.4.0
Using byebug 11.1.3
Using aws-sdk-core 3.171.0
Using vault 0.18.2
Using rspec-core 3.11.0
Using webmock 3.19.1
Using aws-sdk-secretsmanager 1.73.0
Using chef-zero 15.0.11
Using rspec 3.11.0
Using ohai 18.1.11 from https://github.com/chef/ohai.git (at main@d5d0324)
Using domain_name 0.5.20190701
Fetching cheffish 17.1.7 (was 17.1.5)
Using winrm 2.3.6
Using chef-telemetry 1.1.1
Using winrm-fs 1.3.5
Using pry-byebug 3.10.1
Using aws-sdk-kms 1.63.0
Using aws-sdk-s3 1.120.0
Using winrm-elevated 1.2.3
Using chefstyle 2.2.2
Using rspec-its 1.3.0
Using license-acceptance 2.1.13
Using http-cookie 1.0.5
Using inspec-core 5.22.40
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using train-winrm 0.2.13
Using inspec-core-bin 5.22.40
Using train-rest 0.5.0
Using chef 18.5.1 from source at `.`
Using chef-bin 18.5.1 from source at `chef-bin` and installing its executables
Installing cheffish 17.1.7 (was 17.1.5)
Bundle updated!
```
</details>

<details>
<summary>in `knife/` ... `bundle update --conservative ffi ohai`</summary>
```sh
❯ bundle update --conservative ffi ohai
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies....
Using rake 13.2.1
Using public_suffix 6.0.0
Using ast 2.4.2
Using aws-eventstream 1.3.0
Using jmespath 1.6.2
Using base64 0.2.0
Using bcrypt_pbkdf 1.1.1
Using bigdecimal 3.1.8
Using debug_inspector 1.2.0
Using builder 3.3.0
Using ffi 1.16.3
Using rack 2.2.9
Using uuidtools 2.2.0
Using webrick 1.8.1
Using diff-lcs 1.5.1
Using erubis 2.7.0
Fetching aws-partitions 1.959.0 (was 1.955.0)
Using iniparse 1.5.0
Using chef-vault 4.1.11
Using parallel 1.25.1
Using racc 1.8.0
Using rainbow 3.1.1
Using strscan 3.1.0
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.5.0
Using uri 0.13.0
Using logger 1.6.0
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using regexp_parser 2.9.2
Using tty-cursor 0.7.1
Using byebug 11.1.3
Using tty-screen 0.8.2
Using method_source 1.1.0
Using tomlrb 1.3.0
Using parslet 2.0.0
Using bundler 2.3.18
Using hashie 4.1.0
Using rubyzip 2.3.2
Using semverse 3.0.2
Using sslshake 1.3.1
Using wisper 2.0.1
Using json 2.7.2
Using net-ssh 7.2.3
Using mixlib-authentication 3.0.10
Using mixlib-cli 2.1.8
Using timeout 0.4.1
Using date 3.3.4
Using rspec-support 3.12.2
Using plist 3.7.1
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using http-accept 1.7.0
Using domain_name 0.6.20240107
Using coderay 1.1.3
Using netrc 0.11.0
Using erubi 1.13.0
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using multi_json 1.15.0
Using unf_ext 0.0.8.2
Using hashdiff 1.1.0
Using highline 2.1.0
Using addressable 2.8.7
Using thor 1.2.2
Using ipaddress 0.8.3
Using rubyntlm 0.6.5
Using unicode_utils 1.4.0
Fetching nori 2.7.1 (was 2.7.0)
Using mixlib-log 3.1.1
Using mime-types-data 3.2024.0702
Using corefoundation 0.3.13
Using multipart-post 2.4.1
Using binding_of_caller 1.0.1
Using parser 3.3.4.0
Using net-http 0.4.1
Using concurrent-ruby 1.3.3
Using libyajl2 2.1.0
Using gssapi 1.3.1
Using ffi-libarchive 1.1.14
Using rexml 3.3.1
Fetching aws-sigv4 1.9.1 (was 1.8.0)
Using net-sftp 4.0.0
Using net-ssh-gateway 2.0.0
Using mixlib-config 3.0.27
Using tty-reader 0.9.0
Using net-scp 4.0.0
Using rspec-mocks 3.12.7
Using pry 0.14.2
Using http-cookie 1.0.6
Using fuzzyurl 0.9.0
Using strings 0.2.1
Using logging 2.4.0
Using mime-types 3.5.2
Using time 0.3.0
Fetching faraday-net_http 3.1.1 (was 3.1.0)
Using rspec-core 3.12.3
Using chef-utils 19.0.2 (was 18.5.1) from source at `/Users/powell/projects/chef/chef-utils`
Using mixlib-archive 1.1.7
Using rubocop-ast 1.31.3
Using pastel 0.8.0
Using crack 0.4.5
Using net-ssh-multi 1.2.1
Using pry-byebug 3.10.1
Using pry-stack_explorer 0.6.1
Using rest-client 2.1.0
Using gyoku 1.4.0
Using rspec-expectations 3.12.4
Using tty-prompt 0.23.1
Using rubocop 1.25.1
Using webmock 3.23.1
Using tty-table 0.12.0
Using ffi-yajl 2.6.0
Using cookstyle 7.32.8
Using chefstyle 2.2.3 from https://github.com/chef/chefstyle.git (at main@c1fed9c)
Using tty-box 0.7.0
Using chef-zero 15.0.11
Using rspec 3.12.0
Using net-protocol 0.2.2
Using rspec-its 1.3.0
Using net-ftp 0.3.7
Using license-acceptance 2.1.13
Using cheffish 17.1.5
Using mixlib-shellout 3.2.8
Using chef-config 19.0.2 (was 18.5.1) from source at `/Users/powell/projects/chef/chef-config`
Using train-core 3.12.5
Using ohai 19.0.0 (was 18.2.0) from https://github.com/chef/ohai.git (at main@a235eac)
Using chef-telemetry 1.1.1
Installing aws-partitions 1.959.0 (was 1.955.0)
Installing nori 2.7.1 (was 2.7.0)
Installing faraday-net_http 3.1.1 (was 3.1.0)
Installing aws-sigv4 1.9.1 (was 1.8.0)
Using faraday 2.10.0
Using faraday-follow_redirects 0.3.0
Using inspec-core 5.22.50
Using train-rest 0.5.0
Using vault 0.18.2
Fetching aws-sdk-core 3.201.3 (was 3.201.1)
Using winrm 2.3.8
Using winrm-fs 1.3.5
Using winrm-elevated 1.2.3
Using train-winrm 0.2.13
Installing aws-sdk-core 3.201.3 (was 3.201.1)
Using aws-sdk-kms 1.88.0
Fetching aws-sdk-secretsmanager 1.102.0 (was 1.101.0)
Using aws-sdk-s3 1.156.0
Installing aws-sdk-secretsmanager 1.102.0 (was 1.101.0)
Using chef 19.0.2 (was 18.5.1) from source at `..`
Using chef-bin 19.0.2 (was 18.5.1) from source at `../chef-bin` and installing its executables
Using knife 19.0.2 (was 18.5.1) from source at `.` and installing its executables
Note: ffi version regressed from 1.17.0 to 1.16.3
Bundle updated!
```
</details>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
