### PR TITLE
Disable _snap kitchen-test on docker ubuntu

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -217,4 +217,8 @@ include_recipe "::_ifconfig"
 #   end
 # end
 
-include_recipe "::_snap" if platform?("ubuntu") && !File.exist?("/.dockerenv")
+# Snap doesn't work on docker (you can make it do so with some work, see:
+#   https://ograblog.wordpress.com/2017/06/02/dock-a-snap/)
+# But testing on just the VMs is sufficient, so we exclude docker from
+# running this recipe
+include_recipe "::_snap" if platform?("ubuntu") && !docker?

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -217,4 +217,4 @@ include_recipe "::_ifconfig"
 #   end
 # end
 
-include_recipe "::_snap" if platform?("ubuntu")
+include_recipe "::_snap" if platform?("ubuntu") && !File.exist?('/.dockerenv')

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -217,4 +217,4 @@ include_recipe "::_ifconfig"
 #   end
 # end
 
-include_recipe "::_snap" if platform?("ubuntu") && !File.exist?('/.dockerenv')
+include_recipe "::_snap" if platform?("ubuntu") && !File.exist?("/.dockerenv")

--- a/kitchen-tests/kitchen.linux.ci.yml
+++ b/kitchen-tests/kitchen.linux.ci.yml
@@ -23,7 +23,7 @@ lifecycle:
     - remote: sudo apt-get update && sudo apt-get install -y curl
       includes:
         - ubuntu-18.04
-    - remote: sudo systemd start snapd
+    - remote: sudo snap set system proxy.http=""; sudo snap set system proxy.https=""
       includes:
         - ubuntu-20.04
     - remote: sudo dnf install -y openssl cronie

--- a/kitchen-tests/kitchen.linux.ci.yml
+++ b/kitchen-tests/kitchen.linux.ci.yml
@@ -23,6 +23,9 @@ lifecycle:
     - remote: sudo apt-get update && sudo apt-get install -y curl
       includes:
         - ubuntu-18.04
+    - remote: sudo systemd start snapd
+      includes:
+        - ubuntu-20.04
     - remote: sudo dnf install -y openssl cronie
       includes:
         - fedora-latest

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -128,7 +128,8 @@ class Chef
         def call_snap_api(method, uri, post_data = nil?)
           request = "#{method} #{uri} HTTP/1.0\r\n" +
             "Accept: application/json\r\n" +
-            "Content-Type: application/json\r\n"
+            "Content-Type: application/json\r\n" +
+            "Snap-Device-Series: 16\r\n"
           if method == "POST"
             pdata = post_data.to_json.to_s
             request.concat("Content-Length: #{pdata.bytesize}\r\n\r\n#{pdata}")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We have a VM for Ubuntu that still tests this.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
