### PR TITLE
Fix for mac 11 arm64 and windows platforms for chef-18 adhoc build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    psych (5.1.2)
+    psych (4.0.2)
       stringio
     public_suffix (6.0.1)
     racc (1.8.1)
@@ -398,7 +398,7 @@ GEM
     rubyzip (2.3.2)
     semverse (3.0.2)
     sslshake (1.3.1)
-    stringio (3.1.1)
+    stringio (3.0.1.1)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
       tomlrb (>= 1.2, < 3.0)
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
-    license_scout (1.3.14)
+    license_scout (1.3.15)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)

--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -74,7 +74,7 @@ package :msi do
   wix_candle_extension "WixUtilExtension"
   wix_light_extension "WixUtilExtension"
   signing_identity ENV.fetch("OMNIBUS_SIGNING_IDENTITY", "7D16AE73AB249D473362E9332D029089DBBB89B2"), machine_store: false, keypair_alias: "key_875762014"
-  parameters ChefLogDllPath: windows_safe_path(gem_path("chef-[0-9]*-x64-mingw-ucrt/ext/win32-eventlog/chef-log.dll")),
+  parameters ChefLogDllPath: windows_safe_path(gem_path("chef-[0-9]*-universal-mingw-ucrt/ext/win32-eventlog/chef-log.dll")),
              ProjectLocationDir: project_location_dir
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
There are errors on windows and mac os 11 arm 64 platforms on chef-18

Windows is failing due to regex mis match for windows gem platform name for chef , so modified that to match it with the gem name. since it expects folder suffix to be universal-mingw-ucrt while the available match is for x64-mingw-ucrt
<img width="1588" alt="Screenshot 2024-10-29 at 9 33 31 PM" src="https://github.com/user-attachments/assets/5d7e9711-f70e-4838-a655-762fb9d88d67">

Mac os 11 arm64 is failing due to psych and stringio gem code sign , lowering the versions of these two given the success build

<img width="1588" alt="Screenshot 2024-10-29 at 9 33 48 PM" src="https://github.com/user-attachments/assets/ce91465e-c2b6-4d62-a919-fc960572bb73">

adhoc run against this pr : https://buildkite.com/chef/chef-chef-chef-18-validate-adhoc/builds/165#_

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
