### PR TITLE
Filter before to match after for registry keys

### DIFF
--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -271,13 +271,17 @@ class Chef
 
         message = Chef::DataCollector::RunEndMessage.construct_message(self, status)
 
-        if ChefUtils.windows?
-          # Remove registry key values that are not present in the after state - CHEF-9126
-          message["resources"]&.each do |resource|
-            next unless resource["type"] == :registry_key
+        begin
+          if ChefUtils.windows?
+            # Remove registry key values that are not present in the after state - CHEF-9126
+            message["resources"]&.each do |resource|
+              next unless resource["type"] == :registry_key
 
-            resource["before"][:values].reject! { |value| !resource["after"][:values].any? { |after_value| after_value[:name] == value[:name] } }
+              resource["before"][:values].reject! { |value| !resource["after"][:values].any? { |after_value| after_value[:name] == value[:name] } }
+            end
           end
+        rescue StandardError => e
+          Chef::Log.warn("Error while processing registry key values: #{e.message}, #{e.backtrace[0..5]}")
         end
 
         send_to_data_collector(message)

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -275,6 +275,7 @@ class Chef
           # Remove registry key values that are not present in the after state - CHEF-9126
           message["resources"]&.each do |resource|
             next unless resource["type"] == :registry_key
+
             resource["before"][:values].reject! { |value| !resource["after"][:values].any? { |after_value| after_value[:name] == value[:name] } }
           end
         end

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -270,6 +270,15 @@ class Chef
         send_run_start unless sent_run_start?
 
         message = Chef::DataCollector::RunEndMessage.construct_message(self, status)
+
+        if ChefUtils.windows?
+          # Remove registry key values that are not present in the after state - CHEF-9126
+          message["resources"]&.each do |resource|
+            next unless resource["type"] == :registry_key
+            resource["before"][:values].reject! { |value| !resource["after"][:values].any? { |after_value| after_value[:name] == value[:name] } }
+          end
+        end
+
         send_to_data_collector(message)
         send_to_output_locations(message)
       end

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-require "spec_helper"
-require "chef/data_collector"
-require "socket"
+require 'spec_helper'
+require 'chef/data_collector'
+require 'socket'
 
 #
 # FIXME FIXME FIXME:  What we need to do here is have the ability to construct a real resource collection
@@ -28,12 +28,12 @@ require "socket"
 describe Chef::DataCollector do
   let(:node) { Chef::Node.new }
 
-  let(:rest_client) { double("Chef::ServerAPI (mock)") }
+  let(:rest_client) { double('Chef::ServerAPI (mock)') }
 
   let(:data_collector) { Chef::DataCollector::Reporter.new(events) }
 
   let(:new_resource) do
-    new_resource = Chef::Resource::File.new("/tmp/a-file.txt")
+    new_resource = Chef::Resource::File.new('/tmp/a-file.txt')
     new_resource.checksum nil
     # This next line is a hack to work around the fact that the name property will not have been autovivified yet
     # in these unit tests which breaks some assumptions.  Really the Formatters::ErrorMapper.resource_failed and
@@ -46,14 +46,14 @@ describe Chef::DataCollector do
   end
 
   let(:current_resource) do
-    current_resource = Chef::Resource::File.new("/tmp/a-file.txt")
-    current_resource.checksum "1234123412341234123412341234123412341234123412341234123412341234"
+    current_resource = Chef::Resource::File.new('/tmp/a-file.txt')
+    current_resource.checksum '1234123412341234123412341234123412341234123412341234123412341234'
     current_resource
   end
 
   let(:after_resource) do
-    after_resource = Chef::Resource::File.new("/tmp/a-file.txt")
-    after_resource.checksum "6789678967896789678967896789678967896789678967896789678967896789"
+    after_resource = Chef::Resource::File.new('/tmp/a-file.txt')
+    after_resource.checksum '6789678967896789678967896789678967896789678967896789678967896789'
     after_resource
   end
 
@@ -69,19 +69,19 @@ describe Chef::DataCollector do
 
   let(:run_list) { node.run_list }
 
-  let(:cookbooks) { node.fetch("cookbooks", {}) }
+  let(:cookbooks) { node.fetch('cookbooks', {}) }
 
   let(:run_id) { run_status.run_id }
 
-  let(:expansion) { Chef::RunList::RunListExpansion.new("_default", run_list.run_list_items) }
+  let(:expansion) { Chef::RunList::RunListExpansion.new('_default', run_list.run_list_items) }
 
-  let(:cookbook_name) { "monkey" }
+  let(:cookbook_name) { 'monkey' }
 
-  let(:recipe_name) { "atlas" }
+  let(:recipe_name) { 'atlas' }
 
-  let(:node_name) { "spitfire" }
+  let(:node_name) { 'spitfire' }
 
-  let(:cookbook_version) { double("Cookbook::Version", version: "1.2.3") }
+  let(:cookbook_version) { double('Cookbook::Version', version: '1.2.3') }
 
   let(:resource_record) { [] }
 
@@ -95,9 +95,9 @@ describe Chef::DataCollector do
 
   let(:expected_run_list) { run_list.for_json }
 
-  let(:node_uuid) { "779196c6-f94f-4501-9dae-af8081ab4d3a" }
+  let(:node_uuid) { '779196c6-f94f-4501-9dae-af8081ab4d3a' }
 
-  let(:request_id) { "5db5d686-d18d-4234-a86a-28848c35dfc2" }
+  let(:request_id) { '5db5d686-d18d-4234-a86a-28848c35dfc2' }
 
   before do
     allow(Time).to receive(:now).and_return(start_time, end_time)
@@ -108,7 +108,7 @@ describe Chef::DataCollector do
     new_resource.recipe_name = recipe_name
     allow(new_resource).to receive(:cookbook_version).and_return(cookbook_version)
 
-    run_list << "recipe[lobster]" << "role[rage]" << "recipe[fist]"
+    run_list << 'recipe[lobster]' << 'role[rage]' << 'recipe[fist]'
     events.register(data_collector)
     events.register(action_collection)
     run_status.run_id = request_id
@@ -121,27 +121,27 @@ describe Chef::DataCollector do
 
   def expect_start_message(keys = nil)
     keys ||= {
-      "chef_server_fqdn" => "localhost",
-      "entity_uuid" => node_uuid,
-      "id" => request_id,
-      "message_type" => "run_start",
-      "message_version" => "1.0.0",
-      "node_name" => node_name,
-      "organization_name" => "unknown_organization",
-      "run_id" => request_id,
-      "source" => "chef_client",
-      "start_time" => start_time.utc.iso8601,
+      'chef_server_fqdn' => 'localhost',
+      'entity_uuid' => node_uuid,
+      'id' => request_id,
+      'message_type' => 'run_start',
+      'message_version' => '1.0.0',
+      'node_name' => node_name,
+      'organization_name' => 'unknown_organization',
+      'run_id' => request_id,
+      'source' => 'chef_client',
+      'start_time' => start_time.utc.iso8601,
     }
     expect(rest_client).to receive(:post).with(
       nil,
       hash_including(keys),
-      { "Content-Type" => "application/json" }
+      { 'Content-Type' => 'application/json' }
     )
   end
 
   def expect_converge_message(keys)
-    keys["message_type"] = "run_converge"
-    keys["message_version"] = "1.1.0"
+    keys['message_type'] = 'run_converge'
+    keys['message_version'] = '1.1.0'
     # if (keys.key?("node") && !keys["node"].empty?)
     #   expect(rest_client).to receive(:post) do |_a, hash, _b|
     #     require 'pry'; binding.pry
@@ -150,160 +150,160 @@ describe Chef::DataCollector do
     expect(rest_client).to receive(:post).with(
       nil,
       hash_including(keys),
-      { "Content-Type" => "application/json" }
+      { 'Content-Type' => 'application/json' }
     )
     # end
   end
 
   def resource_has_diff(new_resource, status)
-    new_resource.respond_to?(:diff) && %w{updated failed}.include?(status)
+    new_resource.respond_to?(:diff) && %w(updated failed).include?(status)
   end
 
   def resource_record_for(new_resource, before_resource, after_resource, action, status, duration)
     {
-      "after" => after_resource&.state_for_resource_reporter || {},
-      "before" => before_resource&.state_for_resource_reporter || {},
-      "cookbook_name" => cookbook_name,
-      "cookbook_version" => cookbook_version&.version,
-      "delta" => resource_has_diff(new_resource, status) ? new_resource.diff : "",
-      "duration" => duration,
-      "id" => new_resource.identity,
-      "ignore_failure" => new_resource.ignore_failure,
-      "name" => new_resource.name,
-      "recipe_name" => recipe_name,
-      "result" => action.to_s,
-      "status" => status,
-      "type" => new_resource.resource_name.to_sym,
+      'after' => after_resource&.state_for_resource_reporter || {},
+      'before' => before_resource&.state_for_resource_reporter || {},
+      'cookbook_name' => cookbook_name,
+      'cookbook_version' => cookbook_version&.version,
+      'delta' => resource_has_diff(new_resource, status) ? new_resource.diff : '',
+      'duration' => duration,
+      'id' => new_resource.identity,
+      'ignore_failure' => new_resource.ignore_failure,
+      'name' => new_resource.name,
+      'recipe_name' => recipe_name,
+      'result' => action.to_s,
+      'status' => status,
+      'type' => new_resource.resource_name.to_sym,
     }
   end
 
   def send_run_failed_or_completed_event
-    status == "success" ? events.run_completed(node, run_status) : events.run_failed(exception, run_status)
+    status == 'success' ? events.run_completed(node, run_status) : events.run_failed(exception, run_status)
   end
 
-  shared_examples_for "sends a converge message" do
-    it "has a chef_server_fqdn" do
-      expect_converge_message("chef_server_fqdn" => "localhost")
+  shared_examples_for 'sends a converge message' do
+    it 'has a chef_server_fqdn' do
+      expect_converge_message('chef_server_fqdn' => 'localhost')
       send_run_failed_or_completed_event
     end
 
-    it "has a start_time" do
-      expect_converge_message("start_time" => start_time.utc.iso8601)
+    it 'has a start_time' do
+      expect_converge_message('start_time' => start_time.utc.iso8601)
       send_run_failed_or_completed_event
     end
 
-    it "has a end_time" do
-      expect_converge_message("end_time" => end_time.utc.iso8601)
+    it 'has a end_time' do
+      expect_converge_message('end_time' => end_time.utc.iso8601)
       send_run_failed_or_completed_event
     end
 
-    it "has a entity_uuid" do
-      expect_converge_message("entity_uuid" => node_uuid)
+    it 'has a entity_uuid' do
+      expect_converge_message('entity_uuid' => node_uuid)
       send_run_failed_or_completed_event
     end
 
-    it "has a expanded_run_list" do
-      expect_converge_message("expanded_run_list" => expected_expansion)
+    it 'has a expanded_run_list' do
+      expect_converge_message('expanded_run_list' => expected_expansion)
       send_run_failed_or_completed_event
     end
 
-    it "has a node" do
-      expect_converge_message("node" => expected_node.is_a?(Chef::Node) ? expected_node.data_for_save : expected_node)
+    it 'has a node' do
+      expect_converge_message('node' => expected_node.is_a?(Chef::Node) ? expected_node.data_for_save : expected_node)
       send_run_failed_or_completed_event
     end
 
-    it "has a node_name" do
-      expect_converge_message("node_name" => node_name)
+    it 'has a node_name' do
+      expect_converge_message('node_name' => node_name)
       send_run_failed_or_completed_event
     end
 
-    it "has an organization" do
-      expect_converge_message("organization_name" => "unknown_organization")
+    it 'has an organization' do
+      expect_converge_message('organization_name' => 'unknown_organization')
       send_run_failed_or_completed_event
     end
 
