### PR TITLE
Give snapd a bit more time to boot?

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
@@ -6,7 +6,7 @@ service "snapd" do
   action :start
 end
 
-execute "sleep 5"
+execute "sleep 10"
 
 snap_package "hello" do
   action :install


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
`kitchen-tests` for `snap` are failing inconsistently in both VM and Docker in GitHub Actions. Trying on a local Hyper-V VM raised the possibility that this is just a timing issue. Doubled the sleep after start just in case.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
