### PR TITLE
skip openssl version check unless adhoc (nightly) omnibus pipeline

### DIFF
--- a/spec/integration/client/open_ssl_spec.rb
+++ b/spec/integration/client/open_ssl_spec.rb
@@ -11,7 +11,7 @@ describe "openssl checks" do
 
   %w{version library_version}.each do |method|
     # macOS just picks up its own for some reason, maybe it circumvents a build step
-    example "check #{method}", not_supported_on_macos: true do
+    example "check #{method}", not_supported_on_macos: true, openssl_version_check: true do
       expect(OpenSSL.const_get("OPENSSL_#{method.upcase}")).to match(openssl_version_default), "OpenSSL doesn't match omnibus_overrides.rb"
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -179,7 +179,7 @@ RSpec.configure do |config|
   config.filter_run_excluding requires_unprivileged_user: true if root?
   config.filter_run_excluding openssl_gte_101: true unless openssl_gte_101?
   config.filter_run_excluding openssl_lt_101: true unless openssl_lt_101?
-  config.filter_run_excluding openssl_version_check: true if ENV.fetch("BUILDKITE_PIPELINE_SLUG", "").match?("verify")
+  config.filter_run_excluding openssl_version_check: true unless ENV.fetch("BUILDKITE_PIPELINE_SLUG", "").match?("adhoc")
   config.filter_run_excluding aes_256_gcm_only: true unless aes_256_gcm?
   config.filter_run_excluding broken: true
   config.filter_run_excluding not_wpar: true unless wpar?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -179,6 +179,7 @@ RSpec.configure do |config|
   config.filter_run_excluding requires_unprivileged_user: true if root?
   config.filter_run_excluding openssl_gte_101: true unless openssl_gte_101?
   config.filter_run_excluding openssl_lt_101: true unless openssl_lt_101?
+  config.filter_run_excluding openssl_version_check: true if ENV.fetch("BUILDKITE_PIPELINE_SLUG", "").match?("verify")
   config.filter_run_excluding aes_256_gcm_only: true unless aes_256_gcm?
   config.filter_run_excluding broken: true
   config.filter_run_excluding not_wpar: true unless wpar?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Addresses

OpenSSL check breakage on [Integration windows-2019](https://buildkite.com/chef-oss/chef-chef-main-verify/builds/18409#01933f1d-4e71-477e-a0b9-91aad063cb47)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
