### PR TITLE
fix: ensure apt_repository keys are always dearmored

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -256,6 +256,8 @@
     "DBCS",
     "dctoken",
     "DDTHH",
+    "dearmor",
+    "dearmored",
     "Decompressor",
     "decompressor",
     "Decryptor",


### PR DESCRIPTION
## Description
Always make sure that keys installed with `signed_by true` are dearmored.
This is required for `apt` to see the keys inside `.gpg` files.

## Related Issue
I fixes a regression #14942 introduced in #14131

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
