### PR TITLE
Updating the rdoc version for Chef-18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?
 # required for FIPS or bundler will pick up default openssl
 gem "openssl", "= 3.2.0" unless Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" }
 
+gem "rdoc", "~> 6.4.1" # 6.4.1.1 required for CVE-2024-27281, allow patch upgrades
+
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout
   gem "chef-bin", path: File.expand_path("chef-bin", __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,11 +341,15 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
+    psych (5.1.2)
+      stringio
     public_suffix (5.0.1)
     rack (2.2.6.4)
     rainbow (3.1.1)
     rake (13.0.6)
     rb-readline (0.5.5)
+    rdoc (6.4.1.1)
+      psych (>= 4.0.0)
     regexp_parser (2.7.0)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -381,6 +385,7 @@ GEM
     rubyzip (2.3.2)
     semverse (3.0.2)
     sslshake (1.3.1)
+    stringio (3.1.1)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)
@@ -510,6 +515,7 @@ DEPENDENCIES
   pry-stack_explorer
   rake
   rb-readline
+  rdoc (~> 6.4.1)
   rest-client!
   rspec
   ruby-shadow!


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The RDoc gem, as installed by base Ruby and not chef, has a CVE. Here we explicitly add/update the rdoc version to overcome that CVE. Notes here: https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/. Chef Bug here - https://chefio.atlassian.net/browse/CHEF-13657

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
