### PR TITLE
removing mac11 from pipeline as its EOL and make 12 as builder

### DIFF
--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -162,7 +162,7 @@ then
       echo "    omnibus-toolchain: \"*\""
     fi
     echo "  plugins:"
-    echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
+    echo "  - chef/omnibus#v0.2.91:"
     echo "      build: chef"
     echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
     echo "      config: omnibus/omnibus.rb"
@@ -185,7 +185,7 @@ then
     echo "  agents:"
     [[ $platform == *"arm"* ]] && echo "    queue: omnibus-mac_os_x-12-arm64" || echo "    queue: omnibus-mac_os_x-12-x86_64"
     echo "  plugins:"
-    echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
+    echo "  - chef/omnibus#v0.2.91:"
     echo "      config: omnibus/omnibus.rb"
     [[ $platform == *"arm"* ]] && echo "      remote-host: buildkite-omnibus-mac_os_x-12-arm64" || echo "      remote-host: buildkite-omnibus-mac_os_x-12-x86_64"
     echo "      notarize-macos-package: chef"
@@ -206,7 +206,7 @@ then
   echo "- key: create-build-record"
   echo "  label: \":artifactory: Create Build Record\""
   echo "  plugins:"
-  echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
+  echo "  - chef/omnibus#v0.2.91:"
   echo "      create-build-record: chef"
 fi
 
@@ -301,7 +301,7 @@ then
       echo "    omnibus-toolchain: \"*\""
     fi
     echo "  plugins:"
-    echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
+    echo "  - chef/omnibus#v0.2.91:"
     echo "      test: chef"
     echo "      test-path: omnibus/omnibus-test.sh"
     echo "      install-dir: \"/opt/chef\""
@@ -327,6 +327,6 @@ then
   echo "- key: promote"
   echo "  label: \":artifactory: Promote to Current\""
   echo "  plugins:"
-  echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
+  echo "  - chef/omnibus#v0.2.91:"
   echo "      promote: chef"
 fi

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -187,7 +187,7 @@ then
     echo "  agents:"
     [[ $platform == *"arm"* ]] && echo "    queue: omnibus-mac_os_x-12-arm64" || echo "    queue: omnibus-mac_os_x-12-x86_64"
     echo "  plugins:"
-    echo "  - chef/omnibus#v0.2.86:"
+    echo "  - chef/omnibus#v0.2.89:"
     echo "      config: omnibus/omnibus.rb"
     [[ $platform == *"arm"* ]] && echo "      remote-host: buildkite-omnibus-mac_os_x-12-arm64" || echo "      remote-host: buildkite-omnibus-mac_os_x-12-x86_64"
     echo "      notarize-macos-package: chef"

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -162,16 +162,14 @@ then
       echo "    omnibus-toolchain: \"*\""
     fi
     echo "  plugins:"
-    echo "  - chef/omnibus#v0.2.89:"
+    echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
     echo "      build: chef"
     echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
     echo "      config: omnibus/omnibus.rb"
     echo "      install-dir: \"/opt/chef\""
-    if [ "$build_key" == "mac_os_x-12-x86_64" ]; then
-        echo "      remote-host: buildkite-omnibus-$platform"
-    elif [ "$build_key" == "mac_os_x-12-arm64" ]; then
-           echo "      remote-host: buildkite-omnibus-$platform"
-    fi           
+    if [[ "$build_key" =~ "mac_os_x-12-" ]] ; then
+      echo " remote-host: buildkite-omnibus-$platform "
+    fi       
     echo "      omnibus-pipeline-definition-path: \".expeditor/release.omnibus.yml\""
     # if [ $build_key == "mac_os_x-11-arm64" ]
     # then
@@ -187,7 +185,7 @@ then
     echo "  agents:"
     [[ $platform == *"arm"* ]] && echo "    queue: omnibus-mac_os_x-12-arm64" || echo "    queue: omnibus-mac_os_x-12-x86_64"
     echo "  plugins:"
-    echo "  - chef/omnibus#v0.2.89:"
+    echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
     echo "      config: omnibus/omnibus.rb"
     [[ $platform == *"arm"* ]] && echo "      remote-host: buildkite-omnibus-mac_os_x-12-arm64" || echo "      remote-host: buildkite-omnibus-mac_os_x-12-x86_64"
     echo "      notarize-macos-package: chef"
@@ -208,7 +206,7 @@ then
   echo "- key: create-build-record"
   echo "  label: \":artifactory: Create Build Record\""
   echo "  plugins:"
-  echo "  - chef/omnibus#v0.2.89:"
+  echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
   echo "      create-build-record: chef"
 fi
 
@@ -303,7 +301,7 @@ then
       echo "    omnibus-toolchain: \"*\""
     fi
     echo "  plugins:"
-    echo "  - chef/omnibus#v0.2.89:"
+    echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
     echo "      test: chef"
     echo "      test-path: omnibus/omnibus-test.sh"
     echo "      install-dir: \"/opt/chef\""
