### PR TITLE
DACLs being misapplied to Windows resources

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,13 +34,6 @@ GIT
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
 
-GIT
-  remote: https://github.com/chef/ruby-shadow
-  revision: 3b8ea40b0e943b5de721d956741308ce805a5c3c
-  branch: lcg/ruby-3.0
-  specs:
-    ruby-shadow (2.5.0)
-
 PATH
   remote: .
   specs:
@@ -445,7 +438,6 @@ GEM
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
     unf_ext (0.0.8.2)
-    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
     uri (0.13.1)
@@ -532,7 +524,6 @@ DEPENDENCIES
   rdoc (~> 6.4.1)
   rest-client!
   rspec
-  ruby-shadow!
   webmock
 
 BUNDLED WITH

--- a/lib/chef/file_access_control/windows.rb
+++ b/lib/chef/file_access_control/windows.rb
@@ -20,6 +20,8 @@
 require_relative "../win32/security"
 require_relative "../win32/file"
 
+require "pry"
+
 class Chef
   class FileAccessControl
     module Windows
@@ -244,7 +246,7 @@ class Chef
       def calculate_flags(rights)
         # Handle inheritance flags
         flags = 0
-
+        binding.pry
         #
         # Configure child inheritance only if the resource is some
         # type of a directory.

--- a/lib/chef/file_content_management/deploy/mv_windows.rb
+++ b/lib/chef/file_content_management/deploy/mv_windows.rb
@@ -63,12 +63,21 @@ class Chef
             raise Chef::Exceptions::WindowsNotAdmin, "can not get the security information for '#{dst}' due to missing Administrator privileges."
           end
 
+          # dacl_present = dst_sd.dacl_present?
+          # if dacl_present
+          #   if dst_sd.dacl.nil?
+          #     apply_dacl = nil
+          #   else
+          #     apply_dacl = ACL.create(dst_sd.dacl.select { |ace| !ace.inherited? })
+          #   end
+          # end
+
           dacl_present = dst_sd.dacl_present?
           if dacl_present
             if dst_sd.dacl.nil?
-              apply_dacl = nil
-            else
               apply_dacl = ACL.create(dst_sd.dacl.select { |ace| !ace.inherited? })
+            else
+              apply_dacl = nil
             end
           end
 

--- a/lib/chef/file_content_management/deploy/mv_windows.rb
+++ b/lib/chef/file_content_management/deploy/mv_windows.rb
@@ -26,6 +26,8 @@ if ChefUtils.windows?
   require_relative "../../win32/security"
 end
 
+require "pry"
+
 class Chef
   class FileContentManagement
     class Deploy
@@ -73,12 +75,16 @@ class Chef
           # end
 
           dacl_present = dst_sd.dacl_present?
+          binding.pry
           if dacl_present
-            if dst_sd.dacl.nil?
-              apply_dacl = ACL.create(dst_sd.dacl.select { |ace| !ace.inherited? })
-            else
-              apply_dacl = nil
-            end
+            apply_dacl = nil
+          else
+            apply_dacl = ACL.create(dst_sd.dacl.select { |ace| !ace.inherited? })
+            # if dst_sd.dacl.nil?
+            #   apply_dacl = ACL.create(dst_sd.dacl.select { |ace| !ace.inherited? })
+            # else
+            #   apply_dacl = nil
+            # end
           end
 
           sacl_present = dst_sd.sacl_present?

--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -20,6 +20,8 @@
 
 require "etc"
 
+require "pry"
+
 shared_context "setup correct permissions" do
   if windows?
     include_context "use Windows permissions"
@@ -554,6 +556,7 @@ shared_examples_for "a securable resource without existing target" do
       end
 
       it "respects mode in string form as an octal number" do
+        binding.pry
         # on windows, mode cannot modify owner and/or group permissions
         # unless the owner and/or group as appropriate is specified
         resource.mode "400"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Windows testing on 23H2 and later is failing in the AdHoc pipeline on verifying that DACL's set of files are correct. They are not. If you walk the code and then look at the actual file after each change, the file gets created during testing and then when it gets updated, this block in mv_windows.rb randomly applies a set of DACL's to the file again. Check the file permissions both before and after the content is updated and you'll see that the block in this PR has fired and borked the permissions. A permissions change like that should only happen in the scenarios where file permissions are explicitly set to not inherit or maybe if there are no permissions on the file object at all. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
