### PR TITLE
[CHEF-12878] Guess the test kitchen context and set workstation entitlement

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -29,6 +29,8 @@ require "rbconfig" unless defined?(RbConfig)
 require_relative "application/exit_code"
 require "chef-utils" unless defined?(ChefUtils::CANARY)
 require_relative "licensing"
+require_relative "context"
+
 module LicenseAcceptance
   autoload :Acceptor, "license_acceptance/acceptor"
 end
@@ -65,6 +67,7 @@ class Chef
       reconfigure
       setup_application
       check_license_acceptance if enforce_license
+      Context.switch_to_workstation_entitlement if Context.test_kitchen_context?
       Chef::Licensing.fetch_and_persist if ChefUtils::Dist::Infra::EXEC == "chef"
       run_application
     end

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -1,0 +1,61 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Chef
+  class Context
+    class << self
+      COMMON_KEY = "2f3b66cbbafa2d326b2856bccc4c8ebe".freeze
+      TMP_FILE_PATH = "/tmp/c769508738d671db424b7442".freeze
+
+      def test_kitchen_context?
+        return @context if defined?(@context)
+
+        @context = false
+        if File.exist?(TMP_FILE_PATH)
+          file_content = {}
+          File.foreach(TMP_FILE_PATH) do |line|
+            key, value = line.strip.split(':')
+            file_content[key] = value
+          end
+
+          received_nonce = file_content['nonce']
+          received_timestamp = file_content['timestamp']
+          received_signature = file_content['signature']
+
+          current_time = Time.now.utc.to_i
+          if (current_time - received_timestamp.to_i).abs < 30
+            message = "#{received_nonce}:#{received_timestamp}"
+            expected_signature = OpenSSL::HMAC.hexdigest('SHA256', COMMON_KEY, message)
+            if expected_signature == received_signature
+              @context = true
+            end
+          end
+          File.delete(TMP_FILE_PATH)
+        end
+
+        @context
+      end
+
+      def switch_to_workstation_entitlement
+        puts "Running under Test-Kitchen: Switching License to Chef Workstation entitlement"
+        ChefLicensing.configure do |config|
+          # Reset entitlement ID to the ID of Chef Workstation
+          config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -1,6 +1,7 @@
 require_relative "base"
 require_relative "../config"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
+require_relative "../context"
 
 class Chef
   module Formatters
@@ -46,6 +47,7 @@ class Chef
         puts_line "OpenSSL FIPS 140 mode enabled" if Chef::Config[:fips]
         puts_line "Infra Phase starting"
         puts_line "Targeting node: #{Chef::Config.target_mode.host}" if Chef::Config.target_mode?
+        puts_line "Running under: #{Context.test_kitchen_context? ? "Test-Kitchen" : "Chef Infra"}"
       end
 
       def total_resources

--- a/lib/chef/telemetry/run_context_probe.rb
+++ b/lib/chef/telemetry/run_context_probe.rb
@@ -1,3 +1,5 @@
+require_relative "../context"
+
 class Chef
   class Telemetry
     # Guesses the run context of Chef - how were we invoked?
@@ -24,9 +26,7 @@ class Chef
       end
 
       def self.kitchen?(stack)
-        # TO TEST
-        stack_match(stack: stack, path: "kitchen/instance", label: "verify_action") &&
-          stack_match(stack: stack, path: "kitchen/instance", label: "verify")
+        Context.test_kitchen_context?
       end
 
       def self.chef_apply?(stack)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
When the test-kitchen invokes the chef-client during the infra-provisioning step, the license usage will be counted, which should not be since it only runs the tests. The solution for this problem is to identify that the test-kitchen has triggered the run and set the workstation's entitlement ID instead of the chef-client's. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
