### PR TITLE
What is going on with Windows bit masks and ACE's

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -44,6 +44,7 @@ require_relative "mixin/provides"
 require_relative "dsl/universal"
 require_relative "constants"
 
+require "pry"
 class Chef
   class Resource
 
@@ -598,6 +599,8 @@ class Chef
         return if should_skip?(action)
 
         with_umask do
+          binding.eval("self", __FILE__, __LINE__).send("provider_for_#{action}").run_action
+          binding.pry
           provider_for_action(action).run_action
         end
       rescue StandardError => e

--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -642,7 +642,23 @@ shared_examples_for "a securable resource without existing target" do
       # non-inherited ACLs. Filter them out here.
       parent_inherited_acls = parent_acls.dacl.collect(&:inherited?)
 
+      # trace = TracePoint.new(:line) do |tp|
+      #   case tp.path
+      #   when /^</
+      #     puts tp.path
+      #   when /^\(eval\)$/
+      #     puts tp.path
+      #   else
+      #     puts "+ #{File.open(tp.path) { |f| f.each_line.to_a[tp.lineno-1] }}"
+      #   end
+      # end
+      
+      # trace.enable
+      binding.pry
       resource.run_action(:create)
+      # trace.disable
+      # line_handler.disable
+      # Similarly filter out the non-inherited ACLs
 
       # Similarly filter out the non-inherited ACLs
       resource_inherited_acls = descriptor.dacl.collect(&:inherited?)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Some change in the security for Windows 23H2 and later is causing an issue where the bit-mask applied to windows ACE's has changed and results in borked permissions being applied to test files. This shows up in the AdHoc pipeline as failures with "securable resources" under Windows 11 only (not the older versions) but also reproduces on Windows 24H2 and Windows Server 2025. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
