### PR TITLE
[Port] Updating Hab paths for openssl

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1109,6 +1109,7 @@
     "REDIR",
     "redirections",
     "REDIRECTOR",
+    "redist",
     "redownloading",
     "Reenable",
     "reenable",

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -44,7 +44,8 @@ function Invoke-SetupEnvironment {
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
 
-    Set-RuntimeEnv -f -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath openssl)/bin;$env:RUBY_DLL_PATH"
+    Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath openssl)/bin"
+    Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath visual-cpp-redist-2015)/bin"
 }
 
 function Invoke-Download() {

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -19,6 +19,7 @@ $pkg_deps=@(
   "core/libarchive"
   "chef/ruby31-plus-devkit"
   "chef/chef-powershell-shim"
+  "core/visual-cpp-redist-2015"
 )
 $pkg_build_deps=@( "core/git")
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Under certain scenarios, running the chef-client as part of a hab package (hab pkg exec chef...)  results in the chef-client throwing a Powershell.dll missing error. This error is erroneous. The real culprit is missing MSVC2015 libraries. The existing command of Set-RuntimeEnv had the effect in comes cases of truncating the runtime path resulting in the error. Here we explicitly PUSH the updated path on to the RUBY_DLL_PATH.

Forward ported from #14914 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
