### PR TITLE
raise a string instead of a hash object, patch 18.04 snap

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
@@ -6,6 +6,13 @@ service "snapd" do
   action :start
 end
 
+snap_package "core" do
+  action :install
+  channel "stable"
+  retries 2
+  retry_delay 15
+end
+
 snap_package "hello" do
   # there was originally a 5 second sleep before this
   action :install

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
@@ -7,6 +7,7 @@ service "snapd" do
 end
 
 snap_package "core" do
+  # this is an attempt to keep Ubuntu 18.04 from failing
   action :install
   channel "stable"
   retries 2

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -223,7 +223,7 @@ class Chef
             when "Do", "Doing", "Undoing", "Undo"
               # Continue
             when "Abort", "Hold", "Error"
-              raise result
+              raise "#{result["result"]["summary"]} - #{result["result"]["status"]} - #{result["result"]["err"]}"
             when "Done"
               waiting = false
             else


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

If `case result["result"]["status"]` results in `"Abort", "Hold", "Error"` then the original code was raising `result`, which is a hash and results in the error: 

```
       [2025-02-19T19:51:56+00:00] FATAL: TypeError: snap_package[hello] (end_to_end::_snap line 9) had an error: TypeError: exception class/object expected
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.0.87/lib/chef/provider/package/snap.rb:226:in `raise'
```

Adding the following to keep Ubuntu 18.04 working for now
```ruby
snap_package "core" do
   # this is an attempt to keep Ubuntu 18.04 from failing
   action :install
   channel "stable"
   retries 2
   retry_delay 15
 end
```



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
