### PR TITLE
Updating glibc on opensuse to make the adhoc pipeline work

### DIFF
--- a/.expeditor/scripts/zypper_prep.sh
+++ b/.expeditor/scripts/zypper_prep.sh
@@ -7,6 +7,8 @@ then
   find /etc/zypp/repos.d -name "SMT-*" -execdir rm -f -- '{}' \;
   zypper addrepo --check --priority 50 --refresh --name "Chefzypper-repo" "https://mirror.fcix.net/opensuse/distribution/leap/15.3/repo/oss/" "chefzypper"
   zypper --gpg-auto-import-keys ref
+  zypper refresh
+  zypper in -t patch SUSE-SLE-Module-Basesystem-15-SPx-202x-2224=1
 else
   echo "--- :hammer_and_wrench: Not Running on openSUSE 15, nothing to do"
 fi


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
OpenSUSE is throwing a missing glibc error in the AdHoc pipeline. Here we're refreshing the base libraries to pull the current versions of glibc in

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
