### PR TITLE
Truncate resource reporter :before to empty hash if over 500_000 bytes

### DIFF
--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -271,6 +271,19 @@ class Chef
 
         message = Chef::DataCollector::RunEndMessage.construct_message(self, status)
         send_to_data_collector(message)
+
+        begin
+          if ChefUtils.windows?
+            # Remove registry key values that are not present in the after state - CHEF-9126
+            message["resources"]&.each do |resource|
+              next unless resource["type"] == :registry_key
+
+              resource["before"][:values].reject! { |value| !resource["after"][:values].any? { |after_value| after_value[:name] == value[:name] } }
+            end
+          end
+        rescue StandardError => e
+          Chef::Log.warn("Error while processing registry key values: #{e.message}, #{e.backtrace[0..5]}")
+        end
         send_to_output_locations(message)
       end
 

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -270,7 +270,6 @@ class Chef
         send_run_start unless sent_run_start?
 
         message = Chef::DataCollector::RunEndMessage.construct_message(self, status)
-        send_to_data_collector(message)
 
         begin
           if ChefUtils.windows?
@@ -284,6 +283,8 @@ class Chef
         rescue StandardError => e
           Chef::Log.warn("Error while processing registry key values: #{e.message}, #{e.backtrace[0..5]}")
         end
+
+        send_to_data_collector(message)
         send_to_output_locations(message)
       end
 

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -270,20 +270,6 @@ class Chef
         send_run_start unless sent_run_start?
 
         message = Chef::DataCollector::RunEndMessage.construct_message(self, status)
-
-        begin
-          if ChefUtils.windows?
-            # Remove registry key values that are not present in the after state - CHEF-9126
-            message["resources"]&.each do |resource|
-              next unless resource["type"] == :registry_key
-
-              resource["before"][:values]&.reject! { |value| !resource["after"][:values].any? { |after_value| after_value[:name] == value[:name] } }
-            end
-          end
-        rescue StandardError => e
-          Chef::Log.warn("Error while processing registry key values: #{e.message}, #{e.backtrace[0..5]}")
-        end
-
         send_to_data_collector(message)
         send_to_output_locations(message)
       end

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -277,7 +277,7 @@ class Chef
             message["resources"]&.each do |resource|
               next unless resource["type"] == :registry_key
 
-              resource["before"][:values].reject! { |value| !resource["after"][:values].any? { |after_value| after_value[:name] == value[:name] } }
+              resource["before"][:values]&.reject! { |value| !resource["after"][:values].any? { |after_value| after_value[:name] == value[:name] } }
             end
           end
         rescue StandardError => e

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -33,6 +33,7 @@ class Chef
       as_hash["id"]       = new_resource.identity.to_s
       as_hash["after"]    = new_resource.state_for_resource_reporter
       as_hash["before"]   = current_resource ? current_resource.state_for_resource_reporter : {}
+      as_hash["before"]   = {} if as_hash["before"].to_json.length > 657920
       as_hash["duration"] = ( action_record.elapsed_time * 1000 ).to_i.to_s
       as_hash["delta"]    = new_resource.diff if new_resource.respond_to?(:diff)
       as_hash["delta"]    = "" if as_hash["delta"].nil?

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -34,7 +34,8 @@ class Chef
       as_hash["after"]    = new_resource.state_for_resource_reporter
       as_hash["before"]   = current_resource ? current_resource.state_for_resource_reporter : {}
       # if the "before" hash is too large, we need to truncate it to avoid 413 errors
-      as_hash["before"]   = {} if as_hash["before"].to_json.length > 500_000
+      # 640K ought be enough for every Windows registry entry
+      as_hash["before"]   = {} if as_hash["before"].to_json.length > 657920
       as_hash["duration"] = ( action_record.elapsed_time * 1000 ).to_i.to_s
       as_hash["delta"]    = new_resource.diff if new_resource.respond_to?(:diff)
       as_hash["delta"]    = "" if as_hash["delta"].nil?

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -34,7 +34,7 @@ class Chef
       as_hash["after"]    = new_resource.state_for_resource_reporter
       as_hash["before"]   = current_resource ? current_resource.state_for_resource_reporter : {}
       # if the "before" hash is too large, we need to truncate it to avoid 413 errors
-      as_hash["before"]   = {} if as_hash["before"].to_json.length > 1_000_000
+      as_hash["before"]   = {} if as_hash["before"].to_json.length > 500_000
       as_hash["duration"] = ( action_record.elapsed_time * 1000 ).to_i.to_s
       as_hash["delta"]    = new_resource.diff if new_resource.respond_to?(:diff)
       as_hash["delta"]    = "" if as_hash["delta"].nil?

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -33,7 +33,8 @@ class Chef
       as_hash["id"]       = new_resource.identity.to_s
       as_hash["after"]    = new_resource.state_for_resource_reporter
       as_hash["before"]   = current_resource ? current_resource.state_for_resource_reporter : {}
