### PR TITLE
try symlink for install

### DIFF
--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -25,6 +25,9 @@ lifecycle:
     - remote: /opt/chef/bin/ohai -v
     - remote: echo "Installing appbundler and appbundle-updater gems:"
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+    - remote: sudo ln -s /usr/bin/install /bin/install
+      includes:
+        - debian-11
     - remote: sudo yum install centos-release-scl
       includes:
         - centos-7

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -27,6 +27,7 @@ lifecycle:
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
     - remote: sudo ln -s /usr/bin/install /bin/install
       includes:
+        - opensuse-leap-15
         - debian-11
     - remote: sudo yum install centos-release-scl
       includes:

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -25,6 +25,7 @@ lifecycle:
     - remote: /opt/chef/bin/ohai -v
     - remote: echo "Installing appbundler and appbundle-updater gems:"
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+    # back compat for pre-unified-/usr distros, do not add new OSes
     - remote: sudo ln -s /usr/bin/install /bin/install
       includes:
         - opensuse-leap-15

--- a/kitchen-tests/kitchen.linux.ci.yml
+++ b/kitchen-tests/kitchen.linux.ci.yml
@@ -23,6 +23,9 @@ lifecycle:
     - remote: sudo apt-get update && sudo apt-get install -y curl
       includes:
         - ubuntu-18.04
+    - remote: sudo ln -s /usr/bin/install /bin/install
+      includes:
+        - debian-11
     - remote: sudo dnf install -y openssl cronie
       includes:
         - fedora-latest

--- a/kitchen-tests/kitchen.linux.ci.yml
+++ b/kitchen-tests/kitchen.linux.ci.yml
@@ -26,6 +26,7 @@ lifecycle:
     - remote: sudo ln -s /usr/bin/install /bin/install
       includes:
         - debian-11
+        - opensuse-leap-15
     - remote: sudo dnf install -y openssl cronie
       includes:
         - fedora-latest

--- a/kitchen-tests/kitchen.linux.ci.yml
+++ b/kitchen-tests/kitchen.linux.ci.yml
@@ -23,10 +23,6 @@ lifecycle:
     - remote: sudo apt-get update && sudo apt-get install -y curl
       includes:
         - ubuntu-18.04
-    - remote: sudo ln -s /usr/bin/install /bin/install
-      includes:
-        - debian-11
-        - opensuse-leap-15
     - remote: sudo dnf install -y openssl cronie
       includes:
         - fedora-latest


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
In docker images (VMs don't exhibit this)
Debian 11 `install` is in `/usr/bin/install`
Debian 12 `install` is in `/bin/install`

No references to this in the `ruby/json` repo and couldn't find hard reference in 2.7.6 of json to indicate that this is a common problem.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
