### PR TITLE
Fix regex used to get installed version so it handles multiple spaces

### DIFF
--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -254,7 +254,7 @@ class Chef
         end
 
         def get_version_from_stdout(stdout)
-          stdout.match(/version: (\S+)/)[1]
+          stdout.match(/version:\s+(\S+)/)[1]
         end
 
         def install_snap_from_source(name, path)


### PR DESCRIPTION
Fix regex used to get installed version so it handles multiple spaces

## Description
`snap info` does not always return version information with single space delimiter. This PR is to support both space and tab delimiter cases.

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [ x All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
