### PR TITLE
Use instance_method / refine_method to patch Chef::Resource::Registry

### DIFF
--- a/spec/functional/resource/registry_spec.rb
+++ b/spec/functional/resource/registry_spec.rb
@@ -1,11 +1,31 @@
+#
+# Author:: Thomas Powell (<powell@progress.com>)
+# Copyright:: Copyright (c) 2025 Progress Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "spec_helper"
 
 describe Chef::Resource::RegistryKey do
-  class ::Chef::Resource::RegistryKey
-    # for test purposes only, don't scrub the values
-    def scrub_values(values)
+  around do
+    original_method = described_class.instance_method(:scrub_values)
+    described_class.define_method(:scrub_values) do |values|
       values
     end
+    yield
+    described_class.define_method(original_method.name, original_method)
   end
 
   let(:events) { Chef::EventDispatch::Dispatcher.new }

--- a/spec/functional/resource/registry_spec.rb
+++ b/spec/functional/resource/registry_spec.rb
@@ -19,12 +19,12 @@
 require "spec_helper"
 
 describe Chef::Resource::RegistryKey do
-  around do
+  around(:example) do |example|
     original_method = described_class.instance_method(:scrub_values)
     described_class.define_method(:scrub_values) do |values|
       values
     end
-    yield
+    example.run
     described_class.define_method(original_method.name, original_method)
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Use `instance_method`/`define_method` to save / restore the implementation of `scrub_values` in `Chef::Resource::Registry` to minimize leakage into other tests/classes.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
