### PR TITLE
Add ActiveSupport-like methods to Immutablize Mixins for Array and Hash

### DIFF
--- a/lib/chef/node/mixin/immutablize_array.rb
+++ b/lib/chef/node/mixin/immutablize_array.rb
@@ -130,6 +130,29 @@ class Chef
           uniq
           values_at
           zip
+          blank?
+          presence
+          present?
+          to_yaml
+          compact_blank
+          to_xml
+          to_sentence
+          to_fs
+          to_default_s
+          to_formatted_s
+          pick
+          index_by
+          in_order_of
+          many?
+          sole
+          exclude?
+          excluding
+          minimum
+          maximum
+          pluck
+          including
+          without
+          index_with
           |
         }.freeze
         # A list of methods that mutate Array. Each of these is overridden to
@@ -170,6 +193,8 @@ class Chef
           sort_by!
           uniq!
           unshift
+          compact_blank!
+          extract_options!
         }.freeze
 
         # Redefine all of the methods that mutate a Hash to raise an error when called.

--- a/lib/chef/node/mixin/immutablize_hash.rb
+++ b/lib/chef/node/mixin/immutablize_hash.rb
@@ -128,9 +128,37 @@ class Chef
           values
           values_at
           zip
+          deep_merge
+          symbolize_keys
+          stringify_keys
+          compact_blank
+          deep_symbolize_keys
+          extractable_options?
+          assert_valid_keys
+          to_options
+          to_options!
+          deep_transform_keys
+          deep_stringify_keys
+          pick
+          index_by
+          in_order_of
+          many?
+          sole
+          exclude?
+          excluding
+          minimum
+          maximum
+          pluck
+          including
+          without
+          index_with
         }.freeze
+
         DISALLOWED_MUTATOR_METHODS = %i{
           []=
+          deep_merge!
+          extract!
+          slice!
           clear
           collect!
           compact!
@@ -156,6 +184,12 @@ class Chef
           update
           write!
           write
+          stringify_keys!
+          compact_blank!
+          symbolize_keys!
+          deep_transform_keys!
+          deep_symbolize_keys!
+          deep_stringify_keys!
         }.freeze
 
         # Redefine all of the methods that mutate a Hash to raise an error when called.


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR updates the immutablize mixins for Array and Hash by incorporating additional methods inspired by ActiveSupport.

### Context
This change is necessary to facilitate the upcoming licensing integration (#14467), which utilizes the [`chef-licensing`](https://rubygems.org/gems/chef-licensing) library that depends on ActiveSupport. By aligning our mixins with ActiveSupport conventions, we ensure smoother integration and compatibility.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
CHEF-11803: Infra 19 available for Free-tier, trial and commercial users in non-airgapped environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
