### PR TITLE
[Chef-18 Backport] Reenable _tests to trigger GA (#14731)

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
@@ -6,11 +6,12 @@ service "snapd" do
   action :start
 end
 
-execute "sleep 10"
-
 snap_package "hello" do
+  # there was originally a 5 second sleep before this
   action :install
   channel "stable"
+  retries 2
+  retry_delay 15
 end
 
 snap_package "hello" do
@@ -36,4 +37,9 @@ snap_package "hello" do
   action :remove
 end
 
-snap_package %w{hello expect}
+snap_package %w{hello expect} do
+  # this action seems to be finicky after the removal
+  # action
+  retries 2
+  retry_delay 60
+end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -202,7 +202,7 @@ include_recipe "::_alternatives"
 include_recipe "::_cron" unless amazon? && node["platform_version"] >= "2023" # TODO: look into cron.d template file issue with resource
 include_recipe "::_ohai_hint"
 include_recipe "::_openssl"
-# include_recipe "::_tests" # generates UTF-8 error
+include_recipe "::_tests" # comment out if it generates UTF-8 error
 include_recipe "::_mount"
 include_recipe "::_ifconfig"
 # TODO: re-enable when habitat recipes are fixed


### PR DESCRIPTION
retry on the problematic `snap_package` lines

<!--- Provide a short summary of your changes in the Title above -->

## Description
Backport of #14731 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
