### PR TITLE
[Backport 18] Reverse the default for only_record_changes 

### DIFF
--- a/lib/chef/provider/registry_key.rb
+++ b/lib/chef/provider/registry_key.rb
@@ -52,8 +52,6 @@ class Chef
         if registry.key_exists?(new_resource.key)
           current_registry_values = registry.get_values(new_resource.key) || []
           if new_resource.only_record_changes
-            p current_registry_values
-            p new_resource.values
             current_registry_values.select! { |v| new_resource.values.any? { |nv| nv[:name] == v[:name] } }
           end
           current_resource.values(current_registry_values)

--- a/lib/chef/provider/registry_key.rb
+++ b/lib/chef/provider/registry_key.rb
@@ -51,6 +51,7 @@ class Chef
         current_resource.recursive(new_resource.recursive)
         if registry.key_exists?(new_resource.key)
           current_registry_values = registry.get_values(new_resource.key) || []
+
           if new_resource.only_record_changes
             current_registry_values.select! { |v| new_resource.values.any? { |nv| nv[:name] == v[:name] } }
           end

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -165,9 +165,9 @@ class Chef
       property :recursive, [TrueClass, FalseClass], default: false
       property :architecture, Symbol, default: :machine, equal_to: %i{machine x86_64 i386}
       property :only_record_changes, [TrueClass, FalseClass],
-               default: false,
+               default: true,
                introduced: "19.0",
-               description: "Suppress reporting of the current value of sibling values in a registry key."
+               description: "Suppress reporting of the current value of sibling values in a registry key. Setting this to false may result in a large number of values reported."
 
       # Some registry key data types may not be safely reported as json.
       # Example (CHEF-5323):

--- a/spec/functional/resource/registry_spec.rb
+++ b/spec/functional/resource/registry_spec.rb
@@ -295,9 +295,8 @@ describe Chef::Resource::RegistryKey do
           end
         end
 
-        context "when only_record_changes is true" do
+        context "when only_record_changes is the default (true)" do
           before do
-            new_resource.only_record_changes(true)
             prepopulate(registry_key, prepopulated_values)
           end
           let(:registry_key) { "#{reg_child}\\OnlyRecordChanges" }
@@ -319,8 +318,9 @@ describe Chef::Resource::RegistryKey do
           end
         end
 
-        context "when only_record_changes is the default(false)" do
+        context "when only_record_changes is false" do
           before do
+            new_resource.only_record_changes(false)
             prepopulate(registry_key, prepopulated_values)
           end
           let(:registry_key) { "#{reg_child}\\RecordItAll" }

--- a/spec/unit/provider/registry_key_spec.rb
+++ b/spec/unit/provider/registry_key_spec.rb
@@ -26,7 +26,8 @@ shared_examples_for "a registry key" do
     describe "when the key exists" do
       before(:each) do
         expect(@double_registry).to receive(:key_exists?).with(keyname).and_return(true)
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval2 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval2] )
+        @new_resource.only_record_changes false
         @provider.load_current_resource
       end
 
@@ -66,7 +67,7 @@ shared_examples_for "a registry key" do
       end
       it "should do nothing if the if a case insensitive key and the value both exist" do
         @provider.new_resource.key(keyname.downcase)
-        expect(@double_registry).to receive(:get_values).with(keyname.downcase).and_return( testval1 )
+        expect(@double_registry).to receive(:get_values).with(keyname.downcase).and_return( [testval1 ])
         expect(@double_registry).not_to receive(:set_value)
         @provider.load_current_resource
         @provider.action_create
