### PR TITLE
[Chef-18] Fix Chef versions in lock files manually as the script was not working before

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,12 +44,12 @@ GIT
 PATH
   remote: .
   specs:
-    chef (18.5.1)
+    chef (18.5.17)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
-      chef-config (= 18.5.1)
-      chef-utils (= 18.5.1)
+      chef-config (= 18.5.17)
+      chef-utils (= 18.5.17)
       chef-vault
       chef-zero (>= 14.0.11)
       corefoundation (~> 0.3.4)
@@ -78,13 +78,13 @@ PATH
       unf_ext (~> 0.0.8.2)
       uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.18.2)
-    chef (18.5.1-x64-mingw-ucrt)
+    chef (18.5.17-x64-mingw-ucrt)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
-      chef-config (= 18.5.1)
+      chef-config (= 18.5.17)
       chef-powershell (~> 18.1.0)
-      chef-utils (= 18.5.1)
+      chef-utils (= 18.5.17)
       chef-vault
       chef-zero (>= 14.0.11)
       corefoundation (~> 0.3.4)
@@ -128,15 +128,15 @@ PATH
 PATH
   remote: chef-bin
   specs:
-    chef-bin (18.5.1)
-      chef (= 18.5.1)
+    chef-bin (18.5.17)
+      chef (= 18.5.17)
 
 PATH
   remote: chef-config
   specs:
-    chef-config (18.5.1)
+    chef-config (18.5.17)
       addressable
-      chef-utils (= 18.5.1)
+      chef-utils (= 18.5.17)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -145,7 +145,7 @@ PATH
 PATH
   remote: chef-utils
   specs:
-    chef-utils (18.5.1)
+    chef-utils (18.5.17)
       concurrent-ruby
 
 GEM

--- a/knife/Gemfile.lock
+++ b/knife/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    chef (18.5.1)
-    chef (18.5.1-x64-mingw-ucrt)
+    chef (18.5.17)
+    chef (18.5.17-x64-mingw-ucrt)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Note: `bundle update --conservative` constraint not applicable due to fixing of a manual update process.

<!--- Describe your changes in detail, what problems does it solve? -->
This is [part2] of fixing expeditor automated version bumps. We the script here https://github.com/chef/chef/pull/14610
In this PR we update Chef version manually in Gemfile.lock and knife/Gemfile.lock so that the script can update the versions there correctly. (Because we fixed the command with `git show chef-18:VERSION` to find the older version to be replaced in lock files, but the versions there were stuck at a value which `sed` could not find hence the script was still failing partly.)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
