### PR TITLE
updating rack and chef-zero in main

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,11 +218,13 @@ GEM
       erubi (>= 1.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 2.0)
-    chef-zero (15.0.11)
+    chef-zero (15.0.17)
+      activesupport (~> 7.0, < 7.1)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 5.0)
       mixlib-log (>= 2.0, < 4.0)
-      rack (~> 2.0, >= 2.0.6)
+      rack (~> 3.1, >= 3.1.10)
+      rackup (~> 2.2, >= 2.2.1)
       uuidtools (~> 2.1)
       webrick
     cheffish (17.1.8)
@@ -381,7 +383,9 @@ GEM
       pry (~> 0.13)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (3.1.12)
+    rackup (2.2.1)
+      rack (>= 3)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-readline (0.5.5)
@@ -540,4 +544,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.27
+   2.6.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       chef-licensing (>= 0.7.5)
       chef-utils (= 19.1.3)
       chef-vault
-      chef-zero (>= 14.0.11)
+      chef-zero (>= 15.0.17)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
@@ -81,7 +81,7 @@ PATH
       chef-powershell (~> 18.1.0)
       chef-utils (= 19.1.3)
       chef-vault
-      chef-zero (>= 14.0.11)
+      chef-zero (>= 15.0.17)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -544,4 +544,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.6.5
+   2.3.27

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7" # template resource / cookbook syntax check
   s.add_dependency "diff-lcs", ">= 1.2.4", "!= 1.4.0", "< 1.6.0" # 1.4 breaks output. Used in lib/chef/util/diff
   s.add_dependency "ffi-libarchive", "~> 1.0", ">= 1.0.3" # archive_file resource
-  s.add_dependency "chef-zero", ">= 14.0.11"
+  s.add_dependency "chef-zero", ">= 15.0.17"
   s.add_dependency "chef-vault" # chef-vault resources and helpers
 
   s.add_dependency "plist", "~> 3.2" # launchd, dscl/mac user, macos_userdefaults, osx_profile and plist resources

--- a/knife/spec/tiny_server.rb
+++ b/knife/spec/tiny_server.rb
@@ -19,6 +19,7 @@
 require "webrick"
 require "webrick/https"
 require "rack"
+require "rackup"
 require "singleton"
 require "open-uri"
 require "chef/config"
@@ -91,7 +92,7 @@ module TinyServer
 
     def create_server(**extra_options)
       server = WEBrick::HTTPServer.new(**options, **extra_options)
-      server.mount("/", Rack::Handler::WEBrick, API.instance)
+      server.mount("/", Rackup::Handler::WEBrick, API.instance)
       server
     end
   end
@@ -172,7 +173,9 @@ module TinyServer
 
     def initialize(response_code = 200, data = nil, headers = nil, &block)
       @response_code, @data = response_code, data
-      @response_headers = headers ? HEADERS.merge(headers) : HEADERS
+      # .merge creates a new hash, headers is sometimes passed as nil, @response_headers gets mutated somewhere
+      # in processing
+      @response_headers = HEADERS.merge(headers || {})
       @block = block_given? ? block : nil
     end
 

--- a/spec/tiny_server.rb
+++ b/spec/tiny_server.rb
@@ -19,6 +19,7 @@
 require "webrick"
 require "webrick/https"
 require "rack"
+require "rackup"
 require "singleton"
 require "open-uri"
 require "chef/config"
@@ -91,7 +92,7 @@ module TinyServer
 
     def create_server(**extra_options)
       server = WEBrick::HTTPServer.new(**options, **extra_options)
-      server.mount("/", Rack::Handler::WEBrick, API.instance)
+      server.mount("/", Rackup::Handler::WEBrick, API.instance)
       server
     end
   end
@@ -172,7 +173,9 @@ module TinyServer
 
     def initialize(response_code = 200, data = nil, headers = nil, &block)
       @response_code, @data = response_code, data
-      @response_headers = headers ? HEADERS.merge(headers) : HEADERS
+      # .merge creates a new hash, headers is sometimes passed as nil, @response_headers gets mutated somewhere
+      # in processing
+      @response_headers = HEADERS.merge(headers || {})
       @block = block_given? ? block : nil
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
pulling an update forward from chef-18 to update cherf-zero and rack

$ bundle update --conservative rack
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Resolving dependencies...
Using rack 3.1.12 (was 2.2.10)
Using chef-zero 15.0.17 (was 15.0.11)
Fetching inspec-core 7.0.38.beta
Installing inspec-core 7.0.38.beta
Fetching inspec-core-bin 7.0.38.beta
Installing inspec-core-bin 7.0.38.beta
Bundle updated!

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
