### PR TITLE
Updating the refresh channel

### DIFF
--- a/.expeditor/scripts/verify-plan.ps1
+++ b/.expeditor/scripts/verify-plan.ps1
@@ -33,7 +33,7 @@ $project_root = "$(git rev-parse --show-toplevel)"
 Set-Location $project_root
 
 Write-Host "--- :construction: Building $Plan"
-$env:DO_CHECK=$true; hab pkg build .
+$env:DO_CHECK=$true; hab pkg build . --refresh-channel LTS-2024
 if (-not $?) { throw "unable to build"}
 
 . results/last_build.ps1

--- a/.expeditor/scripts/verify-plan.sh
+++ b/.expeditor/scripts/verify-plan.sh
@@ -37,7 +37,7 @@ hab origin key generate "$HAB_ORIGIN"
 echo "--- :construction: Building $PLAN (solely for verification testing)"
 (
   cd "$project_root" || error 'cannot change directory to project root'
-  DO_CHECK=true hab pkg build . || error 'unable to build'
+  DO_CHECK=true hab pkg build . --refresh-channel LTS-2024 || error 'unable to build'
 )
 
 source "${project_root}/results/last_build.env" || error 'unable to determine details about this build'


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The plan.sh is failing in the verify pipeline. The problems stemmed from an update that Hab took recently that requires us to specify a "refresh channel" to ensure that packages are pulling from the correct source

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
