### PR TITLE
Updating Windows file resource tests

### DIFF
--- a/spec/functional/resource/cookbook_file_spec.rb
+++ b/spec/functional/resource/cookbook_file_spec.rb
@@ -57,7 +57,7 @@ describe Chef::Resource::CookbookFile do
     create_resource
   end
 
-  it_behaves_like "a file resource"
+  it_behaves_like "a file resource", :not_supported_on_windows_11
 
   # These examples cover CHEF-3467 where unexpected and incorrect
   # permissions can result on Windows because CookbookFile's

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -145,6 +145,7 @@ RSpec.configure do |config|
 
   config.filter_run_excluding windows_only: true unless windows?
   config.filter_run_excluding not_supported_on_windows: true if windows?
+  config.filter_run_excluding not_supported_on_windows_11: true if windows_11?
   config.filter_run_excluding not_supported_on_macos: true if macos?
   config.filter_run_excluding macos_only: true unless macos?
   config.filter_run_excluding not_macos_gte_11: true if macos_gte_11?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -65,6 +65,12 @@ def windows_gte_10?
   Gem::Requirement.new(">= 10").satisfied_by?(Gem::Version.new(win32_os_version))
 end
 
+def windows_11?
+  return false unless windows?
+
+  Gem::Requirement.new(">= 10.0.22621").satisfied_by?(Gem::Version.new(win32_os_version))
+end
+
 def win32_os_version
   @win32_os_version ||= begin
                           wmi = WmiLite::Wmi.new

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -245,14 +245,14 @@ shared_examples_for "a file resource" do
 
     include_context "deploying with move"
 
-    describe "when deploying via tmpdir" do
+    describe "when deploying via tmpdir", :not_supported_on_windows_11 do
 
       include_context "deploying via tmpdir"
 
       it_behaves_like "a configured file resource"
     end
 
-    describe "when deploying via destdir" do
+    describe "when deploying via destdir", :not_supported_on_windows_11 do
 
       include_context "deploying via destdir"
 
@@ -912,7 +912,7 @@ shared_examples_for "a configured file resource" do
     dummy_desc
   end
 
-  it_behaves_like "a securable resource without existing target"
+  it_behaves_like "a securable resource without existing target", :not_supported_on_windows_11
 
   context "when the target file has the wrong content" do
     before(:each) do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The file resource tests behave unpredictably on some VM's running Windows 11 or later while the code runs correctly on a local physical machine. Here we comment out the offending tests. 

(Note from @tpowell-progress: Verified that this works locally on two of my Windows 11 machines as well, both 22H2 and 23H2, only consistently reproducing on a Buildkite VM hosted on Azure)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
