### PR TITLE
[dnf_helper.py] Use ujson if available

### DIFF
--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -6,7 +6,13 @@ import dnf
 import hawkey
 import signal
 import os
-import json
+
+# If python environment has ujson, prefer it
+# Decodes are much faster
+try:
+    import ujson as json
+except ImportError:
+    import json
 
 base = None
 


### PR DESCRIPTION
Signed-off-by: Cooper Lees <me@cooperlees.com>

- If the python environment has ujson, use it
- https://github.com/ultrajson/ultrajson is faster than JSON
  - Since chef on a dnf system forks this a lot per run, could be worth the latency win

Testing:
- Run without ujson
```
cooper@cooper-fedora-MJ0J8MTZ:~/repos/chef$ time echo '{"action":"whatinstalled", "provides": "rpm"}' | python3 lib/chef/provider/package/dnf/dnf_helper.py
rpm 0:4.20.0-1.fc41 x86_64

real	0m1.006s
user	0m0.719s
sys	0m0.270s
```
- `sudo dnf install python3-ujson`
```
cooper@cooper-fedora-MJ0J8MTZ:~/repos/chef$ python3 -V
Python 3.13.1
cooper@cooper-fedora-MJ0J8MTZ:~/repos/chef$ time echo '{"action":"whatinstalled", "provides": "rpm"}' | python3 lib/chef/provider/package/dnf/dnf_helper.py
rpm 0:4.20.0-1.fc41 x86_64

real	0m0.995s
user	0m0.715s
sys	0m0.261s
```


## Checklist:
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
