### PR TITLE
fix: ensure load_all_files ignores broken links in the cookbook dir CHEF-1958

### DIFF
--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -217,6 +217,7 @@ class Chef
           top_path = File.join(cookbook_path, top_filename)
           next if top_filename.start_with?(".") && File.directory?(top_path)
           next unless File.exist?(top_path)
+
           # Use Find.find because it:
           # (a) returns any children, recursively
           # (b) includes top_path as well

--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -213,10 +213,10 @@ class Chef
         # directories at the top level are not included for backcompat), this
         # actually keeps things a bit cleaner.
         Dir.entries(cookbook_path).each do |top_filename|
-          # Skip top-level directories starting with "."
+          # Skip top-level directories starting with "." amd broken links
           top_path = File.join(cookbook_path, top_filename)
           next if top_filename.start_with?(".") && File.directory?(top_path)
-
+          next unless File.exist?(top_path)
           # Use Find.find because it:
           # (a) returns any children, recursively
           # (b) includes top_path as well

--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -213,7 +213,7 @@ class Chef
         # directories at the top level are not included for backcompat), this
         # actually keeps things a bit cleaner.
         Dir.entries(cookbook_path).each do |top_filename|
-          # Skip top-level directories starting with "." amd broken links
+          # Skip top-level directories starting with "." and broken links
           top_path = File.join(cookbook_path, top_filename)
           next if top_filename.start_with?(".") && File.directory?(top_path)
           next unless File.exist?(top_path)


### PR DESCRIPTION
## Description
When Chef client enumerates files in the cookbook parent directory it should ignore all hidden directory entries for compatibility reasons. However if a link to a directory exists and it is broken, it is not evaluated as a directory but as a file, therefore being included in the top_path array.

When the broken link is passed to Find.find() it throws an exception and breaks the client execution.

## Related Issue
* https://github.com/ruby/find/issues/18

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
