### PR TITLE
Release file handles after extraction

### DIFF
--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -129,6 +129,7 @@ class Chef
             archive.each_entry do |e|
               FileUtils.chown(new_resource.owner, new_resource.group, "#{new_resource.destination}/#{e.pathname}")
             end
+            archive.close
           end
         end
       end
@@ -176,6 +177,7 @@ class Chef
               modified = true
             end
           end
+          archive.close
           modified
         end
 

--- a/spec/unit/resource/archive_file_spec.rb
+++ b/spec/unit/resource/archive_file_spec.rb
@@ -95,7 +95,7 @@ describe Chef::Resource::ArchiveFile, :not_supported_on_aix, :not_supported_on_w
       allow(File).to receive(:exist?).with(path).and_return(true)
       allow(File).to receive(:exist?).with(destination).and_return(true)
 
-      allow(Archive::Reader).to receive(:open_filename).with(path, nil, strip_components: 0).and_return(archive_reader)
+      allow(Archive::Reader).to receive(:open_filename).with(path, nil, strip_components: 0).and_yield(archive_reader)
       allow(archive_reader).to receive(:each_entry)
         .and_yield(archive_entry_1)
         .and_yield(archive_entry_2)
@@ -106,7 +106,7 @@ describe Chef::Resource::ArchiveFile, :not_supported_on_aix, :not_supported_on_w
       allow(archive_reader).to receive(:extract).with(archive_entry_3, any_args)
       allow(archive_reader).to receive(:extract).with(archive_entry_4, any_args)
 
-      allow(Archive::Reader).to receive(:open_filename).with(path, nil, strip_components: 1).and_return(archive_reader_with_strip_components_1)
+      allow(Archive::Reader).to receive(:open_filename).with(path, nil, strip_components: 1).and_yield(archive_reader_with_strip_components_1)
       allow(archive_reader_with_strip_components_1).to receive(:each_entry)
         .and_yield(archive_entry_2_s1)
         .and_yield(archive_entry_3_s1)
@@ -115,7 +115,7 @@ describe Chef::Resource::ArchiveFile, :not_supported_on_aix, :not_supported_on_w
       allow(archive_reader_with_strip_components_1).to receive(:extract).with(archive_entry_3_s1, any_args)
       allow(archive_reader_with_strip_components_1).to receive(:extract).with(archive_entry_4_s1, any_args)
 
-      allow(Archive::Reader).to receive(:open_filename).with(path, nil, strip_components: 2).and_return(archive_reader_with_strip_components_2)
+      allow(Archive::Reader).to receive(:open_filename).with(path, nil, strip_components: 2).and_yield(archive_reader_with_strip_components_2)
       allow(archive_reader_with_strip_components_2).to receive(:each_entry)
         .and_yield(archive_entry_4_s2)
       allow(archive_reader_with_strip_components_2).to receive(:extract).with(archive_entry_4_s2, any_args)


### PR DESCRIPTION
## Description

There is a bug in the current implementation of archive_file which causes it to lock the compressed file for remainder of the chef-client run. This prevents you from deleting a compressed file after extracting it within the same execution.

The bug stems from incorrect usage of the Archive::Reader API. When opening a file using open_filename, you need to explicitly close it again afterwards to release the lock that your Ruby process holds on the compressed file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