-    it "has a policy_group" do
-      expect_converge_message("policy_group" => nil)
+    it 'has a policy_group' do
+      expect_converge_message('policy_group' => nil)
       send_run_failed_or_completed_event
     end
 
-    it "has a policy_name" do
-      expect_converge_message("policy_name" => nil)
+    it 'has a policy_name' do
+      expect_converge_message('policy_name' => nil)
       send_run_failed_or_completed_event
     end
 
-    it "has a run_id" do
-      expect_converge_message("run_id" => request_id)
+    it 'has a run_id' do
+      expect_converge_message('run_id' => request_id)
       send_run_failed_or_completed_event
     end
 
-    it "has a run_list" do
-      expect_converge_message("run_list" => expected_run_list)
+    it 'has a run_list' do
+      expect_converge_message('run_list' => expected_run_list)
       send_run_failed_or_completed_event
     end
 
-    it "has a cookbooks" do
-      expect_converge_message("cookbooks" => cookbooks)
+    it 'has a cookbooks' do
+      expect_converge_message('cookbooks' => cookbooks)
       send_run_failed_or_completed_event
     end
 
-    it "has a source" do
-      expect_converge_message("source" => "chef_client")
+    it 'has a source' do
+      expect_converge_message('source' => 'chef_client')
       send_run_failed_or_completed_event
     end
 
-    it "has a status" do
-      expect_converge_message("status" => status)
+    it 'has a status' do
+      expect_converge_message('status' => status)
       send_run_failed_or_completed_event
     end
 
-    it "has no deprecations" do
-      expect_converge_message("deprecations" => [])
+    it 'has no deprecations' do
+      expect_converge_message('deprecations' => [])
       send_run_failed_or_completed_event
     end
 
-    it "has an error field" do
+    it 'has an error field' do
       if exception
         expect_converge_message(
-          "error" => {
-            "class" => exception.class,
-            "message" => exception.message,
-            "backtrace" => exception.backtrace,
-            "description" => error_description,
+          'error' => {
+            'class' => exception.class,
+            'message' => exception.message,
+            'backtrace' => exception.backtrace,
+            'description' => error_description,
           }
         )
       else
         expect(rest_client).to receive(:post).with(
           nil,
-          hash_excluding("error"),
-          { "Content-Type" => "application/json" }
+          hash_excluding('error'),
+          { 'Content-Type' => 'application/json' }
         )
       end
       send_run_failed_or_completed_event
     end
 
-    it "has a total resource count of zero" do
-      expect_converge_message("total_resource_count" => total_resource_count)
+    it 'has a total resource count of zero' do
+      expect_converge_message('total_resource_count' => total_resource_count)
       send_run_failed_or_completed_event
     end
 
-    it "has a updated resource count of zero" do
-      expect_converge_message("updated_resource_count" => updated_resource_count)
+    it 'has a updated resource count of zero' do
+      expect_converge_message('updated_resource_count' => updated_resource_count)
       send_run_failed_or_completed_event
     end
 
-    it "includes the resource record" do
-      expect_converge_message("resources" => resource_record)
+    it 'includes the resource record' do
+      expect_converge_message('resources' => resource_record)
       send_run_failed_or_completed_event
     end
   end
 
-  describe "when the run fails during node load" do
-    let(:exception) { Exception.new("imperial to metric conversion error") }
+  describe 'when the run fails during node load' do
+    let(:exception) { Exception.new('imperial to metric conversion error') }
     let(:error_description) { Chef::Formatters::ErrorMapper.registration_failed(node_name, exception, Chef::Config).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { "failure" }
+    let(:status) { 'failure' }
     let(:expected_node) { {} } # no node because that failed
     let(:expected_run_list) { [] } # no run_list without a node
     let(:expected_expansion) { {} } # no run_list expansion without a run_list
@@ -316,15 +316,15 @@ describe Chef::DataCollector do
       expect_start_message
     end
 
-    it_behaves_like "sends a converge message"
+    it_behaves_like 'sends a converge message'
   end
 
-  describe "when the run fails during node load" do
-    let(:exception) { Exception.new("imperial to metric conversion error") }
+  describe 'when the run fails during node load' do
+    let(:exception) { Exception.new('imperial to metric conversion error') }
     let(:error_description) { Chef::Formatters::ErrorMapper.node_load_failed(node_name, exception, Chef::Config).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { "failure" }
+    let(:status) { 'failure' }
     let(:expected_node) { {} } # no node because that failed
     let(:expected_run_list) { [] } # no run_list without a node
     let(:expected_expansion) { {} } # no run_list expansion without a run_list
@@ -337,15 +337,15 @@ describe Chef::DataCollector do
       expect_start_message
     end
 
-    it_behaves_like "sends a converge message"
+    it_behaves_like 'sends a converge message'
   end
 
-  describe "when the run fails during run_list_expansion" do
-    let(:exception) { Exception.new("imperial to metric conversion error") }
+  describe 'when the run fails during run_list_expansion' do
+    let(:exception) { Exception.new('imperial to metric conversion error') }
     let(:error_description) { Chef::Formatters::ErrorMapper.run_list_expand_failed(node, exception).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { "failure" }
+    let(:status) { 'failure' }
     let(:expected_expansion) { {} } # no run_list expanasion when it failed
     let(:resource_record) { [] } # and no resources
 
@@ -358,15 +358,15 @@ describe Chef::DataCollector do
       expect_start_message
     end
 
-    it_behaves_like "sends a converge message"
+    it_behaves_like 'sends a converge message'
   end
 
-  describe "when the run fails during cookbook resolution" do
-    let(:exception) { Exception.new("imperial to metric conversion error") }
+  describe 'when the run fails during cookbook resolution' do
+    let(:exception) { Exception.new('imperial to metric conversion error') }
     let(:error_description) { Chef::Formatters::ErrorMapper.cookbook_resolution_failed(node, exception).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { "failure" }
+    let(:status) { 'failure' }
     let(:resource_record) { [] } # and no resources
 
     before do
@@ -380,15 +380,15 @@ describe Chef::DataCollector do
       run_status.exception = exception
     end
 
-    it_behaves_like "sends a converge message"
+    it_behaves_like 'sends a converge message'
   end
 
-  describe "when the run fails during cookbook synchronization" do
-    let(:exception) { Exception.new("imperial to metric conversion error") }
+  describe 'when the run fails during cookbook synchronization' do
+    let(:exception) { Exception.new('imperial to metric conversion error') }
     let(:error_description) { Chef::Formatters::ErrorMapper.cookbook_sync_failed(node, exception).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { "failure" }
+    let(:status) { 'failure' }
     let(:resource_record) { [] } # and no resources
 
     before do
@@ -402,10 +402,10 @@ describe Chef::DataCollector do
       run_status.exception = exception
     end
 
-    it_behaves_like "sends a converge message"
+    it_behaves_like 'sends a converge message'
   end
 
-  describe "after successfully starting the run" do
+  describe 'after successfully starting the run' do
     before do
       # these events happen in this order in the client
       events.node_load_success(node)
@@ -414,144 +414,144 @@ describe Chef::DataCollector do
       run_status.start_clock
     end
 
-    describe "run_start_message" do
-      it "sends a run_start_message" do
+    describe 'run_start_message' do
+      it 'sends a run_start_message' do
         expect_start_message
         events.run_started(run_status)
       end
 
-      it "extracts the hostname from the chef_server_url" do
-        Chef::Config[:chef_server_url] = "https://spacex.rockets.local"
-        expect_start_message("chef_server_fqdn" => "spacex.rockets.local")
+      it 'extracts the hostname from the chef_server_url' do
+        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local'
+        expect_start_message('chef_server_fqdn' => 'spacex.rockets.local')
         events.run_started(run_status)
       end
 
-      it "extracts the organization from the chef_server_url" do
-        Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc"
-        expect_start_message("organization_name" => "gnc")
+      it 'extracts the organization from the chef_server_url' do
+        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc'
+        expect_start_message('organization_name' => 'gnc')
         events.run_started(run_status)
       end
 
-      it "extracts the organization from the chef_server_url if there are extra slashes" do
-        Chef::Config[:chef_server_url] = "https://spacex.rockets.local///organizations///gnc"
-        expect_start_message("organization_name" => "gnc")
+      it 'extracts the organization from the chef_server_url if there are extra slashes' do
+        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local///organizations///gnc'
+        expect_start_message('organization_name' => 'gnc')
         events.run_started(run_status)
       end
 
-      it "extracts the organization from the chef_server_url if there is a trailing slash" do
-        Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/"
-        expect_start_message("organization_name" => "gnc")
+      it 'extracts the organization from the chef_server_url if there is a trailing slash' do
+        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/'
+        expect_start_message('organization_name' => 'gnc')
         events.run_started(run_status)
       end
 
       it "sets 'unknown_organization' if the cher_server_url does not contain one" do
-        Chef::Config[:chef_server_url] = "https://spacex.rockets.local"
-        expect_start_message("organization_name" => "unknown_organization")
+        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local'
+        expect_start_message('organization_name' => 'unknown_organization')
         events.run_started(run_status)
       end
 
-      it "still uses the chef_server_url in non-solo mode even if the data_collector organization is set" do
-        Chef::Config[:data_collector][:organization] = "blue-origin"
-        Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/"
-        expect_start_message("organization_name" => "gnc")
+      it 'still uses the chef_server_url in non-solo mode even if the data_collector organization is set' do
+        Chef::Config[:data_collector][:organization] = 'blue-origin'
+        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/'
+        expect_start_message('organization_name' => 'gnc')
         events.run_started(run_status)
       end
 
-      describe "in legacy mode" do
+      describe 'in legacy mode' do
         before do
           Chef::Config[:solo_legacy_mode] = true
-          Chef::Config[:data_collector][:server_url] = "https://nasa.rockets.local/organizations/sls"
+          Chef::Config[:data_collector][:server_url] = 'https://nasa.rockets.local/organizations/sls'
         end
 
-        it "we get the data collector organization" do
-          Chef::Config[:data_collector][:organization] = "blue-origin"
-          Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/" # should be ignored
-          expect_start_message("organization_name" => "blue-origin")
+        it 'we get the data collector organization' do
+          Chef::Config[:data_collector][:organization] = 'blue-origin'
+          Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/' # should be ignored
+          expect_start_message('organization_name' => 'blue-origin')
           events.run_started(run_status)
         end
 
         it "if the data collector org is unset we get 'chef_solo'" do
-          Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/" # should be ignored
-          expect_start_message("organization_name" => "chef_solo")
+          Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/' # should be ignored
+          expect_start_message('organization_name' => 'chef_solo')
           events.run_started(run_status)
         end
 
-        it "sets the source" do
-          expect_start_message("source" => "chef_solo")
+        it 'sets the source' do
+          expect_start_message('source' => 'chef_solo')
           events.run_started(run_status)
         end
       end
 
-      describe "in local mode" do
+      describe 'in local mode' do
         before do
           Chef::Config[:local_mode] = true
-          Chef::Config[:data_collector][:server_url] = "https://nasa.rockets.local/organizations/sls"
+          Chef::Config[:data_collector][:server_url] = 'https://nasa.rockets.local/organizations/sls'
         end
 
-        it "we get the data collector organization" do
-          Chef::Config[:data_collector][:organization] = "blue-origin"
-          Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/" # should be ignored
-          expect_start_message("organization_name" => "blue-origin")
+        it 'we get the data collector organization' do
+          Chef::Config[:data_collector][:organization] = 'blue-origin'
+          Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/' # should be ignored
+          expect_start_message('organization_name' => 'blue-origin')
           events.run_started(run_status)
         end
 
         it "if the data collector org is unset we get 'chef_solo'" do
-          Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/" # should be ignored
-          expect_start_message("organization_name" => "chef_solo")
+          Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/' # should be ignored
+          expect_start_message('organization_name' => 'chef_solo')
           events.run_started(run_status)
         end
 
-        it "sets the source" do
-          expect_start_message("source" => "chef_solo")
+        it 'sets the source' do
+          expect_start_message('source' => 'chef_solo')
           events.run_started(run_status)
         end
       end
     end
 
-    describe "converge messages" do
+    describe 'converge messages' do
       before do
         expect_start_message
         events.run_started(run_status)
         events.cookbook_compilation_start(run_context)
       end
 
-      context "with no resources" do
+      context 'with no resources' do
         let(:total_resource_count) { 0 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) { [ ] }
-        let(:status) { "success" }
+        let(:status) { 'success' }
 
         before do
           run_status.stop_clock
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
 
-        it "sets the policy_group" do
-          node.policy_group = "acceptionsal"
-          expect_converge_message("policy_group" => "acceptionsal")
+        it 'sets the policy_group' do
+          node.policy_group = 'acceptionsal'
+          expect_converge_message('policy_group' => 'acceptionsal')
           send_run_failed_or_completed_event
         end
 
-        it "has a policy_name" do
-          node.policy_name = "webappdb"
-          expect_converge_message("policy_name" => "webappdb")
+        it 'has a policy_name' do
+          node.policy_name = 'webappdb'
+          expect_converge_message('policy_name' => 'webappdb')
           send_run_failed_or_completed_event
         end
 
-        it "collects deprecation messages" do
+        it 'collects deprecation messages' do
           location = Chef::Log.caller_location
-          events.deprecation(Chef::Deprecated.create(:internal_api, "deprecation warning", location))
-          expect_converge_message("deprecations" => [{ location: location, message: "deprecation warning", url: "https://docs.chef.io/deprecations_internal_api/" }])
+          events.deprecation(Chef::Deprecated.create(:internal_api, 'deprecation warning', location))
+          expect_converge_message('deprecations' => [{ location: location, message: 'deprecation warning', url: 'https://docs.chef.io/deprecations_internal_api/' }])
           send_run_failed_or_completed_event
         end
       end
 
-      context "when the run contains a file resource that is up-to-date" do
+      context 'when the run contains a file resource that is up-to-date' do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
-        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, "up-to-date", "1234") ] }
-        let(:status) { "success" }
+        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, 'up-to-date', '1234') ] }
+        let(:status) { 'success' }
 
         before do
           events.resource_action_start(new_resource, :create)
