### PR TITLE
Remove two low value debug lines

### DIFF
--- a/lib/chef/monkey_patches/net-http.rb
+++ b/lib/chef/monkey_patches/net-http.rb
@@ -23,7 +23,6 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
           conn_port = port
         end
 
-        Chef::Log.debug("opening connection to #{conn_addr}:#{conn_port}...")
         s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
           begin
             TCPSocket.open(conn_addr, conn_port, @local_host, @local_port)
@@ -33,7 +32,6 @@ if RUBY_VERSION.split(".")[0..1].join(".") == "3.1"
           end
         }
         s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
-        Chef::Log.debug("opened")
         if use_ssl?
           if proxy?
             plain_sock = BufferedIO.new(s, read_timeout: @read_timeout,


### PR DESCRIPTION
This removes two low value debug lines which produce repeated debug output like

```
[2024-06-14T17:32:08+00:00] DEBUG: opening connection to 169.254.169.254:80...
[2024-06-14T17:32:08+00:00] DEBUG: opened
```

## Description

In #13936 @rjhornsby points out that the fix in #13970 leaves these two debug lines present, though they don't provide much value.

This PR removes those two debug lines.

## Related Issue

* #13936

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Fixes #13936