### PR TITLE
Obvious fix: replace lint download action with curl

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,10 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: carlosperate/download-file-action@v2.0.0
-        id: download-custom-dictionary
-        with:
-          file-url: 'https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt'
-          file-name: 'chef_dictionary.txt'
+      - run: |
+          curl --location 'https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt' --output chef_dictionary.txt
       - uses: streetsidesoftware/cspell-action@v2.12.0
 


### PR DESCRIPTION
## Description
Obvious fix

Partially resolves this warning:
> The following actions use a deprecated Node.js version and will be forced to run on node20: carlosperate/download-file-action@v2.0.0, streetsidesoftware/cspell-action@v2.12.0. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
