### PR TITLE
fix visual c++ depdendency issue for windows habitat package

### DIFF
--- a/habitat/x86_64-windows/hooks/run
+++ b/habitat/x86_64-windows/hooks/run
@@ -1,5 +1,0 @@
-$path = "C:\hab\studios\*\hab\pkgs\core\visual-cpp-redist-2015\*\*\bin"
-$file1 = "msvcp140.dll"
-
-$files = Get-ChildItem -Path $path -Include $file1 -Recurse -ErrorAction SilentlyContinue
-$env:Path = $files.DirectoryName + ";" + $env:Path

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -43,7 +43,7 @@ function Invoke-SetupEnvironment {
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
 
-    Set-RuntimeEnv -f -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath openssl)/bin;$env:RUBY_DLL_PATH"
+    Set-RuntimeEnv -f -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath openssl)/bin;$(Get-HabPackagePath visual-cpp-redist-2015)/bin;$env:RUBY_DLL_PATH"
 }
 
 function Invoke-Download() {


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The habitat package for windows was failing to run chef-client because of some missing dlls for chef powershell shim module. adding the package path to RUBY_DLL_PATH seems to fix this issue. this commit also removes the run hook for windows plan that was added previously to fix this issue in https://github.com/chef/chef/pull/14843 since that is not needed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-18541

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
