### PR TITLE
Testing for what broke adhoc

### DIFF
--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -20,7 +20,7 @@ then
 fi
 
 # array of all esoteric platforms in the format test-platform:build-platform. We reduced this list for Chef-19
-esoteric_platforms=("mac_os_x-11-x86_64:mac_os_x-11-x86_64" "mac_os_x-12-x86_64:mac_os_x-11-x86_64" "mac_os_x-11-arm64:mac_os_x-11-arm64" "mac_os_x-12-arm64:mac_os_x-11-arm64")
+# esoteric_platforms=("mac_os_x-11-x86_64:mac_os_x-11-x86_64" "mac_os_x-12-x86_64:mac_os_x-11-x86_64" "mac_os_x-11-arm64:mac_os_x-11-arm64" "mac_os_x-12-arm64:mac_os_x-11-arm64")
 
 omnibus_build_platforms=()
 omnibus_test_platforms=()
@@ -42,29 +42,29 @@ then
 fi
 
 ## add esoteric platforms in chef/chef-canary
-if [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]]
-then
-  esoteric_build_platforms=()
-  esoteric_test_platforms=()
+# if [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]]
+# then
+#   esoteric_build_platforms=()
+#   esoteric_test_platforms=()
 
-  # build build array and test array based on filter
-  for platform in ${esoteric_platforms[@]}; do
-    case ${platform%:*} in
-        $FILTER)
-            esoteric_build_platforms[${#esoteric_build_platforms[@]}]=${platform#*:}
-            esoteric_test_platforms[${#esoteric_test_platforms[@]}]=$platform
-            ;;
-    esac
-  done
+#   # build build array and test array based on filter
+#   for platform in ${esoteric_platforms[@]}; do
+#     case ${platform%:*} in
+#         $FILTER)
+#             esoteric_build_platforms[${#esoteric_build_platforms[@]}]=${platform#*:}
+#             esoteric_test_platforms[${#esoteric_test_platforms[@]}]=$platform
+#             ;;
+#     esac
+#   done
 
-  # remove duplicates from build array
-  # using shell parameter expansion this checks to make sure the esoteric_build_platforms array isn't empty if OMNIBUS_FILTER is only container platforms
-  # prevents esoteric_build_platforms unbound variable error
-  if [[ ! -z "${esoteric_build_platforms:-}" ]]
-  then
-    esoteric_build_platforms=($(printf "%s\n" "${esoteric_build_platforms[@]}" | sort -u | tr '\n' ' '))
-  fi
-fi
+#   # remove duplicates from build array
+#   # using shell parameter expansion this checks to make sure the esoteric_build_platforms array isn't empty if OMNIBUS_FILTER is only container platforms
+#   # prevents esoteric_build_platforms unbound variable error
+#   if [[ ! -z "${esoteric_build_platforms:-}" ]]
+#   then
+#     esoteric_build_platforms=($(printf "%s\n" "${esoteric_build_platforms[@]}" | sort -u | tr '\n' ' '))
+#   fi
+# fi
 
 # using shell parameter expansion this checks to make sure the omnibus_build_platforms array isn't empty if OMNIBUS_FILTER is only esoteric platforms
 # prevents omnibus_build_platforms unbound variable error

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -20,7 +20,7 @@ then
 fi
 
 # array of all esoteric platforms in the format test-platform:build-platform. We reduced this list for Chef-19
-# esoteric_platforms=("mac_os_x-11-x86_64:mac_os_x-11-x86_64" "mac_os_x-12-x86_64:mac_os_x-11-x86_64" "mac_os_x-11-arm64:mac_os_x-11-arm64" "mac_os_x-12-arm64:mac_os_x-11-arm64")
+esoteric_platforms=("mac_os_x-11-x86_64:mac_os_x-11-x86_64" "mac_os_x-12-x86_64:mac_os_x-11-x86_64" "mac_os_x-11-arm64:mac_os_x-11-arm64" "mac_os_x-12-arm64:mac_os_x-11-arm64")
 
 omnibus_build_platforms=()
 omnibus_test_platforms=()


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating the builders after removing Macos temporarily. Since the esoteric builders array was null, it was causing a silent failure further down which resulted in nothing being built or tested in the AdHoc pipeline. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
