### PR TITLE
Switch/enable chef-18 GitHub Actions on push

### DIFF
--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -5,7 +5,7 @@ name: func_spec
   pull_request:
   push:
     branches:
-      - main
+      - chef-18
 
 concurrency:
   group: func-specs-${{ github.ref }}

--- a/.github/workflows/kitchen-fips.yml
+++ b/.github/workflows/kitchen-fips.yml
@@ -5,7 +5,7 @@ name: kitchen-fips
   pull_request:
   push:
     branches:
-      - main
+      - chef-18
 
 concurrency:
   group: kitchen-fips-${{ github.ref }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -5,7 +5,7 @@ name: kitchen
   pull_request:
   push:
     branches:
-      - main
+      - chef-18
 
 concurrency:
   group: kitchen-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - chef-18
 
 concurrency:
   group: lint-${{ github.ref }}

--- a/.github/workflows/selfhosted-fips.yml
+++ b/.github/workflows/selfhosted-fips.yml
@@ -5,7 +5,7 @@ name: selfhosted-fips
   pull_request:
   push:
     branches:
-      - main
+      - chef-18
 
 concurrency:
   group: selfhosted-fips-${{ github.ref }}

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -5,7 +5,7 @@ name: unit_specs
   pull_request:
   push:
     branches:
-      - main
+      - chef-18
 
 concurrency:
   group: unit-specs-${{ github.ref }}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Enable `chef-18` GitHub Actions runs on push

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
