### PR TITLE
[Chef-19] Fix knife/Gemfile.lock to pull correct chef 19 version instead of 18

### DIFF
--- a/knife/Gemfile.lock
+++ b/knife/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    chef (18.5.1)
-    chef (18.5.1-x64-mingw-ucrt)
+    chef (19.0.20)
+    chef (19.0.20-universal-mingw-ucrt)
 
 PLATFORMS
   ruby


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
While separating chef18 and 19 branches, `knife/Gemfile.lock` was left at chef 18 due to which it is pulling in chef18 which is breaking knife gem due to incorrect dependencies. 
This will also fix automated version bumps on a PR merge not bumping chef versions in `knife/Gemfile.lock` 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
