### PR TITLE
ohai resource: ensure fix_automatic_attributes is called

### DIFF
--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -91,6 +91,7 @@ class Chef
           # the path are picked up by ohai.
           ohai.all_plugins new_resource.plugin
           node.automatic_attrs.merge! ohai.data
+          node.fix_automatic_attributes
           logger.info("#{new_resource} reloaded")
         end
       end

--- a/spec/functional/resource/ohai_spec.rb
+++ b/spec/functional/resource/ohai_spec.rb
@@ -42,6 +42,15 @@ describe Chef::Resource::Ohai do
     it_behaves_like "reloaded :uptime"
   end
 
+  describe "when reloading all plugins" do
+    let(:ohai_resource) { Chef::Resource::Ohai.new("reload all", run_context) }
+
+    it "should leave platform_version as a Chef::VersionString" do
+      ohai_resource.run_action(:reload)
+      expect(run_context.node["platform_version"]).to be_an_instance_of(Chef::VersionString)
+    end
+  end
+
   describe "when reloading only uptime" do
     let(:ohai_resource) do
       r = Chef::Resource::Ohai.new("reload all", run_context)


### PR DESCRIPTION
fix_automatic_attributes does some tricks like promote platform_version to a Chef::VersionString for easy comparisons; if ohai.reload is called it clobbers this and resets node['platform_version'] back to a normal string. this fixes that
