### PR TITLE
Fix windows plan

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -35,7 +35,7 @@ function Invoke-SetupEnvironment {
     Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
 
     Set-RuntimeEnv APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
-    Set-RuntimeEnv FORCE_FFI_YAJL "ext" # default: ext - Always use the C-extensions because we use MRI on all the things and C is fast.
+    Set-RuntimeEnv FORCE_FFI_YAJL "ffi" # default: ext - Always use the C-extensions because we use MRI on all the things and C is fast.
     Set-RuntimeEnv -f -IsPath SSL_CERT_FILE "$(Get-HabPackagePath cacerts)/ssl/cert.pem"
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
@@ -78,6 +78,9 @@ function Invoke-Prepare {
         if (-not $?) { throw "unable to configure bundler to restrict gems to be installed" }
         bundle config --local retry 5
         bundle config --local silence_root_warning 1
+        $openssl_dir = "$(Get-HabPackagePath core/openssl)"
+        Write-BuildLine "OpenSSL Dir $openssl_dir"
+        bundle config build.openssl --with-openssl-dir=$openssl_dir
     } finally {
         Pop-Location
     }
@@ -89,8 +92,15 @@ function Invoke-Build {
 
         $env:_BUNDLER_WINDOWS_DLLS_COPIED = "1"
 
+        Write-BuildLine " ** Setting Bundler Platform to x64-mingw-ucrt"
+        bundle config specific_platform x64-mingw-ucrt
+
+        Write-BuildLine " ** Installing FFI with a mingw platform"
+        gem install ffi --platform=x64-mingw-ucrt
+        $openssl_dir = "$(Get-HabPackagePath core/openssl)"
+        gem install openssl -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
-        bundle install --jobs=3 --retry=3
+        bundle install --jobs=3 --retry=3 --prefer-local
         if (-not $?) { throw "unable to install gem dependencies" }
         Write-BuildLine " ** 'rake install' any gem sourced as a git reference so they'll look like regular gems."
         foreach($git_gem in (Get-ChildItem "$env:GEM_HOME/bundler/gems")) {

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -95,7 +95,7 @@ function Invoke-Build {
         $env:_BUNDLER_WINDOWS_DLLS_COPIED = "1"
 
         $openssl_dir = "$(Get-HabPackagePath core/openssl)"
-        gem install openssl -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
+        gem install openssl:3.2.0 -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
         bundle install --jobs=3 --retry=3
         if (-not $?) { throw "unable to install gem dependencies" }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -39,6 +39,8 @@ function Invoke-SetupEnvironment {
     Set-RuntimeEnv -f -IsPath SSL_CERT_FILE "$(Get-HabPackagePath cacerts)/ssl/cert.pem"
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
+
+    Set-RuntimeEnv -f -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath openssl)/bin;$env:RUBY_DLL_PATH"
 }
 
 function Invoke-Download() {

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -100,7 +100,7 @@ function Invoke-Build {
         $openssl_dir = "$(Get-HabPackagePath core/openssl)"
         gem install openssl -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
-        bundle install --jobs=3 --retry=3 --prefer-local
+        bundle install --jobs=3 --retry=3
         if (-not $?) { throw "unable to install gem dependencies" }
         Write-BuildLine " ** 'rake install' any gem sourced as a git reference so they'll look like regular gems."
         foreach($git_gem in (Get-ChildItem "$env:GEM_HOME/bundler/gems")) {

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -35,7 +35,7 @@ function Invoke-SetupEnvironment {
     Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
 
     Set-RuntimeEnv APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
-    Set-RuntimeEnv FORCE_FFI_YAJL "ffi" # default: ext - Always use the C-extensions because we use MRI on all the things and C is fast.
+    # Set-RuntimeEnv FORCE_FFI_YAJL "ffi" # default: ext - Always use the C-extensions because we use MRI on all the things and C is fast.
     Set-RuntimeEnv -f -IsPath SSL_CERT_FILE "$(Get-HabPackagePath cacerts)/ssl/cert.pem"
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
@@ -92,11 +92,6 @@ function Invoke-Build {
 
         $env:_BUNDLER_WINDOWS_DLLS_COPIED = "1"
 
-        Write-BuildLine " ** Setting Bundler Platform to x64-mingw-ucrt"
-        bundle config specific_platform x64-mingw-ucrt
-
-        Write-BuildLine " ** Installing FFI with a mingw platform"
-        gem install ffi --platform=x64-mingw-ucrt
         $openssl_dir = "$(Get-HabPackagePath core/openssl)"
         gem install openssl -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Fixes the Windows plan that resolves the issue of failing to load the openssl.so file.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The OpenSSL gem is unable to resolve the OpenSSL libraries installed with core/openssl. This PR installs the OpenSSL gem with flags that point to the core/openssl Habitat package.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
