### PR TITLE
Checking the Test-kitchen context with env variable

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -29,6 +29,8 @@ require "rbconfig" unless defined?(RbConfig)
 require_relative "application/exit_code"
 require "chef-utils" unless defined?(ChefUtils::CANARY)
 require_relative "licensing"
+require_relative "context"
+
 module LicenseAcceptance
   autoload :Acceptor, "license_acceptance/acceptor"
 end
@@ -65,6 +67,7 @@ class Chef
       reconfigure
       setup_application
       check_license_acceptance if enforce_license
+      Context.switch_to_workstation_entitlement if Context.test_kitchen_context?
       Chef::Licensing.fetch_and_persist if ChefUtils::Dist::Infra::EXEC == "chef"
       run_application
     end

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -1,0 +1,61 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Chef
+  class Context
+    class << self
+      COMMON_KEY = "2f3b66cbbafa2d326b2856bccc4c8ebe".freeze
+      TMP_FILE_PATH = "/tmp/c769508738d671db424b7442".freeze
+
+      def test_kitchen_context?
+        return @context if defined?(@context)
+
+        @context = false
+        if File.exist?(TMP_FILE_PATH)
+          file_content = {}
+          File.foreach(TMP_FILE_PATH) do |line|
+            key, value = line.strip.split(':')
+            file_content[key] = value
+          end
+
+          received_nonce = file_content['nonce']
+          received_timestamp = file_content['timestamp']
+          received_signature = file_content['signature']
+
+          current_time = Time.now.utc.to_i
+          if (current_time - received_timestamp.to_i).abs < 30
+            message = "#{received_nonce}:#{received_timestamp}"
+            expected_signature = OpenSSL::HMAC.hexdigest('SHA256', COMMON_KEY, message)
+            if expected_signature == received_signature
+              @context = true
+            end
+          end
+          File.delete(TMP_FILE_PATH)
+        end
+
+        @context
+      end
+
+      def switch_to_workstation_entitlement
+        puts "Running under Test-Kitchen: Switching License to Chef Workstation entitlement"
+        ChefLicensing.configure do |config|
+          # Reset entitlement ID to the ID of Chef Workstation
+          config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -20,7 +20,7 @@ class Chef
   class Context
     class << self
       def test_kitchen_context?
-        return @context if defined?(@context)
+        return @context unless @context.nil?
 
         @context = false
         return @context if context_secret.nil? || context_secret.empty?
@@ -75,6 +75,10 @@ class Chef
       def expected_signature(nonce, timestamp)
         message = "#{nonce}:#{timestamp}"
         OpenSSL::HMAC.hexdigest("SHA256", context_secret, message)
+      end
+
+      def reset_context
+        @context = nil
       end
     end
   end

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -23,7 +23,7 @@ class Chef
 
     class << self
       # When chef-test-kitchen-enterprise invokes the chef-client during the converge phase,
-      # it sets the env variable IS_KITCHEN to true. This method checks the existance of the env variable
+      # it sets the env variable IS_KITCHEN to true. This method checks the existence of the ENV variable
       # and returns if the chef-client is running in the test-kitchen context.
       def test_kitchen_context?
         @context ||= (fetch_env_value == "true")

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -1,3 +1,4 @@
+# freeze_string_literal: true
 #
 # Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
@@ -17,18 +18,21 @@
 class Chef
   class Context
     class << self
-      COMMON_KEY = "2f3b66cbbafa2d326b2856bccc4c8ebe".freeze
-      TMP_FILE_PATH = "/tmp/c769508738d671db424b7442".freeze
+      COMMON_KEY = "2f3b66cbbafa2d326b2856bccc4c8ebe"
+      FILE_NAME = "c769508738d671db424b7442"
 
       def test_kitchen_context?
         return @context if defined?(@context)
 
         @context = false
-        if File.exist?(TMP_FILE_PATH)
+        file_path = (ChefUtils.windows? ? Dir.tmpdir : "/tmp") + "/kitchen/#{FILE_NAME}"
+        if File.exist?(file_path)
           file_content = {}
-          File.foreach(TMP_FILE_PATH) do |line|
-            key, value = line.strip.split(':')
-            file_content[key] = value
+          File.open(file_path, "r:bom|utf-16le:utf-8") do |file|
+            file.each_line do |line|
+              key, value = line.strip.split(':')
+              file_content[key] = value
+            end
           end
 
           received_nonce = file_content['nonce']

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -14,40 +14,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+require_relative "licensing_config"
 
 class Chef
   class Context
     class << self
-      COMMON_KEY = "2f3b66cbbafa2d326b2856bccc4c8ebe".freeze
-      FILE_NAME = "c769508738d671db424b7442".freeze
-
       def test_kitchen_context?
         return @context if defined?(@context)
 
         @context = false
-        file_path = (ChefUtils.windows? ? Dir.tmpdir : "/tmp") + "/kitchen/#{FILE_NAME}"
-        if File.exist?(file_path)
-          file_content = {}
-          File.open(file_path, "r:bom|utf-16le:utf-8") do |file|
-            file.each_line do |line|
-              key, value = line.strip.split(":")
-              file_content[key] = value
-            end
-          end
+        return @context if context_secret.nil? || context_secret.empty?
 
