### PR TITLE
downgraded ISO8601 support because this thing is 3-6 months from EOL

### DIFF
--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -222,9 +222,9 @@ class Chef
         description: "Delays the task up to a given time (in seconds)."
 
       property :execution_time_limit, [String, Integer],
-        description: "The maximum time the task will run. This field accepts either seconds or an ISO8601 duration value.",
-        default: "PT72H",
-        default_description: "PT72H (72 hours in ISO8601 duration format)"
+        description: "The maximum time the task will run, in seconds. This field accepts a max value of '259200'",
+        default: 259200,
+        default_description: "An amount of time, desribed in seconds, that is less than 72 hours"
 
       property :minutes_duration, [String, Integer],
         description: ""
@@ -270,8 +270,7 @@ class Chef
         end
 
         if execution_time_limit
-          execution_time_limit(259200) if execution_time_limit == "PT72H"
-          raise ArgumentError, "Invalid value passed for `execution_time_limit`. Please pass seconds as an Integer (e.g. 60) or a String with numeric values only (e.g. '60')." unless numeric_value_in_string?(execution_time_limit)
+          raise ArgumentError, "Invalid value passed for `execution_time_limit`. Please pass seconds as an Integer (e.g. 60) or a String with numeric values only (e.g. '60')." unless execution_time_limit.to_i <= 259200
 
           execution_time_limit(sec_to_min(execution_time_limit))
         end

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -224,7 +224,7 @@ class Chef
       property :execution_time_limit, [String, Integer],
         description: "The maximum time the task will run, in seconds. This field accepts a max value of '259200'",
         default: 259200,
-        default_description: "An amount of time, desribed in seconds, that is less than 72 hours"
+        default_description: "An amount of time, described in seconds, that is less than 72 hours"
 
       property :minutes_duration, [String, Integer],
         description: ""


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The windows task scheduler was completely borked. It was supposed to support ISO8601 time formats but had no way to actually do that. I looked into how you might actually pull that off and it was 100's of lines of code to fix that. The two most popular gems that could do that work for us are both EOL by at least 4 years and they both required a LOT of code to work correctly. Since Chef-17 is so close to EOL and since the amount of effort to support ISO8601 is pretty Herculean at this point, I am opting to remove support. Tasks are all specified in seconds only

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
