### PR TITLE
Updating builders and testers

### DIFF
--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -16,7 +16,7 @@ container_platforms=("amazon-2:centos-7" "amazon-2-arm:amazon-2-arm" "centos-7:c
 # add rest of windows platforms to tests, if not on chef-oss org
 if [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]]
 then
-  container_platforms=( "${container_platforms[@]}" "windows-2012:windows-2019" "windows-2012r2:windows-2019" "windows-2016:windows-2019" "windows-2022:windows-2019" "windows-10:windows-2019" "windows-11:windows-2019" )
+  container_platforms=( "${container_platforms[@]}" "windows-2016:windows-2019" "windows-2022:windows-2019" "windows-10:windows-2019" "windows-11:windows-2019" )
 fi
 
 # array of all esoteric platforms in the format test-platform:build-platform

--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -74,10 +74,6 @@ builder-to-testers-map:
     - sles-15-x86_64
   sles-15-aarch64:
     - sles-15-aarch64
-  # solaris2-5.11-i386:
-  #   - solaris2-5.11-i386
-  # solaris2-5.11-sparc:
-  #   - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
@@ -88,8 +84,6 @@ builder-to-testers-map:
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
   windows-10-x86_64:
-    # - windows-2012-x86_64
-    # - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64

--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -88,8 +88,8 @@ builder-to-testers-map:
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
   windows-10-x86_64:
-    - windows-2012-x86_64
-    - windows-2012r2-x86_64
+    # - windows-2012-x86_64
+    # - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -98,8 +98,8 @@ release_branches:
       version_constraint: 18*
   - chef-17:
       version_constraint: 17*
-  - chef-16:
-      version_constraint: 16*
+  # - chef-16:
+  #     version_constraint: 16*
 
 changelog:
   rollup_header: Changes not yet released to stable

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -98,8 +98,6 @@ release_branches:
       version_constraint: 18*
   - chef-17:
       version_constraint: 17*
-  # - chef-16:
-  #     version_constraint: 16*
 
 changelog:
   rollup_header: Changes not yet released to stable
@@ -145,11 +143,6 @@ subscriptions:
             - "Expeditor: Skip Habitat"
             - "Expeditor: Skip All"
           only_if: built_in:bump_version
-      # - trigger_pipeline:omnibus/release:
-      #     ignore_labels:
-      #       - "Expeditor: Skip Omnibus"
-      #       - "Expeditor: Skip All"
-      #     only_if: built_in:bump_version
       - trigger_pipeline:validate/release:
           ignore_labels:
             - "Expeditor: Skip Omnibus"

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -16,10 +16,6 @@ builder-to-testers-map:
    - aix-7.1-powerpc
    - aix-7.2-powerpc
    - aix-7.3-powerpc
-      #  amazon-2022-aarch64:
-      #    - amazon-2022-aarch64
-      #  amazon-2022-x86_64:
-      #    - amazon-2022-x86_64
   amazon-2023-aarch64:
     - amazon-2023-aarch64
   amazon-2023-x86_64:
@@ -31,8 +27,6 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  # el-6-x86_64:
-  #   - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64
@@ -89,8 +83,6 @@ builder-to-testers-map:
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
   windows-10-x86_64:
-    # - windows-2012-x86_64
-    # - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -89,8 +89,8 @@ builder-to-testers-map:
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
   windows-10-x86_64:
-    - windows-2012-x86_64
-    - windows-2012r2-x86_64
+    # - windows-2012-x86_64
+    # - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -30,8 +30,8 @@ provisioner:
   chef_license: accept-no-persist
 
 platforms:
-  - name: centos-6
-    run_list: yum-epel::default
+  # - name: centos-6
+  #   run_list: yum-epel::default
   - name: centos-7
     run_list: yum-epel::default
   - name: debian-9
@@ -39,6 +39,10 @@ platforms:
   - name: freebsd-11
     run_list: freebsd::portsnap
   - name: ubuntu-18.04
+    run_list: apt::default
+  - name: ubuntu-22.04
+    run_list: apt::default
+  - name: ubuntu-24.04
     run_list: apt::default
 
   # macOS
@@ -53,52 +57,79 @@ platforms:
       - ['../../omnibus', '/Users/vagrant/omnibus']
       - ['../../omnibus-software', '/Users/vagrant/omnibus-software']
 
-  <% %w(
-    10
-    2012r2
-  ).each do |win_version| %>
-  # Windows 64-bit
-  - name: windows-<%= win_version %>
+  # Windows
+  - name: windows-10
     driver:
-      box: tas50/windows-<%= win_version %> # private
-      synced_folders:
-      # We have to mount this repos enclosing folder as the Omnibus build
-      # gets cranky if the mounted Chef source folder is a symlink. This
-      # mounts at `C:\vagrant\code` and the Chef source folder is available
-      # at `C:\vagrant\code\chef`
-      - ['../..', '/vagrant/code']
-      communicator: winrm
-    provisioner:
-      attributes:
-        omnibus:
-          build_user:          vagrant
-          build_user_group:    Administrators
-          build_user_password: vagrant
-      chef_omnibus_root: /opscode/angrychef
-    transport:
-      name: winrm
-      elevated: true
+      box: stromweld/windows-10
+      customize:
+        memory: 4096
+  - name: windows-11
+    driver:
+      box: stromweld/windows-11
+      customize:
+        memory: 4096
+  - name: windows-2016
+    driver:
+      box: stromweld/windows-2016
+      customize:
+        memory: 4096
+  - name: windows-2019
+    driver:
+      box: stromweld/windows-2019
+      customize:
+        memory: 4096
+  - name: windows-2022
+    driver:
+      box: stromweld/windows-2022
+      customize:
+        memory: 4096
 
