### PR TITLE
Pin appbundle-updater gem install to ~> 1.0.36 to avoid hab version

### DIFF
--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -24,7 +24,8 @@ lifecycle:
     - remote: /opt/chef/bin/chef-client -v
     - remote: /opt/chef/bin/ohai -v
     - remote: echo "Installing appbundler and appbundle-updater gems:"
-    - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+    - remote: /opt/chef/embedded/bin/gem install appbundler --no-doc
+    - remote: /opt/chef/embedded/bin/gem install appbundle-updater -v "~> 1.0.36" --no-doc
     # back compat for pre-unified-/usr distros, do not add new OSes
     - remote: sudo ln -s /usr/bin/install /bin/install
       includes:

--- a/kitchen-tests/kitchen.exec.macos.yml
+++ b/kitchen-tests/kitchen.exec.macos.yml
@@ -17,7 +17,8 @@ lifecycle:
     - remote: /opt/chef/bin/chef-client -v
     - remote: /opt/chef/bin/ohai -v
     - remote: echo "Installing appbundler and appbundle-updater gems:"
-    - remote: sudo /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+    - remote: sudo /opt/chef/embedded/bin/gem install appbundler --no-doc
+    - remote: sudo /opt/chef/embedded/bin/gem install appbundle-updater -v "~> 1.0.36" --no-doc
     - remote: echo "Updating Chef using appbundler-updater:"
     - remote: sudo /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['GITHUB_SHA']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>
     - remote: sudo rm -f /opt/chef/embedded/bin/{htmldiff,ldiff}

--- a/kitchen-tests/kitchen.exec.windows.yml
+++ b/kitchen-tests/kitchen.exec.windows.yml
@@ -31,7 +31,8 @@ lifecycle:
     # so that libyajldll.a is present in the intermediate build step. bundler seems to skip
     # libyajl2 build if already present. gem install seems to build anyway.
     - remote: gem uninstall -I libyajl2
-    - remote: gem install appbundler appbundle-updater --no-doc
+    - remote: gem install appbundler --no-doc
+    - remote: gem install appbundle-updater -v "~> 1.0.36" --no-doc
     - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
     - remote: appbundle-updater chef chef <%= ENV['GITHUB_SHA']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>
     - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/kitchen-tests/kitchen.linux.ci.yml
+++ b/kitchen-tests/kitchen.linux.ci.yml
@@ -37,7 +37,8 @@ lifecycle:
     - remote: /opt/chef/bin/chef-client -v
     - remote: /opt/chef/bin/ohai -v
     - remote: echo "Installing appbundler and appbundle-updater gems:"
-    - remote: sudo /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
+    - remote: sudo /opt/chef/embedded/bin/gem install appbundler --no-doc
+    - remote: sudo /opt/chef/embedded/bin/gem install appbundle-updater -v "~> 1.0.36" --no-doc
     - remote: scl enable devtoolset-7 'sudo /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['GITHUB_SHA']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>'
       includes:
         - oraclelinux-7


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
`appbundle-updater` will receive updates in `main` (versions 19.0...) to support hab, but will potentially break chef-18 CI, so pin chef-18 to the `1.0.x` versions.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
