### PR TITLE
[CHEF-18] fix docker builds

### DIFF
--- a/.expeditor/build-docker-images.sh
+++ b/.expeditor/build-docker-images.sh
@@ -4,10 +4,10 @@ set -eux -o pipefail
 arch=$1
 
 if [[ $arch == "arm64" ]]; then
-  dockerfile_pkg_version="7"
+  dockerfile_pkg_version="9"
   dockerfile_arch="aarch64"
 else
-  dockerfile_pkg_version="6"
+  dockerfile_pkg_version="9"
   dockerfile_arch="x86_64"
 fi
 

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -108,19 +108,19 @@ subscriptions:
   # the omnibus/docker/gem chain
   - workload: artifact_published:unstable:chef:{{version_constraint}}
     actions:
-      # - trigger_pipeline:docker/build
+      - trigger_pipeline:docker/build
       - trigger_pipeline:macos_universal_package
-  # - workload: artifact_published:current:chef:{{version_constraint}}
-  #   actions:
-  #     - bash:.expeditor/promote-docker-images.sh
+  - workload: artifact_published:current:chef:{{version_constraint}}
+    actions:
+      - bash:.expeditor/promote-docker-images.sh
   - workload: project_promoted:{{agent_id}}:*
     actions:
       - built_in:promote_artifactory_artifact
   - workload: artifact_published:stable:chef:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
-      # - bash:.expeditor/update_dockerfile.sh
-      # - bash:.expeditor/promote-docker-images.sh
+      - bash:.expeditor/update_dockerfile.sh
+      - bash:.expeditor/promote-docker-images.sh
       - bash:.expeditor/publish-release-notes.sh
       - bash:.expeditor/announce-release.sh
       - built_in:publish_rubygems

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 ARG CHANNEL=stable
 ARG VERSION=18.3.0
 ARG ARCH=x86_64
-ARG PKG_VERSION=6
+ARG PKG_VERSION=9
 
 RUN wget "http://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/${PKG_VERSION}/chef-${VERSION}-1.el${PKG_VERSION}.${ARCH}.rpm" -O /tmp/chef-client.rpm && \
     rpm2cpio /tmp/chef-client.rpm | cpio -idmv && \


### PR DESCRIPTION
## Description

chef/chef docker builds were disabled due to broken pipeline. I found the pipeline was broken due to the dockerfile using the RHEL-6 OS for downloading the chef-client rpm build. Since RHEL-6 is EOL chef-client isn't built for that platform anymore it thus is breaking the docker pipelines. This bumps it up to use a more modern rpm for RHEL-9.

These builds are needed for kitchen-dokken driver as the chef/chef volume for the desired version is then downloaded and mounted to all docker containers instead of bootstrapped individually on all containers decreasing run times and giving a faster feedback loop.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
