### PR TITLE
Bug fix for apt_repository when creating a new keyring

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -242,7 +242,8 @@ class Chef
         #
         # @return [Boolean] is the key valid or not
         def keyring_key_is_valid?(keyring, key)
-          valid = shell_out("gpg", "--no-default-keyring", "--keyring", keyring, "--list-public-keys", key).stdout.each_line.none?(/\[(expired|revoked):/)
+          out = shell_out("gpg", "--no-default-keyring", "--keyring", keyring, "--list-public-keys", key)
+          valid = out.exitstatus == 0 && out.stdout.each_line.none?(/\[(expired|revoked):/)
 
           logger.debug "key #{key} #{valid ? "is valid" : "is not valid"}"
           valid


### PR DESCRIPTION
## Description
`keyring_key_is_valid` will return true even though the key does not exist.

The keyring_key_is_valid function will run the following:
```
$ gpg --no-default-keyring --keyring  /etc/apt/keyrings/ring.gpg --list-public-keys fingerprint
gpg: error reading key: No public key
$ echo $?
2
```

the `stdout none?` matcher will return true for this error and the key will be delcared "valid" even though it does not exist. This will cause the `not_if` block called from `install_key_from_keyserver_to_keyring` to skip the execute and the key will not be installed.

This updates the function so that it also checks the `exitstatus` of the `shell_out` and will return `false` when the status is not equal to 0.

## Related Issue
#14943

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
