### PR TITLE
Remove 2012 testers from bk adhoc

### DIFF
--- a/.buildkite/build-test-omnibus.sh
+++ b/.buildkite/build-test-omnibus.sh
@@ -16,7 +16,7 @@ container_platforms=("amazon-2:centos-7" "amazon-2-arm:amazon-2-arm" "rhel-9:rhe
 # add rest of windows platforms to tests, if not on chef-oss org
 if [[ $BUILDKITE_ORGANIZATION_SLUG != "chef-oss" ]]
 then
-  container_platforms=( "${container_platforms[@]}" "windows-2012:windows-2019" "windows-2012r2:windows-2019" "windows-2016:windows-2019" "windows-2022:windows-2019" "windows-10:windows-2019" "windows-11:windows-2019" )
+  container_platforms=( "${container_platforms[@]}" "windows-2016:windows-2019" "windows-2022:windows-2019" "windows-10:windows-2019" "windows-11:windows-2019" )
 fi
 
 # array of all esoteric platforms in the format test-platform:build-platform. We reduced this list for Chef-19

--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -22,7 +22,7 @@ builder-to-testers-map:
   amazon-2023-aarch64:
     - amazon-2023-aarch64
   amazon-2023-x86_64:
-    - amazon-2023-x86_64  
+    - amazon-2023-x86_64
   debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
@@ -90,8 +90,6 @@ builder-to-testers-map:
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
   windows-10-x86_64:
-    - windows-2012-x86_64
-    - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -23,7 +23,7 @@ builder-to-testers-map:
   amazon-2023-aarch64:
     - amazon-2023-aarch64
   amazon-2023-x86_64:
-    - amazon-2023-x86_64    
+    - amazon-2023-x86_64
   debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
@@ -66,7 +66,7 @@ builder-to-testers-map:
   rocky-8-x86_64:
     - rocky-8-x86_64
   rocky-9-x86_64:
-    - rocky-9-x86_64  
+    - rocky-9-x86_64
   sles-12-s390x:
     - sles-12-s390x
     - sles-15-s390x
@@ -89,8 +89,6 @@ builder-to-testers-map:
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
   windows-10-x86_64:
-    - windows-2012-x86_64
-    - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Windows 2012* should be retired and now adhoc builds are failing with

```
Failure/Error: win32certstore.add_pfx(tempfile, password, CRYPT_EXPORTABLE)
--
  |  
  | SystemCallError:
  | The specified network password is not correct. - Unable to Add a PFX certificate.

```

Remove the testers.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
