### PR TITLE
Choco deprecation, windows chef-powershell, and Ruby 3.1.6 chef-foundation 

### DIFF
--- a/.buildkite-platform.json
+++ b/.buildkite-platform.json
@@ -1,4 +1,4 @@
 {
-    "chef_foundation": "3.2.8",
+    "chef_foundation": "3.2.10",
     "omnibus_toolchain": "3.0.28"
 }

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -11,7 +11,7 @@ fi
 FILTER="${OMNIBUS_FILTER:=*}"
 
 # array of all container platforms in the format test-platform:build-platform
-container_platforms=("amazon-2:centos-7" "amazon-2-arm:amazon-2-arm" "centos-6:centos-6" "centos-7:centos-7" "centos-7-arm:centos-7-arm" "centos-8:centos-8" "centos-8-arm:centos-8-arm" "sles-15-arm:sles-15-arm" "sles-15:sles-15" "rhel-9:rhel-9" "rhel-9-arm:rhel-9-arm" "debian-9:debian-9" "debian-10:debian-9" "debian-11:debian-9" "ubuntu-1604:ubuntu-1604" "ubuntu-1804:ubuntu-1604" "ubuntu-2004:ubuntu-1604" "ubuntu-2204:ubuntu-1604" "ubuntu-1804-arm:ubuntu-1804-arm" "ubuntu-2004-arm:ubuntu-2004-arm" "ubuntu-2204-arm:ubuntu-2204-arm" "windows-2019:windows-2019" "rocky-8:rocky-8" "rocky-9:rocky-9" "amazon-2023:amazon-2023" "amazon-2023-arm:amazon-2023-arm")
+container_platforms=("amazon-2:centos-7" "amazon-2-arm:amazon-2-arm" "centos-7:centos-7" "centos-7-arm:centos-7-arm" "centos-8:centos-8" "centos-8-arm:centos-8-arm" "sles-15-arm:sles-15-arm" "sles-15:sles-15" "rhel-9:rhel-9" "rhel-9-arm:rhel-9-arm" "debian-9:debian-9" "debian-10:debian-9" "debian-11:debian-9" "ubuntu-1604:ubuntu-1604" "ubuntu-1804:ubuntu-1604" "ubuntu-2004:ubuntu-1604" "ubuntu-2204:ubuntu-1604" "ubuntu-1804-arm:ubuntu-1804-arm" "ubuntu-2004-arm:ubuntu-2004-arm" "ubuntu-2204-arm:ubuntu-2204-arm" "windows-2019:windows-2019" "rocky-8:rocky-8" "rocky-9:rocky-9" "amazon-2023:amazon-2023" "amazon-2023-arm:amazon-2023-arm")
 
 # add rest of windows platforms to tests, if not on chef-oss org
 if [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]]

--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -9,7 +9,7 @@ echo "  BUILD_TIMESTAMP: $(date +%Y-%m-%d_%H-%M-%S)"
 echo "steps:"
 echo ""
 
-test_platforms=("centos-6" "centos-7" "centos-8" "rhel-9" "debian-9" "ubuntu-1604" "sles-15")
+test_platforms=("centos-7" "centos-8" "rhel-9" "debian-9" "ubuntu-1604" "sles-15")
 
 for platform in ${test_platforms[@]}; do
   echo "- label: \"{{matrix}} $platform :ruby:\""

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ PATH
       unf_ext (~> 0.0.8.2)
       uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.18.2)
-    chef (18.5.20-x64-mingw-ucrt)
+    chef (18.5.20-universal-mingw-ucrt)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ PATH
       plist (~> 3.2)
       proxifier2 (~> 1.1)
       syslog-logger (~> 1.6)
-      train-core (~> 3.10)
+      train-core (~> 3.10, < 3.12.5)
       train-rest (>= 0.4.1)
       train-winrm (>= 0.2.5)
       unf_ext (~> 0.0.8.2)
@@ -108,7 +108,7 @@ PATH
       plist (~> 3.2)
       proxifier2 (~> 1.1)
       syslog-logger (~> 1.6)
-      train-core (~> 3.10)
+      train-core (~> 3.10, < 3.12.5)
       train-rest (>= 0.4.1)
       train-winrm (>= 0.2.5)
       unf_ext (~> 0.0.8.2)
@@ -445,8 +445,8 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     win32-api (1.10.1-universal-mingw32)
-    win32-certstore (0.6.15)
-      chef-powershell (>= 1.0.12)
+    win32-certstore (0.6.16)
+      chef-powershell
       ffi
     win32-event (0.6.3)
       win32-ipc (>= 0.6.0)

--- a/chef-universal-mingw-ucrt.gemspec
+++ b/chef-universal-mingw-ucrt.gemspec
@@ -1,6 +1,6 @@
 gemspec = instance_eval(File.read(File.expand_path("chef.gemspec", __dir__)))
 
