### PR TITLE
[RemoteFileVendor#get_filename] only do one files_for

### DIFF
--- a/lib/chef/cookbook/remote_file_vendor.rb
+++ b/lib/chef/cookbook/remote_file_vendor.rb
@@ -43,9 +43,10 @@ class Chef
           raise "get_filename: Cannot determine segment/filename for incoming filename #{filename}"
         end
 
-        raise "No such segment #{segment} in cookbook #{@cookbook_name}" unless @manifest.files_for(segment)
+        files_for_segment = @manifest.files_for(segment)
+        raise "No such segment #{segment} in cookbook #{@cookbook_name}" unless files_for_segment
 
-        found_manifest_record = @manifest.files_for(segment).find { |manifest_record| manifest_record[:path] == filename }
+        found_manifest_record = files_for_segment.find { |manifest_record| manifest_record[:path] == filename }
         raise "No such file #{filename} in #{@cookbook_name}" unless found_manifest_record
 
         cache_filename = File.join("cookbooks", @cookbook_name, found_manifest_record["path"])


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
`#files_for` can be expensive, only do it once.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
