### PR TITLE
Updating ffi support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "main"
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.
 gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt_update1"
 
-gem "ffi", ">= 1.15.5"
+gem "ffi", ">= 1.15.5", "<= 1.17.0"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "main"
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.
 gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt_update1"
 
-gem "ffi", ">= 1.15.5", "<= 1.17.0"
+gem "ffi", ">= 1.15.5", "< 1.17.0"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5)
+      ffi (>= 1.15.5, <= 1.17.0)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
@@ -85,7 +85,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5)
+      ffi (>= 1.15.5, <= 1.17.0)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
@@ -237,10 +237,7 @@ GEM
       net-http
     fauxhai-ng (9.3.0)
       net-ssh
-    ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
-    ffi (1.16.3-x64-mingw32)
-    ffi (1.16.3-x86-mingw32)
+    ffi (1.17.0)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -538,7 +535,7 @@ DEPENDENCIES
   crack (< 0.4.6)
   ed25519 (~> 1.2)
   fauxhai-ng
-  ffi (>= 1.15.5)
+  ffi (>= 1.15.5, <= 1.17.0)
   inspec-core-bin (~> 6.8)
   ohai!
   openssl (= 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,8 @@ GEM
       net-http
     fauxhai-ng (9.3.0)
       net-ssh
-    ffi (1.17.0)
+    ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -520,8 +521,6 @@ PLATFORMS
   arm64-darwin-21
   ruby
   x64-mingw-ucrt
-  x64-mingw32
-  x86-mingw32
 
 DEPENDENCIES
   appbundler
@@ -535,7 +534,7 @@ DEPENDENCIES
   crack (< 0.4.6)
   ed25519 (~> 1.2)
   fauxhai-ng
-  ffi (>= 1.15.5, <= 1.17.0)
+  ffi (>= 1.15.5, < 1.17.0)
   inspec-core-bin (~> 6.8)
   ohai!
   openssl (= 3.2.0)
@@ -551,4 +550,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.7
+   2.3.27

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ohai", "~> 19.0"
   s.add_dependency "inspec-core", "~> 6.8"
 
-  s.add_dependency "ffi", ">= 1.15.5"
+  s.add_dependency "ffi", ">= 1.15.5", "<= 1.17.0"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "net-ftp" # remote_file resource

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ohai", "~> 19.0"
   s.add_dependency "inspec-core", "~> 6.8"
 
-  s.add_dependency "ffi", ">= 1.15.5", "<= 1.17.0"
+  s.add_dependency "ffi", ">= 1.15.5", "< 1.17.0"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "net-ftp" # remote_file resource

--- a/knife/knife.gemspec
+++ b/knife/knife.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 19.0"
-  s.add_dependency "ffi", ">= 1.15" # 1.14 versions are broken on i386 windows
+  s.add_dependency "ffi", ">= 1.15", "<= 1.17.0" # 1.14 versions are broken on i386 windows
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", ">= 5.1", "< 8"
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"

--- a/knife/knife.gemspec
+++ b/knife/knife.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 19.0"
-  s.add_dependency "ffi", ">= 1.15", "<= 1.17.0" # 1.14 versions are broken on i386 windows
+  s.add_dependency "ffi", ">= 1.15", "< 1.17.0" # 1.14 versions are broken on i386 windows
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", ">= 5.1", "< 8"
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Constraining FFI to prevent loading 1.17.x which are broken

I have used --conservative

$ bundle update --conservative ffi
Fetching https://github.com/chef/rest-client
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies.....
Using rake 13.2.1
Fetching public_suffix 6.0.1
Fetching minitest 5.25.1
Fetching concurrent-ruby 1.3.4
Installing minitest 5.25.1
Installing concurrent-ruby 1.3.4
Installing public_suffix 6.0.1
Using mixlib-cli 2.1.8
Fetching ffi 1.16.3
Using wmi-lite 1.0.7
Using ast 2.4.2
Fetching aws-eventstream 1.3.0
Installing ffi 1.16.3 with native extensions
Installing aws-eventstream 1.3.0
Fetching aws-partitions 1.1001.0
Installing aws-partitions 1.1001.0
Fetching jmespath 1.6.2
Installing jmespath 1.6.2
Using base64 0.2.0
Fetching bigdecimal 3.1.8
Installing bigdecimal 3.1.8 with native extensions
Using debug_inspector 1.2.0
Using builder 3.3.0
Using bundler 2.3.27
Using byebug 11.1.3
Fetching fuzzyurl 0.9.0
Installing fuzzyurl 0.9.0
Fetching tomlrb 1.3.0
Installing tomlrb 1.3.0
Fetching uri 0.13.1
Installing uri 0.13.1
Fetching json 2.7.6
Installing json 2.7.6 with native extensions
Fetching logger 1.5.3
Installing logger 1.5.3
Fetching tty-color 0.6.0
Installing tty-color 0.6.0
Fetching tty-cursor 0.7.1
Installing tty-cursor 0.7.1
Fetching tty-screen 0.8.2
Installing tty-screen 0.8.2
Fetching wisper 2.0.1
Installing wisper 2.0.1
Fetching libyajl2 2.1.0
Installing libyajl2 2.1.0 with native extensions
Fetching chef-vault 4.1.11
Installing chef-vault 4.1.11
Fetching hashie 4.1.0
Installing hashie 4.1.0
Fetching mixlib-log 3.0.9
Installing mixlib-log 3.0.9
Fetching rack 2.2.10
Installing rack 2.2.10
Fetching uuidtools 2.2.0
Installing uuidtools 2.2.0
Fetching webrick 1.8.2
Installing webrick 1.8.2
Fetching diff-lcs 1.5.1
Installing diff-lcs 1.5.1
Using erubis 2.7.0
Fetching iniparse 1.5.0
Installing iniparse 1.5.0
Using parallel 1.26.3
Using racc 1.8.1
Using rainbow 3.1.1
Fetching regexp_parser 2.9.2
Installing regexp_parser 2.9.2
Fetching rexml 3.3.9
Installing rexml 3.3.9
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.6.0
Fetching strings-ansi 0.2.0
Installing strings-ansi 0.2.0
Fetching unicode_utils 1.4.0
Installing unicode_utils 1.4.0
Using method_source 1.1.0
Fetching multipart-post 2.4.1
Installing multipart-post 2.4.1
Fetching parslet 1.8.2
Installing parslet 1.8.2
Using coderay 1.1.3
Fetching rspec-support 3.13.1
Installing rspec-support 3.13.1
Fetching rubyzip 2.3.2
Installing rubyzip 2.3.2
Fetching semverse 3.0.2
Installing semverse 3.0.2
Fetching sslshake 1.3.1
Installing sslshake 1.3.1
Fetching thor 1.2.2
Installing thor 1.2.2
Fetching net-ssh 7.3.0
Installing net-ssh 7.3.0
Fetching iso8601 0.13.0
Installing iso8601 0.13.0
Fetching mixlib-authentication 3.0.10
Installing mixlib-authentication 3.0.10
Fetching timeout 0.4.1
Installing timeout 0.4.1
Fetching date 3.4.0
Installing date 3.4.0 with native extensions
Fetching ipaddress 0.8.3
Installing ipaddress 0.8.3
Fetching plist 3.7.1
Installing plist 3.7.1
Fetching proxifier2 1.1.0
Installing proxifier2 1.1.0
Using syslog-logger 1.6.8
Fetching http-accept 1.7.0
Installing http-accept 1.7.0
Fetching domain_name 0.6.20240107
Fetching mime-types-data 3.2024.1105
Installing mime-types-data 3.2024.1105
Fetching netrc 0.11.0
Installing domain_name 0.6.20240107
Fetching erubi 1.13.0
Installing netrc 0.11.0
Fetching httpclient 2.8.3
Installing erubi 1.13.0
Fetching little-plugger 1.1.4
Installing little-plugger 1.1.4
Using multi_json 1.15.0
Fetching unf_ext 0.0.8.2
Installing httpclient 2.8.3
Fetching win32-api 1.10.1 (universal-mingw32)
Installing unf_ext 0.0.8.2 with native extensions
Installing win32-api 1.10.1 (universal-mingw32)
Fetching structured_warnings 0.4.0
Fetching ed25519 1.3.0
Installing structured_warnings 0.4.0
Fetching hashdiff 1.1.1
Installing ed25519 1.3.0 with native extensions
Installing hashdiff 1.1.1
Fetching openssl 3.2.0
Installing openssl 3.2.0 with native extensions
Fetching stringio 3.1.1
Installing stringio 3.1.1 with native extensions
Using rb-readline 0.5.5
Fetching addressable 2.8.7
Installing addressable 2.8.7
Fetching aws-sigv4 1.10.1
Fetching i18n 1.14.6
Installing aws-sigv4 1.10.1
Fetching tzinfo 2.0.6
Installing i18n 1.14.6
Using chef-utils 19.0.87 from source at `chef-utils`
Fetching rubyntlm 0.6.5
Installing tzinfo 2.0.6
Using binding_of_caller 1.0.1
Fetching mixlib-config 3.0.27
Installing rubyntlm 0.6.5
Installing mixlib-config 3.0.27
Fetching net-http 0.4.1
Fetching pastel 0.8.0
Installing pastel 0.8.0
Fetching tty-spinner 0.9.3
Installing net-http 0.4.1
Fetching tty-reader 0.9.0
Installing tty-spinner 0.9.3
Fetching ffi-yajl 2.6.0
Installing tty-reader 0.9.0
Fetching mixlib-archive 1.1.7 (universal-mingw32)
Installing ffi-yajl 2.6.0 with native extensions
Installing mixlib-archive 1.1.7 (universal-mingw32)
Fetching parser 3.3.6.0
Installing parser 3.3.6.0
Fetching gyoku 1.4.0
Installing gyoku 1.4.0
Fetching crack 0.4.5
Installing crack 0.4.5
Fetching strings 0.2.1
Installing strings 0.2.1
Fetching pry 0.13.0
Installing pry 0.13.0
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Using rspec-expectations 3.13.3
Using rspec-mocks 3.13.2
Fetching net-scp 4.0.0
Installing net-scp 4.0.0
Fetching net-sftp 4.0.0
Installing net-sftp 4.0.0
Fetching fauxhai-ng 9.3.0
Installing fauxhai-ng 9.3.0
Fetching net-protocol 0.2.2
Installing net-protocol 0.2.2
Using ffi-win32-extensions 1.0.4
Using win32-process 0.10.0
Fetching corefoundation 0.3.13
Installing corefoundation 0.3.13
Fetching ffi-libarchive 1.1.14
Installing ffi-libarchive 1.1.14
Fetching gssapi 1.3.1
Installing gssapi 1.3.1
Fetching win32-ipc 0.7.0
Installing win32-ipc 0.7.0
Using win32-eventlog 0.6.3
Using win32-mmap 0.4.2
Fetching nori 2.7.1
Installing nori 2.7.1
Fetching mime-types 3.6.0
Installing mime-types 3.6.0
Fetching http-cookie 1.0.7
Installing http-cookie 1.0.7
Fetching logging 2.4.0
Installing logging 2.4.0
Fetching time 0.4.0
Installing time 0.4.0
Fetching win32-taskscheduler 2.0.4
Installing win32-taskscheduler 2.0.4
Fetching psych 5.1.2
Fetching aws-sdk-core 3.211.0
Installing psych 5.1.2 with native extensions
Installing aws-sdk-core 3.211.0
Fetching vault 0.18.2
Installing vault 0.18.2
Fetching activesupport 7.0.8.6
Installing activesupport 7.0.8.6
Fetching faraday-net_http 3.3.0
Installing faraday-net_http 3.3.0
Fetching tty-prompt 0.23.1
Installing tty-prompt 0.23.1
Fetching rubocop-ast 1.34.0
Installing rubocop-ast 1.34.0
Fetching webmock 3.24.0
Installing webmock 3.24.0
Fetching tty-box 0.7.0
Installing tty-box 0.7.0
Fetching tty-table 0.12.0
Installing tty-table 0.12.0
Using pry-byebug 3.10.1
Using pry-stack_explorer 0.6.1
Using rspec 3.13.0
Fetching rspec-its 1.3.1
Installing rspec-its 1.3.1
Fetching win32-service 2.3.2
Installing win32-service 2.3.2
Using mixlib-shellout 3.3.6 (x64-mingw-ucrt)
Fetching win32-event 0.6.3
Installing win32-event 0.6.3
Fetching win32-mutex 0.4.3
Installing win32-mutex 0.4.3
Using rest-client 2.1.0 (x64-mingw-ucrt) from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Fetching winrm 2.3.8
Installing winrm 2.3.8
Fetching net-ftp 0.3.8
Installing net-ftp 0.3.8
Fetching chef-powershell 18.1.0
Fetching chef-zero 15.0.11
Installing chef-zero 15.0.11
Fetching aws-sdk-kms 1.95.0
Installing aws-sdk-kms 1.95.0
Fetching aws-sdk-secretsmanager 1.109.0
Installing aws-sdk-secretsmanager 1.109.0
Fetching faraday 2.12.0
Installing faraday 2.12.0
Using rubocop 1.25.1
Fetching license-acceptance 2.1.13
Installing license-acceptance 2.1.13
Fetching appbundler 0.13.4
Installing appbundler 0.13.4
Using chef-config 19.0.87 from source at `chef-config`
Fetching train-core 3.12.7
Installing train-core 3.12.7
Fetching winrm-fs 1.3.5
Installing winrm-fs 1.3.5
Using rdoc 6.4.1.1
Fetching cheffish 17.1.8
Installing cheffish 17.1.8
Fetching aws-sdk-s3 1.169.0
Installing aws-sdk-s3 1.169.0
Fetching faraday-http-cache 2.5.1
Installing faraday-http-cache 2.5.1
Fetching cookstyle 7.32.8
Installing cookstyle 7.32.8
Fetching faraday-follow_redirects 0.3.0
Installing faraday-follow_redirects 0.3.0
Using chefstyle 2.2.3
Fetching chef-telemetry 1.1.1
Installing chef-telemetry 1.1.1
Using ohai 19.0.5 from https://github.com/chef/ohai.git (at main@fb50e01)
Fetching train-rest 0.5.0
Installing train-rest 0.5.0
Fetching winrm-elevated 1.2.3
Installing winrm-elevated 1.2.3
Fetching chef-licensing 1.0.4
Installing chef-licensing 1.0.4
Fetching train-winrm 0.2.13
Installing train-winrm 0.2.13
Fetching inspec-core 6.8.11
Installing inspec-core 6.8.11
Fetching inspec-core-bin 6.8.11
Installing inspec-core-bin 6.8.11
Installing chef-powershell 18.1.0
Fetching win32-certstore 0.6.16
Installing win32-certstore 0.6.16
Using chef 19.0.87 (universal-mingw-ucrt) from source at `.`
Using chef-bin 19.0.87 from source at `chef-bin` and installing its executables
Bundler attempted to update ffi but its version stayed the same
Bundle updated!
Post-install message from i18n:
PSA: I18n will be dropping support for Ruby < 3.2 in the next major release (April 2025), due to Ruby's end of life for 3.1 and below (https://endoflife.date/ruby). Please upgrade to Ruby 3.2 or newer by April 2025 to continue using future versions of this gem.
Post-install message from rubyzip:
RubyZip 3.0 is coming!
**********************

The public API of some Rubyzip classes has been modernized to use named
parameters for optional arguments. Please check your usage of the
following classes:
  * `Zip::File`
  * `Zip::Entry`
  * `Zip::InputStream`
  * `Zip::OutputStream`

Please ensure that your Gemfiles and .gemspecs are suitably restrictive
to avoid an unexpected breakage when 3.0 is released (e.g. ~> 2.3.0).
See https://github.com/rubyzip/rubyzip for details. The Changelog also
lists other enhancements and bugfixes that have been implemented since
version 2.3.0.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
