### PR TITLE
[Chef-18]Bump license_scout to fix build failures

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
       tomlrb (>= 1.2, < 3.0)
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
-    license_scout (1.3.10)
+    license_scout (1.3.11)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Current build failures:
```

Encountered error(s) with project's licensing information.
--
  | Failing the build because :fatal_licensing_warnings is set in the configuration.
  | Error(s):
  |  
  | Can not automatically detect licensing information for 'chef' using license_scout. Error is: 'Network error while fetching 'https://raw.githubusercontent.com/ruby/time/master/LICENSE.txt'
  | 404 Not Found'
  |  
  | If you are encountering missing license or missing license file errors for **transitive** dependencies, you can provide overrides for the missing information at https://github.com/chef/license_scout/blob/1-stable/lib/license_scout/overrides.rb#L93.
  | Promote license_scout to Rubygems with `/expeditor promote chef/license_scout:1-stable X.Y.Z` in slack.
  |  
  |  
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/licensing.rb:446:in `raise_if_warnings_fatal!'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/licensing.rb:545:in `rescue in collect_transitive_dependency_licenses_for'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/licensing.rb:515:in `collect_transitive_dependency_licenses_for'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/licensing.rb:148:in `execute_post_build'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/software.rb:1254:in `block in execute_build'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/software.rb:1254:in `each'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/software.rb:1254:in `execute_build'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/software.rb:1131:in `build_me'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/project.rb:1081:in `block (2 levels) in build'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/project.rb:1080:in `each'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/project.rb:1080:in `block in build'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/licensing.rb:62:in `block in create_incrementally'
  | <internal:kernel>:90:in `tap'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/licensing.rb:57:in `create_incrementally'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/project.rb:1079:in `build'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/cli.rb:95:in `build'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/cli/base.rb:33:in `dispatch'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/gems/thor-1.3.1/lib/thor/base.rb:584:in `start'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/lib/omnibus/cli.rb:42:in `execute!'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bundler/gems/omnibus-5c0122b185a6/bin/omnibus:16:in `<top (required)>'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bin/omnibus:25:in `load'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/bin/omnibus:25:in `<top (required)>'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/cli.rb:484:in `exec'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:48:in `block in <top (required)>'
  | /opt/omnibus-toolchain/embedded/lib/ruby/3.1.0/bundler/friendly_errors.rb:103:in `with_friendly_errors'
  | /opt/omnibus-toolchain/embedded/lib/ruby/gems/3.1.0/gems/bundler-2.3.7/libexec/bundle:36:in `<top (required)>'
  | /opt/omnibus-toolchain/bin/bundle:25:in `load'
  | /opt/omnibus-toolchain/bin/bundle:25:in `<main>'
  | 🚨 Error: The command exited with status 1


```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
