### PR TITLE
fix RUBY_DLL_PATH setting in hab plan

### DIFF
--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -43,7 +43,8 @@ function Invoke-SetupEnvironment {
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
 
-    Set-RuntimeEnv -f -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath openssl)/bin;$(Get-HabPackagePath visual-cpp-redist-2015)/bin;$env:RUBY_DLL_PATH"
+    Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath openssl)/bin"
+    Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath visual-cpp-redist-2015)/bin"
 }
 
 function Invoke-Download() {


### PR DESCRIPTION
When adding an environment with multiple paths, the correct syntax is to push each path via `Push-RuntimeEnv` rather than setting the entire semi-colon delimited value with `Set-RuntimeEnv`. This will work fine when using the package directly ala `hab pkg exec chef/chef-infra-client` but it will break a build when using this package as a dependency. The build program does some path parsing magic when reassembling the paths for a parent package which breaks with a multivalued variable.

NOTE: this does make me think that we should have some logic in habitat that would fail a build if it sees you are trying to set multiple paths with `Set-RuntimeEnv`.