### PR TITLE
disabling this value

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -2,8 +2,9 @@
 ---
 
 # The name of the product keys for this product (from mixlib-install)
-product_key:
-  - chef
+# setting this value also tells expeditor its an omnibus build.
+# product_key:
+#   - chef
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -112,18 +112,7 @@ changelog:
   rollup_header: Changes not yet released to stable
 
 subscriptions:
-  # the omnibus/docker/gem chain
-  - workload: artifact_published:unstable:chef:{{version_constraint}}
-    actions:
-      # - trigger_pipeline:docker/build
-      - trigger_pipeline:macos_universal_package
-  # - workload: artifact_published:current:chef:{{version_constraint}}
-  #   actions:
-  #     - bash:.expeditor/promote-docker-images.sh
   - workload: project_promoted:{{agent_id}}:*
-    actions:
-      - built_in:promote_artifactory_artifact
-  - workload: artifact_published:stable:chef:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
       # - bash:.expeditor/update_dockerfile.sh


### PR DESCRIPTION
this is a value that tells expeditor to do things with packages and omnibus builds. This one in particular is apart of some logic for omnibus packages and yum/apt repo binary creation. 

this is going to be one of many configuration updates before we get this ready to be promoted via expeditor.

NOTE: Packages will still be available in Chef 19 - but they'll be hab-based RPM/Debs, not omnibus-based ones.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
