### PR TITLE
Fix fedora-latest tests: install dnf

### DIFF
--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -155,6 +155,7 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+        - RUN dnf -y install python3-libdnf python3-dnf
 
   - name: ubuntu-18.04
     driver:


### PR DESCRIPTION
Fix fedora-latest tests: install dnf

fedora-latest defaults to dnf5, and we need to install dnf4 libs to
keep Chef working.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