-gemspec.platform = Gem::Platform.new(%w{x64-mingw-ucrt})
+gemspec.platform = Gem::Platform.new(%w{universal mingw-ucrt})
 
 gemspec.add_dependency "win32-api", "~> 1.10.0"
 gemspec.add_dependency "win32-event", "~> 0.6.1"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
   s.add_dependency "chef-utils", "= #{Chef::VERSION}"
-  s.add_dependency "train-core", "~> 3.10", "< 3.12.5"  # 3.2.28 fixes sudo prompts. See https://github.com/chef/chef/pull/9635
+  s.add_dependency "train-core", "~> 3.10", "< 3.12.5"
   s.add_dependency "train-winrm", ">= 0.2.5"
   s.add_dependency "train-rest", ">= 0.4.1" # target mode with rest APIs
 

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
   s.add_dependency "chef-utils", "= #{Chef::VERSION}"
-  s.add_dependency "train-core", "~> 3.10" # 3.2.28 fixes sudo prompts. See https://github.com/chef/chef/pull/9635
+  s.add_dependency "train-core", "~> 3.10", "< 3.12.5"  # 3.2.28 fixes sudo prompts. See https://github.com/chef/chef/pull/9635
   s.add_dependency "train-winrm", ">= 0.2.5"
   s.add_dependency "train-rest", ">= 0.4.1" # target mode with rest APIs
 

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -153,7 +153,7 @@ class Chef
 
         # Choco V2 uses 'Search' for remote repositories and 'List' for local packages
         def query_command
-          return "list" if get_choco_version.match?(/^1/)
+          return "list" if Gem::Dependency.new("", "< 1.4.0").match?("", get_choco_version)
 
           "search"
         end
@@ -240,7 +240,7 @@ class Chef
           @choco_exe ||= begin
               # if this check is in #define_resource_requirements, it won't get
               # run before choco.exe gets called from #load_current_resource.
-              exe_path = ::File.join(choco_install_path, "bin", "choco.exe")
+              exe_path = ::File.join(choco_install_path, "choco.exe")
               raise Chef::Exceptions::MissingLibrary, CHOCO_MISSING_MSG unless ::File.exist?(exe_path)
 
               exe_path

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -26,6 +26,11 @@ if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
     autoload :Registry, File.expand_path("../monkey_patches/win32/registry", __dir__)
   end
   require_relative "api/registry"
+
+  require "win32/resolv"
+  ::Win32::Registry.define_method :export_string do |str, enc = (Encoding.default_internal || "utf-8")|
+     str.encode(enc)
+  end
 end
 
 class Chef

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -29,7 +29,7 @@ if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
 
   require "win32/resolv"
   ::Win32::Registry.define_method :export_string do |str, enc = (Encoding.default_internal || "utf-8")|
-     str.encode(enc)
+    str.encode(enc)
   end
 end
 

--- a/spec/integration/client/open_ssl_spec.rb
+++ b/spec/integration/client/open_ssl_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "openssl checks" do
   let(:openssl_version_default) do
     if windows?
-      "1.0.2zi"
+      "3.0.9"
     elsif macos?
       "1.1.1m"
     else

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -228,6 +228,8 @@ def aes_256_gcm?
 end
 
 def fips_mode_build?
+  return false if ENV.fetch("BUILDKITE_PIPELINE_SLUG", "") =~ /verify$/
+
   if ENV.include?("BUILDKITE_LABEL") # try keying directly off Buildkite environments
     # regex version of chef/chef-foundation:.expeditor/release.omnibus.yml:fips-platforms
     [/el-.*-x86_64/, /el-.*-ppc64/, /el-.*aarch/, /ubuntu-/, /windows-/, /amazon-2/].any? do |os_arch|

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -92,7 +92,7 @@ describe Chef::Provider::Package::Chocolatey, :windows_only do
 
   describe "choco searches change with the version" do
     it "Choco V1 uses List" do
-      allow(provider).to receive(:powershell_exec!).with("Get-ItemProperty #{choco_exe} | select-object -expandproperty versioninfo | select-object -expandproperty productversion").and_return(double(result: "1.4.0"))
+      allow(provider).to receive(:powershell_exec!).with("Get-ItemProperty #{choco_exe} | select-object -expandproperty versioninfo | select-object -expandproperty productversion").and_return(double(result: "1.3.0"))
       expect(provider.query_command).to eql("list")
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Have query_command check look for 1.3 instead of 1.4 Use Gem::Dependency to check < 1.4
Use universal gemspec
Force win32/resolv load and then patch

`bundle install` instead of `bundle update --conversative` due to the change in `.gemfile` for Windows

