### PR TITLE
Add cgroup attribute to execute module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ PATH
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 3.1.1, < 4.0)
+      mixlib-shellout (~> 3.3.8)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
       ohai (~> 19.0)
@@ -96,7 +96,7 @@ PATH
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 3.1.1, < 4.0)
+      mixlib-shellout (~> 3.3.8)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
       ohai (~> 19.0)
@@ -331,16 +331,14 @@ GEM
     minitest (5.25.1)
     mixlib-archive (1.1.7)
       mixlib-log
-    mixlib-archive (1.1.7-universal-mingw32)
-      mixlib-log
     mixlib-authentication (3.0.10)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
     mixlib-log (3.0.9)
-    mixlib-shellout (3.3.6)
+    mixlib-shellout (3.3.8)
       chef-utils
-    mixlib-shellout (3.3.6-x64-mingw-ucrt)
+    mixlib-shellout (3.3.8-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
@@ -487,7 +485,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.2)
-    win32-api (1.10.1-universal-mingw32)
+    win32-api (1.10.1)
     win32-certstore (0.6.16)
       chef-powershell
       ffi
@@ -544,4 +542,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.27
+   2.3.7

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"
   s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
-  s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
+  s.add_dependency "mixlib-shellout", "~> 3.3.8"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 19.0"
   s.add_dependency "inspec-core", "~> 7.0.38.beta"

--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -27,7 +27,7 @@ class Chef
 
       provides :execute, target_mode: true
 
-      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates, :elevated, :default_env, :timeout, :input, :login
+      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates, :elevated, :default_env, :timeout, :input, :login, :cgroup
 
       def load_current_resource
         current_resource = Chef::Resource::Execute.new(new_resource.name)
@@ -96,6 +96,7 @@ class Chef
         opts[:default_env] = default_env
         opts[:log_level]   = :info
         opts[:log_tag]     = new_resource.to_s
+        opts[:cgroup]      = cgroup if cgroup
         if (logger.info? || live_stream?) && !sensitive?
           if run_context.events.formatter?
             opts[:live_stream] = Chef::EventDispatch::EventsOutputStream.new(run_context.events, name: :execute)

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -577,7 +577,7 @@ class Chef
         introduced: "17.0",
         description: "Use a login shell to run the commands instead of inheriting the existing execution environment."
 
-      property :cgroup [String],
+      property :cgroup, [String],
         introduced: "18.5",
         description: "Linux only: Run the command within a specific cgroup, creating it if it doesn't exist."
 

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -577,6 +577,10 @@ class Chef
         introduced: "17.0",
         description: "Use a login shell to run the commands instead of inheriting the existing execution environment."
 
+      property :cgroup [String],
+        introduced: "18.5",
+        description: "Linux only: Run the command within a specific cgroup, creating it if it doesn't exist."
+
       alias :env :environment
 
       def self.set_guard_inherited_attributes(*inherited_attributes)

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -578,7 +578,7 @@ class Chef
         description: "Use a login shell to run the commands instead of inheriting the existing execution environment."
 
       property :cgroup, [String],
-        introduced: "18.5",
+        introduced: "19.0",
         description: "Linux only: Run the command within a specific cgroup, creating it if it doesn't exist."
 
       alias :env :environment


### PR DESCRIPTION
## Description
This is the first diff needed to add support for cgroupsv2. The code will be in mixlib-shellout, but we need to add this attribute first.

Output from `bundle update --conservative mixlib-shellout`:

