### PR TITLE
temporary removal of macos 11 support from the AdHoc

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -56,8 +56,8 @@ builder-to-testers-map:
   mac_os_x-11-x86_64:
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  # mac_os_x-11-arm64:
+  #   - mac_os_x-11-arm64
   #   - mac_os_x-12-arm64     canary org doesn't yet have a macos 12 arm64 omnibus worker
   rocky-8-x86_64:
     - rocky-8-x86_64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Macos 11 support is EOL. We are in the midst of adding macos 12 support. However, the arm builders are broken and we need to get a full AdHoc build/test cycle. Here we temporarily remove support for Macos11 in the AdHoc pipeline to get testing coverage exposed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
