### PR TITLE
remove homebrew/cask tap in cask install

### DIFF
--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -40,10 +40,6 @@ class Chef
       property :options, String,
         description: "Options to pass to the brew command during installation."
 
-      property :install_cask, [TrueClass, FalseClass],
-        description: "Automatically install the Homebrew cask tap, if necessary.",
-        default: true
-
       property :homebrew_path, String,
         description: "The path to the Homebrew binary."
 
@@ -71,13 +67,6 @@ class Chef
       end
 
       action :remove, description: "Remove an application that is packaged as a Homebrew cask." do
-        if new_resource.install_cask
-          homebrew_tap "homebrew/cask" do
-            homebrew_path homebrew_bin_path(new_resource.homebrew_path)
-            owner new_resource.owner
-          end
-        end
-
         if casked?
           converge_by("uninstall cask #{new_resource.cask_name}") do
             shell_out!("#{homebrew_bin_path(new_resource.homebrew_path)} uninstall --cask #{new_resource.cask_name}",

--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -49,13 +49,6 @@ class Chef
         default_description: "Calculated default username"\
 
       action :install, description: "Install an application that is packaged as a Homebrew cask." do
-        if new_resource.install_cask
-          homebrew_tap "homebrew/cask" do
-            homebrew_path homebrew_bin_path(new_resource.homebrew_path)
-            owner new_resource.owner
-          end
-        end
-
         unless casked?
           converge_by("install cask #{new_resource.cask_name} #{new_resource.options}") do
             shell_out!("#{homebrew_bin_path(new_resource.homebrew_path)} install --cask #{new_resource.cask_name} #{new_resource.options}",


### PR DESCRIPTION
## Description

This fixes an error in the latest version of homebrew for a while now removed the need for homebrew cask tap. 

This currently generates an error when ran:
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it for contributing to Homebrew.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
