### PR TITLE
Clear user privileges before deleting user in Windows

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1358,6 +1358,7 @@
     "TERMSRV",
     "testswapfile",
     "testswapfiledir",
+    "testuser",
     "texteditor",
     "Theaker",
     "THRDS",

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_windows_user_privilege.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_windows_user_privilege.rb
@@ -1,0 +1,21 @@
+ # Add a user to the system
+ user "testuser"
+
+ # Update a privilege to include the new user account
+ windows_user_privilege "SeNetworkLogonRight" do
+   privilege "SeNetworkLogonRight"
+   users ["BUILTIN\\Administrators", "NT AUTHORITY\\Authenticated Users", "testuser"]
+   action :set
+ end
+
+ # Remove the added test user
+ user "testuser" do
+   action :remove
+ end
+
+ # Attempt to manage the same privilege and an exception will be raised when the resource attempts to remove `testuser` from the listing
+ windows_user_privilege "SeNetworkLogonRight" do
+   privilege "SeNetworkLogonRight"
+   users ["BUILTIN\\Administrators", "NT AUTHORITY\\Authenticated Users"]
+   action :set
+ end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_windows_user_privilege.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_windows_user_privilege.rb
@@ -1,21 +1,21 @@
- # Add a user to the system
- user "testuser"
+# Add a user to the system
+user "testuser"
 
- # Update a privilege to include the new user account
- windows_user_privilege "SeNetworkLogonRight" do
-   privilege "SeNetworkLogonRight"
-   users ["BUILTIN\\Administrators", "NT AUTHORITY\\Authenticated Users", "testuser"]
-   action :set
- end
+# Update a privilege to include the new user account
+windows_user_privilege "SeNetworkLogonRight" do
+  privilege "SeNetworkLogonRight"
+  users ["BUILTIN\\Administrators", "NT AUTHORITY\\Authenticated Users", "testuser"]
+  action :set
+end
 
- # Remove the added test user
- user "testuser" do
-   action :remove
- end
+# Remove the added test user
+user "testuser" do
+  action :remove
+end
 
- # Attempt to manage the same privilege and an exception will be raised when the resource attempts to remove `testuser` from the listing
- windows_user_privilege "SeNetworkLogonRight" do
-   privilege "SeNetworkLogonRight"
-   users ["BUILTIN\\Administrators", "NT AUTHORITY\\Authenticated Users"]
-   action :set
- end
+# Attempt to manage the same privilege and an exception will be raised when the resource attempts to remove `testuser` from the listing
+windows_user_privilege "SeNetworkLogonRight" do
+  privilege "SeNetworkLogonRight"
+  users ["BUILTIN\\Administrators", "NT AUTHORITY\\Authenticated Users"]
+  action :set
+end

--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -85,7 +85,12 @@ class Chef
           @net_user.update(**set_options)
         end
 
+        def clear_account_rights(name)
+          Chef::ReservedNames::Win32::Security.clear_account_rights(name)
+        end
+
         def remove_user
+          clear_account_rights(name)
           @net_user.delete
         end
 

--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -90,7 +90,7 @@ class Chef
         end
 
         def remove_user
-          clear_account_rights(name)
+          clear_account_rights(new_resource.username)
           @net_user.delete
         end
 

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -130,6 +130,14 @@ class Chef
         end
       end
 
+      def self.clear_account_rights(name)
+        return if get_account_right(name) == []
+        with_lsa_policy(name) do |policy_handle, sid|
+          result = LsaRemoveAccountRights(policy_handle.read_pointer, sid, true, nil, 1)
+          test_and_raise_lsa_nt_status(result)
+        end
+      end
+
       def self.adjust_token_privileges(token, privileges)
         token = token.handle if token.respond_to?(:handle)
         old_privileges_size = FFI::Buffer.new(:long).write_long(privileges.size_with_privileges)

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -132,6 +132,7 @@ class Chef
 
       def self.clear_account_rights(name)
         return if get_account_right(name) == []
+
         with_lsa_policy(name) do |policy_handle, sid|
           result = LsaRemoveAccountRights(policy_handle.read_pointer, sid, true, nil, 1)
           test_and_raise_lsa_nt_status(result)

--- a/spec/unit/provider/user/windows_spec.rb
+++ b/spec/unit/provider/user/windows_spec.rb
@@ -158,6 +158,7 @@ describe Chef::Provider::User::Windows do
 
   describe "when removing the user" do
     it "should call @net_user.delete" do
+      allow(Chef::ReservedNames::Win32::Security).to receive(:clear_account_rights)
       expect(@net_user).to receive(:delete)
       @provider.remove_user
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

<details><summary>When a security principal is granted a Windows user right and then deleted any future attempt to manage that user right using the windows_user_privilege will cause a converge failure.</summary>

Reproduction case:

```ruby
 # Add a user to the system
 user "testuser"

 # Update a privilege to include the new user account
 windows_user_privilege "SeNetworkLogonRight" do
   privilege "SeNetworkLogonRight"
   users ["BUILTIN\\Administrators", "NT AUTHORITY\\Authenticated Users", "testuser"]
   action :set
 end

 # Remove the added test user
 user "testuser" do
   action :remove
 end

 # Attempt to manage the same privilege and an exception will be raised when the resource attempts to remove `testuser` from the listing
 windows_user_privilege "SeNetworkLogonRight" do
   privilege "SeNetworkLogonRight"
   users ["BUILTIN\\Administrators", "NT AUTHORITY\\Authenticated Users"]
   action :set
 end
```
</details>

### Fix
Clear user permissions prior to deleting.

## Related Issue
[chef/chef Issue #12212](https://github.com/chef/chef/issues/12212) 
Internal issue: [CHEF-5590](https://chefio.atlassian.net/browse/CHEF-5590)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


[CHEF-5590]: https://chefio.atlassian.net/browse/CHEF-5590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