-          received_nonce = file_content["nonce"]
-          received_timestamp = file_content["timestamp"]
-          received_signature = file_content["signature"]
-
+        if File.exist?(signed_file_path)
+          received_nonce, received_timestamp, received_signature = read_file_content
           current_time = Time.now.utc.to_i
           if (current_time - received_timestamp.to_i).abs < 30
-            message = "#{received_nonce}:#{received_timestamp}"
-            expected_signature = OpenSSL::HMAC.hexdigest("SHA256", COMMON_KEY, message)
-            if expected_signature == received_signature
+            if expected_signature(received_nonce, received_timestamp) == received_signature
               @context = true
             end
+
           end
-          File.delete(TMP_FILE_PATH)
+          File.delete(signed_file_path)
         end
 
         @context
@@ -57,8 +44,35 @@ class Chef
         puts "Running under Test-Kitchen: Switching License to Chef Workstation entitlement"
         ChefLicensing.configure do |config|
           # Reset entitlement ID to the ID of Chef Workstation
-          config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
+          config.chef_entitlement_id = Chef::LicensingConfig::WORKSTATION_ENTITLEMENT_ID
         end
+      end
+
+      private
+
+      def context_secret
+        ENV.fetch("TEST_KITCHEN_CONTEXT", "")
+      end
+
+      def signed_file_path
+        "#{Dir.tmpdir}/kitchen/#{context_secret}"
+      end
+
+      def read_file_content
+        file_content = {}
+        File.open(signed_file_path, "r:bom|utf-16le:utf-8") do |file|
+          file.each_line do |line|
+            key, value = line.strip.split(":")
+            file_content[key] = value
+          end
+        end
+
+        [file_content["nonce"], file_content["timestamp"], file_content["signature"]]
+      end
+
+      def expected_signature(nonce, timestamp)
+        message = "#{nonce}:#{timestamp}"
+        OpenSSL::HMAC.hexdigest("SHA256", context_secret, message)
       end
     end
   end

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -42,7 +42,7 @@ class Chef
 
       # Get the value of the ENV variable
       def fetch_env_value
-        ENV.fetch(KITCHEN_CONTEXT_ENV_NAME, false)
+        ENV.fetch(KITCHEN_CONTEXT_ENV_NAME, "")
       end
 
       def reset_context

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -18,8 +18,8 @@
 class Chef
   class Context
     class << self
-      COMMON_KEY = "2f3b66cbbafa2d326b2856bccc4c8ebe"
-      FILE_NAME = "c769508738d671db424b7442"
+      COMMON_KEY = "2f3b66cbbafa2d326b2856bccc4c8ebe".freeze
+      FILE_NAME = "c769508738d671db424b7442".freeze
 
       def test_kitchen_context?
         return @context if defined?(@context)
@@ -30,19 +30,19 @@ class Chef
           file_content = {}
           File.open(file_path, "r:bom|utf-16le:utf-8") do |file|
             file.each_line do |line|
-              key, value = line.strip.split(':')
+              key, value = line.strip.split(":")
               file_content[key] = value
             end
           end
 
-          received_nonce = file_content['nonce']
-          received_timestamp = file_content['timestamp']
-          received_signature = file_content['signature']
+          received_nonce = file_content["nonce"]
+          received_timestamp = file_content["timestamp"]
+          received_signature = file_content["signature"]
 
           current_time = Time.now.utc.to_i
           if (current_time - received_timestamp.to_i).abs < 30
             message = "#{received_nonce}:#{received_timestamp}"
-            expected_signature = OpenSSL::HMAC.hexdigest('SHA256', COMMON_KEY, message)
+            expected_signature = OpenSSL::HMAC.hexdigest("SHA256", COMMON_KEY, message)
             if expected_signature == received_signature
               @context = true
             end

--- a/lib/chef/context.rb
+++ b/lib/chef/context.rb
@@ -26,14 +26,16 @@ class Chef
         return @context if context_secret.nil? || context_secret.empty?
 
         if File.exist?(signed_file_path)
+          # Read the nonce, timestamp and signature from the file
           received_nonce, received_timestamp, received_signature = read_file_content
           current_time = Time.now.utc.to_i
+          # Check if the nonce is within 30 seconds of the current time
           if (current_time - received_timestamp.to_i).abs < 30
             if expected_signature(received_nonce, received_timestamp) == received_signature
               @context = true
             end
-
           end
+          # Delete the file after reading the content
           File.delete(signed_file_path)
         end
 

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -1,7 +1,6 @@
 require_relative "base"
 require_relative "../config"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
-require_relative "../context"
 
 class Chef
   module Formatters

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -1,6 +1,7 @@
 require_relative "base"
 require_relative "../config"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
+require_relative "../context"
 
 class Chef
   module Formatters
@@ -46,6 +47,7 @@ class Chef
         puts_line "OpenSSL FIPS 140 mode enabled" if Chef::Config[:fips]
         puts_line "Infra Phase starting"
         puts_line "Targeting node: #{Chef::Config.target_mode.host}" if Chef::Config.target_mode?
