### PR TITLE
prefer extra_paths first when looking for bin file

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/which.rb
+++ b/chef-utils/lib/chef-utils/dsl/which.rb
@@ -78,7 +78,7 @@ module ChefUtils
       #
       def where(*cmds, extra_path: nil, &block)
         extra_path ||= __extra_path
-        paths = __env_path.split(File::PATH_SEPARATOR) + Array(extra_path)
+        paths = Array(extra_path) + __env_path.split(File::PATH_SEPARATOR)
         paths.uniq!
         exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : []
         exts.unshift("")


### PR DESCRIPTION
When passing extra paths users would expect either command to be looked in the extra_path parameter first for cases of multiple bin commands existing on system or this should add tiny performance enhancement as likely the bin isn't in a default bin dir and user is adding extra dirs to lookin. Thus looking in them first will match early.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
