### PR TITLE
new hab pkg bin location prefix

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -136,7 +136,7 @@ module ChefConfig
     #
     def self.c_opscode_dir(windows: ChefUtils.windows?)
       drive = windows_installation_drive || "C:"
-      PathHelper.join(drive, ChefUtils::Dist::Org::LEGACY_CONF_DIR, ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
+      PathHelper.join(drive, ChefUtils::Dist::Infra::DIR_PREFIX, ChefUtils::Dist::Infra::DIR_SUFFIX, windows: windows)
     end
 
     # the drive where Chef is installed on a windows host. This is determined

--- a/chef-utils/lib/chef-utils/dist.rb
+++ b/chef-utils/lib/chef-utils/dist.rb
@@ -62,6 +62,9 @@ module ChefUtils
       # "chef" => /etc/cinc, /var/cinc, C:\\cinc
       DIR_SUFFIX = "chef"
 
+      # Parent directory that DIR_SUFFIX lives under, omnibus build /opt/chef, hab pkg build /hab/chef
+      DIR_PREFIX = 'hab'
+
       # The client's gem
       GEM = "chef"
 

--- a/lib/chef/resource/chef_client_cron.rb
+++ b/lib/chef/resource/chef_client_cron.rb
@@ -126,7 +126,7 @@ class Chef
         description: "Append to the log file instead of overwriting the log file on each run."
 
       property :chef_binary_path, String,
-        default: "/opt/#{ChefUtils::Dist::Infra::DIR_SUFFIX}/bin/#{ChefUtils::Dist::Infra::CLIENT}",
+        default: "/#{ChefUtils::Dist::Infra::DIR_PREFIX}/#{ChefUtils::Dist::Infra::DIR_SUFFIX}/bin/#{ChefUtils::Dist::Infra::CLIENT}",
         description: "The path to the #{ChefUtils::Dist::Infra::CLIENT} binary."
 
       property :daemon_options, Array,

--- a/lib/chef/resource/chef_client_launchd.rb
+++ b/lib/chef/resource/chef_client_launchd.rb
@@ -81,7 +81,7 @@ class Chef
 
       property :chef_binary_path, String,
         description: "The path to the #{ChefUtils::Dist::Infra::CLIENT} binary.",
-        default: "/opt/#{ChefUtils::Dist::Infra::DIR_SUFFIX}/bin/#{ChefUtils::Dist::Infra::CLIENT}"
+        default: "/#{ChefUtils::Dist::Infra::DIR_PREFIX}/#{ChefUtils::Dist::Infra::DIR_SUFFIX}/bin/#{ChefUtils::Dist::Infra::CLIENT}"
 
       property :daemon_options, Array,
         description: "An array of options to pass to the #{ChefUtils::Dist::Infra::CLIENT} command.",

--- a/lib/chef/resource/chef_client_scheduled_task.rb
+++ b/lib/chef/resource/chef_client_scheduled_task.rb
@@ -136,7 +136,7 @@ class Chef
 
       property :chef_binary_path, String,
         description: "The path to the #{ChefUtils::Dist::Infra::CLIENT} binary.",
-        default: "C:/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/#{ChefUtils::Dist::Infra::DIR_SUFFIX}/bin/#{ChefUtils::Dist::Infra::CLIENT}"
+        default: "C:/#{ChefUtils::Dist::Infra::DIR_PREFIX}/#{ChefUtils::Dist::Infra::DIR_SUFFIX}/bin/#{ChefUtils::Dist::Infra::CLIENT}"
 
       property :daemon_options, Array,
         description: "An array of options to pass to the #{ChefUtils::Dist::Infra::CLIENT} command.",

--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -87,7 +87,7 @@ class Chef
 
       property :chef_binary_path, String,
         description: "The path to the #{ChefUtils::Dist::Infra::CLIENT} binary.",
-        default: "/opt/#{ChefUtils::Dist::Infra::DIR_SUFFIX}/bin/#{ChefUtils::Dist::Infra::CLIENT}"
+        default: "/#{ChefUtils::Dist::Infra::DIR_PREFIX}/#{ChefUtils::Dist::Infra::DIR_SUFFIX}/bin/#{ChefUtils::Dist::Infra::CLIENT}"
 
       property :daemon_options, Array,
         description: "An array of options to pass to the #{ChefUtils::Dist::Infra::CLIENT} command.",

--- a/spec/unit/resource/chef_client_cron_spec.rb
+++ b/spec/unit/resource/chef_client_cron_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Resource::ChefClientCron do
   end
 
   it "builds a default value for chef_binary_path dist values" do
-    expect(resource.chef_binary_path).to eql("/opt/chef/bin/chef-client")
+    expect(resource.chef_binary_path).to eql("/hab/chef/bin/chef-client")
   end
 
   it "raises an error if nice is less than -20" do
@@ -98,34 +98,34 @@ describe Chef::Resource::ChefClientCron do
 
     it "creates a valid command if using all default properties" do
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c #{root_path} >> /var/log/chef/client.log 2>&1"
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c #{root_path} >> /var/log/chef/client.log 2>&1"
       )
     end
 
     it "uses daemon_options if set" do
       resource.daemon_options ["--foo 1", "--bar 2"]
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client --foo 1 --bar 2 -c #{root_path} >> /var/log/chef/client.log 2>&1"
+        "/bin/sleep 123; /hab/chef/bin/chef-client --foo 1 --bar 2 -c #{root_path} >> /var/log/chef/client.log 2>&1"
       )
     end
 
     it "uses custom config dir if set" do
       resource.config_directory "/etc/some_other_dir"
