### PR TITLE
Prevent trivial diff display

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -422,7 +422,7 @@ class Chef
                      "[" + options_list.join(" ") + "]"
                    end
           info = [ optstr, uri.normalize.to_s, distribution, components ].compact.join(" ")
-          repo =  "deb      #{info}\n"
+          repo =  "deb #{info}\n"
           repo << "deb-src  #{info}\n" if add_src
           repo
         end


### PR DESCRIPTION
Removing white space causing a diff to display when there is no functional changes.

Obvious fix.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Every time I run chef-client, the apt_repository output will display a diff, even though there is no actual change, as seen below.

```
    * file[/etc/apt/sources.list.d/postgresql.list] action create
      - update content in file /etc/apt/sources.list.d/postgresql.list from f4f2c9 to 7bf91c
      --- /etc/apt/sources.list.d/postgresql.list       2024-07-18 15:26:26.247455217 +0800
      +++ /etc/apt/sources.list.d/.chef-postgresql20240718-2537-44afjr.list     2024-07-18 15:27:36.263750046 +0800
      @@ -1 +1 @@
      -deb      http://apt.postgresql.org/pub/repos/apt jammy-pgdg main
      +deb http://apt.postgresql.org/pub/repos/apt jammy-pgdg main
```

The proposed changed removes the white space causing this output, which makes it easier to see what is really changing with each run.

I tested this on my client, works well. Since this seems an "obvious fix" to me, I don't believe there's a need for new tests or documentation.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).