### PR TITLE
[Chef18] dnf: ignore sack excludes in 'whatinstalled'

### DIFF
--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -92,6 +92,13 @@ def query(command):
     q = subj.get_best_query(sack, with_provides=True)
 
     if command['action'] == "whatinstalled":
+        # When attempting to figure out what is installed, we should ignore any
+        # excludes that are configured, otherwise the "best" query for a given
+        # subject may refer to a package that is installed that provides that
+        # subject, but we really want to know if a package by that name exists
+        # in any available repository
+        q = subj.get_best_query(sack, with_provides=True, query=sack.query(flags=hawkey.IGNORE_EXCLUDES))
+
         q = q.installed()
 
     if command['action'] == "whatavailable":


### PR DESCRIPTION
Backport of #14821

Summary:
When attempting to remove a package, the `whatinstalled` command is run in the helper to run a `dnf` query to check what installed package `provides` the subject.

Usually `provides` is the package **name** (according to [the docs](https://docs.chef.io/resources/dnf_package/#properties) it always is, with the resource property `package_name`), but it does not **have to be**.

As long as there is *any* available package that has the same name as `provides`, everything works just fine - `whatinstalled` will report that the package is not installed. However, if there is no *available* package named `provides`, then `whatinstalled` may report a different package  that provides `provides`.

The **availability** constraint is important, because `dnf-plugin-versionlock` makes some packages unavailable.

Consider this situation
1) All related `rpm*` (including at least `rpm` and `rpm-selinux`) packages are all desired to hold the same version (eg `4.16.1.3-34.2.hsx.el9.x86_64`)

2) `dnf versionlock` has a `versionlock.list` to ensure that this holds true
```
rpm-4.16.1.3-34.2.hsx.el9
rpm-selinux-4.16.1.3-34.2.hsx.el9
```

3) Locked version of `rpm-selinux` is not available in any repo
```
❯ dnf list available rpm-selinux
rpm-selinux.noarch 4.16.1.3-11.3.hsx.el9
rpm-selinux.noarch 4.16.1.3-17.1.hsx.el9
rpm-selinux.noarch 4.16.1.3-19.2.hsx.el9
rpm-selinux.noarch 4.16.1.3-21.1.hsx.el9
rpm-selinux.noarch 4.16.1.3-22.1.hsx.el9
rpm-selinux.noarch 4.16.1.3-22.1.hsx.el9
rpm-selinux.noarch 4.16.1.3-22.2.hsx.el9
```

4) `rpm` *provides* the subject `rpm-selinux`
```
❯ rpm -q --provides rpm
config(rpm) = 4.16.1.3-34.2.hsx.el9
rpm = 4.16.1.3-34.2.hsx.el9
rpm(pr1470)
rpm(pr1470_1)
rpm(x86-64) = 4.16.1.3-34.2.hsx.el9
rpm-selinux = rpm-4.16.1.3
```

5) `rpm-selinux` is not installed
```
❯ rpm -q rpm-selinux
package rpm-selinux is not installed
```

6) I have a `dnf_package` resource ensuring removal of `rpm-selinux`
```
dnf_package 'rpm-selinux' do
  action :remove
end
```

In this situation, `{"action": "whatinstalled", "provides": "rpm-selinux"}` should report `rpm-selinux nil nil` since `rpm-selinux` is not actually installed. However, it instead produces `rpm 0:4.16.1.3-34.2.hsx.el9 x86_64`, causing the `dnf_package` resource to attempt to remove `rpm` itself.

NOTE: arguably, reporting `rpm 0:4.16.1.3-34.2.hsx.el9 x86_64` is actually **more** correct since `rpm` claims to basically *be* `rpm-selinux`. However, that interpretation is at odds with the documentation stating that the resource is intended to operate on the package **name**

Test Plan:
Fixed helper correctly operates on package name, not any providers
```
❯ /usr/bin/python3 lib/chef/provider/package/dnf/dnf_helper.py <<< '{"action": "whatinstalled", "provides": "rpm-selinux"}'
rpm-selinux nil nil
```

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
