### PR TITLE
[Chef-18] Updating for Mixlib-Log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ install_if -> { RUBY_PLATFORM !~ /darwin/ } do
   gem "openssl", "= 3.2.0"
 end
 
+install_if -> { RUBY_VERSION < "3.1" } do
+  gem "mixlib-log", ">= 2.0.3", "<= 3.1.1"
+end
+
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout
   gem "chef-bin", path: File.expand_path("chef-bin", __dir__)
@@ -44,7 +48,7 @@ end
 
 # Everything except AIX and Windows
 group(:ruby_shadow) do
-  install_if -> { RUBY_PLATFORM != "x64-mingw-ucrt" } do
+  install_if -> { RUBY_PLATFORM.match?(/mingw/) } do
     # if ruby-shadow does a release that supports ruby-3.0 this can be removed
     gem "ruby-shadow", git: "https://github.com/chef/ruby-shadow", branch: "lcg/ruby-3.0", platforms: :ruby
   end

--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,6 @@ install_if -> { RUBY_PLATFORM !~ /darwin/ } do
   gem "openssl", "= 3.2.0"
 end
 
-install_if -> { RUBY_VERSION < "3.1" } do
-  gem "mixlib-log", ">= 2.0.3", "<= 3.1.1"
-end
-
 if File.exist?(File.expand_path("chef-bin", __dir__))
   # bundling in a git checkout
   gem "chef-bin", path: File.expand_path("chef-bin", __dir__)
@@ -48,7 +44,7 @@ end
 
 # Everything except AIX and Windows
 group(:ruby_shadow) do
-  install_if -> { RUBY_PLATFORM.match?(/mingw/) } do
+  install_if -> { !RUBY_PLATFORM.match?(/mingw/) } do
     # if ruby-shadow does a release that supports ruby-3.0 this can be removed
     gem "ruby-shadow", git: "https://github.com/chef/ruby-shadow", branch: "lcg/ruby-3.0", platforms: :ruby
   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,6 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -100,7 +99,6 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -333,8 +331,8 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.2.0)
-      ffi (~> 1.9, <= 1.17.0)
+    mixlib-log (3.1.1)
+      ffi (< 1.17.0)
     mixlib-shellout (3.3.6)
       chef-utils
     mixlib-shellout (3.3.6-x64-mingw-ucrt)
@@ -525,6 +523,7 @@ DEPENDENCIES
   fauxhai-ng
   ffi (>= 1.15.5, <= 1.17.0)
   inspec-core-bin (>= 5, < 6)
+  mixlib-log (>= 2.0.3, <= 3.1.1)
   ohai!
   openssl (= 3.2.0)
   pry (= 0.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
+      mixlib-log (>= 2.0.3, <= 3.1.1)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -99,6 +100,7 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
+      mixlib-log (>= 2.0.3, <= 3.1.1)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -523,7 +525,6 @@ DEPENDENCIES
   fauxhai-ng
   ffi (>= 1.15.5, <= 1.17.0)
   inspec-core-bin (>= 5, < 6)
-  mixlib-log (>= 2.0.3, <= 3.1.1)
   ohai!
   openssl (= 3.2.0)
   pry (= 0.13.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
-  s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"
   s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
   s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
+  s.add_dependency "mixlib-log", ">= 2.0.3", "<= 3.1.1"
   s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
   s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The current build config loads mixlib-log-3.2.0. This version is incompatible with Ruby 3.0 which we're using on AIX only. This update locks 3.1.1 for all platforms

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
