### PR TITLE
CHEF-12738: Ensure that there is a separate software_entitlement_check call for compliance phase

### DIFF
--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -133,7 +133,7 @@ class Chef
         end
         logger.info "Chef Infra Compliance Phase Complete"
       rescue Chef::Licensing::EntitlementError => e
-        logger.error "Skipping Chef Infra Compliance Phase due to lack of entitlement."
+        logger.error "Skipping Chef Infra Compliance Phase because the license does not have the required entitlement for Chef InSpec."
         return
       end
 

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -116,6 +116,7 @@ class Chef
 
       def report(report = nil)
         logger.info "Starting Chef Infra Compliance Phase"
+        Chef::Licensing.check_software_entitlement_compliance_phase!
         report ||= generate_report
         # This is invoked at report-time instead of with the normal validations at node loaded,
         # because we want to ensure that it is visible in the output - and not lost in back-scroll.
@@ -131,6 +132,9 @@ class Chef
           @reporters[reporter_type].send_report(report)
         end
         logger.info "Chef Infra Compliance Phase Complete"
+      rescue Chef::Licensing::EntitlementError => e
+        logger.error "Skipping Chef Infra Compliance Phase due to lack of entitlement."
+        return
       end
 
       def inputs_from_attributes

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -116,7 +116,7 @@ class Chef
 
       def report(report = nil)
         logger.info "Starting Chef Infra Compliance Phase"
-        Chef::Licensing.check_software_entitlement_compliance_phase!
+        Chef::Licensing.check_software_entitlement_compliance_phase! if ChefUtils::Dist::Inspec::EXEC == "inspec"
         report ||= generate_report
         # This is invoked at report-time instead of with the normal validations at node loaded,
         # because we want to ensure that it is visible in the output - and not lost in back-scroll.

--- a/lib/chef/licensing.rb
+++ b/lib/chef/licensing.rb
@@ -11,6 +11,9 @@ class Chef
       rescue ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError
         Chef::Log.error "Infra cannot execute without valid licenses." # TODO: Replace Infra with the product name dynamically
         Chef::Application.exit! "License not set", 174 # 174 is the exit code for LICENSE_NOT_SET defined in lib/chef/application/exit_code.rb
+      rescue ChefLicensing::SoftwareNotEntitled
+        Chef::Log.error "License is not entitled to use Chef Infra."
+        Chef::Application.exit! "License not entitled", 173 # 173 is the exit code for LICENSE_NOT_ENTITLED defined in lib/chef/application/exit_code.rb
       rescue ChefLicensing::Error => e
         Chef::Log.error e.message
         Chef::Application.exit! "Usage error", 1 # Generic failure
@@ -20,7 +23,7 @@ class Chef
         puts "Checking software entitlement..."
         ChefLicensing.check_software_entitlement!
       rescue ChefLicensing::SoftwareNotEntitled
-        Chef::Log.error "License is not entitled to use Infra."
+        Chef::Log.error "License is not entitled to use Chef Infra."
         Chef::Application.exit! "License not entitled", 173 # 173 is the exit code for LICENSE_NOT_ENTITLED defined in lib/chef/application/exit_code.rb
       rescue ChefLicensing::Error => e
         Chef::Log.error e.message
@@ -30,7 +33,6 @@ class Chef
       def check_software_entitlement_compliance_phase!
         puts "Checking software entitlement for compliance phase..."
         # set the chef_entitlement_id to the value for Compliance Phase entitlement (i.e. InSpec's entitlement ID)
-        #
         ChefLicensing::Config.chef_entitlement_id = Chef::LicensingConfig::COMPLIANCE_ENTITLEMENT_ID
         ChefLicensing.check_software_entitlement!
         # reset the chef_entitlement_id to the default value
@@ -38,7 +40,6 @@ class Chef
       rescue ChefLicensing::SoftwareNotEntitled
         # reset the chef_entitlement_id to the default value
         ChefLicensing::Config.chef_entitlement_id = Chef::LicensingConfig::INFRA_ENTITLEMENT_ID
-        Chef::Log.error "License is not entitled to use Compliance Phase."
         raise EntitlementError, "License not entitled"
       rescue ChefLicensing::Error => e
         # resetting of chef_entitlement_id is not needed here as the application will exit!

--- a/lib/chef/licensing.rb
+++ b/lib/chef/licensing.rb
@@ -65,8 +65,6 @@ class Chef
               Entitled for period of subscription purchased
               Entitled for commercial use
 
-            knife license add: This command helps users to generate or add an additional license (not applicable to local licensing service)
-
             For more information please visit:
             www.chef.io/licensing/faqs
 

--- a/lib/chef/licensing_config.rb
+++ b/lib/chef/licensing_config.rb
@@ -3,8 +3,8 @@ require_relative "log"
 
 class Chef
   class LicensingConfig
-    INFRA_ENTITLEMENT_ID = "a5213d76-181f-4924-adba-4b7ed2b098b5"
-    COMPLIANCE_ENTITLEMENT_ID = "3ff52c37-e41f-4f6c-ad4d-365192205968" # InSpec's entitlement ID
+    INFRA_ENTITLEMENT_ID = "a5213d76-181f-4924-adba-4b7ed2b098b5".freeze
+    COMPLIANCE_ENTITLEMENT_ID = "3ff52c37-e41f-4f6c-ad4d-365192205968".freeze # InSpec's entitlement ID
   end
 end
 

--- a/lib/chef/licensing_config.rb
+++ b/lib/chef/licensing_config.rb
@@ -1,11 +1,18 @@
 require "chef-licensing"
 require_relative "log"
 
+class Chef
+  class LicensingConfig
+    INFRA_ENTITLEMENT_ID = "a5213d76-181f-4924-adba-4b7ed2b098b5"
+    COMPLIANCE_ENTITLEMENT_ID = "3ff52c37-e41f-4f6c-ad4d-365192205968" # InSpec's entitlement ID
+  end
+end
+
 ChefLicensing.configure do |config|
   config.chef_product_name = "Infra"
-  config.chef_entitlement_id = "a5213d76-181f-4924-adba-4b7ed2b098b5"
+  config.chef_entitlement_id = Chef::LicensingConfig::INFRA_ENTITLEMENT_ID
   config.chef_executable_name = "chef-client"
-  config.license_server_url = "https://services.chef.io/licensing"
+  config.license_server_url = "https://services.chef.io/licensing" unless config.license_server_url
   config.logger = Chef::Log
   config.license_add_command = "--license-add"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR adds a software entitlement check for the compliance phase. With this check to run the compliance phase in Infra, the user's license must include entitlements for both Infra and InSpec.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-12738: Ensure that there is a separate software_entitlement_check call for compliance phase

CHEF-11810: InSpec Validation by Infra License

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
