### PR TITLE
Knife supermarket share error when cookbook exists

### DIFF
--- a/knife/lib/chef/knife/supermarket_share.rb
+++ b/knife/lib/chef/knife/supermarket_share.rb
@@ -133,7 +133,7 @@ class Chef
         res = Chef::JSONCompat.from_json(http_resp.body)
         if http_resp.code.to_i != 201
           if res["error_messages"]
-            if /Version already exists/.match?(res["error_messages"][0]) || /Version has already been taken/.match?(res["error_messages"][0])
+            if res["error_messages"][0].match?(/Version (already exists|has already been taken)/)
               ui.error "The same version of this cookbook already exists on Supermarket."
               exit(1)
             else

--- a/knife/lib/chef/knife/supermarket_share.rb
+++ b/knife/lib/chef/knife/supermarket_share.rb
@@ -95,11 +95,12 @@ class Chef
             do_upload("#{tmp_cookbook_dir}/#{cookbook_name}.tgz", category, Chef::Config[:node_name], Chef::Config[:client_key])
             ui.info("Upload complete")
             Chef::Log.trace("Removing local staging directory at #{tmp_cookbook_dir}")
-            FileUtils.rm_rf tmp_cookbook_dir
           rescue => e
             ui.error("Error uploading cookbook #{cookbook_name} to Supermarket: #{e.message}. Increase log verbosity (-VV) for more information.")
             Chef::Log.trace("\n#{e.backtrace.join("\n")}")
             exit(1)
+          ensure
+            FileUtils.rm_rf tmp_cookbook_dir
           end
 
         else
@@ -132,7 +133,7 @@ class Chef
         res = Chef::JSONCompat.from_json(http_resp.body)
         if http_resp.code.to_i != 201
           if res["error_messages"]
-            if /Version already exists/.match?(res["error_messages"][0])
+            if /Version already exists/.match?(res["error_messages"][0]) || /Version has already been taken/.match?(res["error_messages"][0])
               ui.error "The same version of this cookbook already exists on Supermarket."
               exit(1)
             else


### PR DESCRIPTION
in case of same cookbook version exists in private supermarket in getting failed to delete tmp dir fixed the exit case and now no exception is raised in case same cookbook shared twice

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
