### PR TITLE
update glob string for chef-log.dll

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -74,7 +74,7 @@ package :msi do
   wix_candle_extension "WixUtilExtension"
   wix_light_extension "WixUtilExtension"
   signing_identity ENV.fetch("OMNIBUS_SIGNING_IDENTITY", "7D16AE73AB249D473362E9332D029089DBBB89B2"), machine_store: false, keypair_alias: "key_875762014"
-  parameters ChefLogDllPath: windows_safe_path(gem_path("chef-[0-9]*-universal-mingw-ucrt/ext/win32-eventlog/chef-log.dll")),
+  parameters ChefLogDllPath: windows_safe_path(gem_path("chef-[0-9]*-mingw-ucrt/ext/win32-eventlog/chef-log.dll")),
              ProjectLocationDir: project_location_dir
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
chef-18 omnibus build is failing (https://buildkite.com/chef/chef-chef-main-validate-adhoc/builds/1908) to find chef log dll since it expects folder suffix to be `x64-mingw-ucrt` while the available match is for `universal-mingw-ucrt`. This change updates the glob to `chef-[0-9]*-mingw-ucrt/ext/win32-eventlog/chef-log.dll` so it matches both suffixes.

adhoc run: https://buildkite.com/chef/chef-chef-chef-18-validate-adhoc/builds/143

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
