### PR TITLE
updating broken docker file that relies on the system installed libcr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,28 @@
 # in this file and also tag that image as "latest" on Docker Hub. Additionally major and minor tags will be
 # applied so 15.0.260 would be tagged as "latest", "stable", "15" and "15.0", as well as "15.0.260".
 
-FROM busybox
+
+FROM almalinux:8
 LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 
 ARG CHANNEL=stable
 ARG VERSION=18.7.6
 ARG ARCH=x86_64
-ARG PKG_VERSION=9
+ARG PKG_VERSION=8
+
+RUN dnf -y upgrade && \
+    dnf -y --skip-broken \
+    install \
+    libxcrypt-compat \
+    hostname \
+    libffi-devel \ 
+    gcc \
+    gcc-c++ \
+    make \ 
+    rpm2cpio \ 
+    wget \
+    cpio
+
 
 RUN wget "http://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/${PKG_VERSION}/chef-${VERSION}-1.el${PKG_VERSION}.${ARCH}.rpm" -O /tmp/chef-client.rpm && \
     rpm2cpio /tmp/chef-client.rpm | cpio -idmv && \


### PR DESCRIPTION
…ypt.so.1

this will have to be fixed for sure on the next chef 18 omnibus build by making sure we package and ship the libcrypt.so.2 with the tool

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
