### PR TITLE
[chef18] Enhance resource inspector to understand LWRP files containing multiple resources

### DIFF
--- a/lib/chef/resource_inspector.rb
+++ b/lib/chef/resource_inspector.rb
@@ -79,19 +79,37 @@ class Chef
       Array(equal_to).map(&:inspect)
     end
 
+    def self.load_from_resources(resources, complete)
+      resources.each_with_object({}) do |r, res|
+        pth = r["full_path"]
+        # Here we do some magic to extract resources from files where there are multiple resources
+        # in a file - to do this, we load the file, and take the delta of which resources
+        # exist in object space
+        existing_classes = []
+        ObjectSpace.each_object(Class).select { |k| k < Chef::Resource }.each { |klass| existing_classes << klass }
+        # Load the set of resources from this file
+        Chef::Resource::LWRPBase.build_from_file(name, pth, Chef::RunContext.new(Chef::Node.new, nil, nil))
+        # Finally, process every new class added to the object space by that
+        ObjectSpace.each_object(Class).select { |k| k < Chef::Resource }.each do |klass|
+          unless existing_classes.include?(klass)
+            # Skip over anything which creates resources that start with exactly this - that happens
+            # because if there is no non-classed resource in here, LWRPBase.build_from_file builds a
+            # dummy object from it - we don't need that polluting out output!
+            next if klass.resource_name.start_with?("Chef__ResourceInspector")
+
+            res[klass.resource_name] = extract_resource(klass, complete)
+          end
+        end
+      end
+    end
+
     def self.extract_cookbook(path, complete)
       path = File.expand_path(path)
       dir, name = File.split(path)
       Chef::Cookbook::FileVendor.fetch_from_disk(path)
       loader = Chef::CookbookLoader.new(dir)
       cookbook = loader.load_cookbook(name)
-      resources = cookbook.files_for(:resources)
-
-      resources.each_with_object({}) do |r, res|
-        pth = r["full_path"]
-        cur = Chef::Resource::LWRPBase.build_from_file(name, pth, Chef::RunContext.new(Chef::Node.new, nil, nil))
-        res[cur.resource_name] = extract_resource(cur, complete)
-      end
+      load_from_resources(cookbook.files_for(:resources), complete)
     end
 
     # If we're given no resources, dump all of Chef's built ins

--- a/spec/unit/resource_inspector_spec.rb
+++ b/spec/unit/resource_inspector_spec.rb
@@ -17,6 +17,20 @@
 require "spec_helper"
 require "chef/resource_inspector"
 
+COMBINED_RESOURCE_TEXT = <<~EOF.freeze
+  class Dummy1 < Chef::Resource::LWRPBase
+    resource_name :dummy1
+    description "A dummy resource"
+    property :first, String, description: "My First Property", introduced: "14.0"
+  end
+
+  class Dummy2 < Chef::Resource::LWRPBase
+    resource_name :dummy2
+    description "Another dummy resource"
+    property :second, String, description: "My Second Property", introduced: "14.0"
+  end
+EOF
+
 class DummyResource < Chef::Resource
   resource_name :dummy
   description "A dummy resource"
@@ -60,6 +74,28 @@ describe Chef::ResourceInspector do
         expect(subject[:properties].count).to be > 1
         expect(subject[:properties].map { |n| n[:name] }).to include(:name, :first, :sensitive)
       end
+    end
+  end
+
+  describe "inspecting a multi-resource file" do
+    # Call the inspector with a fake file containing two resources, and ensure that we get
+    # both of them back!
+    subject {
+      Chef::ResourceInspector.load_from_resources([
+        { "full_path" => "/cookbooks/fake_cookbook/resources/big_resource.rb" },
+      ], false)
+    }
+    it "has elephants" do
+      allow(File).to receive(:file?).with("/cookbooks/fake_cookbook/resources/big_resource.rb").and_return(true)
+      allow(File).to receive(:readable?).with("/cookbooks/fake_cookbook/resources/big_resource.rb").and_return(true)
+      allow(IO).to receive(:read).with("/cookbooks/fake_cookbook/resources/big_resource.rb").and_return(COMBINED_RESOURCE_TEXT)
+      expect(subject.keys.count).to be 2
+      expect(subject.keys.sort).to eq(%i{dummy1 dummy2})
+      # This is correct - because they're not fully realised resources at this point, sensitive and friends are not added yet.
+      expect(subject[:dummy1][:properties].count).to be 1
+      expect(subject[:dummy2][:properties].count).to be 1
+      expect(subject[:dummy1][:properties][0][:description]).to eq "My First Property"
+      expect(subject[:dummy2][:properties][0][:description]).to eq "My Second Property"
     end
   end
 end


### PR DESCRIPTION
[backport]

This enhances chef-resource-inspector to understand LWRP files which contain multiple resources.  This allows for using the resource inspector in documenation flows where these resources have been generated outside chef, as an example

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