-      expect(provider.client_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -c /etc/some_other_dir/client.rb >> /var/log/chef/client.log 2>&1")
+      expect(provider.client_command).to eql("/bin/sleep 123; /hab/chef/bin/chef-client -c /etc/some_other_dir/client.rb >> /var/log/chef/client.log 2>&1")
     end
 
     it "uses custom log files / paths if set" do
       resource.log_file_name "my-client.log"
       resource.log_directory "/var/log/my-chef/"
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c #{root_path} >> /var/log/my-chef/my-client.log 2>&1"
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c #{root_path} >> /var/log/my-chef/my-client.log 2>&1"
       )
     end
 
     it "uses mailto if set" do
       resource.mailto "bob@example.com"
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c #{root_path} >> /var/log/chef/client.log 2>&1 || echo \"Chef Infra Client execution failed\""
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c #{root_path} >> /var/log/chef/client.log 2>&1 || echo \"Chef Infra Client execution failed\""
       )
     end
 
@@ -139,14 +139,14 @@ describe Chef::Resource::ChefClientCron do
     it "appends to the log file appending if set to false" do
       resource.append_log_file false
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c #{root_path} > /var/log/chef/client.log 2>&1"
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c #{root_path} > /var/log/chef/client.log 2>&1"
       )
     end
 
     it "sets the license acceptance flag if set" do
       resource.accept_chef_license true
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c #{root_path} --chef-license accept >> /var/log/chef/client.log 2>&1"
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c #{root_path} --chef-license accept >> /var/log/chef/client.log 2>&1"
       )
     end
 
@@ -154,7 +154,7 @@ describe Chef::Resource::ChefClientCron do
       allow(provider).to receive(:which).with("nice").and_return("/usr/bin/nice")
       resource.nice(-15)
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /usr/bin/nice -n -15 /opt/chef/bin/chef-client -c #{root_path} >> /var/log/chef/client.log 2>&1"
+        "/bin/sleep 123; /usr/bin/nice -n -15 /hab/chef/bin/chef-client -c #{root_path} >> /var/log/chef/client.log 2>&1"
       )
     end
   end

--- a/spec/unit/resource/chef_client_launchd_spec.rb
+++ b/spec/unit/resource/chef_client_launchd_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Resource::ChefClientLaunchd do
   end
 
   it "builds a default value for chef_binary_path dist values" do
-    expect(resource.chef_binary_path).to eql("/opt/chef/bin/chef-client")
+    expect(resource.chef_binary_path).to eql("/hab/chef/bin/chef-client")
   end
 
   it "raises an error if interval is not a positive number" do
