### PR TITLE
disabling omnibus production builds

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,11 +30,11 @@ pipelines:
       public: true
       env:
         - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems.
-  - validate/release:
-      definition: .expeditor/verify.pipeline.yml
-      env:
-        - IGNORE_CACHE: true # caching causes constant build failures
-        - IGNORE_ARTIFACTORY_RUBY_PROXY: true
+  # - validate/release:
+  #     definition: .expeditor/verify.pipeline.yml
+  #     env:
+  #       - IGNORE_CACHE: true # caching causes constant build failures
+  #       - IGNORE_ARTIFACTORY_RUBY_PROXY: true
   - validate/adhoc:
       definition: .expeditor/verify.adhoc.pipeline.yml
       env:
@@ -55,10 +55,10 @@ pipelines:
   - habitat/test:
       definition: .expeditor/habitat-test.pipeline.yml
       trigger: default
-  - omnibus/release:
-      env:
-        - IGNORE_CACHE: true # caching causes constant build failures
-        - IGNORE_ARTIFACTORY_RUBY_PROXY: true
+  # - omnibus/release:
+  #     env:
+  #       - IGNORE_CACHE: true # caching causes constant build failures
+  #       - IGNORE_ARTIFACTORY_RUBY_PROXY: true
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
@@ -123,7 +123,7 @@ subscriptions:
       # - bash:.expeditor/promote-docker-images.sh
       - bash:.expeditor/publish-release-notes.sh
       - bash:.expeditor/announce-release.sh
-      - built_in:publish_rubygems
+      # - built_in:publish_rubygems
       - built_in:promote_habitat_packages
       - built_in:notify_chefio_slack_channels
 


### PR DESCRIPTION
* Disable pushing of build artifacts to omnitruck via disabling of `/release` pipelines.
* Disable Expeditor promotion of chef builds to Rubygems.


<!--- Provide a short summary of your changes in the Title above -->

## Description
https://chefcommunity.slack.com/archives/C042KK33E8K/p1722972507202219 

With the new PI upcoming this is a start to ensure we dont build an omnibus production release. This is an initial step so that we can begin work on the new habitat release(s) 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
