### PR TITLE
[Backport 18] Remove rdoc since 3.1.6 has patch version already

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -85,7 +85,8 @@ jobs:
           - almalinux-9
           - debian-11
           - debian-12
-          - fedora-latest
+          - fedora-40
+          # - fedora-latest
           - opensuse-leap-15
           - oraclelinux-8
           - oraclelinux-9
@@ -118,7 +119,8 @@ jobs:
           - almalinux-9
           - debian-11
           - debian-12
-          - fedora-latest
+          - fedora-40
+          # - fedora-latest
 #          - freebsd-13 runner is broken
           - freebsd-14
           - opensuse-leap-15

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,6 @@ install_if -> { RUBY_PLATFORM !~ /darwin/ } do
   gem "openssl", "= 3.2.0"
 end
 
-gem "rdoc", "~> 6.4.1" # 6.4.1.1 required for CVE-2024-27281, allow patch upgrades
-
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout
   gem "chef-bin", path: File.expand_path("chef-bin", __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,17 +368,12 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    psych (5.2.3)
-      date
-      stringio
     public_suffix (6.0.1)
     racc (1.8.1)
     rack (2.2.10)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-readline (0.5.5)
-    rdoc (6.4.1.1)
-      psych (>= 4.0.0)
     regexp_parser (2.10.0)
     rexml (3.4.0)
     rspec (3.12.0)
@@ -414,7 +409,6 @@ GEM
     rubyzip (2.4.1)
     semverse (3.0.2)
     sslshake (1.3.1)
-    stringio (3.1.2)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)
@@ -524,7 +518,6 @@ DEPENDENCIES
   pry-stack_explorer
   rake (>= 12.3.3)
   rb-readline
-  rdoc (~> 6.4.1)
   rest-client!
   rspec
   ruby-shadow!

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_gem.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_gem.rb
@@ -15,3 +15,8 @@ chef_gem gem_name do
   action :install
   compile_time false
 end
+
+chef_gem "awk-sdk-ec2" do
+  action :install
+  compile_time false
+end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_gem.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_gem.rb
@@ -16,7 +16,7 @@ chef_gem gem_name do
   compile_time false
 end
 
-chef_gem "awk-sdk-ec2" do
+chef_gem "aws-sdk-ec2" do
   action :install
   compile_time false
 end

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -154,6 +154,14 @@ platforms:
         - RUN mkdir /etc/sysconfig/network-scripts # missing from the oracle image
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
+  - name: fedora-40
+    driver:
+      image: dokken/fedora-40
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+        - RUN dnf -y install python3-libdnf python3-dnf
+
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest

--- a/kitchen-tests/kitchen.linux.ci.yml
+++ b/kitchen-tests/kitchen.linux.ci.yml
@@ -25,6 +25,7 @@ lifecycle:
         - ubuntu-18.04
     - remote: sudo dnf install -y openssl cronie
       includes:
+        - fedora-40
         - fedora-latest
     - remote: sudo pkg update && sudo pkg install -y git gcc gmake autoconf automake libtool
       includes:
@@ -59,6 +60,7 @@ platforms:
   - name: amazonlinux-2023
   - name: debian-12
   - name: debian-11
+  - name: fedora-40
   - name: fedora-latest
   - name: freebsd-13
   - name: freebsd-14


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Per https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/

Affected versions:
* Ruby 3.0.6 or lower
* Ruby 3.1.4 or lower
* Ruby 3.2.3 or lower
* Ruby 3.3.0
* RDoc gem 6.3.3 or lower, 6.4.0 through 6.6.2 without the patch versions (6.3.4, 6.4.1, 6.5.1)

Adding the fix for 3.1.6 was unnecessary and is complicating the dependency resolution with AWS gems.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