@@ -77,25 +78,25 @@ shared_examples_for "a registry key" do
         expect(@double_registry).to receive(:key_exists?).twice.with(keyname).and_return(true)
       end
       it "should do nothing if the key and the value both exist" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1] )
         expect(@double_registry).not_to receive(:set_value)
         @provider.load_current_resource
         @provider.action_create
       end
       it "should create the value if the key exists but the value does not" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval2 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval2] )
         expect(@double_registry).to receive(:set_value).with(keyname, testval1)
         @provider.load_current_resource
         @provider.action_create
       end
       it "should set the value if the key exists but the data does not match" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1_wrong_data )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1_wrong_data] )
         expect(@double_registry).to receive(:set_value).with(keyname, testval1)
         @provider.load_current_resource
         @provider.action_create
       end
       it "should set the value if the key exists but the type does not match" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1_wrong_type )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1_wrong_type] )
         expect(@double_registry).to receive(:set_value).with(keyname, testval1)
         @provider.load_current_resource
         @provider.action_create
@@ -105,7 +106,7 @@ shared_examples_for "a registry key" do
       it "when a value is in the key, it should do nothing" do
         @provider.new_resource.values([])
         expect(@double_registry).to receive(:key_exists?).twice.with(keyname).and_return(true)
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1] )
         expect(@double_registry).not_to receive(:create_key)
         expect(@double_registry).not_to receive(:set_value)
         @provider.load_current_resource
@@ -150,25 +151,25 @@ shared_examples_for "a registry key" do
         expect(@double_registry).to receive(:key_exists?).twice.with(keyname).and_return(true)
       end
       it "should do nothing if the key and the value both exist" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1] )
         expect(@double_registry).not_to receive(:set_value)
         @provider.load_current_resource
         @provider.action_create_if_missing
       end
       it "should create the value if the key exists but the value does not" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval2 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval2] )
         expect(@double_registry).to receive(:set_value).with(keyname, testval1)
         @provider.load_current_resource
         @provider.action_create_if_missing
       end
       it "should not set the value if the key exists but the data does not match" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1_wrong_data )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1_wrong_data] )
         expect(@double_registry).not_to receive(:set_value)
         @provider.load_current_resource
         @provider.action_create_if_missing
       end
       it "should not set the value if the key exists but the type does not match" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1_wrong_type )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1_wrong_type] )
         expect(@double_registry).not_to receive(:set_value)
         @provider.load_current_resource
         @provider.action_create_if_missing
@@ -193,25 +194,25 @@ shared_examples_for "a registry key" do
         expect(@double_registry).to receive(:key_exists?).twice.with(keyname).and_return(true)
       end
       it "deletes the value when the value exists" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1] )
         expect(@double_registry).to receive(:delete_value).with(keyname, testval1)
         @provider.load_current_resource
         @provider.action_delete
       end
       it "deletes the value when the value exists, but the type is wrong" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1_wrong_type )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1_wrong_type] )
         expect(@double_registry).to receive(:delete_value).with(keyname, testval1)
         @provider.load_current_resource
         @provider.action_delete
       end
       it "deletes the value when the value exists, but the data is wrong" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1_wrong_data )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1_wrong_data] )
         expect(@double_registry).to receive(:delete_value).with(keyname, testval1)
         @provider.load_current_resource
         @provider.action_delete
       end
       it "does not delete the value when the value does not exist" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval2 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval2] )
         expect(@double_registry).not_to receive(:delete_value)
         @provider.load_current_resource
         @provider.action_delete
@@ -235,7 +236,7 @@ shared_examples_for "a registry key" do
         expect(@double_registry).to receive(:key_exists?).twice.with(keyname).and_return(true)
       end
       it "deletes the key" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( testval1 )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval1] )
         expect(@double_registry).to receive(:delete_key).with(keyname, false)
         @provider.load_current_resource
         @provider.action_delete_key
@@ -303,7 +304,7 @@ describe Chef::Provider::RegistryKey do
       end
 
       it "does not make a change for datatype of data value differing" do
-        expect(@double_registry).to receive(:get_values).with(keyname).and_return( dword_passed_as_integer )
+        expect(@double_registry).to receive(:get_values).with(keyname).and_return( [dword_passed_as_integer] )
         expect(@double_registry).not_to receive(:set_value)
         @provider.load_current_resource
         @provider.action_create


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Per discussions with the customer who opened the ticket and reasoning about the nature of registry keys and values, it was determined that the more surprising and error prone behavior was to report all values within a key, regardless of change. Switching the default due to this.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