@@ -564,15 +564,15 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when the run contains a file resource that is up-to-date from a @recipe_files, returns nil for the version" do
+      context 'when the run contains a file resource that is up-to-date from a @recipe_files, returns nil for the version' do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
-        let(:cookbook_name) { "@recipe_files" }
-        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, "up-to-date", "1234") ] }
-        let(:status) { "success" }
+        let(:cookbook_name) { '@recipe_files' }
+        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, 'up-to-date', '1234') ] }
+        let(:status) { 'success' }
         let(:cookbook_version) { nil }
 
         before do
@@ -587,14 +587,14 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when the run contains a file resource that is updated" do
+      context 'when the run contains a file resource that is updated' do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 1 }
-        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, "updated", "1234") ] }
-        let(:status) { "success" }
+        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, 'updated', '1234') ] }
+        let(:status) { 'success' }
 
         before do
           events.resource_action_start(new_resource, :create)
@@ -607,27 +607,27 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "When there is an embedded resource, it includes the sub-resource in the report" do
+      context 'When there is an embedded resource, it includes the sub-resource in the report' do
         let(:total_resource_count) { 2 }
         let(:updated_resource_count) { 2 }
         let(:implementation_resource) do
-          r = Chef::Resource::CookbookFile.new("/preseed-file.txt")
+          r = Chef::Resource::CookbookFile.new('/preseed-file.txt')
           r.cookbook_name = cookbook_name
           r.recipe_name = recipe_name
           allow(r).to receive(:cookbook_version).and_return(cookbook_version)
           r
         end
-        let(:resource_record) { [ resource_record_for(implementation_resource, implementation_resource, implementation_resource, :create, "updated", "2345"), resource_record_for(new_resource, current_resource, after_resource, :create, "updated", "1234") ] }
-        let(:status) { "success" }
+        let(:resource_record) { [ resource_record_for(implementation_resource, implementation_resource, implementation_resource, :create, 'updated', '2345'), resource_record_for(new_resource, current_resource, after_resource, :create, 'updated', '1234') ] }
+        let(:status) { 'success' }
 
         before do
           events.resource_action_start(new_resource, :create)
           events.resource_current_state_loaded(new_resource, :create, current_resource)
 
-          events.resource_action_start(implementation_resource , :create)
+          events.resource_action_start(implementation_resource, :create)
           events.resource_current_state_loaded(implementation_resource, :create, implementation_resource)
           events.resource_updated(implementation_resource, :create)
           events.resource_after_state_loaded(implementation_resource, :create, implementation_resource)
@@ -642,18 +642,18 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when the run contains a file resource that is skipped due to a block conditional" do
+      context 'when the run contains a file resource that is skipped due to a block conditional' do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) do
-          rec = resource_record_for(new_resource, nil, nil, :create, "skipped", "1234")
-          rec["conditional"] = "not_if { #code block }" # FIXME: "#code block" is poor, is there some way to fix this?
+          rec = resource_record_for(new_resource, nil, nil, :create, 'skipped', '1234')
+          rec['conditional'] = 'not_if { #code block }' # FIXME: "#code block" is poor, is there some way to fix this?
           [ rec ]
         end
-        let(:status) { "success" }
+        let(:status) { 'success' }
 
         before do
           conditional = (new_resource.not_if { true }).first
@@ -665,21 +665,21 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when the run contains a file resource that is skipped due to a string conditional" do
+      context 'when the run contains a file resource that is skipped due to a string conditional' do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) do
-          rec = resource_record_for(new_resource, nil, nil, :create, "skipped", "1234")
-          rec["conditional"] = 'not_if "true"'
+          rec = resource_record_for(new_resource, nil, nil, :create, 'skipped', '1234')
+          rec['conditional'] = 'not_if "true"'
           [ rec ]
         end
-        let(:status) { "success" }
+        let(:status) { 'success' }
 
         before do
-          conditional = (new_resource.not_if "true").first
+          conditional = (new_resource.not_if 'true').first
           events.resource_action_start(new_resource, :create)
           events.resource_skipped(new_resource, :create, conditional)
           new_resource.instance_variable_set(:@elapsed_time, 1.2345)
