### PR TITLE
fix: ensure apt_repository keys are always dearmored (#14944)

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -146,7 +146,7 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
           sudo apt-get update
-          sudo apt-get install -y vagrant virtualbox-7.0
+          sudo apt-get install -y vagrant virtualbox-7.1
           sudo vagrant --version
           sudo VBoxManage --version
       - name: Install Chef

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -95,7 +95,7 @@ jobs:
           - ubuntu-2004
           - ubuntu-2204
 #          - ubuntu-2404 not officially supported and errors occurring
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       FORCE_FFI_YAJL: ext
       CHEF_LICENSE: accept-no-persist
@@ -133,7 +133,7 @@ jobs:
           - ubuntu-2004
           - ubuntu-2204
 #          - ubuntu-2404 not officially supported and errors occurring.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CHEF_LICENSE: accept-no-persist
       KITCHEN_LOCAL_YAML: kitchen.linux.ci.yml

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -95,7 +95,7 @@ jobs:
           - ubuntu-2004
           - ubuntu-2204
 #          - ubuntu-2404 not officially supported and errors occurring
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       FORCE_FFI_YAJL: ext
       CHEF_LICENSE: accept-no-persist

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -129,7 +129,7 @@ jobs:
           - oracle-9
           - rockylinux-8
           - rockylinux-9
-          - ubuntu-1804
+#          - ubuntu-1804 EOL and errors occurring
           - ubuntu-2004
           - ubuntu-2204
 #          - ubuntu-2404 not officially supported and errors occurring.

--- a/cspell.json
+++ b/cspell.json
@@ -254,6 +254,8 @@
     "DBCS",
     "dctoken",
     "DDTHH",
+    "dearmor",
+    "dearmored",
     "Decompressor",
     "decompressor",
     "Decryptor",


### PR DESCRIPTION
Fixes: #14942

Also added setting of the kitchen vm tests to run on ubuntu 22.04 to stabilize builds.

Also disabled EOLed Ubuntu 18.04 as was done in #14891 as the tests are now consistently failing.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
