### PR TITLE
Commit the Gemfile.lock from fixed Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,7 +442,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    win32-api (1.10.1)
+    win32-api (1.10.1-universal-mingw32)
     win32-certstore (0.6.16)
       chef-powershell
       ffi

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,7 @@ GEM
     netrc (0.11.0)
     nori (2.7.1)
       bigdecimal
+    openssl (3.2.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -441,7 +442,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    win32-api (1.10.1-universal-mingw32)
+    win32-api (1.10.1)
     win32-certstore (0.6.16)
       chef-powershell
       ffi
@@ -507,6 +508,7 @@ DEPENDENCIES
   ffi (>= 1.15.5)
   inspec-core-bin (>= 5, < 6)
   ohai!
+  openssl (= 3.2.0)
   pry (= 0.13.0)
   pry-byebug
   pry-stack_explorer


### PR DESCRIPTION
Instead of `bundle update --conservative` this is running a `bundle install` on the `install_if` Gemfile

```sh
❯ bundle install
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies........
Using rake 13.2.1
Using public_suffix 5.0.1
Using ast 2.4.2
Using aws-eventstream 1.3.0
Using aws-partitions 1.958.0
Using jmespath 1.6.2
Using base64 0.2.0
Using bigdecimal 3.1.8
Using bundler 2.3.7
Using builder 3.3.0
Using debug_inspector 1.1.0
Using byebug 11.1.3
Using concurrent-ruby 1.2.2
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using libyajl2 2.1.0
Using chef-vault 4.1.11
Using rack 2.2.6.4
Using mixlib-log 3.0.9
Using hashie 4.1.0
Using webrick 1.8.1
Using diff-lcs 1.5.0
Using erubis 2.7.0
Using ffi 1.16.3
Using iniparse 1.5.0
Using ruby2_keywords 0.0.5
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using uuidtools 2.2.0
Using faraday-net_http 3.0.2
Using tty-cursor 0.7.1
Using tty-screen 0.8.1
Using wisper 2.0.1
Using method_source 1.0.0
Using multipart-post 2.3.0
Using parallel 1.22.1
Using parslet 1.8.2
Using coderay 1.1.3
Using rspec-support 3.11.1
Using rubyzip 2.3.2
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.2.1
Using json 2.6.3
Using net-ssh 7.1.0
Using mixlib-authentication 3.0.10
Using mixlib-cli 2.1.8
Using unicode_utils 1.4.0
Using date 3.3.4
Using unicode-display_width 2.4.2
Using ipaddress 0.8.3
Using wmi-lite 1.0.7
Using timeout 0.4.1
Using plist 3.7.0
Using proxifier2 1.1.0
Using unf_ext 0.0.8.2
Using mime-types-data 3.2023.0218.1
Using syslog-logger 1.6.8
Using http-accept 1.7.0
Using netrc 0.11.0
Using rexml 3.2.5
Using erubi 1.13.0
Using little-plugger 1.1.4
Using httpclient 2.8.3
Using multi_json 1.15.0
Using rainbow 3.1.1
Using regexp_parser 2.7.0
Using ruby-progressbar 1.13.0
Using hashdiff 1.0.1
Using ed25519 1.3.0
Using stringio 3.1.1
Using addressable 2.8.2
Using aws-sigv4 1.9.0
Using parser 3.2.2.0
Using rubyntlm 0.6.5
Using binding_of_caller 1.0.0
Using nori 2.7.1
Using chef-utils 19.0.40 from source at `chef-utils`
Using mixlib-config 3.0.27
Using ffi-yajl 2.6.0
Using mixlib-archive 1.1.7
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.14
Using gssapi 1.3.1
Using pastel 0.8.0
Using faraday 2.7.4
Using tty-reader 0.9.0
Using pry 0.13.0
Using rspec-core 3.11.0
Using rspec-expectations 3.11.1
Using rspec-mocks 3.11.2
Using net-scp 4.0.0
Using net-sftp 4.0.0
Using ruby-shadow 2.5.1
Using strings 0.2.1
Using net-protocol 0.2.2
Using unf 0.1.4
Using mime-types 3.4.1
Using gyoku 1.4.0
Using crack 0.4.5
Using logging 2.4.0
Using aws-sdk-core 3.201.3
Using vault 0.18.2
Using fauxhai-ng 9.3.0
Using time 0.3.0
Using rubocop-ast 1.28.0
Using psych 5.1.2
Using chef-zero 15.0.11
Using faraday-follow_redirects 0.3.0
Using tty-prompt 0.23.1
Using rspec 3.11.0
Using mixlib-shellout 3.2.8
Using pry-byebug 3.10.1
Using aws-sdk-kms 1.88.0
Using rspec-its 1.3.0
Using aws-sdk-secretsmanager 1.102.0
Using tty-table 0.12.0
Using net-ftp 0.3.7
Using domain_name 0.5.20190701
Using winrm 2.3.8
Using pry-stack_explorer 0.6.1
Using webmock 3.19.1
Using cheffish 17.1.5
Using rdoc 6.4.1.1
Using chef-config 19.0.40 from source at `chef-config`
Using train-core 3.10.7
Using tty-box 0.7.0
Using aws-sdk-s3 1.156.0
Using chef-telemetry 1.1.1
Using ohai 19.0.3 from https://github.com/chef/ohai.git (at main@38116d1)
Using rubocop 1.25.1
Using http-cookie 1.0.5
Using winrm-fs 1.3.5
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using license-acceptance 2.1.13
Using winrm-elevated 1.2.3
Using chefstyle 2.2.2
Using inspec-core 5.22.40
Using train-winrm 0.2.13
Using train-rest 0.5.0
Using chef 19.0.40 from source at `.`
Using chef-bin 19.0.40 from source at `chef-bin` and installing its executables
Bundle complete! 25 Gemfile dependencies, 142 gems now installed.
Gems in the group 'omnibus_package' were not installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