```
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies....
Using rake 13.2.1
Using minitest 5.25.1
Using bundler 2.3.7
Using byebug 11.1.3
Using mixlib-cli 2.1.8
Using ast 2.4.2
Using uri 0.13.1
Using fuzzyurl 0.9.0
Using bigdecimal 3.1.8
Using builder 3.3.0
Using tty-color 0.6.0
Using aws-eventstream 1.3.0
Using debug_inspector 1.2.0
Using wisper 2.0.1
Using public_suffix 6.0.1
Using aws-partitions 1.1001.0
Using jmespath 1.6.2
Using mixlib-log 3.0.9
Using json 2.7.6
Using logger 1.5.3
Using concurrent-ruby 1.3.4
Using tty-cursor 0.7.1
Using tty-screen 0.8.2
Using chef-vault 4.1.11
Using tomlrb 1.3.0
Using libyajl2 2.1.0
Using hashie 4.1.0
Using base64 0.2.0
Using rack 2.2.10
Using uuidtools 2.2.0
Using webrick 1.8.2
Using ffi 1.16.3
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using method_source 1.1.0
Using parallel 1.26.3
Using racc 1.8.1
Using rainbow 3.1.1
Using regexp_parser 2.9.2
Using rexml 3.3.9
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.6.0
Using strings-ansi 0.2.0
Using unicode_utils 1.4.0
Using iniparse 1.5.0
Using multipart-post 2.4.1
Using parslet 1.8.2
Using coderay 1.1.3
Using rspec-support 3.13.1
Using rubyzip 2.3.2
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.2.2
Using net-ssh 7.3.0
Using mixlib-authentication 3.0.10
Using netrc 0.11.0
Using erubi 1.13.0
Using date 3.4.0
Using little-plugger 1.1.4
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using http-accept 1.7.0
Using domain_name 0.6.20240107
Using mime-types-data 3.2024.1105
Using timeout 0.4.1
Using httpclient 2.8.3
Using ipaddress 0.8.3
Using plist 3.7.1
Using multi_json 1.15.0
Using unf_ext 0.0.8.2
Using ed25519 1.3.0
Using mixlib-archive 1.1.7
Using tzinfo 2.0.6
Using chef-utils 19.0.91 from source at `chef-utils`
Using hashdiff 1.1.1
Using tty-spinner 0.9.3
Using tty-reader 0.9.0
Using mixlib-config 3.0.27
Using ffi-yajl 2.6.0
Using binding_of_caller 1.0.1
Using addressable 2.8.7
Using i18n 1.14.6
Using openssl 3.2.0
Using rb-readline 0.5.5
Using ruby-shadow 2.5.1
Using crack 0.4.5
Using net-http 0.4.1
Using nori 2.7.0
Using rspec-core 3.13.2
Using rspec-mocks 3.13.2
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.14
Using gssapi 1.3.1
Using parser 3.3.6.0
Using chef-gyoku 1.4.1
Using strings 0.2.1
Using pastel 0.8.0
Using logging 2.4.0
Using chef-zero 15.0.11
Using activesupport 7.0.8.6
Using rspec-expectations 3.13.3
Using net-scp 4.0.0
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using time 0.4.0
Using http-cookie 1.0.7
Using mime-types 3.6.0
Using net-protocol 0.2.2
Using pry 0.13.0
Using aws-sigv4 1.10.1
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using faraday-net_http 3.3.0
Using webmock 3.24.0
Using net-ftp 0.3.8
Using rubocop-ast 1.34.0
Using tty-prompt 0.23.1
Using tty-box 0.7.0
Using tty-table 0.12.0
Using cheffish 17.1.8
Using rspec 3.13.0
Using rspec-its 1.3.1
Using rubyntlm 0.6.5
Using mixlib-shellout 3.3.8 (was 3.3.6)
Using pry-byebug 3.10.1
Using chef-config 19.0.91 from source at `chef-config`
Using train-core 3.12.7
Using vault 0.18.2
Using faraday 2.12.0
Using rubocop 1.25.1
Using faraday-http-cache 2.5.1
Using chef-winrm 2.3.11
Using pry-stack_explorer 0.6.1
Using chef-winrm-fs 1.3.7
Using aws-sdk-core 3.211.0
Using license-acceptance 2.1.13
Using faraday-follow_redirects 0.3.0
Using cookstyle 7.32.8
Using chefstyle 2.2.3
Using appbundler 0.13.4
Using ohai 19.0.5 from https://github.com/chef/ohai.git (at main@fb50e01)
Using chef-winrm-elevated 1.2.5
Using chef-licensing 1.0.4
Using chef-telemetry 1.1.1
Using aws-sdk-secretsmanager 1.109.0
Using train-winrm 0.2.17
Using aws-sdk-kms 1.95.0
Using inspec-core 6.8.11
Using aws-sdk-s3 1.169.0
Using inspec-core-bin 6.8.11
Using train-rest 0.5.0
Using chef 19.0.91 from source at `.`
Using chef-bin 19.0.91 from source at `chef-bin` and installing its executables
Bundle updated!
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
