### PR TITLE
Temporarily bypass licensing in kitchen until Progress solves this

### DIFF
--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -370,7 +370,11 @@ class Chef::Application::Base < Chef::Application
 
   # Run the chef client, optionally daemonizing or looping at intervals.
   def run_application
-    Chef::Licensing.check_software_entitlement! if ChefUtils::Dist::Infra::EXEC == "chef"
+    if ENV["TEST_KITCHEN"]
+      puts "Temporarily bypassing licensing check in Kitchen"
+    else
+      Chef::Licensing.check_software_entitlement! if ChefUtils::Dist::Infra::EXEC == "chef"
+    end
     if Chef::Config[:version]
       puts "#{ChefUtils::Dist::Infra::PRODUCT} version: #{::Chef::VERSION}"
     end

--- a/lib/chef/licensing.rb
+++ b/lib/chef/licensing.rb
@@ -6,8 +6,12 @@ class Chef
   class Licensing
     class << self
       def fetch_and_persist
-        Chef::Log.info "Fetching and persisting license..."
-        license_keys = ChefLicensing.fetch_and_persist
+        if ENV["TEST_KITCHEN"]
+          puts "Temporarily bypassing licensing check in Kitchen"
+        else
+          Chef::Log.info "Fetching and persisting license..."
+          license_keys = ChefLicensing.fetch_and_persist
+        end
       rescue ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError
         Chef::Log.error "Chef Infra cannot execute without valid licenses." # TODO: Replace Infra with the product name dynamically
         Chef::Application.exit! "License not set", 174 # 174 is the exit code for LICENSE_NOT_SET defined in lib/chef/application/exit_code.rb


### PR DESCRIPTION
Temporarily bypass licensing in kitchen until Progress solves this

Summary:

People need to get work done. Until progress figures out how they want licensing to work in their pipelines, let tests work.

Test Plan:

Tests pass.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
