### PR TITLE
Updating psych gem to get it to run on a Mac ARM

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    psych (5.1.2)
+    psych (4.0.2)
       stringio
     public_suffix (6.0.1)
     racc (1.8.1)
@@ -398,7 +398,7 @@ GEM
     rubyzip (2.3.2)
     semverse (3.0.2)
     sslshake (1.3.1)
-    stringio (3.1.1)
+    stringio (3.0.6)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)

--- a/knife/knife.gemspec
+++ b/knife/knife.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config", ">= #{Chef::Knife::VERSION.split(".").first}"
   s.add_dependency "chef-utils", ">= #{Chef::Knife::VERSION.split(".").first}"
   s.add_dependency "chef", ">= #{Chef::Knife::VERSION.split(".").first}"
-  s.add_dependency "train-core", "~> 3.10" # 3.2.28 fixes sudo prompts. See https://github.com/chef/chef/pull/9635
+  s.add_dependency "train-core", "~> 3.10", "<= 3.12.7" # 3.2.28 fixes sudo prompts. See https://github.com/chef/chef/pull/9635
   s.add_dependency "train-winrm", ">= 0.2.5"
   s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating the psych gem so it will load and run correctly on Mac ARM platforms.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