@@ -688,27 +688,27 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when the run contains a file resource that threw an exception" do
-        let(:exception) { Exception.new("imperial to metric conversion error") }
+      context 'when the run contains a file resource that threw an exception' do
+        let(:exception) { Exception.new('imperial to metric conversion error') }
         let(:error_description) { Chef::Formatters::ErrorMapper.resource_failed(new_resource, :create, exception).for_json }
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) do
-          rec = resource_record_for(new_resource, current_resource, nil, :create, "failed", "1234")
-          rec["error_message"] = "imperial to metric conversion error"
-          rec["error"] = {
-            "class" => exception.class,
-            "message" => exception.message,
-            "backtrace" => exception.backtrace,
-            "description" => error_description,
+          rec = resource_record_for(new_resource, current_resource, nil, :create, 'failed', '1234')
+          rec['error_message'] = 'imperial to metric conversion error'
+          rec['error'] = {
+            'class' => exception.class,
+            'message' => exception.message,
+            'backtrace' => exception.backtrace,
+            'description' => error_description,
           }
 
           [ rec ]
         end
-        let(:status) { "failure" }
+        let(:status) { 'failure' }
 
         before do
           exception.set_backtrace(caller)
@@ -722,28 +722,28 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when the run contains a file resource that threw an exception in load_current_resource" do
-        let(:exception) { Exception.new("imperial to metric conversion error") }
+      context 'when the run contains a file resource that threw an exception in load_current_resource' do
+        let(:exception) { Exception.new('imperial to metric conversion error') }
         let(:error_description) { Chef::Formatters::ErrorMapper.resource_failed(new_resource, :create, exception).for_json }
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) do
-          rec = resource_record_for(new_resource, nil, nil, :create, "failed", "1234")
-          rec["before"] = {}
-          rec["error_message"] = "imperial to metric conversion error"
-          rec["error"] = {
-            "class" => exception.class,
-            "message" => exception.message,
-            "backtrace" => exception.backtrace,
-            "description" => error_description,
+          rec = resource_record_for(new_resource, nil, nil, :create, 'failed', '1234')
+          rec['before'] = {}
+          rec['error_message'] = 'imperial to metric conversion error'
+          rec['error'] = {
+            'class' => exception.class,
+            'message' => exception.message,
+            'backtrace' => exception.backtrace,
+            'description' => error_description,
           }
 
           [ rec ]
         end
-        let(:status) { "failure" }
+        let(:status) { 'failure' }
 
         before do
           exception.set_backtrace(caller)
@@ -757,35 +757,35 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when the resource collection contains a resource that was unprocessed due to prior errors" do
-        let(:exception) { Exception.new("imperial to metric conversion error") }
+      context 'when the resource collection contains a resource that was unprocessed due to prior errors' do
+        let(:exception) { Exception.new('imperial to metric conversion error') }
         let(:error_description) { Chef::Formatters::ErrorMapper.resource_failed(new_resource, :create, exception).for_json }
         let(:total_resource_count) { 2 }
         let(:updated_resource_count) { 0 }
         let(:unprocessed_resource) do
-          res = Chef::Resource::Service.new("unprocessed service")
+          res = Chef::Resource::Service.new('unprocessed service')
           res.cookbook_name = cookbook_name
           res.recipe_name = recipe_name
           allow(res).to receive(:cookbook_version).and_return(cookbook_version)
           res
         end
         let(:resource_record) do
-          rec1 = resource_record_for(new_resource, current_resource, nil, :create, "failed", "1234")
-          rec1["error_message"] = "imperial to metric conversion error"
-          rec1["error"] = {
-            "class" => exception.class,
-            "message" => exception.message,
-            "backtrace" => exception.backtrace,
-            "description" => error_description,
+          rec1 = resource_record_for(new_resource, current_resource, nil, :create, 'failed', '1234')
+          rec1['error_message'] = 'imperial to metric conversion error'
+          rec1['error'] = {
+            'class' => exception.class,
+            'message' => exception.message,
+            'backtrace' => exception.backtrace,
+            'description' => error_description,
           }
 
-          rec2 = resource_record_for(unprocessed_resource, nil, nil, :nothing, "unprocessed", "")
+          rec2 = resource_record_for(unprocessed_resource, nil, nil, :nothing, 'unprocessed', '')
           [ rec1, rec2 ]
         end
-        let(:status) { "failure" }
+        let(:status) { 'failure' }
 
         before do
           run_context.resource_collection << new_resource
@@ -802,15 +802,15 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when cookbook resolution fails" do
-        let(:exception) { Exception.new("imperial to metric conversion error") }
+      context 'when cookbook resolution fails' do
+        let(:exception) { Exception.new('imperial to metric conversion error') }
         let(:error_description) { Chef::Formatters::ErrorMapper.cookbook_resolution_failed(expansion, exception).for_json }
         let(:total_resource_count) { 0 }
         let(:updated_resource_count) { 0 }
-        let(:status) { "failure" }
+        let(:status) { 'failure' }
 
         before do
           events.cookbook_resolution_failed(expansion, exception)
@@ -818,15 +818,15 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "When cookbook synchronization fails" do
-        let(:exception) { Exception.new("imperial to metric conversion error") }
+      context 'When cookbook synchronization fails' do
+        let(:exception) { Exception.new('imperial to metric conversion error') }
         let(:error_description) { Chef::Formatters::ErrorMapper.cookbook_sync_failed({}, exception).for_json }
         let(:total_resource_count) { 0 }
         let(:updated_resource_count) { 0 }
-        let(:status) { "failure" }
+        let(:status) { 'failure' }
 
         before do
           events.cookbook_sync_failed(expansion, exception)
@@ -834,61 +834,60 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like "sends a converge message"
+        it_behaves_like 'sends a converge message'
       end
 
-      context "when node attributes are block-listed" do
-        let(:status) { "success" }
+      context 'when node attributes are block-listed' do
+        let(:status) { 'success' }
         before do
           Chef::Config[:blocked_default_attributes] = [
-            %w{secret key_to_the_kingdom},
+            %w(secret key_to_the_kingdom),
           ]
           node.default = {
-            "secret" => { "key_to_the_kingdom" => "under the flower pot to the left of the drawbridge" },
-            "publicinfo" => { "num_flower_pots" => 18 },
+            'secret' => { 'key_to_the_kingdom' => 'under the flower pot to the left of the drawbridge' },
+            'publicinfo' => { 'num_flower_pots' => 18 },
           }
         end
 
-        it "payload should exclude blocked attributes" do
+        it 'payload should exclude blocked attributes' do
           expect(rest_client).to receive(:post) do |_addr, hash, _headers|
-            expect(hash["node"]["default"]).to eq({ "secret" => {}, "publicinfo" => { "num_flower_pots" => 18 } })
+            expect(hash['node']['default']).to eq({ 'secret' => {}, 'publicinfo' => { 'num_flower_pots' => 18 } })
           end
           send_run_failed_or_completed_event
         end
       end
 
-      context "when node attributes are allow-listed" do
-        let(:status) { "success" }
+      context 'when node attributes are allow-listed' do
+        let(:status) { 'success' }
         before do
           Chef::Config[:allowed_default_attributes] = [
-            %w{public entrance},
+            %w(public entrance),
           ]
           node.default = {
-            "public" => { "entrance" => "is the drawbridge" },
-            "secret" => { "entrance" => "is the tunnel" },
+            'public' => { 'entrance' => 'is the drawbridge' },
+            'secret' => { 'entrance' => 'is the tunnel' },
           }
         end
 
-        it "payload should include only allowed attributes" do
+        it 'payload should include only allowed attributes' do
           expect(rest_client).to receive(:post) do |_addr, hash, _headers|
-            expect(hash["node"]["default"]).to eq({ "public" => { "entrance" => "is the drawbridge" } })
+            expect(hash['node']['default']).to eq({ 'public' => { 'entrance' => 'is the drawbridge' } })
           end
           send_run_failed_or_completed_event
         end
       end
-
     end
   end
 
-  describe "#send_to_file_location(file_name, message)" do
-    let(:tempfile) { Tempfile.new("rspec-chef-datacollector-out") }
+  describe '#send_to_file_location(file_name, message)' do
+    let(:tempfile) { Tempfile.new('rspec-chef-datacollector-out') }
     let(:shift_jis) { "I have no idea what this character is:\n #{0x83.chr}#{0x80.chr}.\n" }
-    it "handles invalid UTF-8 properly" do
+    it 'handles invalid UTF-8 properly' do
       data_collector.send(:send_to_file_location, tempfile, { invalid: shift_jis })
     end
   end
 
-  describe "#send_to_datacollector" do
+  describe '#send_to_datacollector' do
     def stub_http_client(exception = nil)
       if exception.nil?
         expect(http_client).to receive(:post).with(nil, message, data_collector.send(:headers))
@@ -897,14 +896,14 @@ describe Chef::DataCollector do
       end
     end
 
-    let(:message) { "message" }
+    let(:message) { 'message' }
     let(:http_client) { instance_double(Chef::ServerAPI) }
 
     before do
       expect(data_collector).to receive(:setup_http_client).and_return(http_client)
     end
 
-    it "does not disable the data_collector when no exception is raised" do
+    it 'does not disable the data_collector when no exception is raised' do
       stub_http_client
       expect(data_collector.events).not_to receive(:unregister)
       data_collector.send(:send_to_data_collector, message)
@@ -921,18 +920,18 @@ describe Chef::DataCollector do
           stub_http_client(exception_class)
         end
 
-        it "disables the reporter" do
+        it 'disables the reporter' do
           expect(data_collector.events).to receive(:unregister).with(data_collector)
           data_collector.send(:send_to_data_collector, message)
         end
 
-        it "logs an error and raises when raise_on_failure is enabled" do
+        it 'logs an error and raises when raise_on_failure is enabled' do
           Chef::Config[:data_collector][:raise_on_failure] = true
           expect(Chef::Log).to receive(:error)
           expect { data_collector.send(:send_to_data_collector, message) }.to raise_error(exception_class)
         end
 
-        it "logs a warn message and does not raise an exception when raise_on_failure is disabled" do
+        it 'logs a warn message and does not raise an exception when raise_on_failure is disabled' do
           Chef::Config[:data_collector][:raise_on_failure] = false
           expect(Chef::Log).to receive(:warn)
           data_collector.send(:send_to_data_collector, message)
@@ -940,135 +939,135 @@ describe Chef::DataCollector do
       end
     end
 
-    context "when the client raises a 404 exception" do
+    context 'when the client raises a 404 exception' do
       let(:err) do
-        response = double("Net::HTTP response", code: "404")
-        Net::HTTPClientException.new("Not Found", response)
+        response = double('Net::HTTP response', code: '404')
+        Net::HTTPClientException.new('Not Found', response)
       end
 
       before do
         stub_http_client(err)
       end
 
-      it "disables the reporter" do
+      it 'disables the reporter' do
         expect(data_collector.events).to receive(:unregister).with(data_collector)
         data_collector.send(:send_to_data_collector, message)
       end
 
-      it "logs an error and raises when raise_on_failure is enabled" do
+      it 'logs an error and raises when raise_on_failure is enabled' do
         Chef::Config[:data_collector][:raise_on_failure] = true
         expect(Chef::Log).to receive(:error)
         expect { data_collector.send(:send_to_data_collector, message) }.to raise_error(err)
       end
 
       # this is different specifically for 404s
-      it "logs an info message and does not raise an exception when raise_on_failure is disabled" do
+      it 'logs an info message and does not raise an exception when raise_on_failure is disabled' do
         Chef::Config[:data_collector][:raise_on_failure] = false
         expect(Chef::Log).to receive(:debug).with(/This is normal if you do not have Chef Automate/)
         data_collector.send(:send_to_data_collector, message)
       end
     end
 
-    context "when processing Windows registry keys" do
+    context 'when processing Windows registry keys' do
       let(:total_resource_count) { 1 }
       let(:updated_resource_count) { 1 }
-      let(:status) { "success" }
+      let(:status) { 'success' }
 
       before do
         allow(ChefUtils).to receive(:windows?).and_return(true)
         run_status.stop_clock
       end
 
-      it "removes registry key values not present in after state" do
+      it 'removes registry key values not present in after state' do
         resource = {
-          "type" => :registry_key,
-          "before" => {
+          'type' => :registry_key,
+          'before' => {
             values: [
-              { name: "key1", value: "val1" },
-              { name: "key2", value: "val2" },
-              { name: "key3", value: "val3" }
-            ]
+              { name: 'key1', value: 'val1' },
+              { name: 'key2', value: 'val2' },
+              { name: 'key3', value: 'val3' },
+            ],
           },
-          "after" => {
+          'after' => {
             values: [
-              { name: "key1", value: "new_val1" },
-              { name: "key3", value: "new_val3" }
-            ]
-          }
+              { name: 'key1', value: 'new_val1' },
+              { name: 'key3', value: 'new_val3' },
+            ],
+          },
         }
 
         message = {
-          "resources" => [resource]
+          'resources' => [resource],
         }
 
         # Verify that key2 was removed from before values
         expected_before_values = [
-          { name: "key1", value: "val1" },
-          { name: "key3", value: "val3" }
+          { name: 'key1', value: 'val1' },
+          { name: 'key3', value: 'val3' },
         ]
 
         expect(http_client).to receive(:post).with(
           nil,
-          hash_including("message_type" => "run_start"),
-          { "Content-Type" => "application/json" })
+          hash_including('message_type' => 'run_start'),
+          { 'Content-Type' => 'application/json' })
 
         expect(http_client).to receive(:post).with(
           nil,
           hash_including(
-            "resources" => array_including(
+            'resources' => array_including(
               hash_including(
-                "before" => hash_including(
+                'before' => hash_including(
                   values: array_including(expected_before_values)
                 )
               )
             )
           ),
-          { "Content-Type" => "application/json" }
+          { 'Content-Type' => 'application/json' }
         )
         allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
         data_collector.send(:send_run_completion, message)
       end
 
-      it "handles missing values gracefully" do
+      it 'handles missing values gracefully' do
         resource = {
-          "type" => :registry_key,
-          "before" => {},
-          "after" => { values: [] }
+          'type' => :registry_key,
+          'before' => {},
+          'after' => { values: [] },
         }
 
         message = {
-          "resources" => [resource]
+          'resources' => [resource],
         }
 
         expect(http_client).to receive(:post).with(
           nil,
-          hash_including("message_type" => "run_start"),
-          { "Content-Type" => "application/json" })
+          hash_including('message_type' => 'run_start'),
+          { 'Content-Type' => 'application/json' })
 
-        expect(http_client).to receive(:post).with( nil, message, { "Content-Type" => "application/json" })
+        expect(http_client).to receive(:post).with(nil, message, { 'Content-Type' => 'application/json' })
 
         allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
-        expect { data_collector.send(:send_run_completion, "success") }.not_to raise_error
+        expect { data_collector.send(:send_run_completion, 'success') }.not_to raise_error
       end
 
-      it "ignores non-registry resources" do
+      it 'ignores non-registry resources' do
         resource = {
-          "type" => :file,
-          "before" => { content: "old" },
-          "after" => { content: "new" }
+          'type' => :file,
+          'before' => { content: 'old' },
+          'after' => { content: 'new' },
         }
 
         message = {
-          "resources" => [resource]
+          'resources' => [resource],
         }
-        expect(http_client).to receive(:post).with( nil,
-          hash_including("message_type" => "run_start"),
-          { "Content-Type" => "application/json" })
+        expect(http_client).to receive(:post).with(nil,
+          hash_including('message_type' => 'run_start'),
+          { 'Content-Type' => 'application/json' })
 
-        expect(http_client).to receive(:post).with( nil, message, { "Content-Type" => "application/json" })
+        expect(http_client).to receive(:post).with(nil, message, { 'Content-Type' => 'application/json' })
 
         allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
-        expect { data_collector.send(:send_run_completion, "success") }.not_to raise_error
+        expect { data_collector.send(:send_run_completion, 'success') }.not_to raise_error
       end
     end
   end

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -841,7 +841,7 @@ describe Chef::DataCollector do
         let(:status) { "success" }
         before do
           Chef::Config[:blocked_default_attributes] = [
-            %w(secret key_to_the_kingdom),
+            %w{secret key_to_the_kingdom},
           ]
           node.default = {
             "secret" => { "key_to_the_kingdom" => "under the flower pot to the left of the drawbridge" },
@@ -861,7 +861,7 @@ describe Chef::DataCollector do
         let(:status) { "success" }
         before do
           Chef::Config[:allowed_default_attributes] = [
-            %w(public entrance),
+            %w{public entrance},
           ]
           node.default = {
             "public" => { "entrance" => "is the drawbridge" },
@@ -1009,7 +1009,8 @@ describe Chef::DataCollector do
         expect(http_client).to receive(:post).with(
           nil,
           hash_including("message_type" => "run_start"),
-          { "Content-Type" => "application/json" })
+          { "Content-Type" => "application/json" }
+        )
 
         expect(http_client).to receive(:post).with(
           nil,
@@ -1042,7 +1043,8 @@ describe Chef::DataCollector do
         expect(http_client).to receive(:post).with(
           nil,
           hash_including("message_type" => "run_start"),
-          { "Content-Type" => "application/json" })
+          { "Content-Type" => "application/json" }
+        )
 
         expect(http_client).to receive(:post).with(nil, message, { "Content-Type" => "application/json" })
 

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
-require 'chef/data_collector'
-require 'socket'
+require "spec_helper"
+require "chef/data_collector"
+require "socket"
 
 #
 # FIXME FIXME FIXME:  What we need to do here is have the ability to construct a real resource collection
@@ -28,12 +28,12 @@ require 'socket'
 describe Chef::DataCollector do
   let(:node) { Chef::Node.new }
 
-  let(:rest_client) { double('Chef::ServerAPI (mock)') }
+  let(:rest_client) { double("Chef::ServerAPI (mock)") }
 
   let(:data_collector) { Chef::DataCollector::Reporter.new(events) }
 
   let(:new_resource) do
-    new_resource = Chef::Resource::File.new('/tmp/a-file.txt')
+    new_resource = Chef::Resource::File.new("/tmp/a-file.txt")
     new_resource.checksum nil
     # This next line is a hack to work around the fact that the name property will not have been autovivified yet
     # in these unit tests which breaks some assumptions.  Really the Formatters::ErrorMapper.resource_failed and
@@ -46,14 +46,14 @@ describe Chef::DataCollector do
   end
 
   let(:current_resource) do
-    current_resource = Chef::Resource::File.new('/tmp/a-file.txt')
-    current_resource.checksum '1234123412341234123412341234123412341234123412341234123412341234'
+    current_resource = Chef::Resource::File.new("/tmp/a-file.txt")
+    current_resource.checksum "1234123412341234123412341234123412341234123412341234123412341234"
     current_resource
   end
 
   let(:after_resource) do
-    after_resource = Chef::Resource::File.new('/tmp/a-file.txt')
-    after_resource.checksum '6789678967896789678967896789678967896789678967896789678967896789'
+    after_resource = Chef::Resource::File.new("/tmp/a-file.txt")
+    after_resource.checksum "6789678967896789678967896789678967896789678967896789678967896789"
     after_resource
   end
 
@@ -69,19 +69,19 @@ describe Chef::DataCollector do
 
   let(:run_list) { node.run_list }
 
-  let(:cookbooks) { node.fetch('cookbooks', {}) }
+  let(:cookbooks) { node.fetch("cookbooks", {}) }
 
   let(:run_id) { run_status.run_id }
 
-  let(:expansion) { Chef::RunList::RunListExpansion.new('_default', run_list.run_list_items) }
+  let(:expansion) { Chef::RunList::RunListExpansion.new("_default", run_list.run_list_items) }
 
-  let(:cookbook_name) { 'monkey' }
+  let(:cookbook_name) { "monkey" }
 
-  let(:recipe_name) { 'atlas' }
+  let(:recipe_name) { "atlas" }
 
-  let(:node_name) { 'spitfire' }
+  let(:node_name) { "spitfire" }
 
-  let(:cookbook_version) { double('Cookbook::Version', version: '1.2.3') }
+  let(:cookbook_version) { double("Cookbook::Version", version: "1.2.3") }
 
   let(:resource_record) { [] }
 
@@ -95,9 +95,9 @@ describe Chef::DataCollector do
 
   let(:expected_run_list) { run_list.for_json }
 
-  let(:node_uuid) { '779196c6-f94f-4501-9dae-af8081ab4d3a' }
+  let(:node_uuid) { "779196c6-f94f-4501-9dae-af8081ab4d3a" }
 
-  let(:request_id) { '5db5d686-d18d-4234-a86a-28848c35dfc2' }
+  let(:request_id) { "5db5d686-d18d-4234-a86a-28848c35dfc2" }
 
   before do
     allow(Time).to receive(:now).and_return(start_time, end_time)
@@ -108,7 +108,7 @@ describe Chef::DataCollector do
     new_resource.recipe_name = recipe_name
     allow(new_resource).to receive(:cookbook_version).and_return(cookbook_version)
 
-    run_list << 'recipe[lobster]' << 'role[rage]' << 'recipe[fist]'
+    run_list << "recipe[lobster]" << "role[rage]" << "recipe[fist]"
     events.register(data_collector)
     events.register(action_collection)
     run_status.run_id = request_id
@@ -121,27 +121,27 @@ describe Chef::DataCollector do
 
   def expect_start_message(keys = nil)
     keys ||= {
-      'chef_server_fqdn' => 'localhost',
-      'entity_uuid' => node_uuid,
-      'id' => request_id,
-      'message_type' => 'run_start',
-      'message_version' => '1.0.0',
-      'node_name' => node_name,
-      'organization_name' => 'unknown_organization',
-      'run_id' => request_id,
-      'source' => 'chef_client',
-      'start_time' => start_time.utc.iso8601,
+      "chef_server_fqdn" => "localhost",
+      "entity_uuid" => node_uuid,
+      "id" => request_id,
+      "message_type" => "run_start",
+      "message_version" => "1.0.0",
+      "node_name" => node_name,
+      "organization_name" => "unknown_organization",
+      "run_id" => request_id,
+      "source" => "chef_client",
+      "start_time" => start_time.utc.iso8601,
     }
     expect(rest_client).to receive(:post).with(
       nil,
       hash_including(keys),
-      { 'Content-Type' => 'application/json' }
+      { "Content-Type" => "application/json" }
     )
   end
 
   def expect_converge_message(keys)
-    keys['message_type'] = 'run_converge'
-    keys['message_version'] = '1.1.0'
+    keys["message_type"] = "run_converge"
+    keys["message_version"] = "1.1.0"
     # if (keys.key?("node") && !keys["node"].empty?)
     #   expect(rest_client).to receive(:post) do |_a, hash, _b|
     #     require 'pry'; binding.pry
@@ -150,7 +150,7 @@ describe Chef::DataCollector do
     expect(rest_client).to receive(:post).with(
       nil,
       hash_including(keys),
-      { 'Content-Type' => 'application/json' }
+      { "Content-Type" => "application/json" }
     )
     # end
   end
@@ -161,149 +161,149 @@ describe Chef::DataCollector do
 
   def resource_record_for(new_resource, before_resource, after_resource, action, status, duration)
     {
-      'after' => after_resource&.state_for_resource_reporter || {},
-      'before' => before_resource&.state_for_resource_reporter || {},
-      'cookbook_name' => cookbook_name,
-      'cookbook_version' => cookbook_version&.version,
-      'delta' => resource_has_diff(new_resource, status) ? new_resource.diff : '',
-      'duration' => duration,
-      'id' => new_resource.identity,
-      'ignore_failure' => new_resource.ignore_failure,
-      'name' => new_resource.name,
-      'recipe_name' => recipe_name,
-      'result' => action.to_s,
-      'status' => status,
-      'type' => new_resource.resource_name.to_sym,
+      "after" => after_resource&.state_for_resource_reporter || {},
+      "before" => before_resource&.state_for_resource_reporter || {},
+      "cookbook_name" => cookbook_name,
+      "cookbook_version" => cookbook_version&.version,
+      "delta" => resource_has_diff(new_resource, status) ? new_resource.diff : "",
+      "duration" => duration,
+      "id" => new_resource.identity,
+      "ignore_failure" => new_resource.ignore_failure,
+      "name" => new_resource.name,
+      "recipe_name" => recipe_name,
+      "result" => action.to_s,
+      "status" => status,
+      "type" => new_resource.resource_name.to_sym,
     }
   end
 
   def send_run_failed_or_completed_event
-    status == 'success' ? events.run_completed(node, run_status) : events.run_failed(exception, run_status)
+    status == "success" ? events.run_completed(node, run_status) : events.run_failed(exception, run_status)
   end
 
-  shared_examples_for 'sends a converge message' do
-    it 'has a chef_server_fqdn' do
-      expect_converge_message('chef_server_fqdn' => 'localhost')
+  shared_examples_for "sends a converge message" do
+    it "has a chef_server_fqdn" do
+      expect_converge_message("chef_server_fqdn" => "localhost")
       send_run_failed_or_completed_event
     end
 
-    it 'has a start_time' do
-      expect_converge_message('start_time' => start_time.utc.iso8601)
+    it "has a start_time" do
+      expect_converge_message("start_time" => start_time.utc.iso8601)
       send_run_failed_or_completed_event
     end
 
-    it 'has a end_time' do
-      expect_converge_message('end_time' => end_time.utc.iso8601)
+    it "has a end_time" do
+      expect_converge_message("end_time" => end_time.utc.iso8601)
       send_run_failed_or_completed_event
     end
 
-    it 'has a entity_uuid' do
-      expect_converge_message('entity_uuid' => node_uuid)
+    it "has a entity_uuid" do
+      expect_converge_message("entity_uuid" => node_uuid)
       send_run_failed_or_completed_event
     end
 
-    it 'has a expanded_run_list' do
-      expect_converge_message('expanded_run_list' => expected_expansion)
+    it "has a expanded_run_list" do
+      expect_converge_message("expanded_run_list" => expected_expansion)
       send_run_failed_or_completed_event
     end
 
-    it 'has a node' do
-      expect_converge_message('node' => expected_node.is_a?(Chef::Node) ? expected_node.data_for_save : expected_node)
+    it "has a node" do
+      expect_converge_message("node" => expected_node.is_a?(Chef::Node) ? expected_node.data_for_save : expected_node)
       send_run_failed_or_completed_event
     end
 
-    it 'has a node_name' do
-      expect_converge_message('node_name' => node_name)
+    it "has a node_name" do
+      expect_converge_message("node_name" => node_name)
       send_run_failed_or_completed_event
     end
 
-    it 'has an organization' do
-      expect_converge_message('organization_name' => 'unknown_organization')
+    it "has an organization" do
+      expect_converge_message("organization_name" => "unknown_organization")
       send_run_failed_or_completed_event
     end
 
-    it 'has a policy_group' do
-      expect_converge_message('policy_group' => nil)
+    it "has a policy_group" do
+      expect_converge_message("policy_group" => nil)
       send_run_failed_or_completed_event
     end
 
-    it 'has a policy_name' do
-      expect_converge_message('policy_name' => nil)
+    it "has a policy_name" do
+      expect_converge_message("policy_name" => nil)
       send_run_failed_or_completed_event
     end
 
-    it 'has a run_id' do
-      expect_converge_message('run_id' => request_id)
+    it "has a run_id" do
+      expect_converge_message("run_id" => request_id)
       send_run_failed_or_completed_event
     end
 
-    it 'has a run_list' do
-      expect_converge_message('run_list' => expected_run_list)
+    it "has a run_list" do
+      expect_converge_message("run_list" => expected_run_list)
       send_run_failed_or_completed_event
     end
 
-    it 'has a cookbooks' do
-      expect_converge_message('cookbooks' => cookbooks)
+    it "has a cookbooks" do
+      expect_converge_message("cookbooks" => cookbooks)
       send_run_failed_or_completed_event
     end
 
-    it 'has a source' do
-      expect_converge_message('source' => 'chef_client')
+    it "has a source" do
+      expect_converge_message("source" => "chef_client")
       send_run_failed_or_completed_event
     end
 
-    it 'has a status' do
-      expect_converge_message('status' => status)
+    it "has a status" do
+      expect_converge_message("status" => status)
       send_run_failed_or_completed_event
     end
 
-    it 'has no deprecations' do
-      expect_converge_message('deprecations' => [])
+    it "has no deprecations" do
+      expect_converge_message("deprecations" => [])
       send_run_failed_or_completed_event
     end
 
-    it 'has an error field' do
+    it "has an error field" do
       if exception
         expect_converge_message(
-          'error' => {
-            'class' => exception.class,
-            'message' => exception.message,
-            'backtrace' => exception.backtrace,
-            'description' => error_description,
+          "error" => {
+            "class" => exception.class,
+            "message" => exception.message,
+            "backtrace" => exception.backtrace,
+            "description" => error_description,
           }
         )
       else
         expect(rest_client).to receive(:post).with(
           nil,
-          hash_excluding('error'),
-          { 'Content-Type' => 'application/json' }
+          hash_excluding("error"),
+          { "Content-Type" => "application/json" }
         )
       end
       send_run_failed_or_completed_event
     end
 
-    it 'has a total resource count of zero' do
-      expect_converge_message('total_resource_count' => total_resource_count)
+    it "has a total resource count of zero" do
+      expect_converge_message("total_resource_count" => total_resource_count)
       send_run_failed_or_completed_event
     end
 
-    it 'has a updated resource count of zero' do
-      expect_converge_message('updated_resource_count' => updated_resource_count)
+    it "has a updated resource count of zero" do
+      expect_converge_message("updated_resource_count" => updated_resource_count)
       send_run_failed_or_completed_event
     end
 
-    it 'includes the resource record' do
-      expect_converge_message('resources' => resource_record)
+    it "includes the resource record" do
+      expect_converge_message("resources" => resource_record)
       send_run_failed_or_completed_event
     end
   end
 
-  describe 'when the run fails during node load' do
-    let(:exception) { Exception.new('imperial to metric conversion error') }
+  describe "when the run fails during node load" do
+    let(:exception) { Exception.new("imperial to metric conversion error") }
     let(:error_description) { Chef::Formatters::ErrorMapper.registration_failed(node_name, exception, Chef::Config).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { 'failure' }
+    let(:status) { "failure" }
     let(:expected_node) { {} } # no node because that failed
     let(:expected_run_list) { [] } # no run_list without a node
     let(:expected_expansion) { {} } # no run_list expansion without a run_list
@@ -316,15 +316,15 @@ describe Chef::DataCollector do
       expect_start_message
     end
 
-    it_behaves_like 'sends a converge message'
+    it_behaves_like "sends a converge message"
   end
 
-  describe 'when the run fails during node load' do
-    let(:exception) { Exception.new('imperial to metric conversion error') }
+  describe "when the run fails during node load" do
+    let(:exception) { Exception.new("imperial to metric conversion error") }
     let(:error_description) { Chef::Formatters::ErrorMapper.node_load_failed(node_name, exception, Chef::Config).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { 'failure' }
+    let(:status) { "failure" }
     let(:expected_node) { {} } # no node because that failed
     let(:expected_run_list) { [] } # no run_list without a node
     let(:expected_expansion) { {} } # no run_list expansion without a run_list
@@ -337,15 +337,15 @@ describe Chef::DataCollector do
       expect_start_message
     end
 
-    it_behaves_like 'sends a converge message'
+    it_behaves_like "sends a converge message"
   end
 
-  describe 'when the run fails during run_list_expansion' do
-    let(:exception) { Exception.new('imperial to metric conversion error') }
+  describe "when the run fails during run_list_expansion" do
+    let(:exception) { Exception.new("imperial to metric conversion error") }
     let(:error_description) { Chef::Formatters::ErrorMapper.run_list_expand_failed(node, exception).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { 'failure' }
+    let(:status) { "failure" }
     let(:expected_expansion) { {} } # no run_list expanasion when it failed
     let(:resource_record) { [] } # and no resources
 
@@ -358,15 +358,15 @@ describe Chef::DataCollector do
       expect_start_message
     end
 
-    it_behaves_like 'sends a converge message'
+    it_behaves_like "sends a converge message"
   end
 
-  describe 'when the run fails during cookbook resolution' do
-    let(:exception) { Exception.new('imperial to metric conversion error') }
+  describe "when the run fails during cookbook resolution" do
+    let(:exception) { Exception.new("imperial to metric conversion error") }
     let(:error_description) { Chef::Formatters::ErrorMapper.cookbook_resolution_failed(node, exception).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { 'failure' }
+    let(:status) { "failure" }
     let(:resource_record) { [] } # and no resources
 
     before do
@@ -380,15 +380,15 @@ describe Chef::DataCollector do
       run_status.exception = exception
     end
 
-    it_behaves_like 'sends a converge message'
+    it_behaves_like "sends a converge message"
   end
 
-  describe 'when the run fails during cookbook synchronization' do
-    let(:exception) { Exception.new('imperial to metric conversion error') }
+  describe "when the run fails during cookbook synchronization" do
+    let(:exception) { Exception.new("imperial to metric conversion error") }
     let(:error_description) { Chef::Formatters::ErrorMapper.cookbook_sync_failed(node, exception).for_json }
     let(:total_resource_count) { 0 }
     let(:updated_resource_count) { 0 }
-    let(:status) { 'failure' }
+    let(:status) { "failure" }
     let(:resource_record) { [] } # and no resources
 
     before do
@@ -402,10 +402,10 @@ describe Chef::DataCollector do
       run_status.exception = exception
     end
 
-    it_behaves_like 'sends a converge message'
+    it_behaves_like "sends a converge message"
   end
 
-  describe 'after successfully starting the run' do
+  describe "after successfully starting the run" do
     before do
       # these events happen in this order in the client
       events.node_load_success(node)
@@ -414,144 +414,144 @@ describe Chef::DataCollector do
       run_status.start_clock
     end
 
-    describe 'run_start_message' do
-      it 'sends a run_start_message' do
+    describe "run_start_message" do
+      it "sends a run_start_message" do
         expect_start_message
         events.run_started(run_status)
       end
 
-      it 'extracts the hostname from the chef_server_url' do
-        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local'
-        expect_start_message('chef_server_fqdn' => 'spacex.rockets.local')
+      it "extracts the hostname from the chef_server_url" do
+        Chef::Config[:chef_server_url] = "https://spacex.rockets.local"
+        expect_start_message("chef_server_fqdn" => "spacex.rockets.local")
         events.run_started(run_status)
       end
 
-      it 'extracts the organization from the chef_server_url' do
-        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc'
-        expect_start_message('organization_name' => 'gnc')
+      it "extracts the organization from the chef_server_url" do
+        Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc"
+        expect_start_message("organization_name" => "gnc")
         events.run_started(run_status)
       end
 
-      it 'extracts the organization from the chef_server_url if there are extra slashes' do
-        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local///organizations///gnc'
-        expect_start_message('organization_name' => 'gnc')
+      it "extracts the organization from the chef_server_url if there are extra slashes" do
+        Chef::Config[:chef_server_url] = "https://spacex.rockets.local///organizations///gnc"
+        expect_start_message("organization_name" => "gnc")
         events.run_started(run_status)
       end
 
-      it 'extracts the organization from the chef_server_url if there is a trailing slash' do
-        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/'
-        expect_start_message('organization_name' => 'gnc')
+      it "extracts the organization from the chef_server_url if there is a trailing slash" do
+        Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/"
+        expect_start_message("organization_name" => "gnc")
         events.run_started(run_status)
       end
 
       it "sets 'unknown_organization' if the cher_server_url does not contain one" do
-        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local'
-        expect_start_message('organization_name' => 'unknown_organization')
+        Chef::Config[:chef_server_url] = "https://spacex.rockets.local"
+        expect_start_message("organization_name" => "unknown_organization")
         events.run_started(run_status)
       end
 
-      it 'still uses the chef_server_url in non-solo mode even if the data_collector organization is set' do
-        Chef::Config[:data_collector][:organization] = 'blue-origin'
-        Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/'
-        expect_start_message('organization_name' => 'gnc')
+      it "still uses the chef_server_url in non-solo mode even if the data_collector organization is set" do
+        Chef::Config[:data_collector][:organization] = "blue-origin"
+        Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/"
+        expect_start_message("organization_name" => "gnc")
         events.run_started(run_status)
       end
 
-      describe 'in legacy mode' do
+      describe "in legacy mode" do
         before do
           Chef::Config[:solo_legacy_mode] = true
-          Chef::Config[:data_collector][:server_url] = 'https://nasa.rockets.local/organizations/sls'
+          Chef::Config[:data_collector][:server_url] = "https://nasa.rockets.local/organizations/sls"
         end
 
-        it 'we get the data collector organization' do
-          Chef::Config[:data_collector][:organization] = 'blue-origin'
-          Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/' # should be ignored
-          expect_start_message('organization_name' => 'blue-origin')
+        it "we get the data collector organization" do
+          Chef::Config[:data_collector][:organization] = "blue-origin"
+          Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/" # should be ignored
+          expect_start_message("organization_name" => "blue-origin")
           events.run_started(run_status)
         end
 
         it "if the data collector org is unset we get 'chef_solo'" do
-          Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/' # should be ignored
-          expect_start_message('organization_name' => 'chef_solo')
+          Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/" # should be ignored
+          expect_start_message("organization_name" => "chef_solo")
           events.run_started(run_status)
         end
 
-        it 'sets the source' do
-          expect_start_message('source' => 'chef_solo')
+        it "sets the source" do
+          expect_start_message("source" => "chef_solo")
           events.run_started(run_status)
         end
       end
 
-      describe 'in local mode' do
+      describe "in local mode" do
         before do
           Chef::Config[:local_mode] = true
-          Chef::Config[:data_collector][:server_url] = 'https://nasa.rockets.local/organizations/sls'
+          Chef::Config[:data_collector][:server_url] = "https://nasa.rockets.local/organizations/sls"
         end
 
-        it 'we get the data collector organization' do
-          Chef::Config[:data_collector][:organization] = 'blue-origin'
-          Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/' # should be ignored
-          expect_start_message('organization_name' => 'blue-origin')
+        it "we get the data collector organization" do
+          Chef::Config[:data_collector][:organization] = "blue-origin"
+          Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/" # should be ignored
+          expect_start_message("organization_name" => "blue-origin")
           events.run_started(run_status)
         end
 
         it "if the data collector org is unset we get 'chef_solo'" do
-          Chef::Config[:chef_server_url] = 'https://spacex.rockets.local/organizations/gnc/' # should be ignored
-          expect_start_message('organization_name' => 'chef_solo')
+          Chef::Config[:chef_server_url] = "https://spacex.rockets.local/organizations/gnc/" # should be ignored
+          expect_start_message("organization_name" => "chef_solo")
           events.run_started(run_status)
         end
 
-        it 'sets the source' do
-          expect_start_message('source' => 'chef_solo')
+        it "sets the source" do
+          expect_start_message("source" => "chef_solo")
           events.run_started(run_status)
         end
       end
     end
 
-    describe 'converge messages' do
+    describe "converge messages" do
       before do
         expect_start_message
         events.run_started(run_status)
         events.cookbook_compilation_start(run_context)
       end
 
-      context 'with no resources' do
+      context "with no resources" do
         let(:total_resource_count) { 0 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) { [ ] }
-        let(:status) { 'success' }
+        let(:status) { "success" }
 
         before do
           run_status.stop_clock
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
 
-        it 'sets the policy_group' do
-          node.policy_group = 'acceptionsal'
-          expect_converge_message('policy_group' => 'acceptionsal')
+        it "sets the policy_group" do
+          node.policy_group = "acceptionsal"
+          expect_converge_message("policy_group" => "acceptionsal")
           send_run_failed_or_completed_event
         end
 
-        it 'has a policy_name' do
-          node.policy_name = 'webappdb'
-          expect_converge_message('policy_name' => 'webappdb')
+        it "has a policy_name" do
+          node.policy_name = "webappdb"
+          expect_converge_message("policy_name" => "webappdb")
           send_run_failed_or_completed_event
         end
 
-        it 'collects deprecation messages' do
+        it "collects deprecation messages" do
           location = Chef::Log.caller_location
-          events.deprecation(Chef::Deprecated.create(:internal_api, 'deprecation warning', location))
-          expect_converge_message('deprecations' => [{ location: location, message: 'deprecation warning', url: 'https://docs.chef.io/deprecations_internal_api/' }])
+          events.deprecation(Chef::Deprecated.create(:internal_api, "deprecation warning", location))
+          expect_converge_message("deprecations" => [{ location: location, message: "deprecation warning", url: "https://docs.chef.io/deprecations_internal_api/" }])
           send_run_failed_or_completed_event
         end
       end
 
-      context 'when the run contains a file resource that is up-to-date' do
+      context "when the run contains a file resource that is up-to-date" do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
-        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, 'up-to-date', '1234') ] }
-        let(:status) { 'success' }
+        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, "up-to-date", "1234") ] }
+        let(:status) { "success" }
 
         before do
           events.resource_action_start(new_resource, :create)
@@ -564,15 +564,15 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when the run contains a file resource that is up-to-date from a @recipe_files, returns nil for the version' do
+      context "when the run contains a file resource that is up-to-date from a @recipe_files, returns nil for the version" do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
-        let(:cookbook_name) { '@recipe_files' }
-        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, 'up-to-date', '1234') ] }
-        let(:status) { 'success' }
+        let(:cookbook_name) { "@recipe_files" }
+        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, "up-to-date", "1234") ] }
+        let(:status) { "success" }
         let(:cookbook_version) { nil }
 
         before do
