### PR TITLE
[chef-18] Fix docker container

### DIFF
--- a/.expeditor/build-docker-images.sh
+++ b/.expeditor/build-docker-images.sh
@@ -3,6 +3,9 @@ set -eux -o pipefail
 
 arch=$1
 
+# dockerfile_pkg_version is the enterprise linux version of packages to install
+# for maximum compatibility with various OSs' use the lowest version still supported to get the minimal gcc version available
+# using latest el version may have pkg versions higher than what is available in older OS versions
 if [[ $arch == "arm64" ]]; then
   dockerfile_pkg_version="8"
   dockerfile_arch="aarch64"

--- a/.expeditor/build-docker-images.sh
+++ b/.expeditor/build-docker-images.sh
@@ -4,10 +4,10 @@ set -eux -o pipefail
 arch=$1
 
 if [[ $arch == "arm64" ]]; then
-  dockerfile_pkg_version="9"
+  dockerfile_pkg_version="8"
   dockerfile_arch="aarch64"
 else
-  dockerfile_pkg_version="9"
+  dockerfile_pkg_version="8"
   dockerfile_arch="x86_64"
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 ARG CHANNEL=stable
 ARG VERSION=18.6.2
 ARG ARCH=x86_64
-ARG PKG_VERSION=9
+ARG PKG_VERSION=8
 
 RUN wget "http://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/${PKG_VERSION}/chef-${VERSION}-1.el${PKG_VERSION}.${ARCH}.rpm" -O /tmp/chef-client.rpm && \
     rpm2cpio /tmp/chef-client.rpm | cpio -idmv && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 ARG CHANNEL=stable
 ARG VERSION=18.6.2
 ARG ARCH=x86_64
-ARG PKG_VERSION=8
+ARG PKG_VERSION=9
 
 RUN wget "http://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/${PKG_VERSION}/chef-${VERSION}-1.el${PKG_VERSION}.${ARCH}.rpm" -O /tmp/chef-client.rpm && \
     rpm2cpio /tmp/chef-client.rpm | cpio -idmv && \


### PR DESCRIPTION
## Description

This fixes the docker container error when loading: unable to load libcrypt.so.2 due to newer package used at time of build that is not available in older OS versions.

## Related Issue

#14760 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
