### PR TITLE
Add unimplemented property back

### DIFF
--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -151,6 +151,10 @@ class Chef
       }
       property :recursive, [TrueClass, FalseClass], default: false
       property :architecture, Symbol, default: :machine, equal_to: %i{machine x86_64 i386}
+      property :only_record_changes, [TrueClass, FalseClass],
+         default: true,
+         introduced: "18.7.3",
+         description: "(no-op) disabled functionality to only record registry value changes"
 
       # Some registry key data types may not be safely reported as json.
       # Example (CHEF-5323):

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -154,7 +154,8 @@ class Chef
       property :only_record_changes, [TrueClass, FalseClass],
          default: true,
          introduced: "18.7.3",
-         description: "(no-op) disabled functionality to only record registry value changes"
+         description: "(no-op) disabled functionality to only record registry value changes",
+         deprecated: true
 
       # Some registry key data types may not be safely reported as json.
       # Example (CHEF-5323):


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Add the `only_record_changes` property back to the `registry_key` resource, in case any users of 18.7.3 modified their recipes to use it. It will effectively be a no-op.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
