### PR TITLE
Updating cert env variables

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -59,7 +59,7 @@ do_setup_environment() {
   push_runtime_env GEM_PATH "${pkg_prefix}/vendor"
 
   set_runtime_env APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
-  set_runtime_env SSL_CERT_FILE "$(pkg_path_for cacerts)/ssl/cert.pem"
+  # set_runtime_env SSL_CERT_FILE "$(pkg_path_for cacerts)/ssl/cert.pem"
   set_runtime_env LANG "en_US.UTF-8"
   set_runtime_env LC_CTYPE "en_US.UTF-8"
 }
@@ -68,7 +68,7 @@ do_prepare() {
   export GEM_HOME="${pkg_prefix}/vendor"
   export OPENSSL_LIB_DIR="$(pkg_path_for openssl)/lib"
   export OPENSSL_INCLUDE_DIR="$(pkg_path_for openssl)/include"
-  export SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
+  # export SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
   export CPPFLAGS="${CPPFLAGS} ${CFLAGS}"
 
   ( cd "$CACHE_PATH"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Hab is throwing errors during builds that the path to the cacert.pem is already being set by a package. We're removing the re-definition here. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