-  # Windows 32-bit
-  # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
-  # will load the 32-bit version of the MinGW toolchain.
-  - name: windows-<%= win_version %>-i386
-    driver:
-      box: tas50/windows-<%= win_version %> # private
-      synced_folders:
-      - ['../..', '/vagrant/code']
-      communicator: winrm
-    provisioner:
-      attributes:
-        omnibus:
-          build_user:          vagrant
-          build_user_group:    Administrators
-          build_user_password: vagrant
-      chef_omnibus_root: /opscode/angrychef
-    transport:
-      name: winrm
-      elevated: true
-  <% end %>
+  # <% %w(
+  #   10
+  #   2012r2
+  # ).each do |win_version| %>
+  # # Windows 64-bit
+  # - name: windows-<%= win_version %>
+  #   driver:
+  #     box: tas50/windows-<%= win_version %> # private
+  #     synced_folders:
+  #     # We have to mount this repos enclosing folder as the Omnibus build
+  #     # gets cranky if the mounted Chef source folder is a symlink. This
+  #     # mounts at `C:\vagrant\code` and the Chef source folder is available
+  #     # at `C:\vagrant\code\chef`
+  #     - ['../..', '/vagrant/code']
+  #     communicator: winrm
+  #   provisioner:
+  #     attributes:
+  #       omnibus:
+  #         build_user:          vagrant
+  #         build_user_group:    Administrators
+  #         build_user_password: vagrant
+  #     chef_omnibus_root: /opscode/angrychef
+  #   transport:
+  #     name: winrm
+  #     elevated: true
+
+  # # Windows 32-bit
+  # # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
+  # # will load the 32-bit version of the MinGW toolchain.
+  # - name: windows-<%= win_version %>-i386
+  #   driver:
+  #     box: tas50/windows-<%= win_version %> # private
+  #     synced_folders:
+  #     - ['../..', '/vagrant/code']
+  #     communicator: winrm
+  #   provisioner:
+  #     attributes:
+  #       omnibus:
+  #         build_user:          vagrant
+  #         build_user_group:    Administrators
+  #         build_user_password: vagrant
+  #     chef_omnibus_root: /opscode/angrychef
+  #   transport:
+  #     name: winrm
+  #     elevated: true
+  # <% end %>
 
 suites:
   # - name: angrychef

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -30,8 +30,6 @@ provisioner:
   chef_license: accept-no-persist
 
 platforms:
-  # - name: centos-6
-  #   run_list: yum-epel::default
   - name: centos-7
     run_list: yum-epel::default
   - name: debian-9
@@ -84,61 +82,7 @@ platforms:
       customize:
         memory: 4096
 
-  # <% %w(
-  #   10
-  #   2012r2
-  # ).each do |win_version| %>
-  # # Windows 64-bit
-  # - name: windows-<%= win_version %>
-  #   driver:
-  #     box: tas50/windows-<%= win_version %> # private
-  #     synced_folders:
-  #     # We have to mount this repos enclosing folder as the Omnibus build
-  #     # gets cranky if the mounted Chef source folder is a symlink. This
-  #     # mounts at `C:\vagrant\code` and the Chef source folder is available
-  #     # at `C:\vagrant\code\chef`
-  #     - ['../..', '/vagrant/code']
-  #     communicator: winrm
-  #   provisioner:
-  #     attributes:
-  #       omnibus:
-  #         build_user:          vagrant
-  #         build_user_group:    Administrators
-  #         build_user_password: vagrant
-  #     chef_omnibus_root: /opscode/angrychef
-  #   transport:
-  #     name: winrm
-  #     elevated: true
-
-  # # Windows 32-bit
-  # # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
-  # # will load the 32-bit version of the MinGW toolchain.
-  # - name: windows-<%= win_version %>-i386
-  #   driver:
-  #     box: tas50/windows-<%= win_version %> # private
-  #     synced_folders:
-  #     - ['../..', '/vagrant/code']
-  #     communicator: winrm
-  #   provisioner:
-  #     attributes:
-  #       omnibus:
-  #         build_user:          vagrant
-  #         build_user_group:    Administrators
-  #         build_user_password: vagrant
-  #     chef_omnibus_root: /opscode/angrychef
-  #   transport:
-  #     name: winrm
-  #     elevated: true
-  # <% end %>
-
 suites:
-  # - name: angrychef
-  #   attributes:
-  #     omnibus:
-  #       <<: *attribute_defaults
-  #       install_dir: /opt/angrychef
-  #   run_list:
-  #     - omnibus::default
   - name: chef
     attributes:
       omnibus:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
As we come to the final builds of Chef-18, we need to do some cleanup to ensure we are testing and building on supported platforms using current toolsets. I updated some of the kitchen testers to more modern versions and generally removed anything to do with Windows 2012 - it has not been supported by anyone for a while now.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
