### PR TITLE
[Chef-18] logger regression fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source "https://rubygems.org"
 
 gem "chef", path: "."
 
-# Mixlib-log 3.1.1 has a regression fixed in 3.1.2. 3.1.2 was not released to rubygems.org so loading it from GitHub repo.
-# 3.2.0 was released to rubygems but has issues with ruby 3.0 and aix according to this Pr https://github.com/chef/chef/pull/14905
-gem "mixlib-log", git: "https://github.com/chef/mixlib-log.git", tag: "v3.1.2"
-
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "18-stable"
 
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source "https://rubygems.org"
 
 gem "chef", path: "."
 
+# Mixlib-log 3.1.1 has a regression fixed in 3.1.2. 3.1.2 was not released to rubygems.org so loading it from GitHub repo.
+# 3.2.0 was released to rubygems but has issues with ruby 3.0 and aix according to this Pr https://github.com/chef/chef/pull/14905
+gem "mixlib-log", git: "https://github.com/chef/mixlib-log.git", tag: "v3.1.2"
+
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "18-stable"
 
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, <= 3.1.1)
+      mixlib-log (>= 2.0.3, <= 3.1.2)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -100,7 +100,7 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, <= 3.1.1)
+      mixlib-log (>= 2.0.3, <= 3.1.2)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -333,7 +333,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.1.1)
+    mixlib-log (3.1.2)
       ffi (< 1.17.0)
     mixlib-shellout (3.3.6)
       chef-utils

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, <= 3.1.1)
+      mixlib-log (>= 2.0.3, < 3.2)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -100,7 +100,7 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, <= 3.1.1)
+      mixlib-log (>= 2.0.3, < 3.2)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -333,7 +333,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.1.1)
+    mixlib-log (3.1.2.1)
       ffi (< 1.17.0)
     mixlib-shellout (3.3.6)
       chef-utils

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, <= 3.1.2)
+      mixlib-log (>= 2.0.3, <= 3.1.1)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -100,7 +100,7 @@ PATH
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
-      mixlib-log (>= 2.0.3, <= 3.1.2)
+      mixlib-log (>= 2.0.3, <= 3.1.1)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-ftp
       net-sftp (>= 2.1.2, < 5.0)
@@ -333,7 +333,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.1.2)
+    mixlib-log (3.1.1)
       ffi (< 1.17.0)
     mixlib-shellout (3.3.6)
       chef-utils

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
-  s.add_dependency "mixlib-log", ">= 2.0.3", "<= 3.1.2"
+  s.add_dependency "mixlib-log", ">= 2.0.3", "< 3.2"
   s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
   s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
-  s.add_dependency "mixlib-log", ">= 2.0.3", "<= 3.1.1"
+  s.add_dependency "mixlib-log", ">= 2.0.3", "<= 3.1.2"
   s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
   s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

mixlib-log 3.1.1 has a regression that was fixed in 3.1.2. 3.2.0 according to this PR https://github.com/chef/chef/pull/14905 it has issues with ruby 3.0 and aix. So bumping dep to < 3.2.0.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