@@ -587,14 +587,14 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when the run contains a file resource that is updated' do
+      context "when the run contains a file resource that is updated" do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 1 }
-        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, 'updated', '1234') ] }
-        let(:status) { 'success' }
+        let(:resource_record) { [ resource_record_for(new_resource, current_resource, after_resource, :create, "updated", "1234") ] }
+        let(:status) { "success" }
 
         before do
           events.resource_action_start(new_resource, :create)
@@ -607,21 +607,21 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'When there is an embedded resource, it includes the sub-resource in the report' do
+      context "When there is an embedded resource, it includes the sub-resource in the report" do
         let(:total_resource_count) { 2 }
         let(:updated_resource_count) { 2 }
         let(:implementation_resource) do
-          r = Chef::Resource::CookbookFile.new('/preseed-file.txt')
+          r = Chef::Resource::CookbookFile.new("/preseed-file.txt")
           r.cookbook_name = cookbook_name
           r.recipe_name = recipe_name
           allow(r).to receive(:cookbook_version).and_return(cookbook_version)
           r
         end
-        let(:resource_record) { [ resource_record_for(implementation_resource, implementation_resource, implementation_resource, :create, 'updated', '2345'), resource_record_for(new_resource, current_resource, after_resource, :create, 'updated', '1234') ] }
-        let(:status) { 'success' }
+        let(:resource_record) { [ resource_record_for(implementation_resource, implementation_resource, implementation_resource, :create, "updated", "2345"), resource_record_for(new_resource, current_resource, after_resource, :create, "updated", "1234") ] }
+        let(:status) { "success" }
 
         before do
           events.resource_action_start(new_resource, :create)
