### PR TITLE
Trigger keyring code in kitchen-tests and fix accidental inclusion of TargetIO code

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
@@ -26,6 +26,6 @@ end
 apt_repository "test" do
   uri "http://ftp.be.debian.org/debian/"
   distribution "bookworm"
-  components %w[main contrib non-free]
+  components %w{main contrib non-free}
   key "https://ftp-master.debian.org/keys/archive-key-12.asc"
 end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
@@ -22,3 +22,10 @@ end
 apt_preference "libmysqlclient16" do
   action :remove
 end
+
+apt_repository "test" do
+  uri "http://ftp.be.debian.org/debian/"
+  distribution "bookworm"
+  components ["main", "contrib", "non-free"]
+  key "https://ftp-master.debian.org/keys/archive-key-12.asc"
+end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
@@ -26,6 +26,6 @@ end
 apt_repository "test" do
   uri "http://ftp.be.debian.org/debian/"
   distribution "bookworm"
-  components ["main", "contrib", "non-free"]
+  components %w[main contrib non-free]
   key "https://ftp-master.debian.org/keys/archive-key-12.asc"
 end

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -308,8 +308,8 @@ class Chef
         def install_key_from_uri(key)
           key_name = key.gsub(/[^0-9A-Za-z\-]/, "_")
           keyfile_path = ::File.join(Chef::Config[:file_cache_path], key_name)
-          tmp_dir = TargetIO::Dir.mktmpdir(".gpg")
-          at_exit { TargetIO::FileUtils.remove_entry(tmp_dir) }
+          tmp_dir = Dir.mktmpdir(".gpg")
+          at_exit { FileUtils.remove_entry(tmp_dir) }
 
           if new_resource.signed_by
             keyfile_path = keyring_path


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
[The backport](https://github.com/chef/chef/commit/218772abb7f55099e4dea0dc8373e783a7c32702) of https://github.com/chef/chef/pull/14131 erroneously kept the namespace of `TargetIO` on the new code, which only exists in Chef 19 and beyond. This tests and then fixes that inclusion.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
