### PR TITLE
Reopen Inspec 7 fresh off main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,6 @@ end
 # Moving webmock here - the testers keep filtering this out and tests are failing
 gem "webmock"
 
-# since we are using ruby 3.1.x, rdoc needs to be on 6.4.1.1 so we use this
-gem "rdoc", "~> 6.4.1"
-
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout
   gem "chef-bin", path: File.expand_path("chef-bin", __dir__)

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ end
 gem "cheffish", ">= 17"
 
 group(:omnibus_package) do
-  gem "appbundler"
+  gem "appbundler", git: "https://github.com/chef/appbundler", branch: "tp/appbundler-debug"
   gem "rb-readline"
   # gem "inspec-core-bin", "~> 6.8" # need to provide the binaries for inspec
   gem "chef-vault"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gem "chef", path: "."
 
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "main"
 
+gem "inspec-core", git: "https://github.com/inspec/inspec.git", branch: "inspec-7", glob: "inspec-core.gemspec"
+gem "inspec-core-bin", git: "https://github.com/inspec/inspec.git", branch: "inspec-7", glob: "inspec-bin/inspec-core-bin.gemspec"
+
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.
 gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt_update1"
 
@@ -15,6 +18,9 @@ gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?
 install_if -> { !Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" } } do
   gem "openssl", "= 3.2.0"
 end
+
+# Moving webmock here - the testers keep filtering this out and tests are failing
+gem "webmock"
 
 # since we are using ruby 3.1.x, rdoc needs to be on 6.4.1.1 so we use this
 gem "rdoc", "~> 6.4.1"
@@ -32,7 +38,7 @@ gem "cheffish", ">= 17"
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec-core-bin", "~> 6.8" # need to provide the binaries for inspec
+  # gem "inspec-core-bin", "~> 6.8" # need to provide the binaries for inspec
   gem "chef-vault"
 end
 
@@ -62,7 +68,7 @@ end
 group(:development, :test) do
   gem "rake", ">= 12.3.3"
   gem "rspec"
-  gem "webmock"
+  # gem "webmock"
   gem "crack", "< 0.4.6" # due to https://github.com/jnunemaker/crack/pull/75
   gem "fauxhai-ng" # for chef-utils gem
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/appbundler
-  revision: 5d8b8fdaa8a3e45c25bd449f3d4274c821d65c41
+  revision: c61f8469a9e6193c81f49c9aa8291eaed4680d17
   branch: tp/appbundler-debug
   specs:
     appbundler (0.13.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,17 +389,12 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    psych (5.2.3)
-      date
-      stringio
     public_suffix (6.0.1)
     racc (1.8.1)
     rack (2.2.11)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-readline (0.5.5)
-    rdoc (6.4.1.1)
-      psych (>= 4.0.0)
     regexp_parser (2.10.0)
     rexml (3.4.1)
     rspec (3.13.0)
@@ -436,7 +431,6 @@ GEM
     rubyzip (2.4.1)
     semverse (3.0.2)
     sslshake (1.3.1)
-    stringio (3.1.5)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)
@@ -551,7 +545,6 @@ DEPENDENCIES
   pry-stack_explorer
   rake (>= 12.3.3)
   rb-readline
-  rdoc (~> 6.4.1)
   rest-client!
   rspec
   ruby-shadow

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: fb50e0151df1e9caf80a8ef1979901b8214139dc
+  revision: 0129eb894e3382e33c88be3cc3f97d1841544c30
   branch: main
   specs:
-    ohai (19.0.5)
+    ohai (19.0.9)
       chef-config (>= 14.12, < 20)
       chef-utils (>= 16.0, < 20)
-      ffi (~> 1.9)
+      ffi (>= 1.15.5, < 1.17.0)
       ffi-yajl (~> 2.2)
       ipaddress
       mixlib-cli (>= 1.7.0)
       mixlib-config (>= 2.0, < 4.0)
       mixlib-log (>= 2.0.1, < 4.0)
-      mixlib-shellout (~> 3.2, >= 3.2.5)
+      mixlib-shellout (~> 3.3.6)
       plist (~> 3.1)
       train-core
       wmi-lite (~> 1.0)
@@ -23,12 +23,6 @@ GIT
   branch: jfm/ucrt_update1
   specs:
     rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    rest-client (2.1.0-x64-mingw-ucrt)
-      ffi (~> 1.15)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -185,7 +179,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8.6)
+    activesupport (7.0.8.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -196,27 +190,28 @@ GEM
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.2)
-    aws-eventstream (1.3.0)
-    aws-partitions (1.1001.0)
-    aws-sdk-core (3.211.0)
+    aws-eventstream (1.3.1)
+    aws-partitions (1.1055.0)
+    aws-sdk-core (3.219.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
+      base64
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.95.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-kms (1.99.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.169.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-s3 (1.182.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
-    aws-sdk-secretsmanager (1.109.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-secretsmanager (1.113.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.10.1)
+    aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
     builder (3.3.0)
@@ -272,30 +267,30 @@ GEM
     chefstyle (2.2.3)
       rubocop (= 1.25.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.5)
     cookstyle (7.32.8)
       rubocop (= 1.25.1)
     corefoundation (0.3.13)
       ffi (>= 1.15.0)
     crack (0.4.5)
       rexml
-    date (3.4.0)
+    date (3.4.1)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     domain_name (0.6.20240107)
     ed25519 (1.3.0)
-    erubi (1.13.0)
+    erubi (1.13.1)
     erubis (2.7.0)
-    faraday (2.12.0)
-      faraday-net_http (>= 2.0, < 3.4)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
-    faraday-net_http (3.3.0)
-      net-http
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     fauxhai-ng (9.3.0)
       net-ssh
     ffi (1.16.3)
@@ -309,19 +304,20 @@ GEM
     fuzzyurl (0.9.0)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    hashdiff (1.1.1)
+    hashdiff (1.1.2)
     hashie (4.1.0)
     http-accept (1.7.0)
-    http-cookie (1.0.7)
+    http-cookie (1.0.8)
       domain_name (~> 0.5)
-    httpclient (2.8.3)
-    i18n (1.14.6)
+    httpclient (2.9.0)
+      mutex_m
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
     ipaddress (0.8.3)
     iso8601 (0.13.0)
     jmespath (1.6.2)
-    json (2.7.6)
+    json (2.10.1)
     libyajl2 (2.1.0)
     license-acceptance (2.1.13)
       pastel (~> 0.7)
@@ -337,8 +333,8 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1105)
-    minitest (5.25.1)
+    mime-types-data (3.2025.0220)
+    minitest (5.25.4)
     mixlib-archive (1.1.7)
       mixlib-log
     mixlib-archive (1.1.7-universal-mingw32)
@@ -347,7 +343,8 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.0.9)
+    mixlib-log (3.2.0)
+      ffi (~> 1.9, <= 1.17.0)
     mixlib-shellout (3.3.6)
       chef-utils
     mixlib-shellout (3.3.6-x64-mingw-ucrt)
@@ -357,14 +354,15 @@ GEM
       wmi-lite (~> 1.0)
     multi_json (1.15.0)
     multipart-post (2.4.1)
+    mutex_m (0.3.0)
     net-ftp (0.3.8)
       net-protocol
       time
-    net-http (0.4.1)
+    net-http (0.6.0)
       uri
     net-protocol (0.2.2)
       timeout
-    net-scp (4.0.0)
+    net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
@@ -374,13 +372,13 @@ GEM
       bigdecimal
     openssl (3.2.0)
     parallel (1.26.3)
-    parser (3.3.6.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     parslet (1.8.2)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    plist (3.7.1)
+    plist (3.7.2)
     proxifier2 (1.1.0)
     pry (0.13.0)
       coderay (~> 1.1)
@@ -391,23 +389,24 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    psych (5.1.2)
+    psych (5.2.3)
+      date
       stringio
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.11)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-readline (0.5.5)
     rdoc (6.4.1.1)
       psych (>= 4.0.0)
-    regexp_parser (2.9.2)
-    rexml (3.3.9)
+    regexp_parser (2.10.0)
+    rexml (3.4.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -418,7 +417,7 @@ GEM
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
+    rspec-support (3.13.2)
     rubocop (1.25.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -428,16 +427,16 @@ GEM
       rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.34.0)
+    rubocop-ast (1.38.1)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     ruby-shadow (2.5.1)
     rubyntlm (0.6.5)
       base64
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     semverse (3.0.2)
     sslshake (1.3.1)
-    stringio (3.1.1)
+    stringio (3.1.5)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)
@@ -446,9 +445,9 @@ GEM
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
     thor (1.2.2)
-    time (0.4.0)
+    time (0.4.1)
       date
-    timeout (0.4.1)
+    timeout (0.4.3)
     tomlrb (1.3.0)
     train-core (3.12.7)
       addressable (~> 2.5)
@@ -491,15 +490,15 @@ GEM
     unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
-    uri (0.13.1)
+    uri (1.0.3)
     uuidtools (2.2.0)
     vault (0.18.2)
       aws-sigv4
-    webmock (3.24.0)
+    webmock (3.25.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.2)
+    webrick (1.9.1)
     win32-api (1.10.1-universal-mingw32)
     win32-certstore (0.6.16)
       chef-powershell
@@ -526,7 +525,7 @@ GEM
     wmi-lite (1.0.7)
 
 PLATFORMS
-  arm64-darwin-21
+  arm64-darwin-23
   ruby
   x64-mingw-ucrt
 
@@ -559,4 +558,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.27
+   2.6.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/chef/appbundler
+  revision: 5d8b8fdaa8a3e45c25bd449f3d4274c821d65c41
+  branch: tp/appbundler-debug
+  specs:
+    appbundler (0.13.5)
+      mixlib-cli (>= 1.4, < 3.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+
+GIT
   remote: https://github.com/chef/ohai.git
   revision: 0129eb894e3382e33c88be3cc3f97d1841544c30
   branch: main
@@ -186,9 +195,6 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    appbundler (0.13.4)
-      mixlib-cli (>= 1.4, < 3.0)
-      mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.2)
     aws-eventstream (1.3.1)
     aws-partitions (1.1055.0)
@@ -524,7 +530,7 @@ PLATFORMS
   x64-mingw-ucrt
 
 DEPENDENCIES
-  appbundler
+  appbundler!
   chef!
   chef-bin!
   chef-config!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/appbundler
-  revision: c61f8469a9e6193c81f49c9aa8291eaed4680d17
+  revision: e6855a51b5aa317831917506d54f4b3e8c575ed3
   branch: tp/appbundler-debug
   specs:
     appbundler (0.13.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,47 @@ GIT
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
 
+GIT
+  remote: https://github.com/inspec/inspec.git
+  revision: 433e5002bd644b801a6161b4ce824dcf303e943e
+  branch: inspec-7
+  glob: inspec-bin/inspec-core-bin.gemspec
+  specs:
+    inspec-core-bin (7.0.36)
+      inspec-core (= 7.0.36)
+
+GIT
+  remote: https://github.com/inspec/inspec.git
+  revision: 433e5002bd644b801a6161b4ce824dcf303e943e
+  branch: inspec-7
+  glob: inspec-core.gemspec
+  specs:
+    inspec-core (7.0.36)
+      addressable (~> 2.4)
+      chef-licensing (>= 1.0.2)
+      chef-telemetry (~> 1.0, >= 1.0.8)
+      cookstyle
+      faraday (>= 1, < 3)
+      faraday-follow_redirects (~> 0.3)
+      hashie (>= 3.4, < 6.0)
+      license-acceptance (>= 0.2.13, < 3.0)
+      method_source (>= 0.8, < 2.0)
+      mixlib-log (~> 3.0)
+      multipart-post (~> 2.0)
+      parallel (~> 1.9)
+      parslet (>= 1.5, < 2.0)
+      pry (~> 0.13)
+      rspec (>= 3.9, <= 3.14)
+      rspec-its (~> 1.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      semverse (~> 3.0)
+      sslshake (~> 1.2)
+      thor (>= 0.20, < 1.3.0)
+      tomlrb (>= 1.2, < 2.1)
+      train-core (>= 3.11.0)
+      tty-prompt (~> 0.17)
+      tty-table (~> 0.10)
+
 PATH
   remote: .
   specs:
@@ -53,7 +94,6 @@ PATH
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
-      inspec-core (~> 6.8)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
@@ -89,7 +129,6 @@ PATH
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
-      inspec-core (~> 6.8)
       iso8601 (>= 0.12.1, < 0.14)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
@@ -279,33 +318,6 @@ GEM
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
-    inspec-core (6.8.11)
-      addressable (~> 2.4)
-      chef-licensing (>= 1.0.2)
-      chef-telemetry (~> 1.0, >= 1.0.8)
-      cookstyle
-      faraday (>= 1, < 3)
-      faraday-follow_redirects (~> 0.3)
-      hashie (>= 3.4, < 6.0)
-      license-acceptance (>= 0.2.13, < 3.0)
-      method_source (>= 0.8, < 2.0)
-      mixlib-log (~> 3.0)
-      multipart-post (~> 2.0)
-      parallel (~> 1.9)
-      parslet (>= 1.5, < 2.0)
-      pry (~> 0.13)
-      rspec (>= 3.9, <= 3.14)
-      rspec-its (~> 1.2)
-      rubyzip (>= 1.2.2, < 3.0)
-      semverse (~> 3.0)
-      sslshake (~> 1.2)
-      thor (>= 0.20, < 1.3.0)
-      tomlrb (>= 1.2, < 2.1)
-      train-core (>= 3.11.0)
-      tty-prompt (~> 0.17)
-      tty-table (~> 0.10)
-    inspec-core-bin (6.8.11)
-      inspec-core (= 6.8.11)
     ipaddress (0.8.3)
     iso8601 (0.13.0)
     jmespath (1.6.2)
@@ -531,7 +543,8 @@ DEPENDENCIES
   ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5, < 1.17.0)
-  inspec-core-bin (~> 6.8)
+  inspec-core!
+  inspec-core-bin!
   ohai!
   openssl (= 3.2.0)
   pry (= 0.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/appbundler
-  revision: e6855a51b5aa317831917506d54f4b3e8c575ed3
+  revision: fafe06eb6c602c6d043b44eeca966d52ecbc9b6a
   branch: tp/appbundler-debug
   specs:
     appbundler (0.13.5)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 19.0"
-  s.add_dependency "inspec-core", "~> 6.8"
 
   s.add_dependency "ffi", ">= 1.15.5", "< 1.17.0"
   s.add_dependency "ffi-yajl", "~> 2.2"

--- a/cspell.json
+++ b/cspell.json
@@ -1540,6 +1540,7 @@
     "wchars",
     "WEBHOSTING",
     "webroot",
+    "webmock",
     "webserver",
     "whatavailable",
     "whateverd",

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -2,6 +2,9 @@ source "https://rubygems.org"
 
 gem "knife", path: "."
 
+gem "inspec-core", git: "https://github.com/inspec/inspec.git", branch: "inspec-7", glob: "inspec-core.gemspec"
+gem "inspec-core-bin", git: "https://github.com/inspec/inspec.git", branch: "inspec-7", glob: "inspec-bin/inspec-core-bin.gemspec"
+
 group(:development, :test) do
   gem "cheffish", ">= 14" # testing only , but why didn't this need to explicit in chef?
   gem "webmock"

--- a/knife/Gemfile.lock
+++ b/knife/Gemfile.lock
@@ -1,35 +1,562 @@
+GIT
+  remote: https://github.com/chef/ohai.git
+  revision: 0129eb894e3382e33c88be3cc3f97d1841544c30
+  branch: main
+  specs:
+    ohai (19.0.9)
+      chef-config (>= 14.12, < 20)
+      chef-utils (>= 16.0, < 20)
+      ffi (>= 1.15.5, < 1.17.0)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli (>= 1.7.0)
+      mixlib-config (>= 2.0, < 4.0)
+      mixlib-log (>= 2.0.1, < 4.0)
+      mixlib-shellout (~> 3.3.6)
+      plist (~> 3.1)
+      train-core
+      wmi-lite (~> 1.0)
+
+GIT
+  remote: https://github.com/inspec/inspec.git
+  revision: 433e5002bd644b801a6161b4ce824dcf303e943e
+  branch: inspec-7
+  glob: inspec-bin/inspec-core-bin.gemspec
+  specs:
+    inspec-core-bin (7.0.36)
+      inspec-core (= 7.0.36)
+
+GIT
+  remote: https://github.com/inspec/inspec.git
+  revision: 433e5002bd644b801a6161b4ce824dcf303e943e
+  branch: inspec-7
+  glob: inspec-core.gemspec
+  specs:
+    inspec-core (7.0.36)
+      addressable (~> 2.4)
+      chef-licensing (>= 1.0.2)
+      chef-telemetry (~> 1.0, >= 1.0.8)
+      cookstyle
+      faraday (>= 1, < 3)
+      faraday-follow_redirects (~> 0.3)
+      hashie (>= 3.4, < 6.0)
+      license-acceptance (>= 0.2.13, < 3.0)
+      method_source (>= 0.8, < 2.0)
+      mixlib-log (~> 3.0)
+      multipart-post (~> 2.0)
+      parallel (~> 1.9)
+      parslet (>= 1.5, < 2.0)
+      pry (~> 0.13)
+      rspec (>= 3.9, <= 3.14)
+      rspec-its (~> 1.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      semverse (~> 3.0)
+      sslshake (~> 1.2)
+      thor (>= 0.20, < 1.3.0)
+      tomlrb (>= 1.2, < 2.1)
+      train-core (>= 3.11.0)
+      tty-prompt (~> 0.17)
+      tty-table (~> 0.10)
+
+PATH
+  remote: ../chef-bin
+  specs:
+    chef-bin (19.0.89)
+      chef (= 19.0.89)
+
 PATH
   remote: ..
   specs:
     chef (19.0.89)
+      addressable
+      aws-sdk-s3 (~> 1.91)
+      aws-sdk-secretsmanager (~> 1.46)
+      chef-config (= 19.0.89)
+      chef-licensing (>= 0.7.5)
+      chef-utils (= 19.0.89)
+      chef-vault
+      chef-zero (>= 14.0.11)
+      corefoundation (~> 0.3.4)
+      diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
+      erubis (~> 2.7)
+      ffi (>= 1.15.5, < 1.17.0)
+      ffi-libarchive (~> 1.0, >= 1.0.3)
+      ffi-yajl (~> 2.2)
+      iniparse (~> 1.4)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-authentication (>= 2.1, < 4)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      mixlib-log (>= 2.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
+      net-ftp
+      net-sftp (>= 2.1.2, < 5.0)
+      ohai (~> 19.0)
+      plist (~> 3.2)
+      proxifier2 (~> 1.1)
+      syslog-logger (~> 1.6)
+      train-core (~> 3.10, <= 3.12.7)
+      train-rest (>= 0.4.1)
+      train-winrm (>= 0.2.17)
+      unf_ext (~> 0.0.8.2)
+      uuidtools (>= 2.1.5, < 3.0)
+      vault (~> 0.18.2)
     chef (19.0.89-universal-mingw-ucrt)
+      addressable
+      aws-sdk-s3 (~> 1.91)
+      aws-sdk-secretsmanager (~> 1.46)
+      chef-config (= 19.0.89)
+      chef-licensing (>= 0.7.5)
+      chef-powershell (~> 18.1.0)
+      chef-utils (= 19.0.89)
+      chef-vault
+      chef-zero (>= 14.0.11)
+      corefoundation (~> 0.3.4)
+      diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
+      erubis (~> 2.7)
+      ffi (>= 1.15.5, < 1.17.0)
+      ffi-libarchive (~> 1.0, >= 1.0.3)
+      ffi-yajl (~> 2.2)
+      iniparse (~> 1.4)
+      iso8601 (>= 0.12.1, < 0.14)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-authentication (>= 2.1, < 4)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      mixlib-log (>= 2.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
+      net-ftp
+      net-sftp (>= 2.1.2, < 5.0)
+      ohai (~> 19.0)
+      plist (~> 3.2)
+      proxifier2 (~> 1.1)
+      syslog-logger (~> 1.6)
+      train-core (~> 3.10, <= 3.12.7)
+      train-rest (>= 0.4.1)
+      train-winrm (>= 0.2.17)
+      unf_ext (~> 0.0.8.2)
+      uuidtools (>= 2.1.5, < 3.0)
+      vault (~> 0.18.2)
+      win32-api (~> 1.10.0)
+      win32-certstore (~> 0.6.15)
+      win32-event (~> 0.6.1)
+      win32-eventlog (= 0.6.3)
+      win32-mmap (~> 0.4.1)
+      win32-mutex (~> 0.4.2)
+      win32-process (~> 0.9)
+      win32-service (>= 2.1.5, < 3.0)
+      win32-taskscheduler (~> 2.0)
+      wmi-lite (~> 1.0)
+
+PATH
+  remote: .
+  specs:
+    knife (19.0.89)
+      bcrypt_pbkdf (~> 1.1)
+      chef (>= 19)
+      chef-config (>= 19)
+      chef-utils (>= 19)
+      chef-vault
+      erubis (~> 2.7)
+      ffi (>= 1.15, < 1.17.0)
+      ffi-yajl (~> 2.2)
+      highline (>= 1.6.9, < 3)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      net-ssh (>= 5.1, < 8)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (~> 19.0)
+      pastel
+      proxifier2 (~> 1.1)
+      train-core (~> 3.10)
+      train-winrm (>= 0.2.17)
+      tty-prompt (~> 0.21)
+      tty-screen (~> 0.6)
+      tty-table (~> 0.11)
+
+PATH
+  remote: /Users/powell/projects/chef/chef-config
+  specs:
+    chef-config (19.0.89)
+      addressable
+      chef-utils (= 19.0.89)
+      fuzzyurl
+      mixlib-config (>= 2.2.12, < 4.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      tomlrb (~> 1.2)
+
+PATH
+  remote: /Users/powell/projects/chef/chef-utils
+  specs:
+    chef-utils (19.0.89)
+      concurrent-ruby
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.8.7)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    ast (2.4.2)
+    aws-eventstream (1.3.1)
+    aws-partitions (1.1055.0)
+    aws-sdk-core (3.219.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.99.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.182.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-secretsmanager (1.113.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.11.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.2.0)
+    bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-x64-mingw-ucrt)
+    bigdecimal (3.1.9)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
+    builder (3.3.0)
+    byebug (11.1.3)
+    chef-gyoku (1.4.1)
+      builder (>= 2.1.2)
+      rexml (~> 3.3)
+    chef-licensing (1.0.4)
+      activesupport (~> 7.0, < 7.1)
+      chef-config (>= 15)
+      faraday (>= 1, < 3)
+      faraday-http-cache
+      tty-prompt (~> 0.23)
+      tty-spinner (~> 0.9.3)
+    chef-powershell (18.1.0)
+      ffi (~> 1.15)
+      ffi-yajl (~> 2.4)
+    chef-telemetry (1.1.1)
+      chef-config
+      concurrent-ruby (~> 1.0)
+    chef-vault (4.1.11)
+    chef-winrm (2.3.11)
+      builder (>= 2.1.2)
+      chef-gyoku (>= 1.4.1)
+      erubi (~> 1.8)
+      gssapi (~> 1.2)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (= 2.7.0)
+      rexml (~> 3.3)
+      rubyntlm (~> 0.6.0, >= 0.6.3)
+    chef-winrm-elevated (1.2.5)
+      chef-winrm (>= 2.3.11)
+      chef-winrm-fs (>= 1.3.7)
+      erubi (~> 1.8)
+    chef-winrm-fs (1.3.7)
+      chef-winrm (>= 2.3.11)
+      erubi (>= 1.7)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 2.0)
+    chef-zero (15.0.11)
+      ffi-yajl (~> 2.2)
+      hashie (>= 2.0, < 5.0)
+      mixlib-log (>= 2.0, < 4.0)
+      rack (~> 2.0, >= 2.0.6)
+      uuidtools (~> 2.1)
+      webrick
+    cheffish (17.1.8)
+      chef-utils (>= 17.0)
+      chef-zero (>= 14.0)
+      logger (< 1.6.0)
+      net-ssh
+    coderay (1.1.3)
+    concurrent-ruby (1.3.5)
+    cookstyle (7.32.8)
+      rubocop (= 1.25.1)
+    corefoundation (0.3.13)
+      ffi (>= 1.15.0)
+    crack (0.4.5)
+      rexml
+    date (3.4.1)
+    debug_inspector (1.2.0)
+    diff-lcs (1.5.1)
+    domain_name (0.6.20240107)
+    erubi (1.13.1)
+    erubis (2.7.0)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-http-cache (2.5.1)
+      faraday (>= 0.8)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
+    ffi-libarchive (1.1.14)
+      ffi (~> 1.0)
+    ffi-win32-extensions (1.0.4)
+      ffi
+    ffi-yajl (2.6.0)
+      libyajl2 (>= 1.2)
+    fuzzyurl (0.9.0)
+    gssapi (1.3.1)
+      ffi (>= 1.0.1)
+    hashdiff (1.1.2)
+    hashie (4.1.0)
+    highline (2.1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
+    httpclient (2.9.0)
+      mutex_m
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    iniparse (1.5.0)
+    ipaddress (0.8.3)
+    iso8601 (0.13.0)
+    jmespath (1.6.2)
+    json (2.10.1)
+    libyajl2 (2.1.0)
+    license-acceptance (2.1.13)
+      pastel (~> 0.7)
+      tomlrb (>= 1.2, < 3.0)
+      tty-box (~> 0.6)
+      tty-prompt (~> 0.20)
+    little-plugger (1.1.4)
+    logger (1.5.3)
+    logging (2.4.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.14)
+    method_source (1.1.0)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0220)
+    minitest (5.25.4)
+    mixlib-archive (1.1.7)
+      mixlib-log
+    mixlib-archive (1.1.7-universal-mingw32)
+      mixlib-log
+    mixlib-authentication (3.0.10)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
+      tomlrb
+    mixlib-log (3.2.0)
+      ffi (~> 1.9, <= 1.17.0)
+    mixlib-shellout (3.3.6)
+      chef-utils
+    mixlib-shellout (3.3.6-x64-mingw-ucrt)
+      chef-utils
+      ffi-win32-extensions (~> 1.0.3)
+      win32-process (~> 0.9)
+      wmi-lite (~> 1.0)
+    multi_json (1.15.0)
+    multipart-post (2.4.1)
+    mutex_m (0.3.0)
+    net-ftp (0.3.8)
+      net-protocol
+      time
+    net-http (0.6.0)
+      uri
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-ssh (7.3.0)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
+    net-ssh-multi (1.2.1)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
+    netrc (0.11.0)
+    nori (2.7.0)
+      bigdecimal
+    parallel (1.26.3)
+    parser (3.3.7.1)
+      ast (~> 2.4.1)
+      racc
+    parslet (1.8.2)
+    pastel (0.8.0)
+      tty-color (~> 0.5)
+    plist (3.7.2)
+    proxifier2 (1.1.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-stack_explorer (0.6.1)
+      binding_of_caller (~> 1.0)
+      pry (~> 0.13)
+    public_suffix (6.0.1)
+    racc (1.8.1)
+    rack (2.2.11)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rexml (3.4.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.3)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (1.3.1)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+    rubocop (1.25.1)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.15.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.38.1)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    rubyntlm (0.6.5)
+      base64
+    rubyzip (2.4.1)
+    semverse (3.0.2)
+    sslshake (1.3.1)
+    strings (0.2.1)
+      strings-ansi (~> 0.2)
+      unicode-display_width (>= 1.5, < 3.0)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.2.0)
+    structured_warnings (0.4.0)
+    syslog-logger (1.6.8)
+    thor (1.2.2)
+    time (0.4.1)
+      date
+    timeout (0.4.3)
+    tomlrb (1.3.0)
+    train-core (3.12.7)
+      addressable (~> 2.5)
+      ffi (!= 1.13.0)
+      json (>= 1.8, < 3.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      net-scp (>= 1.2, < 5.0)
+      net-ssh (>= 2.9, < 8.0)
+    train-rest (0.5.0)
+      aws-sigv4 (~> 1.5)
+      rest-client (~> 2.1)
+      train-core (~> 3.0)
+    train-winrm (0.2.17)
+      chef-winrm (>= 2.3.11)
+      chef-winrm-elevated (>= 1.2.5)
+      chef-winrm-fs (>= 1.3.7)
+    tty-box (0.7.0)
+      pastel (~> 0.8)
+      strings (~> 0.2.0)
+      tty-cursor (~> 0.7)
+    tty-color (0.6.0)
+    tty-cursor (0.7.1)
+    tty-prompt (0.23.1)
+      pastel (~> 0.8)
+      tty-reader (~> 0.8)
+    tty-reader (0.9.0)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      wisper (~> 2.0)
+    tty-screen (0.8.2)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
+    tty-table (0.12.0)
+      pastel (~> 0.8)
+      strings (~> 0.2.0)
+      tty-screen (~> 0.8)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unf_ext (0.0.8.2)
+    unf_ext (0.0.8.2-x64-mingw-ucrt)
+    unicode-display_width (2.6.0)
+    unicode_utils (1.4.0)
+    uri (1.0.3)
+    uuidtools (2.2.0)
+    vault (0.18.2)
+      aws-sigv4
+    webmock (3.25.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.9.1)
+    win32-api (1.10.1-universal-mingw32)
+    win32-certstore (0.6.16)
+      chef-powershell
+      ffi
+    win32-event (0.6.3)
+      win32-ipc (>= 0.6.0)
+    win32-eventlog (0.6.3)
+      ffi
+    win32-ipc (0.7.0)
+      ffi
+    win32-mmap (0.4.2)
+      ffi
+    win32-mutex (0.4.3)
+      win32-ipc (>= 0.6.0)
+    win32-process (0.10.0)
+      ffi (>= 1.0.0)
+    win32-service (2.3.2)
+      ffi
+      ffi-win32-extensions
+    win32-taskscheduler (2.0.4)
+      ffi
+      structured_warnings
+    wisper (2.0.1)
+    wmi-lite (1.0.7)
 
 PLATFORMS
   ruby
   x64-mingw-ucrt
 
 DEPENDENCIES
-  appbundler
   chef!
   chef-bin!
   chef-config!
   chef-utils!
-  chef-vault
-  cheffish (>= 17.1.5)
+  cheffish (>= 14)
   cookstyle (>= 7.32.8)
-  ed25519 (~> 1.2)
-  fauxhai-ng
-  ffi (>= 1.15.5)
-  inspec-core-bin (>= 5)
+  crack (< 0.4.6)
+  inspec-core!
+  inspec-core-bin!
+  knife!
   ohai!
-  pry (= 0.13.0)
+  pry
   pry-byebug
   pry-stack_explorer
-  rake
-  rb-readline
-  rest-client!
+  rake (>= 12.3.3)
   rspec
-  ruby-shadow!
   webmock
 
 BUNDLED WITH

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -130,6 +130,7 @@ If ($lastexitcode -ne 0) { Throw $lastexitcode }
 
 # temp fix until we figure out whats going on in our specific environment as it pertains to unf_ext#
 gem install unf_ext -v 0.0.8.2 --source https://rubygems.org/gems/unf_ext
+em install webmock # required for some tests. It gets filtered out during setup.
 
 bundle
 If ($lastexitcode -ne 0) { Throw $lastexitcode }

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -77,6 +77,21 @@ if [[ ! -L $USR_BIN_DIR/ohai ]] || [[ $(ls -l $USR_BIN_DIR/ohai | awk '{print$NF
   exit 1
 fi
 
+echo " --- Let's install Inspec ---"
+export HAB_BLDR_CHANNEL="LTS-2024-current"
+export HAB_REFRESH_CHANNEL="LTS-2024-current"
+export HAB_LICENSE="accept-no-persist"
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash
+hab pkg install chef/inspec/7.0.30/20250130053644
+
+echo " --- Let's Move Inspec to the embedded bin dir ---"
+
+echo " What if we search for Inspec?"
+inspec="$(find / -name inspec -type f | head -n 1)"
+
+echo " copying the binary to the embedded bin dir"
+cp "${inspec}" $EMBEDDED_BIN_DIR/inspec
+
 if [[ ! -x $EMBEDDED_BIN_DIR/inspec ]]; then
   echo "$EMBEDDED_BIN_DIR/inspec does not exist!"
   exit 1


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
```
❯ bundle install
Fetching https://github.com/inspec/inspec.git
Fetching https://github.com/inspec/inspec.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using rake 13.2.1
Using concurrent-ruby 1.3.4
Using minitest 5.25.1
Using public_suffix 6.0.1
Using mixlib-cli 2.1.8
Using ast 2.4.2
Using aws-eventstream 1.3.0
Using aws-partitions 1.1001.0
Using jmespath 1.6.2
Using uri 0.13.1
Using bigdecimal 3.1.8
Using debug_inspector 1.2.0
Using builder 3.3.0
Using bundler 2.3.27
Using byebug 11.1.3
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using hashie 4.1.0
Using base64 0.2.0
Using rack 2.2.10
Using tty-color 0.6.0
Using webrick 1.8.2
Using ffi 1.16.3
Using diff-lcs 1.5.1
Using chef-vault 4.1.11
Using tty-cursor 0.7.1
Using erubis 2.7.0
Using iniparse 1.5.0
Using unicode_utils 1.4.0
Using logger 1.5.3
Using tty-screen 0.8.2
Using uuidtools 2.2.0
Using net-ssh 7.3.0
Using ipaddress 0.8.3
Using strings-ansi 0.2.0
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using http-accept 1.7.0
Using domain_name 0.6.20240107
Using mime-types-data 3.2024.1105
Using netrc 0.11.0
Using rexml 3.3.9
Using unicode-display_width 2.6.0
Using plist 3.7.1
Using mixlib-log 3.0.9
Using multi_json 1.15.0
Using rubyzip 2.3.2
Using unf_ext 0.0.8.2
Using parallel 1.26.3
Using libyajl2 2.1.0
Using erubi 1.13.0
Using json 2.7.6
Using httpclient 2.8.3
Using wisper 2.0.1
Using regexp_parser 2.9.2
Using ruby-progressbar 1.13.0
Using method_source 1.1.0
Using coderay 1.1.3
Using mixlib-authentication 3.0.10
Using parslet 1.8.2
Using rspec-support 3.13.1
Using sslshake 1.3.1
Using timeout 0.4.1
Using racc 1.8.1
Using thor 1.2.2
Using ruby-shadow 2.5.1
Using ed25519 1.3.0
Using tzinfo 2.0.6
Using addressable 2.8.7
Using chef-utils 19.0.89 from source at `chef-utils`
Using rainbow 3.1.1
Using little-plugger 1.1.4
Using net-http 0.4.1
Using date 3.4.0
Using binding_of_caller 1.0.1
Using mixlib-config 3.0.27
Using semverse 3.0.2
Using hashdiff 1.1.1
Using tty-spinner 0.9.3
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.14
Using net-sftp 4.0.0
Using net-scp 4.0.0
Using http-cookie 1.0.7
Using mime-types 3.6.0
Using fauxhai-ng 9.3.0
Using strings 0.2.1
Using chef-gyoku 1.4.1
Using stringio 3.1.1
Using mixlib-archive 1.1.7
Using crack 0.4.5
Using nori 2.7.0
Using pry 0.13.0
Using rubyntlm 0.6.5
Using i18n 1.14.6
Using rb-readline 0.5.5
Using rspec-mocks 3.13.2
Using ffi-yajl 2.6.0
Using aws-sigv4 1.10.1
Using gssapi 1.3.1
Using time 0.4.0
Using tty-reader 0.9.0
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using multipart-post 2.4.1
Using psych 5.1.2
Using webmock 3.24.0
Using net-protocol 0.2.2
Using mixlib-shellout 3.3.6
Using activesupport 7.0.8.6
Using pry-byebug 3.10.1
Using chef-zero 15.0.11
Using aws-sdk-core 3.211.0
Using rdoc 6.4.1.1
Using logging 2.4.0
Using chef-config 19.0.89 from source at `chef-config`
Using pastel 0.8.0
Using pry-stack_explorer 0.6.1
Using vault 0.18.2
Using rspec-core 3.13.2
Using rspec-expectations 3.13.3
Using aws-sdk-secretsmanager 1.109.0
Using chef-winrm 2.3.11
Using parser 3.3.6.0
Using tty-box 0.7.0
Using tty-table 0.12.0
Using cheffish 17.1.8
Using aws-sdk-kms 1.95.0
Using faraday-net_http 3.3.0
Using rspec-its 1.3.1
Using rspec 3.13.0
Using rubocop-ast 1.34.0
Using appbundler 0.13.4
Using chef-telemetry 1.1.1
Using chef-winrm-fs 1.3.7

❯ bundle install
Fetching https://github.com/chef/ohai.git
Fetching https://github.com/inspec/inspec.git
Fetching https://github.com/inspec/inspec.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies........
Using rake 13.2.1
Using concurrent-ruby 1.3.5
Using minitest 5.25.4
Using debug_inspector 1.2.0
Using bundler 2.3.18
Using ast 2.4.2
Using aws-partitions 1.1055.0
Using fuzzyurl 0.9.0
Using base64 0.2.0
Using jmespath 1.6.2
Using bcrypt_pbkdf 1.1.1
Using public_suffix 6.0.1
Using tty-cursor 0.7.1
Using builder 3.3.0
Using wisper 2.0.1
Using byebug 11.1.3
Using libyajl2 2.1.0
Using hashie 4.1.0
Using ffi 1.16.3
Using logger 1.5.3
Using rack 2.2.11
Using webrick 1.9.1
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using iniparse 1.5.0
Using strings-ansi 0.2.0
Using unicode-display_width 2.6.0
Using unicode_utils 1.4.0
Using json 2.10.1
Using tty-color 0.6.0
Using timeout 0.4.3
Using date 3.4.1
Using net-ssh 7.3.0
Using ipaddress 0.8.3
Using uuidtools 2.2.0
Using plist 3.7.2
Using bigdecimal 3.1.9
Using mixlib-authentication 3.0.10
Using http-accept 1.7.0
Using mixlib-cli 2.1.8
Using mime-types-data 3.2025.0220
Using netrc 0.11.0
Using rexml 3.4.1
Using erubi 1.13.1
Using mutex_m 0.3.0
Using wmi-lite 1.0.7
Using little-plugger 1.1.4
Using proxifier2 1.1.0
Using rubyzip 2.4.1
Using coderay 1.1.3
Using parallel 1.26.3
Using racc 1.8.1
Using tty-screen 0.8.2
Using regexp_parser 2.10.0
Using multi_json 1.15.0
Using unf_ext 0.0.8.2
Using ruby-progressbar 1.13.0
Using hashdiff 1.1.2
Using highline 2.1.0
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 1.8.2
Using rspec-support 3.13.2
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.2.2
Using chef-utils 19.0.89 from source at `/Users/powell/projects/chef/chef-utils`
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using uri 1.0.3
Using binding_of_caller 1.0.1
Using tty-spinner 0.9.3
Using ffi-yajl 2.6.0
Using mixlib-log 3.2.0
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.14
Using gssapi 1.3.1
Using strings 0.2.1
Using syslog-logger 1.6.8
Using addressable 2.8.7
Using time 0.4.1
Using net-sftp 4.0.0
Using net-scp 4.1.0
Using net-protocol 0.2.2
Using i18n 1.14.7
Using rainbow 3.1.1
Using pastel 0.8.0
Using domain_name 0.6.20240107
Using nori 2.7.0
Using httpclient 2.9.0
Using aws-eventstream 1.3.1
Using tty-reader 0.9.0
Using rubyntlm 0.6.5
Using mime-types 3.6.0
Using rspec-core 3.13.3
Using rspec-expectations 3.13.3
Using crack 0.4.5
Using rspec-mocks 3.13.2
Using net-ssh-gateway 2.0.0
Using logging 2.4.0
Using pry 0.15.2
Using net-ftp 0.3.8
Using tty-box 0.7.0
Using mixlib-config 3.0.27
Using parser 3.3.7.1
Using net-http 0.6.0
Using tty-prompt 0.23.1
Using mixlib-archive 1.1.7
Using chef-gyoku 1.4.1
Using rspec 3.13.0
Using tty-table 0.12.0
Using pry-byebug 3.8.0
Using pry-stack_explorer 0.6.1
Using aws-sigv4 1.11.0
Using rspec-its 1.3.1
Using rubocop-ast 1.38.1
Using tzinfo 2.0.6
Using net-ssh-multi 1.2.1
Using vault 0.18.2
Using http-cookie 1.0.8
Using chef-zero 15.0.11
Using license-acceptance 2.1.13
Using webmock 3.25.0
Using chef-winrm 2.3.11
Using aws-sdk-core 3.219.0
Using cheffish 17.1.8
Using rubocop 1.25.1
Using activesupport 7.0.8.7
Using rest-client 2.1.0
Using mixlib-shellout 3.3.6
Using chef-winrm-fs 1.3.7
Using train-core 3.12.7
Using aws-sdk-kms 1.99.0
Using train-rest 0.5.0
Using cookstyle 7.32.8
Using chef-config 19.0.89 from source at `/Users/powell/projects/chef/chef-config`
Using faraday-net_http 3.4.0
Using chef-winrm-elevated 1.2.5
Using aws-sdk-secretsmanager 1.113.0
Using ohai 19.0.9 from https://github.com/chef/ohai.git (at main@0129eb8)
Using aws-sdk-s3 1.182.0
Using faraday 2.12.2
Using chef-telemetry 1.1.1
Using train-winrm 0.2.17
Using faraday-http-cache 2.5.1
Using faraday-follow_redirects 0.3.0
Using chef-licensing 1.0.4
Using inspec-core 7.0.36 from https://github.com/inspec/inspec.git (at inspec-7@433e500, glob: inspec-core.gemspec)
Using inspec-core-bin 7.0.36 from https://github.com/inspec/inspec.git (at inspec-7@433e500, glob: inspec-bin/inspec-core-bin.gemspec)
Using chef 19.0.89 from source at `..`
Using chef-bin 19.0.89 from source at `../chef-bin` and installing its executables
Using knife 19.0.89 from source at `.` and installing its executables
Bundle complete! 17 Gemfile dependencies, 152 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

```
❯ bundle install
Fetching https://github.com/chef/rest-client
Fetching https://github.com/inspec/inspec.git
Fetching https://github.com/inspec/inspec.git
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Bundle complete! 26 Gemfile dependencies, 156 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
