### PR TITLE
Fix windows_user_privilege example.

### DIFF
--- a/lib/chef/resource/windows_user_privilege.rb
+++ b/lib/chef/resource/windows_user_privilege.rb
@@ -76,7 +76,7 @@ class Chef
       ```ruby
       windows_user_privilege 'Create Pagefile' do
         privilege      'SeCreatePagefilePrivilege'
-        users          ['BUILTIN\\Guests']
+        principal      'BUILTIN\\Guests'
         action         :remove
       end
       ```


### PR DESCRIPTION
The current docs have an example of using the `:remove` action with the `users` property, though the docs say "Use only with `:set` action." As such, the example code block will fail with error code 1332.

```ruby
windows_user_privilege 'Create Pagefile' do
  privilege      'SeCreatePagefilePrivilege'
  users          ['BUILTIN\Guests']
  action         :remove
end
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)