### PR TITLE
[CHEF-18381] Fixed the issues with knife bootstrap failing on the airgapped envs

### DIFF
--- a/knife/lib/chef/utils/licensing_handler.rb
+++ b/knife/lib/chef/utils/licensing_handler.rb
@@ -30,13 +30,16 @@ class Chef
 
       class << self
         def validate!
-          begin
-            license_keys = ChefLicensing::LicenseKeyFetcher.fetch
-          rescue
-            return new(nil, nil)
-          end
+          license_keys = begin
+                           ChefLicensing::LicenseKeyFetcher.fetch
+                         # If the env is airgapped or the local licensing service is unreachable,
+                         # the licensing gem will raise ChefLicensing::RestfulClientConnectionError.
+                         # In such cases, we are assuming the license is not available.
+                         rescue ChefLicensing::RestfulClientConnectionError
+                           []
+                         end
 
-          return new(nil, nil) if license_keys.blank?
+          return new(nil, nil) if  license_keys.nil? || license_keys.empty?
 
           licenses_metadata = ChefLicensing::Api::Describe.list({
             license_keys: license_keys,

--- a/knife/lib/chef/utils/licensing_handler.rb
+++ b/knife/lib/chef/utils/licensing_handler.rb
@@ -39,7 +39,7 @@ class Chef
                            []
                          end
 
-          return new(nil, nil) if license_keys.nil? || license_keys.empty?
+          return new(nil, nil) if license_keys&.empty?
 
           licenses_metadata = ChefLicensing::Api::Describe.list({
             license_keys: license_keys,

--- a/knife/lib/chef/utils/licensing_handler.rb
+++ b/knife/lib/chef/utils/licensing_handler.rb
@@ -30,7 +30,11 @@ class Chef
 
       class << self
         def validate!
-          license_keys = ChefLicensing::LicenseKeyFetcher.fetch
+          begin
+            license_keys = ChefLicensing::LicenseKeyFetcher.fetch
+          rescue
+            return new(nil, nil)
+          end
 
           return new(nil, nil) if license_keys.blank?
 

--- a/knife/lib/chef/utils/licensing_handler.rb
+++ b/knife/lib/chef/utils/licensing_handler.rb
@@ -39,7 +39,7 @@ class Chef
                            []
                          end
 
-          return new(nil, nil) if  license_keys.nil? || license_keys.empty?
+          return new(nil, nil) if license_keys.nil? || license_keys.empty?
 
           licenses_metadata = ChefLicensing::Api::Describe.list({
             license_keys: license_keys,


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
In https://github.com/chef/chef/pull/14669, we have introduced a warning for non-licensed users when they run the knife bootstrap command to familiarise them with the chef-infra-19 licensing. They can get rid of it by activating a license.

This issue happens when the licensing service hits the `v1/listLicenses` API to determine whether it is a global or on-prem local licensing service. This will work fine on the global one, but it will raise an exception when the user uses an air-gapped environment and doesn't have the local licensing server URL set in the env variable(`CHEF_LICENSE_SERVER`).

This PR will fix the connection issue with the global licensing service on airgapped envs. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