Old-ish output from `bundle install`
```
❯ bundle install
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies....
Using rake 13.0.6
Using public_suffix 5.0.1
Using ast 2.4.2
Using aws-eventstream 1.3.0 (was 1.2.0)
Using jmespath 1.6.2
Fetching aws-partitions 1.970.0 (was 1.739.0)
Using base64 0.2.0
Using bigdecimal 3.1.8
Using debug_inspector 1.1.0
Using builder 3.3.0 (was 3.2.4)
Using bundler 2.3.7
Using byebug 11.1.3
Using concurrent-ruby 1.2.2
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using libyajl2 2.1.0
Using hashie 4.1.0
Using mixlib-log 3.0.9
Using uuidtools 2.2.0
Using webrick 1.8.1
Using ffi 1.16.3
Using diff-lcs 1.5.0
Using erubis 2.7.0
Using rack 2.2.6.4
Using iniparse 1.5.0
Using ruby2_keywords 0.0.5
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using unicode-display_width 2.4.2
Using faraday-net_http 3.0.2
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using wisper 2.0.1
Using method_source 1.0.0
Using multipart-post 2.3.0
Using tty-screen 0.8.1
Using parslet 1.8.2
Using coderay 1.1.3
Using parallel 1.22.1
Using rubyzip 2.3.2
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.2.1
Using json 2.6.3
Using net-ssh 7.1.0
Using mixlib-authentication 3.0.10
Using mixlib-cli 2.1.8
Using rspec-support 3.11.1
Using date 3.3.4 (was 3.3.3)
Using ipaddress 0.8.3
Using plist 3.7.0
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using http-accept 1.7.0
Using timeout 0.4.1 (was 0.3.2)
Using mime-types-data 3.2023.0218.1
Using netrc 0.11.0
Using erubi 1.13.0 (was 1.12.0)
Using rexml 3.2.5
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using multi_json 1.15.0
Using rainbow 3.1.1
Using regexp_parser 2.7.0
Using ruby-progressbar 1.13.0
Using ed25519 1.3.0
Using hashdiff 1.0.1
Using stringio 3.1.1
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using unf_ext 0.0.8.2
Using addressable 2.8.2
Using aws-sigv4 1.9.1 (was 1.5.2)
Using parser 3.2.2.0
Using rubyntlm 0.6.5 (was 0.6.3)
Using nori 2.7.1 (was 2.6.0)
Using binding_of_caller 1.0.0
Using chef-utils 18.5.9 (was 18.5.1) from source at `chef-utils`
Using ffi-yajl 2.6.0
Using corefoundation 0.3.13
Using mixlib-config 3.0.27
Using ffi-libarchive 1.1.14 (was 1.1.3)
Using gssapi 1.3.1
Using faraday 2.7.4
Using pastel 0.8.0
Using mixlib-archive 1.1.7
Using strings 0.2.1
Using pry 0.13.0
Using net-scp 4.0.0
Using net-sftp 4.0.0
Using tty-reader 0.9.0
Using fauxhai-ng 9.3.0
Using rspec-expectations 3.11.1
Using rspec-mocks 3.11.2
Using net-protocol 0.2.2 (was 0.2.1)
Using time 0.3.0 (was 0.2.2)
Using mime-types 3.4.1
Using gyoku 1.4.0
Using logging 2.4.0 (was 2.3.1)
Using crack 0.4.5
Using rspec-core 3.11.0
Using psych 5.1.2
Using vault 0.18.2
Using rubocop-ast 1.28.0
Using mixlib-shellout 3.2.8
Using chef-zero 15.0.11
Using faraday-follow_redirects 0.3.0
Using unf 0.1.4
Using tty-box 0.7.0
Using pry-byebug 3.10.1
Using pry-stack_explorer 0.6.1
Using tty-prompt 0.23.1
Using net-ftp 0.3.7 (was 0.2.0)
Using winrm 2.3.9 (was 2.3.6)
Using webmock 3.19.1
Using chef-config 18.5.9 (was 18.5.1) from source at `chef-config`
Using rspec 3.11.0
Using rspec-its 1.3.0
Using tty-table 0.12.0
Using cheffish 17.1.5
Using train-core 3.10.7
Using rubocop 1.25.1
Using chef-telemetry 1.1.1
Using license-acceptance 2.1.13
Using domain_name 0.5.20190701
Using winrm-fs 1.3.5
Using rdoc 6.4.1.1
Using ohai 18.2.0 from https://github.com/chef/ohai.git (at 18-stable@f68338d)
Using inspec-core 5.22.40
Using http-cookie 1.0.5
Using winrm-elevated 1.2.3
Using chefstyle 2.2.2
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using train-winrm 0.2.13
Using train-rest 0.5.0
Installing aws-partitions 1.970.0 (was 1.739.0)
Fetching aws-sdk-core 3.202.2 (was 3.171.0)
Installing aws-sdk-core 3.202.2 (was 3.171.0)
Using aws-sdk-kms 1.88.0 (was 1.63.0)
Using aws-sdk-secretsmanager 1.102.0 (was 1.73.0)
Using aws-sdk-s3 1.159.0 (was 1.120.0)
Using chef 18.5.9 (was 18.5.1) from source at `.`
Using chef-bin 18.5.9 (was 18.5.1) from source at `chef-bin` and installing its executables
Bundle complete! 25 Gemfile dependencies, 142 gems now installed.
Gems in the group 'omnibus_package' were not installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

Supersedes #14591 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
