### PR TITLE
Fix for error when 'chef-vault' attr undefined

### DIFF
--- a/lib/chef/dsl/chef_vault.rb
+++ b/lib/chef/dsl/chef_vault.rb
@@ -39,7 +39,7 @@ class Chef
       def chef_vault_item(bag, id)
         if ::ChefVault::Item.vault?(bag, id)
           ::ChefVault::Item.load(bag, id)
-        elsif node["chef-vault"]["databag_fallback"]
+        elsif node.read("chef-vault", "databag_fallback")
           data_bag_item(bag, id)
         else
           raise "Trying to load a regular data bag item #{id} from #{bag}, and databag_fallback is disabled"


### PR DESCRIPTION
Obvious fix; When the using the `chef_vault_item()` helper the method produces an `undefined method '[]' for nil:NilClass` error if the `chef-vault` attribute key is undefined.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
