### PR TITLE
Fix chef-utils README

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -42,7 +42,8 @@ The Platform Family helpers provide an alternative to comparing values from `nod
 
 Super Families:
 
-* `fedora_based?` - anything of fedora lineage (fedora, redhat, centos, amazon, pidora, etc)
+* `fedora_derived?` - anything of fedora lineage (fedora, redhat, centos, amazon, pidora, etc)
+* `redhat_based?` - fedora and rhel platform_families, nothing else. This is most likely not as useful as the `fedora_derived?` helper.
 * `rpm_based?`- all `fedora_based` systems plus `suse` and any future linux distros based on RPM (excluding AIX)
 * `solaris_based?`- all solaris-derived systems (omnios, smartos, openindiana, etc)
 * `bsd_based?`- all bsd-derived systems (freebsd, netbsd, openbsd, dragonflybsd).


### PR DESCRIPTION
Unlike everything else in super_family that's `_based?`, fedora is
`_derived?` - but the docs still said `_based?`.

I'd fix the code, but honestly, people probably use this so I'll just
fix the docs.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