@@ -642,18 +642,18 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when the run contains a file resource that is skipped due to a block conditional' do
+      context "when the run contains a file resource that is skipped due to a block conditional" do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) do
-          rec = resource_record_for(new_resource, nil, nil, :create, 'skipped', '1234')
-          rec['conditional'] = 'not_if { #code block }' # FIXME: "#code block" is poor, is there some way to fix this?
+          rec = resource_record_for(new_resource, nil, nil, :create, "skipped", "1234")
+          rec["conditional"] = "not_if { #code block }" # FIXME: "#code block" is poor, is there some way to fix this?
           [ rec ]
         end
-        let(:status) { 'success' }
+        let(:status) { "success" }
 
         before do
           conditional = (new_resource.not_if { true }).first
@@ -665,21 +665,21 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when the run contains a file resource that is skipped due to a string conditional' do
+      context "when the run contains a file resource that is skipped due to a string conditional" do
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) do
-          rec = resource_record_for(new_resource, nil, nil, :create, 'skipped', '1234')
-          rec['conditional'] = 'not_if "true"'
+          rec = resource_record_for(new_resource, nil, nil, :create, "skipped", "1234")
+          rec["conditional"] = 'not_if "true"'
           [ rec ]
         end
-        let(:status) { 'success' }
+        let(:status) { "success" }
 
         before do
