### PR TITLE
Tweaking resources and tests for FreeBSD

### DIFF
--- a/lib/chef/provider/group/pw.rb
+++ b/lib/chef/provider/group/pw.rb
@@ -38,7 +38,11 @@ class Chef
 
         # Create the group
         def create_group
-          command = [ "pw", "groupadd", set_options ]
+          command = if freebsd? # Freebsd 13.x doesn't accept running the whole script under sudo and throws an error when creating/deleting groups
+                      [ "sudo", "pw", "groupadd", set_options ]
+                    else
+                      [ "pw", "groupadd", set_options ]
+                    end
           unless new_resource.members.empty?
             # pw group[add|mod] -M is used to set the full membership list on a
             # new or existing group. Because pw groupadd does not support the -m
@@ -65,7 +69,11 @@ class Chef
 
         # Remove the group
         def remove_group
-          shell_out!("pw", "groupdel", new_resource.group_name)
+          if freebsd? # Freebsd 13.x doesn't accept running the whole script under sudo and throws an error when creating/deleting groups
+            shell_out!("sudo", "pw", "groupdel", new_resource.group_name)
+          else
+            shell_out!("pw", "groupdel", new_resource.group_name)
+          end
         end
 
         # Little bit of magic as per Adam's useradd provider to pull and assign the command line flags


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
FreeBSD is throwing errors during AdHoc testing indicating that the tester lacks permissions to add/remove groups and users. Here, we explicitly have 'sudo' create and delete the resources

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