@@ -329,6 +327,6 @@ then
   echo "- key: promote"
   echo "  label: \":artifactory: Promote to Current\""
   echo "  plugins:"
-  echo "  - chef/omnibus#v0.2.89:"
+  echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
   echo "      promote: chef"
 fi

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -162,7 +162,7 @@ then
       echo "    omnibus-toolchain: \"*\""
     fi
     echo "  plugins:"
-    echo "  - chef/omnibus#v0.2.90:"
+    echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
     echo "      build: chef"
     echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
     echo "      config: omnibus/omnibus.rb"
@@ -185,7 +185,7 @@ then
     echo "  agents:"
     [[ $platform == *"arm"* ]] && echo "    queue: omnibus-mac_os_x-12-arm64" || echo "    queue: omnibus-mac_os_x-12-x86_64"
     echo "  plugins:"
-    echo "  - chef/omnibus#v0.2.90:"
+    echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
     echo "      config: omnibus/omnibus.rb"
     [[ $platform == *"arm"* ]] && echo "      remote-host: buildkite-omnibus-mac_os_x-12-arm64" || echo "      remote-host: buildkite-omnibus-mac_os_x-12-x86_64"
     echo "      notarize-macos-package: chef"
@@ -206,7 +206,7 @@ then
   echo "- key: create-build-record"
   echo "  label: \":artifactory: Create Build Record\""
   echo "  plugins:"
-  echo "  - chef/omnibus#v0.2.90:"
+  echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
   echo "      create-build-record: chef"
 fi
 
@@ -301,7 +301,7 @@ then
       echo "    omnibus-toolchain: \"*\""
     fi
     echo "  plugins:"
-    echo "  - chef/omnibus#v0.2.90:"
+    echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
     echo "      test: chef"
     echo "      test-path: omnibus/omnibus-test.sh"
     echo "      install-dir: \"/opt/chef\""
@@ -327,6 +327,6 @@ then
   echo "- key: promote"
   echo "  label: \":artifactory: Promote to Current\""
   echo "  plugins:"
-  echo "  - chef/omnibus#v0.2.90:"
+  echo "  - chef/omnibus#befb39b28e41f2d45edfdc848a7e5abbfd0b01b1:"
   echo "      promote: chef"
 fi

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -162,14 +162,14 @@ then
       echo "    omnibus-toolchain: \"*\""
     fi
     echo "  plugins:"
-    echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
+    echo "  - chef/omnibus#v0.2.90:"
     echo "      build: chef"
     echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
     echo "      config: omnibus/omnibus.rb"
     echo "      install-dir: \"/opt/chef\""
-    if [[ "$build_key" =~ "mac_os_x-12-" ]] ; then
-      echo " remote-host: buildkite-omnibus-$platform "
-    fi       
+    if [ "$build_key" == "mac_os_x-12-x86_64" ] || [ "$build_key" == "mac_os_x-12-arm64" ]; then
+        echo "      remote-host: buildkite-omnibus-$platform"
+    fi        
     echo "      omnibus-pipeline-definition-path: \".expeditor/release.omnibus.yml\""
     # if [ $build_key == "mac_os_x-11-arm64" ]
     # then
@@ -185,7 +185,7 @@ then
     echo "  agents:"
     [[ $platform == *"arm"* ]] && echo "    queue: omnibus-mac_os_x-12-arm64" || echo "    queue: omnibus-mac_os_x-12-x86_64"
     echo "  plugins:"
-    echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
+    echo "  - chef/omnibus#v0.2.90:"
     echo "      config: omnibus/omnibus.rb"
     [[ $platform == *"arm"* ]] && echo "      remote-host: buildkite-omnibus-mac_os_x-12-arm64" || echo "      remote-host: buildkite-omnibus-mac_os_x-12-x86_64"
     echo "      notarize-macos-package: chef"
@@ -206,7 +206,7 @@ then
   echo "- key: create-build-record"
   echo "  label: \":artifactory: Create Build Record\""
   echo "  plugins:"
-  echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
+  echo "  - chef/omnibus#v0.2.90:"
   echo "      create-build-record: chef"
 fi
 
@@ -301,7 +301,7 @@ then
       echo "    omnibus-toolchain: \"*\""
     fi
     echo "  plugins:"
-    echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
+    echo "  - chef/omnibus#v0.2.90:"
     echo "      test: chef"
     echo "      test-path: omnibus/omnibus-test.sh"
     echo "      install-dir: \"/opt/chef\""
@@ -327,6 +327,6 @@ then
   echo "- key: promote"
   echo "  label: \":artifactory: Promote to Current\""
   echo "  plugins:"
-  echo "  - chef/omnibus#7c9a144b6a3304b4bbfa9a2a14c6c5c6cb9d0479:"
+  echo "  - chef/omnibus#v0.2.90:"
   echo "      promote: chef"
 fi

--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -20,7 +20,7 @@ then
 fi
 
 # array of all esoteric platforms in the format test-platform:build-platform
