### PR TITLE
updating slug to correct chef-18 release pipeline

### DIFF
--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -201,7 +201,7 @@ then
   fi
 fi
 
-if [[ $BUILDKITE_PIPELINE_SLUG == "chef-chef-main-validate-release" ]]
+if [[ $BUILDKITE_PIPELINE_SLUG == "chef-chef-chef-18-validate-release" ]]
 then
   echo "- wait: ~"
   echo "- key: create-build-record"
@@ -322,7 +322,7 @@ then
   done
 fi
 
-if [[ $BUILDKITE_PIPELINE_SLUG == "chef-chef-main-validate-release" ]]
+if [[ $BUILDKITE_PIPELINE_SLUG == "chef-chef-chef-18-validate-release" ]]
 then
   echo "- wait: ~"
   echo "- key: promote"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
we need to modify these values so that we can cut a new release for chef-18 pipeline. 

## Description
This solves the issue where the create build record, and promote to current pipeline steps are missing on the validate release pipeline. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
