### PR TITLE
[WIP] Pin ffi at 1.17.0 to fix pipeline failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "18-stable"
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.
 gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt_update1"
 
-gem "ffi", ">= 1.15.5"
+gem "ffi", ">= 1.15.5", "<= 1.17.0"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,7 @@ GEM
     ffi (1.17.0-x64-mingw-ucrt)
     ffi (1.17.0-x64-mingw32)
     ffi (1.17.0-x86-mingw32)
+    ffi (1.17.0-x86_64-linux-gnu)
     ffi-libarchive (1.1.3)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -507,6 +508,7 @@ PLATFORMS
   x64-mingw-ucrt
   x64-mingw32
   x86-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   appbundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5, <= 1.16.3)
+      ffi (>= 1.15.5, <= 1.17.0)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
@@ -90,7 +90,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5, <= 1.16.3)
+      ffi (>= 1.15.5, <= 1.17.0)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
@@ -228,10 +228,10 @@ GEM
       net-http
     fauxhai-ng (9.3.0)
       net-ssh
-    ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
-    ffi (1.16.3-x64-mingw32)
-    ffi (1.16.3-x86-mingw32)
+    ffi (1.17.0)
+    ffi (1.17.0-x64-mingw-ucrt)
+    ffi (1.17.0-x64-mingw32)
+    ffi (1.17.0-x86-mingw32)
     ffi-libarchive (1.1.3)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -520,7 +520,7 @@ DEPENDENCIES
   crack (< 0.4.6)
   ed25519 (~> 1.2)
   fauxhai-ng
-  ffi (>= 1.15.5)
+  ffi (>= 1.15.5, <= 1.17.0)
   inspec-core-bin (>= 5, < 6)
   ohai!
   openssl (= 3.2.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ohai", "~> 18.0"
   s.add_dependency "inspec-core", ">= 5", "< 6"
 
-  s.add_dependency "ffi", ">= 1.15.5", "<= 1.16.3"
+  s.add_dependency "ffi", ">= 1.15.5", "<= 1.17.0"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "net-ftp" # remote_file resource

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -8,7 +8,7 @@ gem "artifactory"
 
 gem "pedump"
 
-gem "ffi", "< 1.17"
+gem "ffi", "= 1.17.0"
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,10 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 28c9c9f8419094cef59ca37802084db716166ace
+  revision: caad6827c5423bc9df89922b6002c0ab1d390eda
   branch: main
   specs:
     omnibus-software (24.6.323)
-      ffi (< 1.17.0)
       omnibus (>= 9.0.0)
 
 GIT
@@ -194,7 +193,7 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.1.0)
       net-http
-    ffi (1.16.3)
+    ffi (1.17.0)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -516,7 +515,7 @@ PLATFORMS
 DEPENDENCIES
   artifactory
   berkshelf (>= 8.0)
-  ffi (< 1.17)
+  ffi (= 1.17.0)
   kitchen-vagrant (>= 1.3.1)
   omnibus!
   omnibus-software!


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
There are failures in verify pipelines habitat linux plans. (link - ?)


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