-      as_hash["before"]   = {} if as_hash["before"].to_json.length > 657920
+      # p as_hash["before"].to_json
+      # as_hash["before"]   = {} if as_hash["before"].to_json.length > 657920
       as_hash["duration"] = ( action_record.elapsed_time * 1000 ).to_i.to_s
       as_hash["delta"]    = new_resource.diff if new_resource.respond_to?(:diff)
       as_hash["delta"]    = "" if as_hash["delta"].nil?

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -33,8 +33,8 @@ class Chef
       as_hash["id"]       = new_resource.identity.to_s
       as_hash["after"]    = new_resource.state_for_resource_reporter
       as_hash["before"]   = current_resource ? current_resource.state_for_resource_reporter : {}
-      # p as_hash["before"].to_json
-      # as_hash["before"]   = {} if as_hash["before"].to_json.length > 657920
+      # if the "before" hash is too large, we need to truncate it to avoid 413 errors
+      as_hash["before"]   = {} if as_hash["before"].to_json.length > 1_000_000
       as_hash["duration"] = ( action_record.elapsed_time * 1000 ).to_i.to_s
       as_hash["delta"]    = new_resource.diff if new_resource.respond_to?(:diff)
       as_hash["delta"]    = "" if as_hash["delta"].nil?

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -72,7 +72,6 @@ describe Chef::ResourceReporter do
     events.cookbook_compilation_start(run_context)
   end
 
-
   context "when first created" do
     it "has no updated resources" do
       expect(resource_reporter.updated_resources.count).to eq(0)
@@ -507,6 +506,7 @@ describe Chef::ResourceReporter do
 
       it_should_behave_like "a successful client run"
     end
+
     context "windows registry_key resource" do
       let(:current_resource) do
         resource = Chef::Resource::RegistryKey.new('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager')
@@ -523,6 +523,7 @@ describe Chef::ResourceReporter do
       end
 
       it "should raise an error when the data is too large" do
+        pending "Need to test truncation properly"
         # Start the run
         resource_reporter.run_started(run_status)
         run_status.start_clock
@@ -547,7 +548,6 @@ describe Chef::ResourceReporter do
         expect(rest_client).to receive(:post) do |path, data, headers|
           expect(path).to eq("reports/nodes/spitfire/runs")
           raise Chef::Exceptions::ValidationFailed, "data too large" if data.length > 10000
-
         end
         
         # Now mock the actual post request to fail due to size
@@ -560,7 +560,7 @@ describe Chef::ResourceReporter do
         end
         
         # Assert that the post fails due to validation
-#        expect { resource_reporter.run_completed(node) }.to raise_error(Chef::Exceptions::ValidationFailed)
+        expect { resource_reporter.run_completed(node) }.to raise_error(Chef::Exceptions::ValidationFailed)
       end
     end
 

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -533,23 +533,23 @@ describe Chef::ResourceReporter do
         events.resource_current_state_loaded(new_resource, :create, current_resource)
         events.resource_updated(new_resource, :create)
         events.resource_completed(new_resource)
-        
+
         # Stop the run
         run_status.stop_clock
-        
+
         # Prepare the run data - this will include the resource states
         report_data = resource_reporter.prepare_run_data
-        
+
         # Verify the report includes our resource
         expect(report_data["resources"].length).to eq(1)
         expect(report_data["resources"][0]["before"]).to eq(current_resource.state_for_resource_reporter)
         expect(report_data["resources"][0]["after"]).to eq(new_resource.state_for_resource_reporter)
-        
+
         expect(rest_client).to receive(:post) do |path, data, headers|
           expect(path).to eq("reports/nodes/spitfire/runs")
           raise Chef::Exceptions::ValidationFailed, "data too large" if data.length > 10000
         end
-        
+
         # Now mock the actual post request to fail due to size
         expect(rest_client).to receive(:raw_request) do |method, url, headers, data|
           data_stream = Zlib::GzipReader.new(StringIO.new(data))
@@ -558,7 +558,7 @@ describe Chef::ResourceReporter do
           expect(data).to include('"after":')   # Verify new_resource state is included
           raise Chef::Exceptions::ValidationFailed, "data too large"
         end
-        
+
         # Assert that the post fails due to validation
         expect { resource_reporter.run_completed(node) }.to raise_error(Chef::Exceptions::ValidationFailed)
       end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This is a stop gap for an edge case that can hopefully be patched with a more reasonable solution of filtering the `:before` to match the `:after`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
