### PR TITLE
Limit ffi to 1.17.0 max via Ohai bump.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "18-stable"
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.
 gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt_update1"
 
-gem "ffi", ">= 1.15.5"
+gem "ffi", ">= 1.15.5", "<= 1.17.0"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: d5060f57f7e9f974fca55e0d74c9c62d5b36a622
+  revision: 58ee0df16894c3eace7c35ff1642390d2e487383
   branch: 18-stable
   specs:
-    ohai (18.2.4)
+    ohai (18.2.5)
       chef-config (>= 14.12, < 19)
       chef-utils (>= 16.0, < 19)
-      ffi (~> 1.9)
+      ffi (~> 1.9, <= 1.17.0)
       ffi-yajl (~> 2.2)
       ipaddress
       mixlib-cli (>= 1.7.0)
@@ -520,7 +520,7 @@ DEPENDENCIES
   crack (< 0.4.6)
   ed25519 (~> 1.2)
   fauxhai-ng
-  ffi (>= 1.15.5)
+  ffi (>= 1.15.5, <= 1.17.0)
   inspec-core-bin (>= 5, < 6)
   ohai!
   openssl (= 3.2.0)

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -8,7 +8,7 @@ gem "artifactory"
 
 gem "pedump"
 
-gem "ffi", "< 1.17"
+gem "ffi", "<= 1.17.0"
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -516,7 +516,7 @@ PLATFORMS
 DEPENDENCIES
   artifactory
   berkshelf (>= 8.0)
-  ffi (< 1.17)
+  ffi (<= 1.17.0)
   kitchen-vagrant (>= 1.3.1)
   omnibus!
   omnibus-software!


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
See https://github.com/chef/ohai/pull/1860 and https://github.com/ffi/ffi/issues/1139

