### PR TITLE
GitHub Actions test cleanup

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -136,6 +136,10 @@ class Chef
             if defined?(Gem::Format) && Gem::Package.respond_to?(:open)
               Gem::Format.from_file_by_path(file).spec
             else
+              # Gem::Package is getting defined as an empty class as of bundler 2.5.23
+              # and therefore won't autoload
+              # ["bundler-2.5.23/lib/bundler/rubygems_ext.rb", 457]
+              require 'rubygems/package' if Gem::Package.method(:new).source_location.nil?
               Gem::Package.new(file).spec
             end
           end
@@ -422,7 +426,7 @@ class Chef
 
         def is_omnibus?
           if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|#{ChefUtils::Dist::Workstation::DIR_SUFFIX})/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
-            logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
+              logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true
           elsif RbConfig::CONFIG["bindir"].sub(/^\w:/, "") == "/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/#{ChefUtils::Dist::Infra::SHORT}/embedded/bin"

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -139,7 +139,7 @@ class Chef
               # Gem::Package is getting defined as an empty class as of bundler 2.5.23
               # and therefore won't autoload
               # ["bundler-2.5.23/lib/bundler/rubygems_ext.rb", 457]
-              require 'rubygems/package' if Gem::Package.method(:new).source_location.nil?
+              require "rubygems/package" if Gem::Package.method(:new).source_location.nil?
               Gem::Package.new(file).spec
             end
           end
@@ -426,7 +426,7 @@ class Chef
 
         def is_omnibus?
           if %r{/(#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}|#{ChefUtils::Dist::Infra::SHORT}|#{ChefUtils::Dist::Workstation::DIR_SUFFIX})/embedded/bin}.match?(RbConfig::CONFIG["bindir"])
-              logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
+            logger.trace("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG["bindir"]}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true
           elsif RbConfig::CONFIG["bindir"].sub(/^\w:/, "") == "/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/#{ChefUtils::Dist::Infra::SHORT}/embedded/bin"

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -278,9 +278,7 @@ rescue
 end
 
 def hab_test?
-  STDERR.puts "<<<<<<<<<<<<<<<<<<<<==hab_test? called-->>>>>>>>>>>>>>>>>>>>"
   return @hab_test unless @hab_test.nil?
 
-  STDERR.puts ENV.inspect
   @hab_test = ENV["HAB_TEST"] =~ /true/i ? true : false
 end


### PR DESCRIPTION
* force rubygems/package to be required if `:new` is an empty method - A change to
[rubygems_ext.rb](https://github.com/rubygems/rubygems/commit/d478ec403ff5dc5c1205eb6948029816bbdd6f12#diff-dd13cb568c0fc396fbad7bc3665465e0fc81ce91042afc2d0d537d08a31c649eR437) as of at least bundler 2.5.23 broken the autoloading of `Gem::Package` due to an empty `Gem::Package` already being declared.
* remove hab test debugging

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
