### PR TITLE
fix: loosen the regex to allow bio version to match

### DIFF
--- a/lib/chef/resource/habitat_install.rb
+++ b/lib/chef/resource/habitat_install.rb
@@ -73,7 +73,7 @@ class Chef
       action :install, description: "Installs Habitat. Does nothing if the `hab` binary is found in the default location for the system (`/bin/hab` on Linux, `/usr/local/bin/hab` on macOS, `C:/habitat/hab.exe` on Windows)" do
         if ::TargetIO::File.exist?(hab_path)
           cmd = shell_out!([hab_path, "--version"].flatten.compact.join(" "))
-          version = %r{hab (\d*\.\d*\.\d[^\/]*)}.match(cmd.stdout)[1]
+          version = %r{\w+ (\d*\.\d*\.\d[^\/]*)}.match(cmd.stdout)[1]
           return if version == new_resource.hab_version
         end
 


### PR DESCRIPTION
## Description
Actually the regex match a hardcoded `hab x.y.z` string only.
This change allow `bio x.y.z` to match too 

## Related Issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
