### PR TITLE
Fix: Improve error handling in try block for code-sign verification

### DIFF
--- a/.expeditor/scripts/omnibus_chef_build.ps1
+++ b/.expeditor/scripts/omnibus_chef_build.ps1
@@ -125,11 +125,12 @@ Write-Output "--- Building Chef"
 bundle exec omnibus build chef -l internal --override append_timestamp:false
 if ( -not $? ) { throw "omnibus build chef failed" }
 
-#confirm file is signed
+# Confirm file is signed
 try {
   $directoryPath = "C:\omnibus-ruby\pkg\"
   $msiFile = Get-ChildItem -Path $directoryPath -Filter *.msi | Select-Object -First 1
-  write-output "--- test msi path"
+  Write-Output "--- test msi path"
+
   # Check if an .msi file was found
   if ($msiFile -ne $null) {
     # Display the full path of the found .msi file
@@ -138,14 +139,27 @@ try {
 
     # Assign the full path to a variable ($fullPath) for later use
     $fullPathVariable = $fullPath
-    write-output "--- verify signed file smctl sign verify --input ${fullPathVariable}"
+    Write-Output "--- verify signed file smctl sign verify --input ${fullPathVariable}"
+
+    # Run smctl sign verify and check its exit status
     smctl sign verify --input ${fullPathVariable}
+    if (-not $? ) {
+      Write-Error "Signing verification failed for file: ${fullPathVariable}" -ErrorAction Stop
+    }
+
+    # Run signtool verify and check its exit status
+    Write-Output "--- Running signtool verify"
+    signtool verify /pa "${fullPathVariable}"
+    if (-not $? ) {
+      Write-Error "Signtool verification failed for file: ${fullPathVariable}" -ErrorAction Stop
+    }
   } else {
-    Write-Output "No .msi files found in the directory: $directoryPath or its not signed"
+    Write-Error "No .msi files found in the directory: $directoryPath or the file is not signed" -ErrorAction Stop
   }
 } catch {
-  Write-Output "An error occurred: $_"
-  exit 1
+  Write-Error "An error occurred during signing verification: $_"
+  If ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
+  Exit 1  # Fallback in case $LASTEXITCODE is not set
 }
 
 write-output "--- smctl credentials delete just to clean up"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR addresses improvements to the error handling in the try block for code-sign verification in the omnibus_chef_build.ps1 script. The changes ensure that the script fails and provides clear error messages when code-sign verification fails.

Enhanced Error Handling:
Added checks for the exit status of smctl sign verify and signtool verify commands.
Ensured the script stops execution immediately if either command fails.

Added detailed error messages to help debug issues related to code-sign verification.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