❯ sudo bundle update mixlib-log --conservative
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using rake 13.2.1
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      stringio (>= 0)
      Available/installed versions of this gem:
      - 3.1.2
      - 3.0.1.2
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
Using concurrent-ruby 1.3.5
Using minitest 5.25.5
Using public_suffix 6.0.1
Using mixlib-cli 2.1.8
Using ast 2.4.2
Using aws-eventstream 1.3.0
Using aws-partitions 1.1048.0
Using base64 0.2.0
Using jmespath 1.6.2
Using builder 3.3.0
Using bundler 2.3.7
Using byebug 11.1.3
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using libyajl2 2.1.0
Using hashie 4.1.0
Using rack 3.1.12
Using uuidtools 2.2.0
Using webrick 1.9.1
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using iniparse 1.5.0
Using parallel 1.26.3
Using racc 1.8.1
Using rainbow 3.1.1
Using regexp_parser 2.10.0
Using ruby-progressbar 1.13.0
Using json 2.10.0
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using tty-screen 0.8.2
Using wisper 2.0.1
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 2.0.0
Using coderay 1.1.3
Using rspec-support 3.12.2
Using rubyzip 2.4.1
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.2.2
Using net-ssh 7.3.0
Using mixlib-authentication 3.0.10
Using timeout 0.4.3
Using date 3.4.1
Using plist 3.7.2
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using domain_name 0.6.20240107
Using mime-types-data 3.2025.0204
Using netrc 0.11.0
Using ed25519 1.3.0
Using hashdiff 1.1.1
Using rb-readline 0.5.5
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using debug_inspector 1.2.0
Using fuzzyurl 0.9.0
Using tzinfo 2.0.6
Using addressable 2.8.7
Using chef-utils 18.7.4 from source at `chef-utils`
Using i18n 1.14.7
Using aws-sigv4 1.11.0
Using mixlib-config 3.0.27
Using ffi-yajl 2.6.0
Using rackup 2.2.1
Using parser 3.3.7.1
Using pastel 0.8.0
Using tty-reader 0.9.0
Using pry 0.13.0
Using rspec-core 3.12.3
Using rspec-expectations 3.12.4
Using rspec-mocks 3.12.7
Using net-scp 4.1.0
Using net-protocol 0.2.2
Using time 0.4.1
Using net-sftp 4.0.0
Using rubyntlm 0.6.5
Using fauxhai-ng 9.3.0
Using http-cookie 1.0.8
Using binding_of_caller 1.0.1
Using rexml 3.4.0
Using unicode-display_width 2.6.0
Using tty-prompt 0.23.1
Using rspec 3.12.0
Using uri 1.0.2
Using http-accept 1.7.0
Using multi_json 1.15.0
Using unf_ext 0.0.8.2
Using chef-gyoku 1.4.1
Using crack 0.4.5
Using pry-byebug 3.10.1
Using pry-stack_explorer 0.6.1
Using strings 0.2.1
Using net-http 0.6.0
Using erubi 1.13.1
Using little-plugger 1.1.4
Using httpclient 2.8.3
Using logger 1.5.3
Using logging 2.4.0
Using mime-types 3.6.0
Using net-ftp 0.3.8
Using ipaddress 0.8.3
Using mixlib-shellout 3.3.6
Using bigdecimal 3.1.9
Using tty-box 0.7.0
Using chef-config 18.7.4 from source at `chef-config`
Using nori 2.7.0
Using aws-sdk-core 3.218.1
Using rspec-its 1.3.1
Using chef-telemetry 1.1.1
Using license-acceptance 2.1.13
Using tty-table 0.12.0
Using webmock 3.25.0
Using rubocop-ast 1.38.0
Using aws-sdk-kms 1.98.0
Using rubocop 1.25.1
Using vault 0.18.2
Using aws-sdk-secretsmanager 1.112.0
Using faraday-net_http 3.4.0
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using ffi 1.16.3
Using appbundler 0.13.4
Using aws-sdk-s3 1.180.0
Using activesupport 7.0.8.7
Using mixlib-log 3.1.2.1 (was 3.1.1)
Using corefoundation 0.3.13
Using chef-zero 15.0.17
Using mixlib-archive 1.1.7
Using gssapi 1.3.1
Using chefstyle 2.2.3
Using faraday 2.12.2
Using ffi-libarchive 1.1.3
Using cookstyle 7.32.8
Using chef-winrm 2.3.11
Using cheffish 17.1.8
Using faraday-follow_redirects 0.3.0
Using train-core 3.12.7
Using chef-winrm-fs 1.3.7
Using inspec-core 5.22.72
Using ohai 18.2.5 from https://github.com/chef/ohai.git (at 18-stable@58ee0df)
Using inspec-core-bin 5.22.72
Using chef-winrm-elevated 1.2.5
Using train-winrm 0.2.17
Using train-rest 0.5.0
Using chef 18.7.4 from source at `.`
Using chef-bin 18.7.4 from source at `chef-bin` and installing its executables
Bundle updated!