### PR TITLE
Remove macos-12 from GA kitchen-tests

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -40,7 +40,6 @@ jobs:
       matrix:
         os:
           - macos-13
-          - macos-12
     runs-on: ${{ matrix.os }}
     env:
       CHEF_LICENSE: accept-no-persist
@@ -61,6 +60,8 @@ jobs:
       matrix:
         os:
           - macos-latest
+          - macos-14
+          - macos-15
     runs-on: ${{ matrix.os }}
     env:
       CHEF_LICENSE: accept-no-persist

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest # currently macos-14
+          - macos-14 # currently macos-latest
           - macos-15
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -59,8 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
-          - macos-14
+          - macos-latest # currently macos-14
           - macos-15
     runs-on: ${{ matrix.os }}
     env:

--- a/kitchen-tests/kitchen.exec.macos.yml
+++ b/kitchen-tests/kitchen.exec.macos.yml
@@ -30,4 +30,3 @@ platforms:
   - name: macos-14 # arm64
   - name: macos-14-large # x86_64
   - name: macos-13 # x86_64
-  - name: macos-12 # x86_64

--- a/kitchen-tests/kitchen.exec.macos.yml
+++ b/kitchen-tests/kitchen.exec.macos.yml
@@ -26,7 +26,7 @@ lifecycle:
     - remote: /opt/chef/bin/ohai -v
 
 platforms:
-  - name: macos-15
+  - name: macos-15 # arm64
   - name: macos-14 # arm64
   - name: macos-14-large # x86_64
   - name: macos-13 # x86_64

--- a/kitchen-tests/kitchen.exec.macos.yml
+++ b/kitchen-tests/kitchen.exec.macos.yml
@@ -26,7 +26,6 @@ lifecycle:
     - remote: /opt/chef/bin/ohai -v
 
 platforms:
-  - name: macos-latest # arm64
   - name: macos-15
   - name: macos-14 # arm64
   - name: macos-14-large # x86_64

--- a/kitchen-tests/kitchen.exec.macos.yml
+++ b/kitchen-tests/kitchen.exec.macos.yml
@@ -27,6 +27,7 @@ lifecycle:
 
 platforms:
   - name: macos-latest # arm64
+  - name: macos-15
   - name: macos-14 # arm64
   - name: macos-14-large # x86_64
   - name: macos-13 # x86_64

--- a/kitchen-tests/kitchen.exec.macos.yml
+++ b/kitchen-tests/kitchen.exec.macos.yml
@@ -30,3 +30,4 @@ platforms:
   - name: macos-14 # arm64
   - name: macos-14-large # x86_64
   - name: macos-13 # x86_64
+  - name: macos-12 # x86_64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