@@ -96,28 +96,28 @@ describe Chef::Resource::ChefClientLaunchd do
 
     it "creates a valid command if using all default properties" do
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c #{root_path} -L /Library/Logs/Chef/client.log"
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c #{root_path} -L /Library/Logs/Chef/client.log"
       )
     end
 
     it "adds custom daemon options from daemon_options property" do
       resource.daemon_options %w{foo bar}
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client foo bar -c #{root_path} -L /Library/Logs/Chef/client.log"
+        "/bin/sleep 123; /hab/chef/bin/chef-client foo bar -c #{root_path} -L /Library/Logs/Chef/client.log"
       )
     end
 
     it "adds license acceptance flags if the property is set" do
       resource.accept_chef_license true
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c #{root_path} -L /Library/Logs/Chef/client.log --chef-license accept"
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c #{root_path} -L /Library/Logs/Chef/client.log --chef-license accept"
       )
     end
 
     it "uses custom config dir if set" do
       resource.config_directory "/etc/some_other_dir"
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c /etc/some_other_dir/client.rb -L /Library/Logs/Chef/client.log"
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c /etc/some_other_dir/client.rb -L /Library/Logs/Chef/client.log"
       )
     end
 
@@ -125,7 +125,7 @@ describe Chef::Resource::ChefClientLaunchd do
       resource.log_file_name "my-client.log"
       resource.log_directory "/var/log/my-chef/"
       expect(provider.client_command).to eql(
-        "/bin/sleep 123; /opt/chef/bin/chef-client -c #{root_path} -L /var/log/my-chef/my-client.log"
+        "/bin/sleep 123; /hab/chef/bin/chef-client -c #{root_path} -L /var/log/my-chef/my-client.log"
       )
     end
   end

--- a/spec/unit/resource/chef_client_scheduled_task_spec.rb
+++ b/spec/unit/resource/chef_client_scheduled_task_spec.rb
@@ -80,7 +80,7 @@ describe Chef::Resource::ChefClientScheduledTask do
   end
 
   it "builds a default value for chef_binary_path dist values" do
-    expect(resource.chef_binary_path).to eql("C:/opscode/chef/bin/chef-client")
+    expect(resource.chef_binary_path).to eql("C:/hab/chef/bin/chef-client")
   end
 
   context "priority" do
@@ -116,7 +116,7 @@ describe Chef::Resource::ChefClientScheduledTask do
     end
 
     it "sleeps the same amount each time based on splay before running the task" do
-      expect(provider.full_command).to eql("C:\\Windows\\System32\\cmd.exe /c \"C:/windows/system32/windowspowershell/v1.0/powershell.exe Start-Sleep -s 272 && C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb\"")
+      expect(provider.full_command).to eql("C:\\Windows\\System32\\cmd.exe /c \"C:/windows/system32/windowspowershell/v1.0/powershell.exe Start-Sleep -s 272 && C:/hab/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb\"")
     end
   end
 
@@ -154,23 +154,23 @@ describe Chef::Resource::ChefClientScheduledTask do
 
   describe "#client_cmd" do
     it "creates a valid command if using all default properties" do
-      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb") | eql("C:/opscode/chef/bin/chef-client -L C:\\chef/log/client.log -c C:\\chef/client.rb")
+      expect(provider.client_cmd).to eql("C:/hab/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb") | eql("C:/hab/chef/bin/chef-client -L C:\\chef/log/client.log -c C:\\chef/client.rb")
     end
 
     it "uses daemon_options if set" do
       resource.daemon_options ["--foo 1", "--bar 2"]
-      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb --foo 1 --bar 2") | eql("C:/opscode/chef/bin/chef-client -L C:\\chef/log/client.log -c C:\\chef/client.rb --foo 1 --bar 2")
+      expect(provider.client_cmd).to eql("C:/hab/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb --foo 1 --bar 2") | eql("C:/hab/chef/bin/chef-client -L C:\\chef/log/client.log -c C:\\chef/client.rb --foo 1 --bar 2")
     end
 
     it "uses custom config dir if set" do
       resource.config_directory "C:/foo/bar"
