### PR TITLE
rolling back changes to ohai platform and os detection

### DIFF
--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -441,7 +441,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       end
     end
 
-    describe "when there is a group" do
+    describe "when there is a group", :not_supported_on_macos do
       it_behaves_like "correct group management"
     end
 
@@ -483,7 +483,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
       end
     end
 
-    describe "when there is a group" do
+    describe "when there is a group", :not_supported_on_macos do
       it_behaves_like "correct group management"
     end
 

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -24,7 +24,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
   include Chef::Mixin::ShellOut
 
   def group_should_exist(group)
-    case ohai[:platform]
+    case ohai[:os]
     when "freebsd"
       expect(shell_out("pw groupshow -n #{group}").exitstatus).to eq(0)
     when "windows"
@@ -36,7 +36,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
   end
 
   def user_exist_in_group?(user)
-    case ohai[:platform]
+    case ohai[:platform_family]
     when "freebsd"
       cmd = Mixlib::ShellOut.new("getent group #{group_name}  #{user}").run_command.stdout
       if cmd.include? user
@@ -62,7 +62,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
   end
 
   def group_should_not_exist(group)
-    case ohai[:platform]
+    case ohai[:os]
     when "freebsd"
       expect(shell_out("pw groupshow -n #{group}").exitstatus).to eq(65)
     when "windows"

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -352,7 +352,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
     expect(group_resource.append).to eq(false)
   end
 
-  describe "group create action", :not_supported_on_freebsd_gte_12_3 do
+  describe "group create action", :not_supported_on_freebsd_gte_12_3, :not_supported_on_macos do
     after(:each) do
       group_resource.run_action(:remove)
       group_should_not_exist(group_name)
@@ -409,7 +409,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
   end
 
   describe "group remove action" do
-    describe "when there is a group", :not_supported_on_freebsd_gte_12_3 do
+    describe "when there is a group", :not_supported_on_freebsd_gte_12_3, :not_supported_on_macos do
       before do
         group_resource.run_action(:create)
         group_should_exist(group_name)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
In this [PR](https://github.com/chef/chef/pull/14528) we updated some code in the groups_spec.rb to overcome problems with running the tests on freebsd. However, that update broke tests for macos. This update corrects that 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
