### PR TITLE
add script for exporting and uploading tar from habitat package

### DIFF
--- a/.expeditor/scripts/export_sync_s3.sh
+++ b/.expeditor/scripts/export_sync_s3.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu -o pipefail
+
+s3_bucket_uri="s3://<bucket_uri>/<bucket_path>"
+
+pkg_identifiers=(
+    $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUX
+    $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS
+)
+
+for identifier in "${pkg_identifiers[@]}"; do
+    echo "--- habitat: extracting tar for $identifier ---"
+    hab pkg export tar $identifier --channel LTS-2024
+
+    tar_filename=$(sed 's/\//-/g' <<< $identifier).tar.gz
+    echo "--- aws: uploading $tar_filename to s3 bucket ---"
+    aws s3 cp $tar_filename $s3_bucket_uri/$tar_filename --content-type "application/gzip" --profile "<profile to use>"
+
+    rm $tar_filename
+done


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR adds the bash script to export gzipped tar file for the habitat package and uploading it to s3

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
