### PR TITLE
added nil check for current_record in resource skipped

### DIFF
--- a/lib/chef/action_collection.rb
+++ b/lib/chef/action_collection.rb
@@ -189,8 +189,10 @@ class Chef
     # (see EventDispatch::Base#)
     #
     def resource_skipped(resource, action, conditional)
-      current_record.status = :skipped
-      current_record.conditional = conditional
+      unless current_record.nil?
+        current_record.status = :skipped
+        current_record.conditional = conditional
+      end
     end
 
     # Hook called after an action modifies the system and is marked updated.

--- a/lib/chef/action_collection.rb
+++ b/lib/chef/action_collection.rb
@@ -189,10 +189,9 @@ class Chef
     # (see EventDispatch::Base#)
     #
     def resource_skipped(resource, action, conditional)
-      unless current_record.nil?
-        current_record.status = :skipped
-        current_record.conditional = conditional
-      end
+      return if current_record.nil?
+      current_record.status = :skipped
+      current_record.conditional = conditional
     end
 
     # Hook called after an action modifies the system and is marked updated.

--- a/lib/chef/action_collection.rb
+++ b/lib/chef/action_collection.rb
@@ -190,7 +190,7 @@ class Chef
     #
     def resource_skipped(resource, action, conditional)
       return if current_record.nil?
-      
+
       current_record.status = :skipped
       current_record.conditional = conditional
     end

--- a/lib/chef/action_collection.rb
+++ b/lib/chef/action_collection.rb
@@ -190,6 +190,7 @@ class Chef
     #
     def resource_skipped(resource, action, conditional)
       return if current_record.nil?
+      
       current_record.status = :skipped
       current_record.conditional = conditional
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
after hook resource skipped cause FATAL error when current record is nil and cause entire CDV fail (even tho tests passed successfully). This is ruby fatal error.
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
when running CDV for cinc 18.x and 19.x , after hook resource skipped with current record is nil will cause ruby FATAL error because it attempted to set something not exist
```
2024-08-28 22:45:05 +0000 resource_skipped hook called for execute[test.sh] with action [:run] and conditional #<Chef::Resource::Conditional:0x00007fd770528c18>
#<Chef::Resource::Conditional:0x00007fd770528c18 @positivity=:only_if, @command_opts=nil, @command=nil, @block=#<Proc:0x00007fd770528ab0 /etc/cinc/local-mode-cache/cache/cookbooks/test/recipes/build.rb:52>, @block_given=true, @parent_resource=<execute[test.sh] @name: "test.sh" @before: nil @params: {} @provider: nil @allowed_actions: [:nothing, :run] @action: [:run] @updated: false @updated_by_last_action: false @source_line: "/etc/cinc/local-mode-cache/cache/cookbooks/test/recipes/build.rb:50:in `from_file'" @guard_interpreter: nil @default_guard_interpreter: :execute @elapsed_time: 0.001868606 @command: "/usr/local/bin/test.sh" @is_guard_interpreter: false @declared_type: :execute @cookbook_name: "test" @recipe_name: "build" @domain: nil @user: nil>, @guard_interpreter=nil>
Current Record::::  ::::::::: nil::::::
Current Record::::  ::::::::: true::::::Resource::::::  execute[test.sh] ::::Action::::  [:run] ::::: Conditional:::: #<Chef::Resource::Conditional:0x00007fd770528c18>
[2024-08-28T22:45:05+00:00] FATAL: NoMethodError: undefined method `status=' for nil:NilClass
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
