### PR TITLE
adds environment properties to apt_package, dnf_package and yum_package

### DIFF
--- a/lib/chef/provider/package/deb.rb
+++ b/lib/chef/provider/package/deb.rb
@@ -111,7 +111,7 @@ class Chef
             # Runs command via shell_out with magic environment to disable
             # interactive prompts.
             def run_noninteractive(*command)
-              shell_out!(*command, env: { "DEBIAN_FRONTEND" => "noninteractive" })
+              shell_out!(*command, env: { "DEBIAN_FRONTEND" => "noninteractive" }.merge(new_resource.environment))
             end
 
             private

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -250,7 +250,7 @@ class Chef
         end
 
         def dnf(*args)
-          shell_out!("dnf", *args)
+          shell_out!("dnf", *args, env: new_resource.environment)
         end
 
         def safe_version_array

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -277,7 +277,7 @@ class Chef
         end
 
         def yum(*args)
-          shell_out!(yum_binary, *args)
+          shell_out!(yum_binary, *args, env: new_resource.environment)
         end
 
         def safe_version_array

--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -99,6 +99,11 @@ class Chef
         introduced: "18.3",
         description: "A Boolean flag that indicates whether the package name, which can be a regular expression, must match the entire name of the package (true) or if the regular expression is allowed to match a subset of the name (false).",
         default: false
+
+      property :environment, Hash,
+        introduced: "19.0",
+        description: "A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'} to be set before running the command.",
+        default: {}, desired_state: false
     end
   end
 end

--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -71,6 +71,11 @@ class Chef
         description: "Allow downgrading a package to satisfy requested version requirements.",
         default: true,
         desired_state: false
+
+      property :environment, Hash,
+        introduced: "19.0",
+        description: "A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'} to be set before running the command.",
+        default: {}, desired_state: false
     end
   end
 end

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -156,6 +156,11 @@ class Chef
 
       property :yum_binary, String,
         description: "The path to the yum binary."
+
+      property :environment, Hash,
+        introduced: "19.0",
+        description: "A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'} to be set before running the command.",
+        default: {}, desired_state: false
     end
   end
 end

--- a/spec/functional/resource/apt_package_spec.rb
+++ b/spec/functional/resource/apt_package_spec.rb
@@ -191,6 +191,21 @@ describe Chef::Resource::AptPackage, metadata do
 
       end
 
+      describe "when environment variables are added" do
+        let(:package_resource) do
+          r = base_resource
+          r.environment("FOO" => "BAR")
+          r
+        end
+
+        it "installs the package with environment variables prefixed to the install command" do
+          Chef::Log.level = :debug
+          expect do
+            package_resource.run_action(:install)
+          end.to match(/^FOO=BAR/)
+        end
+      end
+
       describe "when preseeding the install" do
 
         let(:file_cache_path) { Dir.mktmpdir }

--- a/spec/unit/resource/apt_package_spec.rb
+++ b/spec/unit/resource/apt_package_spec.rb
@@ -63,4 +63,9 @@ describe Chef::Resource::AptPackage, "initialize" do
     resource.response_file_variables({ variables: true })
     expect(resource.response_file_variables).to eql({ variables: true })
   end
+
+  it "accepts a hash for environment variables" do
+    resource.environment({ variables: true })
+    expect(resource.environment).to eql({ variables: true })
+  end
 end

--- a/spec/unit/resource/dnf_package_spec.rb
+++ b/spec/unit/resource/dnf_package_spec.rb
@@ -53,6 +53,12 @@ describe Chef::Resource::DnfPackage, "defaults" do
     expect { resource.action :unlock }.not_to raise_error
     expect { resource.action :upgrade }.not_to raise_error
   end
+
+  it "accepts a hash for environment variables" do
+    resource.environment({ variables: true })
+    expect(resource.environment).to eql({ variables: true })
+  end
+
 end
 
 describe Chef::Resource::DnfPackage, "flush_cache" do

--- a/spec/unit/resource/yum_package_spec.rb
+++ b/spec/unit/resource/yum_package_spec.rb
@@ -148,3 +148,12 @@ describe Chef::Resource::YumPackage, "yum_binary" do
     expect(resource.yum_binary).to eql("/usr/bin/yum-something")
   end
 end
+
+describe Chef::Resource::YumPackage, "environment" do
+  let(:resource) { Chef::Resource::YumPackage.new("foo") }
+
+  it "should allow you to specify the environment" do
+    resource.environment({ variables: true })
+    expect(resource.environment).to eql({ variables: true })
+  end
+end


### PR DESCRIPTION
Some packages don't use preseeds but they alter the installation by providing environment variables, percona for example expects a `PERCONA_TELEMETRY_DISABLE=1` to disable the at-install time telemetry.

This commit adds the functionality to add an environment hash that is passed to `shell_out!()`.

A resource with this property could look like something like this:

```ruby
apt_package "percona-xtradb-cluster-server" do
  environemnt({"PERCONA_TELEMETRY_DISABLE" => "1"})
end
```

[percona installation-time telemetry](https://docs.percona.com/percona-server/8.0/telemetry.html#installation-time-telemetry)