-      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L C:/foo/bar/log/client.log -c C:/foo/bar/client.rb")
+      expect(provider.client_cmd).to eql("C:/hab/chef/bin/chef-client -L C:/foo/bar/log/client.log -c C:/foo/bar/client.rb")
     end
 
     it "uses custom log files / paths if set" do
       resource.log_file_name "my-client.log"
       resource.log_directory "C:/foo/bar"
-      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L C:/foo/bar/my-client.log -c /etc/chef/client.rb") | eql("C:/opscode/chef/bin/chef-client -L C:/foo/bar/my-client.log -c C:\\chef/client.rb")
+      expect(provider.client_cmd).to eql("C:/hab/chef/bin/chef-client -L C:/foo/bar/my-client.log -c /etc/chef/client.rb") | eql("C:/hab/chef/bin/chef-client -L C:/foo/bar/my-client.log -c C:\\chef/client.rb")
     end
 
     it "uses custom chef-client binary if set" do
@@ -180,7 +180,7 @@ describe Chef::Resource::ChefClientScheduledTask do
 
     it "sets the license acceptance flag if set" do
       resource.accept_chef_license true
-      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb --chef-license accept") | eql("C:/opscode/chef/bin/chef-client -L C:\\chef/log/client.log -c C:\\chef/client.rb --chef-license accept")
+      expect(provider.client_cmd).to eql("C:/hab/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb --chef-license accept") | eql("C:/hab/chef/bin/chef-client -L C:\\chef/log/client.log -c C:\\chef/client.rb --chef-license accept")
     end
   end
 end

--- a/spec/unit/resource/chef_client_systemd_timer_spec.rb
+++ b/spec/unit/resource/chef_client_systemd_timer_spec.rb
@@ -40,7 +40,7 @@ describe Chef::Resource::ChefClientSystemdTimer do
   end
 
   it "builds a default value for chef_binary_path dist values" do
-    expect(resource.chef_binary_path).to eql("/opt/chef/bin/chef-client")
+    expect(resource.chef_binary_path).to eql("/hab/chef/bin/chef-client")
   end
 
   it "supports :add and :remove actions" do
@@ -53,17 +53,17 @@ describe Chef::Resource::ChefClientSystemdTimer do
     let(:root_path) { windows? ? "C:\\chef/client.rb" : "/etc/chef/client.rb" }
 
     it "creates a valid command if using all default properties" do
-      expect(provider.chef_client_cmd).to eql("/opt/chef/bin/chef-client -c #{root_path}")
+      expect(provider.chef_client_cmd).to eql("/hab/chef/bin/chef-client -c #{root_path}")
     end
 
     it "uses daemon_options if set" do
       resource.daemon_options ["--foo 1", "--bar 2"]
-      expect(provider.chef_client_cmd).to eql("/opt/chef/bin/chef-client --foo 1 --bar 2 -c #{root_path}")
+      expect(provider.chef_client_cmd).to eql("/hab/chef/bin/chef-client --foo 1 --bar 2 -c #{root_path}")
     end
 
     it "uses custom config dir if set" do
       resource.config_directory "/etc/some_other_dir"
-      expect(provider.chef_client_cmd).to eql("/opt/chef/bin/chef-client -c /etc/some_other_dir/client.rb")
+      expect(provider.chef_client_cmd).to eql("/hab/chef/bin/chef-client -c /etc/some_other_dir/client.rb")
     end
 
     it "uses custom chef-client binary if set" do
@@ -73,7 +73,7 @@ describe Chef::Resource::ChefClientSystemdTimer do
 
     it "sets the license acceptance flag if set" do
       resource.accept_chef_license true
-      expect(provider.chef_client_cmd).to eql("/opt/chef/bin/chef-client --chef-license accept -c #{root_path}")
+      expect(provider.chef_client_cmd).to eql("/hab/chef/bin/chef-client --chef-license accept -c #{root_path}")
     end
   end
 


### PR DESCRIPTION
## Description

New hab packing of chef-client moves bins to a binlink folder in /hab/chef/bin. This fixes the location for resources that were hard coded to /opt/ and allows compatibility for community to still use omnitruck and continue using /opt/ with their own patched chef-utils gem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
