### PR TITLE
Bump mixlib-shellout to 3.3.6 to pull in Target mode fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,14 +319,14 @@ GEM
     mixlib-config (3.0.27)
       tomlrb
     mixlib-log (3.0.9)
-    mixlib-shellout (3.3.4)
+    mixlib-shellout (3.3.6)
       chef-utils
-    mixlib-shellout (3.3.4-universal-mingw32)
+    mixlib-shellout (3.3.6-universal-mingw32)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
-    mixlib-shellout (3.3.4-x64-mingw-ucrt)
+    mixlib-shellout (3.3.6-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
https://github.com/chef/mixlib-shellout/pull/254 had  fixes related to Target mode. We are pulling those in here with version 3.3.6

```
bundle update mixlib-shellout --conservative
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies........................
Using rake 13.2.1
Using concurrent-ruby 1.3.4
Using minitest 5.25.1
Using mixlib-cli 2.1.8
Using bundler 2.3.7
Using ast 2.4.2
Using aws-eventstream 1.3.0
Using aws-partitions 1.1001.0
Using jmespath 1.6.2
Using base64 0.2.0
Using bigdecimal 3.1.8
Using debug_inspector 1.2.0
Using tty-screen 0.8.2
Using chef-vault 4.1.11
Using byebug 11.1.3
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using uri 0.13.1
Using json 2.7.6
Using logger 1.5.3
Using tty-color 0.6.0
Using tty-cursor 0.7.1
Using erubis 2.7.0
Using wisper 2.0.1
Using iniparse 1.5.0
Using racc 1.8.1
Using rainbow 3.1.1
Using regexp_parser 2.9.2
Using rexml 3.3.9
Using public_suffix 6.0.1
Using parallel 1.26.3
Using ffi 1.16.3
Using diff-lcs 1.5.1
Using method_source 1.1.0
Using unicode_utils 1.4.0
Using hashie 4.1.0
Using mixlib-log 3.0.9
Using rack 2.2.10
Using uuidtools 2.2.0
Using rubyzip 2.3.2
Using sslshake 1.3.1
Using thor 1.2.2
Using net-ssh 7.3.0
Using ruby-progressbar 1.13.0
Using libyajl2 2.1.0
Using date 3.4.0
Using parslet 1.8.2
Using multipart-post 2.4.1
Using plist 3.7.1
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using webrick 1.8.2
Using domain_name 0.6.20240107
Using http-accept 1.7.0
Using mime-types-data 3.2024.1105
Using netrc 0.11.0
Using erubi 1.13.0
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using multi_json 1.15.0
Using unf_ext 0.0.8.2
Using ed25519 1.3.0
Using strings-ansi 0.2.0
Using rb-readline 0.5.5
Using ruby-shadow 2.5.1
Using mixlib-authentication 3.0.10
Using i18n 1.14.6
Using chef-utils 19.0.70 from source at `chef-utils`
Using coderay 1.1.3
Using aws-sigv4 1.10.1
Using rspec-support 3.13.1
Using nori 2.7.1
Using binding_of_caller 1.0.1
Using hashdiff 1.1.1
Using unicode-display_width 2.6.0
Using pastel 0.8.0
Using tty-spinner 0.9.3
Using net-http 0.4.1
Using syslog-logger 1.6.8
Using parser 3.3.6.0
Using addressable 2.8.7
Using ipaddress 0.8.3
Using crack 0.4.5
Using gssapi 1.3.1
Using mixlib-archive 1.1.7
Using net-scp 4.0.0
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using rubyntlm 0.6.5
Using semverse 3.0.2
Using corefoundation 0.3.13
Using logging 2.4.0
Using mime-types 3.6.0
Using builder 3.3.0
Using ffi-libarchive 1.1.14
Using rspec-core 3.13.2
Using rspec-expectations 3.13.3
Using rspec-mocks 3.13.2
Using vault 0.18.2
Using timeout 0.4.1
Using tzinfo 2.0.6
Using faraday-net_http 3.3.0
Using rubocop-ast 1.34.0
Using webmock 3.24.0
Using gyoku 1.4.0
Using rspec 3.13.0
Using ffi-yajl 2.6.0
Using time 0.4.0
Using strings 0.2.1
Using mixlib-config 3.0.27
Using http-cookie 1.0.7
Using pry 0.13.0
Using stringio 3.1.1
Using activesupport 7.0.8.6
Using faraday 2.12.0
Using chef-zero 15.0.11
Using rubocop 1.25.1
Using tty-table 0.12.0
Using faraday-follow_redirects 0.3.0
Using rspec-its 1.3.1
Using tty-reader 0.9.0
Using tty-box 0.7.0
Using cookstyle 7.32.8
Using pry-byebug 3.10.1
Using pry-stack_explorer 0.6.1
Using net-protocol 0.2.2
Using aws-sdk-core 3.211.0
Using net-ftp 0.3.8
Using faraday-http-cache 2.5.1
Using aws-sdk-secretsmanager 1.109.0
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using psych 5.1.2
Using winrm 2.3.8
Using chefstyle 2.2.3
Using aws-sdk-kms 1.95.0
Using winrm-fs 1.3.5
Using aws-sdk-s3 1.169.0
Using rdoc 6.4.1.1
Using winrm-elevated 1.2.3
Using tty-prompt 0.23.1
Using train-winrm 0.2.13
Using license-acceptance 2.1.13
Using cheffish 17.1.8
Fetching mixlib-shellout 3.3.6 (was 3.3.4)
Installing mixlib-shellout 3.3.6 (was 3.3.4)
Using chef-config 19.0.70 from source at `chef-config`
Using train-core 3.12.7
Using appbundler 0.13.4
Using train-rest 0.5.0
Using ohai 19.0.5 from https://github.com/chef/ohai.git (at main@fb50e01)
Using chef-licensing 1.0.4
Using chef-telemetry 1.1.1
Using inspec-core 6.8.11
Using inspec-core-bin 6.8.11
Using chef 19.0.70 from source at `.`
Using chef-bin 19.0.70 from source at `chef-bin` and installing its executables
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
