### PR TITLE
Updating libarchive

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -16,7 +16,7 @@ $pkg_bin_dirs=@(
 $pkg_deps=@(
   "core/cacerts"
   "core/openssl"
-  "core/libarchive"
+  "core/libarchive/3.7.4/20241220131127"
   "chef/ruby31-plus-devkit"
   "chef/chef-powershell-shim"
 )


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

The issue in play is [here](https://progresssoftware.atlassian.net/browse/CHEF-17572). Customers using the chef-client habitat package are reporting failures with chef-powershell.

The version of core/libarchive specified below has a dependency on openssl 1.1.1w. THAT package has a dependency on MSVC 2015 libraries. When you try to run the chef-client you get an error from Chef-PowerShell telling you about a missing file. Here we update to remove the dependency on MSVC

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