+        puts_line "Running under: #{Context.test_kitchen_context? ? "Test-Kitchen" : "Chef Infra"}"
       end
 
       def total_resources

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -47,7 +47,6 @@ class Chef
         puts_line "OpenSSL FIPS 140 mode enabled" if Chef::Config[:fips]
         puts_line "Infra Phase starting"
         puts_line "Targeting node: #{Chef::Config.target_mode.host}" if Chef::Config.target_mode?
-        puts_line "Running under: #{Context.test_kitchen_context? ? "Test-Kitchen" : "Chef Infra"}"
       end
 
       def total_resources

--- a/lib/chef/licensing_config.rb
+++ b/lib/chef/licensing_config.rb
@@ -3,9 +3,10 @@ require_relative "log"
 
 class Chef
   class LicensingConfig
-    INFRA_ENTITLEMENT_ID = "a5213d76-181f-4924-adba-4b7ed2b098b5".freeze
-    COMPLIANCE_ENTITLEMENT_ID = "3ff52c37-e41f-4f6c-ad4d-365192205968".freeze # InSpec's entitlement ID
-    WORKSTATION_ENTITLEMENT_ID = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0".freeze
+    # These are the licensing entitlement IDs for the various Chef products
+    INFRA_ENTITLEMENT_ID = "a5213d76-181f-4924-adba-4b7ed2b098b5".freeze       # Chef Infra Client
+    COMPLIANCE_ENTITLEMENT_ID = "3ff52c37-e41f-4f6c-ad4d-365192205968".freeze  # InSpec's entitlement ID
+    WORKSTATION_ENTITLEMENT_ID = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0".freeze # Chef-Workstation's entitlement ID
   end
 end
 

--- a/lib/chef/licensing_config.rb
+++ b/lib/chef/licensing_config.rb
@@ -5,6 +5,7 @@ class Chef
   class LicensingConfig
     INFRA_ENTITLEMENT_ID = "a5213d76-181f-4924-adba-4b7ed2b098b5".freeze
     COMPLIANCE_ENTITLEMENT_ID = "3ff52c37-e41f-4f6c-ad4d-365192205968".freeze # InSpec's entitlement ID
+    WORKSTATION_ENTITLEMENT_ID = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0".freeze
   end
 end
 

--- a/spec/unit/context_spec.rb
+++ b/spec/unit/context_spec.rb
@@ -23,24 +23,25 @@ describe Chef::Context do
   describe "when executed normally" do
     before(:each) do
       described_class.send(:reset_context)
+      allow(ENV).to receive(:fetch).with("IS_KITCHEN", "").and_return("")
     end
 
     it "#test_kitchen_context? should return false" do
       expect(described_class.test_kitchen_context?).to be_falsey
     end
 
-    it "#context_secret should be empty" do
-      expect(described_class.send(:fetch_env_value)).to be_falsey
+    it "#fetch_env_value should be empty" do
+      expect(described_class.send(:fetch_env_value)).to eq("")
     end
   end
 
   context "when executed from test kitchen" do
     before(:each) do
       described_class.send(:reset_context)
-      allow(ENV).to receive(:fetch).with("IS_KITCHEN", false).and_return("true")
+      allow(ENV).to receive(:fetch).with("IS_KITCHEN", "").and_return("true")
     end
 
-    it "#context_secret should return the context key" do
+    it "#fetch_env_value should return true" do
       expect(described_class.send(:fetch_env_value)).to eq("true")
     end
 

--- a/spec/unit/context_spec.rb
+++ b/spec/unit/context_spec.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef/context"
+require "openssl"
+
+describe Chef::Context do
+  context "when executed from test kitchen" do
+    let (:context_key) { "key-123" }
+
+    before(:each) do
+      allow(ENV).to receive(:fetch).with("TEST_KITCHEN_CONTEXT", "").and_return(context_key)
+
+      # Mock the signed file content
+      nonce = Base64.encode64(SecureRandom.random_bytes(16)).strip
+      timestamp = Time.now.utc.to_i
+      signature = OpenSSL::HMAC.hexdigest('SHA256', context_key, "#{nonce}:#{timestamp}")
+
+      file_data = "nonce:#{nonce}\ntimestamp:#{timestamp}\nsignature:#{signature}"
+      allow(File).to receive(:exist?).with(described_class.send(:signed_file_path)).and_return(true)
+      allow(File).to receive(:open).with(described_class.send(:signed_file_path), "r:bom|utf-16le:utf-8").and_yield(StringIO.new(file_data))
+      allow(File).to receive(:delete).with(described_class.send(:signed_file_path)).and_return(true)
+    end
+
+    it "#context_secret should return the context key" do
+      expect(described_class.send(:context_secret)).to eq(context_key)
+    end
+
+    it "#test_kitchen_context? should return true" do
+      expect(described_class.test_kitchen_context?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR implements the simpler solution for the #14663 by checking the test-kitchen context using the env variable which was set by the test-kitchen during the kitchen run.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