```ruby
❯ bundle install
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies......
Using rake 13.2.1
Using public_suffix 6.0.1
Using mixlib-cli 2.1.8
Using bundler 2.3.7
Using aws-partitions 1.981.0
Using fuzzyurl 0.9.0
Using jmespath 1.6.2
Using tomlrb 1.3.0
Using base64 0.2.0
Using builder 3.3.0
Using hashie 4.1.0
Using mixlib-log 3.0.9
Using rack 2.2.9
Using uuidtools 2.2.0
Using webrick 1.8.2
Using ffi 1.16.3
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using iniparse 1.5.0
Using parallel 1.26.3
Using concurrent-ruby 1.3.4
Using racc 1.8.1
Using rainbow 3.1.1
Using ruby-progressbar 1.13.0
Using ast 2.4.2
Using unicode-display_width 2.6.0
Using libyajl2 2.1.0
Using json 2.7.2
Using chef-vault 4.1.11
Using logger 1.5.3
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using byebug 11.1.3
Using wisper 2.0.1
Using unicode_utils 1.4.0
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 2.0.0
Using coderay 1.1.3
Using rspec-support 3.12.2
Using rubyzip 2.3.2
Using rexml 3.3.8
Using thor 1.2.2
Using bigdecimal 3.1.8
Using net-ssh 7.2.3
Using mixlib-authentication 3.0.10
Using timeout 0.4.1
Using ipaddress 0.8.3
Using tty-screen 0.8.2
Using aws-eventstream 1.3.0
Using sslshake 1.3.1
Using wmi-lite 1.0.7
Using syslog-logger 1.6.8
Using semverse 3.0.2
Using domain_name 0.6.20240107
Using date 3.3.4
Using debug_inspector 1.2.0
Using plist 3.7.1
Using uri 0.13.1
Using proxifier2 1.1.0
Using unf_ext 0.0.8.2
Using multi_json 1.15.0
Using http-accept 1.7.0
Using mime-types-data 3.2024.0903
Using rb-readline 0.5.5
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using stringio 3.0.1.1
Using addressable 2.8.7
Using mixlib-config 3.0.27
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.3
Using mixlib-archive 1.1.7
Using gssapi 1.3.1
Using rubyntlm 0.6.5
Using chef-utils 18.6.7 from source at `chef-utils`
Using netrc 0.11.0
Using ffi-yajl 2.6.0
Using pastel 0.8.0
Using strings 0.2.1
Using pry 0.13.0
Using ed25519 1.3.0
Using regexp_parser 2.9.2
Using tty-cursor 0.7.1
Using rspec-core 3.12.3
Using httpclient 2.8.3
Using net-scp 4.0.0
Using net-sftp 4.0.0
Using nori 2.7.1
Using crack 0.4.5
Using fauxhai-ng 9.3.0
Using net-protocol 0.2.2
Using aws-sigv4 1.10.0
Using http-cookie 1.0.7
Using time 0.4.0
Using binding_of_caller 1.0.1
Using parser 3.3.5.0
Using mixlib-shellout 3.2.8
Using net-http 0.4.1
Using chef-zero 15.0.11
Using mime-types 3.5.2
Using pry-byebug 3.10.1
Using tty-reader 0.9.0
Using aws-sdk-core 3.209.1
Using rspec-mocks 3.12.7
Using erubi 1.13.0
Using net-ftp 0.3.7
Using vault 0.18.2
Using pry-stack_explorer 0.6.1
Using rubocop-ast 1.32.3
Using faraday-net_http 3.3.0
Using appbundler 0.13.4
Using psych 4.0.2
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using train-core 3.12.7
Using tty-prompt 0.23.1
Using aws-sdk-kms 1.94.0
Using aws-sdk-secretsmanager 1.108.0
Using rubocop 1.25.1
Using faraday 2.12.0
Using little-plugger 1.1.4
Using chef-config 18.6.7 from source at `chef-config`
Using gyoku 1.4.0
Using aws-sdk-s3 1.166.0
Using cookstyle 7.32.8
Using faraday-follow_redirects 0.3.0
Using chefstyle 2.2.3
Using rdoc 6.4.1.1
Using tty-table 0.12.0
Using hashdiff 1.1.1
Using rspec-expectations 3.12.4
Using tty-box 0.7.0
Using cheffish 17.1.7
Using chef-telemetry 1.1.1
Using license-acceptance 2.1.13
Using ohai 18.2.4 from https://github.com/chef/ohai.git (at 18-stable@d5060f5)
Using logging 2.4.0
Using webmock 3.23.1
Using rspec 3.12.0
Using rspec-its 1.3.0
Using inspec-core 5.22.58
Using winrm 2.3.9
Using winrm-fs 1.3.5
Using inspec-core-bin 5.22.58
Using winrm-elevated 1.2.3
Using train-winrm 0.2.13
Using train-rest 0.5.0
Using chef 18.6.7 from source at `.`
Using chef-bin 18.6.7 from source at `chef-bin` and installing its executables
Bundle complete! 25 Gemfile dependencies, 148 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

```ruby
❯ bundle update --conservative ohai
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies......
Using rake 13.2.1
Using public_suffix 6.0.1
Using mixlib-cli 2.1.8
Using ast 2.4.2
Using aws-eventstream 1.3.0
Using aws-partitions 1.981.0
Using tomlrb 1.3.0
Using base64 0.2.0
Using bigdecimal 3.1.8
Using chef-vault 4.1.11
Using libyajl2 2.1.0
Using debug_inspector 1.2.0
Using builder 3.3.0
Using rack 2.2.9
Using ffi 1.16.3
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using fuzzyurl 0.9.0
Using hashie 4.1.0
Using mixlib-log 3.0.9
Using rainbow 3.1.1
Using iniparse 1.5.0
Using rexml 3.3.8
Using concurrent-ruby 1.3.4
Using unicode-display_width 2.6.0
Using uuidtools 2.2.0
Using bundler 2.3.7
Using parallel 1.26.3
Using tty-color 0.6.0
Using racc 1.8.1
Using unicode_utils 1.4.0
Using regexp_parser 2.9.2
Using tty-cursor 0.7.1
Using tty-screen 0.8.2
Using wisper 2.0.1
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 2.0.0
Using coderay 1.1.3
Using webrick 1.8.2
Using rspec-support 3.12.2
Using semverse 3.0.2
Using ruby-progressbar 1.13.0
Using sslshake 1.3.1
Using jmespath 1.6.2
Using logger 1.5.3
Using byebug 11.1.3
Using strings-ansi 0.2.0
Using plist 3.7.1
Using thor 1.2.2
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using http-accept 1.7.0
Using uri 0.13.1
Using netrc 0.11.0
Using date 3.3.4
Using ipaddress 0.8.3
Using httpclient 2.8.3
Using multi_json 1.15.0
Using net-ssh 7.2.3
Using ed25519 1.3.0
Using hashdiff 1.1.1
Using stringio 3.0.1.1
Using rb-readline 0.5.5
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using mixlib-authentication 3.0.10
Using addressable 2.8.7
Using aws-sigv4 1.10.0
Using mixlib-config 3.0.27
Using timeout 0.4.1
Using erubi 1.13.0
Using domain_name 0.6.20240107
Using rubyzip 2.3.2
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.3
Using gssapi 1.3.1
Using mixlib-archive 1.1.7
Using chef-utils 18.6.7 from source at `chef-utils`
Using little-plugger 1.1.4
Using nori 2.7.1
Using crack 0.4.5
Using ffi-yajl 2.6.0
Using pastel 0.8.0
Using parser 3.3.5.0
Using tty-reader 0.9.0
Using rubyntlm 0.6.5
Using rspec-core 3.12.3
Using rspec-expectations 3.12.4
Using strings 0.2.1
Using binding_of_caller 1.0.1
Using net-sftp 4.0.0
Using time 0.4.0
Using unf_ext 0.0.8.2
Using fauxhai-ng 9.3.0
Using net-protocol 0.2.2
Using vault 0.18.2
Using json 2.7.2
Using logging 2.4.0
Using rubocop-ast 1.32.3
Using gyoku 1.4.0
Using rspec-its 1.3.0
Using mime-types-data 3.2024.0903
Using aws-sdk-core 3.209.1
Using chef-zero 15.0.11
Using tty-box 0.7.0
Using tty-table 0.12.0
Using net-http 0.4.1
Using rubocop 1.25.1
Using tty-prompt 0.23.1
Using mime-types 3.5.2
Using webmock 3.23.1
Using aws-sdk-secretsmanager 1.108.0
Using winrm 2.3.9
Using pry 0.13.0
Using faraday-net_http 3.3.0
Using cookstyle 7.32.8
Using psych 4.0.2
Using winrm-fs 1.3.5
Using cheffish 17.1.7
Using net-scp 4.0.0
Using chefstyle 2.2.3
Using winrm-elevated 1.2.3
Using net-ftp 0.3.7
Using pry-stack_explorer 0.6.1
Using mixlib-shellout 3.2.8
Using rdoc 6.4.1.1
Using appbundler 0.13.4
Using license-acceptance 2.1.13
Using train-core 3.12.7
Using faraday 2.12.0
Using rspec-mocks 3.12.7
Using pry-byebug 3.10.1
Using faraday-follow_redirects 0.3.0
Using rspec 3.12.0
Using http-cookie 1.0.7
Using aws-sdk-kms 1.94.0
Using chef-config 18.6.7 from source at `chef-config`
Using train-winrm 0.2.13
Using chef-telemetry 1.1.1
Using ohai 18.2.5 (was 18.2.4) from https://github.com/chef/ohai.git (at 18-stable@58ee0df)
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using aws-sdk-s3 1.166.0
Using inspec-core 5.22.58
Using inspec-core-bin 5.22.58
Using train-rest 0.5.0
Using chef 18.6.7 from source at `.`
Using chef-bin 18.6.7 from source at `chef-bin` and installing its executables
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
