### PR TITLE
Chef::Util::Powershell::PSCredential leaks plaintext on .inspect

### DIFF
--- a/lib/chef/util/powershell/ps_credential.rb
+++ b/lib/chef/util/powershell/ps_credential.rb
@@ -31,8 +31,18 @@ class Chef
           "New-Object System.Management.Automation.PSCredential('#{@username}',('#{encrypt(@password)}' | ConvertTo-SecureString))"
         end
 
+        def to_plaintext
+          "#<Chef::Util::Powershell::PSCredential:#{object_id} @username=#{@username.inspect}>"
+        end
+
+        # These leak an encrypted password, however we can't rely on no-one using
+        # these assuming that behavior.
         alias to_s to_psobject
         alias to_text to_psobject
+
+        # Inspect has no business leaking anything but the username, and to be honest
+        # even that one could be dicey
+        alias inspect to_plaintext
 
         private
 

--- a/spec/unit/util/powershell/ps_credential_spec.rb
+++ b/spec/unit/util/powershell/ps_credential_spec.rb
@@ -35,6 +35,12 @@ describe Chef::Util::Powershell::PSCredential do
       end
     end
 
+    context "when inspect is called" do
+      it "should not contain the password" do
+        expect(ps_credential.inspect).not_to match(/#{password}/)
+      end
+    end
+
     context "when to_text is called" do
       it "should not contain the password" do
         allow(ps_credential).to receive(:encrypt).with(password).and_return("encrypted")


### PR DESCRIPTION
The default ruby implementation of inspect outputs the @'d variables in plaintext, which is unfortunate becuase sometimes, this is the credential.  This aliases inspect to to_psobject, which is already an escaped implementation.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
