### PR TITLE
[backport] quiet mode fix for compliance phase

### DIFF
--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -39,7 +39,7 @@ class Chef
       "insecure" => nil,
 
       # Controls verbosity of Chef InSpec runner. See less output when true.
-      "quiet" => true,
+      "quiet" => false,
 
       # Chef Inspec Compliance profiles to be used for scan of node.
       # See Compliance Phase documentation for further details:

--- a/lib/chef/compliance/default_attributes.rb
+++ b/lib/chef/compliance/default_attributes.rb
@@ -38,7 +38,7 @@ class Chef
       # Allow for connections to HTTPS endpoints using self-signed ssl certificates.
       "insecure" => nil,
 
-      # Controls verbosity of Chef InSpec runner. See less output when true.
+      # When set to true, it will suppress CLI output for compliance phase.
       "quiet" => false,
 
       # Chef Inspec Compliance profiles to be used for scan of node.

--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -368,7 +368,12 @@ class Chef
       end
 
       def requested_reporters
-        (Array(node["audit"]["reporter"]) + ["cli"]).uniq
+        if node["audit"]["quiet"]
+          logger.info "node[\"audit\"][\"quiet\"] is set to true, skipping cli reporter"
+          Array(node["audit"]["reporter"]).uniq - ["cli"]
+        else
+          (Array(node["audit"]["reporter"]) + ["cli"]).uniq
+        end
       end
 
       def create_timestamp_file


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR backports the changes from https://github.com/chef/chef/pull/14779 into chef-18. Fixes the issue where the compliance report was being reported to standard output when the quiet mode was set to true. Removing cli from the reporter list when quiet mode is set to true fixes this issue.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