-esoteric_platforms=("aix-7.1-powerpc:aix-7.1-powerpc" "aix-7.2-powerpc:aix-7.1-powerpc" "aix-7.3-powerpc:aix-7.1-powerpc" "el-7-ppc64:el-7-ppc64" "el-7-ppc64le:el-7-ppc64le" "el-7-s390x:el-7-s390x" "el-8-s390x:el-7-s390x" "freebsd-13-amd64:freebsd-13-amd64" "mac_os_x-11-x86_64:mac_os_x-11-x86_64" "mac_os_x-12-x86_64:mac_os_x-11-x86_64" "mac_os_x-11-arm64:mac_os_x-11-arm64" "mac_os_x-12-arm64:mac_os_x-11-arm64" "solaris2-5.11-i386:solaris2-5.11-i386" "solaris2-5.11-sparc:solaris2-5.11-sparc" "sles-12-x86_64:sles-12-x86_64" "sles-12-s390x:sles-12-s390x" "sles-15-s390x:sles-12-s390x")
+esoteric_platforms=("aix-7.1-powerpc:aix-7.1-powerpc" "aix-7.2-powerpc:aix-7.1-powerpc" "aix-7.3-powerpc:aix-7.1-powerpc" "el-7-ppc64:el-7-ppc64" "el-7-ppc64le:el-7-ppc64le" "el-7-s390x:el-7-s390x" "el-8-s390x:el-7-s390x" "freebsd-13-amd64:freebsd-13-amd64" "mac_os_x-12-x86_64:mac_os_x-12-x86_64" "mac_os_x-12-arm64:mac_os_x-12-arm64" "solaris2-5.11-i386:solaris2-5.11-i386" "solaris2-5.11-sparc:solaris2-5.11-sparc" "sles-12-x86_64:sles-12-x86_64" "sles-12-s390x:sles-12-s390x" "sles-15-s390x:sles-12-s390x")
 
 omnibus_build_platforms=()
 omnibus_test_platforms=()
@@ -167,10 +167,11 @@ then
     echo "      chef-foundation-version: $CHEF_FOUNDATION_VERSION"
     echo "      config: omnibus/omnibus.rb"
     echo "      install-dir: \"/opt/chef\""
-    if [ $build_key == "mac_os_x-11-x86_64" ]
-    then
-      echo "      remote-host: buildkite-omnibus-$platform"
-    fi
+    if [ "$build_key" == "mac_os_x-12-x86_64" ]; then
+        echo "      remote-host: buildkite-omnibus-$platform"
+    elif [ "$build_key" == "mac_os_x-12-arm64" ]; then
+           echo "      remote-host: buildkite-omnibus-$platform"
+    fi           
     echo "      omnibus-pipeline-definition-path: \".expeditor/release.omnibus.yml\""
     # if [ $build_key == "mac_os_x-11-arm64" ]
     # then
@@ -184,11 +185,11 @@ then
     echo "- key: notarize-macos"
     echo "  label: \":lock_with_ink_pen: Notarize macOS Packages\""
     echo "  agents:"
-    echo "    queue: omnibus-mac_os_x-12-x86_64"
+    [[ $platform == *"arm"* ]] && echo "    queue: omnibus-mac_os_x-12-arm64" || echo "    queue: omnibus-mac_os_x-12-x86_64"
     echo "  plugins:"
     echo "  - chef/omnibus#v0.2.86:"
     echo "      config: omnibus/omnibus.rb"
-    echo "      remote-host: buildkite-omnibus-mac_os_x-12-x86_64"
+    [[ $platform == *"arm"* ]] && echo "      remote-host: buildkite-omnibus-mac_os_x-12-arm64" || echo "      remote-host: buildkite-omnibus-mac_os_x-12-x86_64"
     echo "      notarize-macos-package: chef"
     echo "      omnibus-pipeline-definition-path: \".expeditor/release.omnibus.yml\""
     echo "  depends_on:"
@@ -296,7 +297,7 @@ then
     fi
     echo "  agents:"
     echo "    queue: omnibus-${platform%:*}"
-    if [ $build_key == "mac_os_x-11-x86_64" ] || [ $build_key == "mac_os_x-11-arm64" ]
+    if [ $build_key == "mac_os_x-12-x86_64" ] || [ $build_key == "mac_os_x-12-arm64" ]
     then
       echo "    omnibus: tester"
       echo "    omnibus-toolchain: \"*\""

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -48,11 +48,9 @@ builder-to-testers-map:
     - el-9-x86_64
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
     - mac_os_x-12-arm64
   rocky-8-x86_64:
     - rocky-8-x86_64

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,8 +261,6 @@ GEM
     ffi (1.16.3)
     ffi (1.16.3-x64-mingw-ucrt)
     ffi-libarchive (1.1.3)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,8 @@ GEM
     ffi (1.16.3)
     ffi (1.16.3-x64-mingw-ucrt)
     ffi-libarchive (1.1.3)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Since mac 11 is old we are deprecating it and also making mac 12 as builder . along with this change picked latest version of omnibus-buildkite-plugin

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
