### PR TITLE
Back out only_record_changes property

### DIFF
--- a/lib/chef/provider/registry_key.rb
+++ b/lib/chef/provider/registry_key.rb
@@ -52,9 +52,6 @@ class Chef
         if registry.key_exists?(new_resource.key)
           current_registry_values = registry.get_values(new_resource.key) || []
 
-          if new_resource.only_record_changes
-            current_registry_values.select! { |v| new_resource.values.any? { |nv| nv[:name] == v[:name] } }
-          end
           current_resource.values(current_registry_values)
         end
         values_to_hash(current_resource.unscrubbed_values)

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -41,19 +41,6 @@ class Chef
       end
       ```
 
-      ```ruby
-      **Suppress reporting the sibling values of the values being updated in a registry key**
-      registry 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\CONTROL\Session Manager' do
-        values [{
-          name: 'ProtectionMode',
-          type: :dword,
-          data: 1
-        }]
-        only_record_changes true
-        action :create
-      end
-      ```
-
       **Create a registry key with binary data: "\x01\x02\x03"**:
 
       ```ruby
@@ -164,10 +151,6 @@ class Chef
       }
       property :recursive, [TrueClass, FalseClass], default: false
       property :architecture, Symbol, default: :machine, equal_to: %i{machine x86_64 i386}
-      property :only_record_changes, [TrueClass, FalseClass],
-               default: true,
-               introduced: "19.0",
-               description: "Suppress reporting of the current value of sibling values in a registry key. Setting this to false may result in a large number of values reported."
 
       # Some registry key data types may not be safely reported as json.
       # Example (CHEF-5323):

--- a/spec/functional/resource/registry_spec.rb
+++ b/spec/functional/resource/registry_spec.rb
@@ -294,49 +294,6 @@ describe Chef::Resource::RegistryKey do
             expect(registry.value_exists?(registry_key, value)).to be true
           end
         end
-
-        context "when only_record_changes is the default (true)" do
-          before do
-            prepopulate(registry_key, prepopulated_values)
-          end
-          let(:registry_key) { "#{reg_child}\\OnlyRecordChanges" }
-          let(:registry_key_values) { [{ name: "ReportingVal1", type: :string, data: rand(1235..10000) }] }
-
-          it "should only report the changed value" do
-            subject
-            report = resource_reporter.prepare_run_data
-
-            expect(report["action"]).to eq("end")
-            expect(report["resources"][0]["type"]).to eq(:registry_key)
-            expect(report["resources"][0]["name"]).to eq(resource_name)
-            expect(report["resources"][0]["id"]).to eq(registry_key)
-            expect(report["resources"][0]["after"][:values]).to eq(registry_key_values)
-            expect(report["resources"][0]["before"][:values]).to eq(prepopulated_values.select { |ppv| ppv[:name] == "ReportingVal1" })
-            expect(report["resources"][0]["result"]).to eq("create")
-            expect(report["status"]).to eq("success")
-            expect(report["total_res_count"]).to eq("1")
-          end
-        end
-
-        context "when only_record_changes is false" do
-          before do
-            new_resource.only_record_changes(false)
-            prepopulate(registry_key, prepopulated_values)
-          end
-          let(:registry_key) { "#{reg_child}\\RecordItAll" }
-          let(:registry_key_values) { [{ name: "ReportingVal1", type: :string, data: rand(1235..10000) }] }
-
-          it "should only report the changed value" do
-            subject
-            report = resource_reporter.prepare_run_data
-
-            expect(report["resources"][0]["after"][:values]).to eq(registry_key_values)
-            expect(report["resources"][0]["before"][:values]).to eq(prepopulated_values)
-            expect(report["status"]).to eq("success")
-            expect(report["total_res_count"]).to eq("1")
-          end
-
-        end
       end
     end
   end

--- a/spec/unit/provider/registry_key_spec.rb
+++ b/spec/unit/provider/registry_key_spec.rb
@@ -27,7 +27,6 @@ shared_examples_for "a registry key" do
       before(:each) do
         expect(@double_registry).to receive(:key_exists?).with(keyname).and_return(true)
         expect(@double_registry).to receive(:get_values).with(keyname).and_return( [testval2] )
-        @new_resource.only_record_changes false
         @provider.load_current_resource
       end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
There are situations in which the `only_record_changes` option breaks idempotency, but it can't be reliably reproduced. Backing this out to take a different tactic with limiting the output.

[Original PR in main](https://github.com/chef/chef/pull/14767)
[Reversing the default to `true`](https://github.com/chef/chef/pull/14881)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
