### PR TITLE
Fixing missing rspec in hab plan testing

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -111,8 +111,6 @@ do_build() {
     build_line "Installing gem dependencies ..."
     bundle install --jobs=3 --retry=3
     build_line "Installing gems from git repos properly ..."
-  # build_line " ** have my ENV variables changed somewhere yet?"
-  # printenv
 
     ruby ./post-bundle-install.rb
     build_line "Installing this project's gems ..."
@@ -121,18 +119,9 @@ do_build() {
 }
 
 do_install() {
-	build_line " ** Recap - the Pkg Prefix :"
-	echo $pkg_prefix
-
-	appbundler_path="${pkg_prefix}/vendor/bin/"
-	build_line " ** My AppBunndler path is : "
-	echo $appbundler_path
-
   ( cd "$pkg_prefix" || exit_with "unable to enter pkg prefix directory" 1
     export BUNDLE_GEMFILE="${CACHE_PATH}/Gemfile"
 
-	build_line " ** What is my gemfile path, please: "
- 	build_line "${CACHE_PATH}/Gemfile"
     build_line "** fixing binstub shebangs"
     fix_interpreter "${pkg_prefix}/vendor/bin/*" "$_chef_client_ruby" bin/ruby
     for gem in chef-bin chef inspec-core-bin ohai; do

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -84,7 +84,6 @@ do_prepare() {
   export HAB_STUDIO_SECRET_NODE_OPTIONS="--dns-result-order=ipv4first"
   export HAB_STUDIO_SECRET_HAB_BLDR_CHANNEL="LTS-2024"
   export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="LTS-2024"
-
   build_line " ** Securing the /src directory"
   git config --global --add safe.directory /src
 
@@ -112,6 +111,9 @@ do_build() {
     build_line "Installing gem dependencies ..."
     bundle install --jobs=3 --retry=3
     build_line "Installing gems from git repos properly ..."
+  # build_line " ** have my ENV variables changed somewhere yet?"
+  # printenv
+
     ruby ./post-bundle-install.rb
     build_line "Installing this project's gems ..."
     bundle exec rake install:local
@@ -119,8 +121,18 @@ do_build() {
 }
 
 do_install() {
+	build_line " ** Recap - the Pkg Prefix :"
+	echo $pkg_prefix
+
+	appbundler_path="${pkg_prefix}/vendor/bin/"
+	build_line " ** My AppBunndler path is : "
+	echo $appbundler_path
+
   ( cd "$pkg_prefix" || exit_with "unable to enter pkg prefix directory" 1
     export BUNDLE_GEMFILE="${CACHE_PATH}/Gemfile"
+
+	build_line " ** What is my gemfile path, please: "
+ 	build_line "${CACHE_PATH}/Gemfile"
     build_line "** fixing binstub shebangs"
     fix_interpreter "${pkg_prefix}/vendor/bin/*" "$_chef_client_ruby" bin/ruby
     for gem in chef-bin chef inspec-core-bin ohai; do

--- a/habitat/tests/test.sh
+++ b/habitat/tests/test.sh
@@ -34,5 +34,12 @@ for executable in 'chef-client' 'ohai' 'chef-shell' 'chef-apply' 'chef-solo'; do
   hab pkg exec "${pkg_ident}" "${executable}" -- --version || error "${executable} failed to execute properly"
 done
 
+echo "--- :construction: Gotta find RSPEC so testing doesn't immediately fail"
+results=(`find /hab/pkgs -name "rspec" -type f`)
+echo "${results[1]}"
+
 echo "--- :mag_right: Testing ${pkg_ident} functionality"
+# rspec is not on the path by default. We had to find it above. Now we insert it into the path.
+rspec_path=$(dirname ${results[1]})
+export PATH="${rspec_path}":$PATH
 hab pkg exec "${pkg_ident}" rspec --tag ~executables --pattern 'spec/functional/**/*_spec.rb' --exclude-pattern 'spec/functional/knife/**/*.rb' || error 'failures during rspec tests'


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
In bash shell, 'rspec' was not available on the path and that resulted in the hab pkg exec command failing. We correct that here

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