-          conditional = (new_resource.not_if 'true').first
+          conditional = (new_resource.not_if "true").first
           events.resource_action_start(new_resource, :create)
           events.resource_skipped(new_resource, :create, conditional)
           new_resource.instance_variable_set(:@elapsed_time, 1.2345)
@@ -688,27 +688,27 @@ describe Chef::DataCollector do
           run_status.stop_clock
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when the run contains a file resource that threw an exception' do
-        let(:exception) { Exception.new('imperial to metric conversion error') }
+      context "when the run contains a file resource that threw an exception" do
+        let(:exception) { Exception.new("imperial to metric conversion error") }
         let(:error_description) { Chef::Formatters::ErrorMapper.resource_failed(new_resource, :create, exception).for_json }
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) do
-          rec = resource_record_for(new_resource, current_resource, nil, :create, 'failed', '1234')
-          rec['error_message'] = 'imperial to metric conversion error'
-          rec['error'] = {
-            'class' => exception.class,
-            'message' => exception.message,
-            'backtrace' => exception.backtrace,
-            'description' => error_description,
+          rec = resource_record_for(new_resource, current_resource, nil, :create, "failed", "1234")
+          rec["error_message"] = "imperial to metric conversion error"
+          rec["error"] = {
+            "class" => exception.class,
+            "message" => exception.message,
+            "backtrace" => exception.backtrace,
+            "description" => error_description,
           }
 
           [ rec ]
         end
-        let(:status) { 'failure' }
+        let(:status) { "failure" }
 
         before do
           exception.set_backtrace(caller)
@@ -722,28 +722,28 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when the run contains a file resource that threw an exception in load_current_resource' do
-        let(:exception) { Exception.new('imperial to metric conversion error') }
+      context "when the run contains a file resource that threw an exception in load_current_resource" do
+        let(:exception) { Exception.new("imperial to metric conversion error") }
         let(:error_description) { Chef::Formatters::ErrorMapper.resource_failed(new_resource, :create, exception).for_json }
         let(:total_resource_count) { 1 }
         let(:updated_resource_count) { 0 }
         let(:resource_record) do
-          rec = resource_record_for(new_resource, nil, nil, :create, 'failed', '1234')
-          rec['before'] = {}
-          rec['error_message'] = 'imperial to metric conversion error'
-          rec['error'] = {
-            'class' => exception.class,
-            'message' => exception.message,
-            'backtrace' => exception.backtrace,
-            'description' => error_description,
+          rec = resource_record_for(new_resource, nil, nil, :create, "failed", "1234")
+          rec["before"] = {}
+          rec["error_message"] = "imperial to metric conversion error"
+          rec["error"] = {
+            "class" => exception.class,
+            "message" => exception.message,
+            "backtrace" => exception.backtrace,
+            "description" => error_description,
           }
 
           [ rec ]
         end
-        let(:status) { 'failure' }
+        let(:status) { "failure" }
 
         before do
           exception.set_backtrace(caller)
@@ -757,35 +757,35 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when the resource collection contains a resource that was unprocessed due to prior errors' do
-        let(:exception) { Exception.new('imperial to metric conversion error') }
+      context "when the resource collection contains a resource that was unprocessed due to prior errors" do
+        let(:exception) { Exception.new("imperial to metric conversion error") }
         let(:error_description) { Chef::Formatters::ErrorMapper.resource_failed(new_resource, :create, exception).for_json }
         let(:total_resource_count) { 2 }
         let(:updated_resource_count) { 0 }
         let(:unprocessed_resource) do
-          res = Chef::Resource::Service.new('unprocessed service')
+          res = Chef::Resource::Service.new("unprocessed service")
           res.cookbook_name = cookbook_name
           res.recipe_name = recipe_name
           allow(res).to receive(:cookbook_version).and_return(cookbook_version)
           res
         end
         let(:resource_record) do
-          rec1 = resource_record_for(new_resource, current_resource, nil, :create, 'failed', '1234')
-          rec1['error_message'] = 'imperial to metric conversion error'
-          rec1['error'] = {
-            'class' => exception.class,
-            'message' => exception.message,
-            'backtrace' => exception.backtrace,
-            'description' => error_description,
+          rec1 = resource_record_for(new_resource, current_resource, nil, :create, "failed", "1234")
+          rec1["error_message"] = "imperial to metric conversion error"
+          rec1["error"] = {
+            "class" => exception.class,
+            "message" => exception.message,
+            "backtrace" => exception.backtrace,
+            "description" => error_description,
           }
 
-          rec2 = resource_record_for(unprocessed_resource, nil, nil, :nothing, 'unprocessed', '')
+          rec2 = resource_record_for(unprocessed_resource, nil, nil, :nothing, "unprocessed", "")
           [ rec1, rec2 ]
         end
-        let(:status) { 'failure' }
+        let(:status) { "failure" }
 
         before do
           run_context.resource_collection << new_resource
@@ -802,15 +802,15 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when cookbook resolution fails' do
-        let(:exception) { Exception.new('imperial to metric conversion error') }
+      context "when cookbook resolution fails" do
+        let(:exception) { Exception.new("imperial to metric conversion error") }
         let(:error_description) { Chef::Formatters::ErrorMapper.cookbook_resolution_failed(expansion, exception).for_json }
         let(:total_resource_count) { 0 }
         let(:updated_resource_count) { 0 }
-        let(:status) { 'failure' }
+        let(:status) { "failure" }
 
         before do
           events.cookbook_resolution_failed(expansion, exception)
@@ -818,15 +818,15 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'When cookbook synchronization fails' do
-        let(:exception) { Exception.new('imperial to metric conversion error') }
+      context "When cookbook synchronization fails" do
+        let(:exception) { Exception.new("imperial to metric conversion error") }
         let(:error_description) { Chef::Formatters::ErrorMapper.cookbook_sync_failed({}, exception).for_json }
         let(:total_resource_count) { 0 }
         let(:updated_resource_count) { 0 }
-        let(:status) { 'failure' }
+        let(:status) { "failure" }
 
         before do
           events.cookbook_sync_failed(expansion, exception)
@@ -834,44 +834,44 @@ describe Chef::DataCollector do
           run_status.exception = exception
         end
 
-        it_behaves_like 'sends a converge message'
+        it_behaves_like "sends a converge message"
       end
 
-      context 'when node attributes are block-listed' do
-        let(:status) { 'success' }
+      context "when node attributes are block-listed" do
+        let(:status) { "success" }
         before do
           Chef::Config[:blocked_default_attributes] = [
             %w(secret key_to_the_kingdom),
           ]
           node.default = {
-            'secret' => { 'key_to_the_kingdom' => 'under the flower pot to the left of the drawbridge' },
-            'publicinfo' => { 'num_flower_pots' => 18 },
+            "secret" => { "key_to_the_kingdom" => "under the flower pot to the left of the drawbridge" },
+            "publicinfo" => { "num_flower_pots" => 18 },
           }
         end
 
-        it 'payload should exclude blocked attributes' do
+        it "payload should exclude blocked attributes" do
           expect(rest_client).to receive(:post) do |_addr, hash, _headers|
-            expect(hash['node']['default']).to eq({ 'secret' => {}, 'publicinfo' => { 'num_flower_pots' => 18 } })
+            expect(hash["node"]["default"]).to eq({ "secret" => {}, "publicinfo" => { "num_flower_pots" => 18 } })
           end
           send_run_failed_or_completed_event
         end
       end
 
-      context 'when node attributes are allow-listed' do
-        let(:status) { 'success' }
+      context "when node attributes are allow-listed" do
+        let(:status) { "success" }
         before do
           Chef::Config[:allowed_default_attributes] = [
             %w(public entrance),
           ]
           node.default = {
-            'public' => { 'entrance' => 'is the drawbridge' },
-            'secret' => { 'entrance' => 'is the tunnel' },
+            "public" => { "entrance" => "is the drawbridge" },
+            "secret" => { "entrance" => "is the tunnel" },
           }
         end
 
-        it 'payload should include only allowed attributes' do
+        it "payload should include only allowed attributes" do
           expect(rest_client).to receive(:post) do |_addr, hash, _headers|
-            expect(hash['node']['default']).to eq({ 'public' => { 'entrance' => 'is the drawbridge' } })
+            expect(hash["node"]["default"]).to eq({ "public" => { "entrance" => "is the drawbridge" } })
           end
           send_run_failed_or_completed_event
         end
@@ -879,15 +879,15 @@ describe Chef::DataCollector do
     end
   end
 
-  describe '#send_to_file_location(file_name, message)' do
-    let(:tempfile) { Tempfile.new('rspec-chef-datacollector-out') }
+  describe "#send_to_file_location(file_name, message)" do
+    let(:tempfile) { Tempfile.new("rspec-chef-datacollector-out") }
     let(:shift_jis) { "I have no idea what this character is:\n #{0x83.chr}#{0x80.chr}.\n" }
-    it 'handles invalid UTF-8 properly' do
+    it "handles invalid UTF-8 properly" do
       data_collector.send(:send_to_file_location, tempfile, { invalid: shift_jis })
     end
   end
 
-  describe '#send_to_datacollector' do
+  describe "#send_to_datacollector" do
     def stub_http_client(exception = nil)
       if exception.nil?
         expect(http_client).to receive(:post).with(nil, message, data_collector.send(:headers))
@@ -896,14 +896,14 @@ describe Chef::DataCollector do
       end
     end
 
-    let(:message) { 'message' }
+    let(:message) { "message" }
     let(:http_client) { instance_double(Chef::ServerAPI) }
 
     before do
       expect(data_collector).to receive(:setup_http_client).and_return(http_client)
     end
 
-    it 'does not disable the data_collector when no exception is raised' do
+    it "does not disable the data_collector when no exception is raised" do
       stub_http_client
       expect(data_collector.events).not_to receive(:unregister)
       data_collector.send(:send_to_data_collector, message)
@@ -920,18 +920,18 @@ describe Chef::DataCollector do
           stub_http_client(exception_class)
         end
 
-        it 'disables the reporter' do
+        it "disables the reporter" do
           expect(data_collector.events).to receive(:unregister).with(data_collector)
           data_collector.send(:send_to_data_collector, message)
         end
 
-        it 'logs an error and raises when raise_on_failure is enabled' do
+        it "logs an error and raises when raise_on_failure is enabled" do
           Chef::Config[:data_collector][:raise_on_failure] = true
           expect(Chef::Log).to receive(:error)
           expect { data_collector.send(:send_to_data_collector, message) }.to raise_error(exception_class)
         end
 
-        it 'logs a warn message and does not raise an exception when raise_on_failure is disabled' do
+        it "logs a warn message and does not raise an exception when raise_on_failure is disabled" do
           Chef::Config[:data_collector][:raise_on_failure] = false
           expect(Chef::Log).to receive(:warn)
           data_collector.send(:send_to_data_collector, message)
@@ -939,135 +939,135 @@ describe Chef::DataCollector do
       end
     end
 
-    context 'when the client raises a 404 exception' do
+    context "when the client raises a 404 exception" do
       let(:err) do
-        response = double('Net::HTTP response', code: '404')
-        Net::HTTPClientException.new('Not Found', response)
+        response = double("Net::HTTP response", code: "404")
+        Net::HTTPClientException.new("Not Found", response)
       end
 
       before do
         stub_http_client(err)
       end
 
-      it 'disables the reporter' do
+      it "disables the reporter" do
         expect(data_collector.events).to receive(:unregister).with(data_collector)
         data_collector.send(:send_to_data_collector, message)
       end
 
-      it 'logs an error and raises when raise_on_failure is enabled' do
+      it "logs an error and raises when raise_on_failure is enabled" do
         Chef::Config[:data_collector][:raise_on_failure] = true
         expect(Chef::Log).to receive(:error)
         expect { data_collector.send(:send_to_data_collector, message) }.to raise_error(err)
       end
 
       # this is different specifically for 404s
-      it 'logs an info message and does not raise an exception when raise_on_failure is disabled' do
+      it "logs an info message and does not raise an exception when raise_on_failure is disabled" do
         Chef::Config[:data_collector][:raise_on_failure] = false
         expect(Chef::Log).to receive(:debug).with(/This is normal if you do not have Chef Automate/)
         data_collector.send(:send_to_data_collector, message)
       end
     end
 
-    context 'when processing Windows registry keys' do
+    context "when processing Windows registry keys" do
       let(:total_resource_count) { 1 }
       let(:updated_resource_count) { 1 }
-      let(:status) { 'success' }
+      let(:status) { "success" }
 
       before do
         allow(ChefUtils).to receive(:windows?).and_return(true)
         run_status.stop_clock
       end
 
-      it 'removes registry key values not present in after state' do
+      it "removes registry key values not present in after state" do
         resource = {
-          'type' => :registry_key,
-          'before' => {
+          "type" => :registry_key,
+          "before" => {
             values: [
-              { name: 'key1', value: 'val1' },
-              { name: 'key2', value: 'val2' },
-              { name: 'key3', value: 'val3' },
+              { name: "key1", value: "val1" },
+              { name: "key2", value: "val2" },
+              { name: "key3", value: "val3" },
             ],
           },
-          'after' => {
+          "after" => {
             values: [
-              { name: 'key1', value: 'new_val1' },
-              { name: 'key3', value: 'new_val3' },
+              { name: "key1", value: "new_val1" },
+              { name: "key3", value: "new_val3" },
             ],
           },
         }
 
         message = {
-          'resources' => [resource],
+          "resources" => [resource],
         }
 
         # Verify that key2 was removed from before values
         expected_before_values = [
-          { name: 'key1', value: 'val1' },
-          { name: 'key3', value: 'val3' },
+          { name: "key1", value: "val1" },
+          { name: "key3", value: "val3" },
         ]
 
         expect(http_client).to receive(:post).with(
           nil,
-          hash_including('message_type' => 'run_start'),
-          { 'Content-Type' => 'application/json' })
+          hash_including("message_type" => "run_start"),
+          { "Content-Type" => "application/json" })
 
         expect(http_client).to receive(:post).with(
           nil,
           hash_including(
-            'resources' => array_including(
+            "resources" => array_including(
               hash_including(
-                'before' => hash_including(
+                "before" => hash_including(
                   values: array_including(expected_before_values)
                 )
               )
             )
           ),
-          { 'Content-Type' => 'application/json' }
+          { "Content-Type" => "application/json" }
         )
         allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
         data_collector.send(:send_run_completion, message)
       end
 
-      it 'handles missing values gracefully' do
+      it "handles missing values gracefully" do
         resource = {
-          'type' => :registry_key,
-          'before' => {},
-          'after' => { values: [] },
+          "type" => :registry_key,
+          "before" => {},
+          "after" => { values: [] },
         }
 
         message = {
-          'resources' => [resource],
+          "resources" => [resource],
         }
 
         expect(http_client).to receive(:post).with(
           nil,
-          hash_including('message_type' => 'run_start'),
-          { 'Content-Type' => 'application/json' })
+          hash_including("message_type" => "run_start"),
+          { "Content-Type" => "application/json" })
 
-        expect(http_client).to receive(:post).with(nil, message, { 'Content-Type' => 'application/json' })
+        expect(http_client).to receive(:post).with(nil, message, { "Content-Type" => "application/json" })
 
         allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
-        expect { data_collector.send(:send_run_completion, 'success') }.not_to raise_error
+        expect { data_collector.send(:send_run_completion, "success") }.not_to raise_error
       end
 
-      it 'ignores non-registry resources' do
+      it "ignores non-registry resources" do
         resource = {
-          'type' => :file,
-          'before' => { content: 'old' },
-          'after' => { content: 'new' },
+          "type" => :file,
+          "before" => { content: "old" },
+          "after" => { content: "new" },
         }
 
         message = {
-          'resources' => [resource],
+          "resources" => [resource],
         }
         expect(http_client).to receive(:post).with(nil,
-          hash_including('message_type' => 'run_start'),
-          { 'Content-Type' => 'application/json' })
+          hash_including("message_type" => "run_start"),
+          { "Content-Type" => "application/json" })
 
-        expect(http_client).to receive(:post).with(nil, message, { 'Content-Type' => 'application/json' })
+        expect(http_client).to receive(:post).with(nil, message, { "Content-Type" => "application/json" })
 
         allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
-        expect { data_collector.send(:send_run_completion, 'success') }.not_to raise_error
+        expect { data_collector.send(:send_run_completion, "success") }.not_to raise_error
       end
     end
   end

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -968,5 +968,108 @@ describe Chef::DataCollector do
         data_collector.send(:send_to_data_collector, message)
       end
     end
+
+    context "when processing Windows registry keys" do
+      let(:total_resource_count) { 1 }
+      let(:updated_resource_count) { 1 }
+      let(:status) { "success" }
+
+      before do
+        allow(ChefUtils).to receive(:windows?).and_return(true)
+        run_status.stop_clock
+      end
+
+      it "removes registry key values not present in after state" do
+        resource = {
+          "type" => :registry_key,
+          "before" => {
+            values: [
+              { name: "key1", value: "val1" },
+              { name: "key2", value: "val2" },
+              { name: "key3", value: "val3" }
+            ]
+          },
+          "after" => {
+            values: [
+              { name: "key1", value: "new_val1" },
+              { name: "key3", value: "new_val3" }
+            ]
+          }
+        }
+
+        message = {
+          "resources" => [resource]
+        }
+
+        # Verify that key2 was removed from before values
+        expected_before_values = [
+          { name: "key1", value: "val1" },
+          { name: "key3", value: "val3" }
+        ]
+
+        expect(http_client).to receive(:post).with(
+          nil,
+          hash_including("message_type" => "run_start"),
+          { "Content-Type" => "application/json" })
+
+        expect(http_client).to receive(:post).with(
+          nil,
+          hash_including(
+            "resources" => array_including(
+              hash_including(
+                "before" => hash_including(
+                  values: array_including(expected_before_values)
+                )
+              )
+            )
+          ),
+          { "Content-Type" => "application/json" }
+        )
+        allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
+        data_collector.send(:send_run_completion, message)
+      end
+
+      it "handles missing values gracefully" do
+        resource = {
+          "type" => :registry_key,
+          "before" => {},
+          "after" => { values: [] }
+        }
+
+        message = {
+          "resources" => [resource]
+        }
+
+        expect(http_client).to receive(:post).with(
+          nil,
+          hash_including("message_type" => "run_start"),
+          { "Content-Type" => "application/json" })
+
+        expect(http_client).to receive(:post).with( nil, message, { "Content-Type" => "application/json" })
+
+        allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
+        expect { data_collector.send(:send_run_completion, "success") }.not_to raise_error
+      end
+
+      it "ignores non-registry resources" do
+        resource = {
+          "type" => :file,
+          "before" => { content: "old" },
+          "after" => { content: "new" }
+        }
+
+        message = {
+          "resources" => [resource]
+        }
+        expect(http_client).to receive(:post).with( nil,
+          hash_including("message_type" => "run_start"),
+          { "Content-Type" => "application/json" })
+
+        expect(http_client).to receive(:post).with( nil, message, { "Content-Type" => "application/json" })
+
+        allow(Chef::DataCollector::RunEndMessage).to receive(:construct_message).and_return(message)
+        expect { data_collector.send(:send_run_completion, "success") }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -156,7 +156,7 @@ describe Chef::DataCollector do
   end
 
   def resource_has_diff(new_resource, status)
-    new_resource.respond_to?(:diff) && %w(updated failed).include?(status)
+    new_resource.respond_to?(:diff) && %w{updated failed}.include?(status)
   end
 
   def resource_record_for(new_resource, before_resource, after_resource, action, status, duration)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Filtering the before property on the resource side broke idempotency, so I moved the filtering to the data collector side.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
