### PR TITLE
Updating the hab package

### DIFF
--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -13,8 +13,8 @@ $pkg_bin_dirs=@(
 )
 $pkg_deps=@(
   "core/cacerts"
-  "core/openssl"
-  "core/libarchive"
+  "core/openssl/3.0.9/20241220111939"
+  "core/libarchive/3.7.4/20241220131127"
   "chef/ruby31-plus-devkit"
   "chef/chef-powershell-shim"
   "core/visual-cpp-redist-2015/14.0.24215/20240108064521"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Corrects https://github.com/chef/chef/pull/14843

Error: MSVC 2015 libraries missing error. 

The fix in the above PR did not ultimately work. The MSVC error occurred because the hab pkg for chef-18 was pulling in an old version of ffi-libarchive that itself was reliant on the older msvc libraries (indirectly through an ancient version of openssl 1.1.1w that it needed). In testing locally, it appeared that the code would solve the problem. However, in customer testing that did not work.

Here we updated the hab libraries and that has made all the difference. There are zero dependencies on that old stinky version of msvc

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
