### PR TITLE
Remove rdoc since 3.1.6 has patch version already

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,6 @@ install_if -> { !Gem.platforms.any? { |platform| !platform.is_a?(String) && plat
   gem "openssl", "= 3.2.0"
 end
 
-# since we are using ruby 3.1.x, rdoc needs to be on 6.4.1.1 so we use this
-gem "rdoc", "~> 6.4.1"
-
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout
   gem "chef-bin", path: File.expand_path("chef-bin", __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,16 +379,12 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    psych (5.1.2)
-      stringio
     public_suffix (6.0.1)
     racc (1.8.1)
     rack (2.2.10)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-readline (0.5.5)
-    rdoc (6.4.1.1)
-      psych (>= 4.0.0)
     regexp_parser (2.9.2)
     rexml (3.3.9)
     rspec (3.13.0)
@@ -425,7 +421,6 @@ GEM
     rubyzip (2.3.2)
     semverse (3.0.2)
     sslshake (1.3.1)
-    stringio (3.1.1)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)
@@ -539,7 +534,6 @@ DEPENDENCIES
   pry-stack_explorer
   rake (>= 12.3.3)
   rb-readline
-  rdoc (~> 6.4.1)
   rest-client!
   rspec
   ruby-shadow


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Per https://www.ruby-lang.org/en/news/2024/03/21/rce-rdoc-cve-2024-27281/

Affected versions:
* Ruby 3.0.6 or lower
* Ruby 3.1.4 or lower
* Ruby 3.2.3 or lower
* Ruby 3.3.0
* RDoc gem 6.3.3 or lower, 6.4.0 through 6.6.2 without the patch versions (6.3.4, 6.4.1, 6.5.1)

Adding the fix for 3.1.6 was unnecessary and is complicating the dependency resolution with AWS gems.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
