### PR TITLE
Remove broken Resource Reporter spec from CHEF-9126 work that is fill…

### DIFF
--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -507,65 +507,7 @@ describe Chef::ResourceReporter do
       it_should_behave_like "a successful client run"
     end
 
-    context "windows registry_key resource" do
-      let(:current_resource) do
-        resource = Chef::Resource::RegistryKey.new('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager')
-        resource.values([{ name: "PendingFileRenameOperations", type: :multi_string, data: 10000.times.map { |n| "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Temp\\2\\Chef-20140107123456-1234-#{n}" } } ])
-        resource
-      end
-
-      let(:new_resource) do
-        resource = Chef::Resource::RegistryKey.new('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager')
-        resource.values([ { name: "ProtectionMode", type: :dword, data: 1 } ])
-        allow(resource).to receive(:cookbook_name).and_return(cookbook_name)
-        allow(resource).to receive(:cookbook_version).and_return(cookbook_version)
-        resource
-      end
-
-      it "should raise an error when the data is too large" do
-        pending "Need to test truncation properly"
-        # Start the run
-        resource_reporter.run_started(run_status)
-        run_status.start_clock
-
-        # These 4 event callbacks are essential to populate resource state:
-        events.resource_action_start(new_resource, :create)
-        events.resource_current_state_loaded(new_resource, :create, current_resource)
-        events.resource_updated(new_resource, :create)
-        events.resource_completed(new_resource)
-
-        # Stop the run
-        run_status.stop_clock
-
-        # Prepare the run data - this will include the resource states
-        report_data = resource_reporter.prepare_run_data
-
-        # Verify the report includes our resource
-        expect(report_data["resources"].length).to eq(1)
-        expect(report_data["resources"][0]["before"]).to eq(current_resource.state_for_resource_reporter)
-        expect(report_data["resources"][0]["after"]).to eq(new_resource.state_for_resource_reporter)
-
-        expect(rest_client).to receive(:post) do |path, data, headers|
-          expect(path).to eq("reports/nodes/spitfire/runs")
-          raise Chef::Exceptions::ValidationFailed, "data too large" if data.length > 10000
-        end
-
-        # Now mock the actual post request to fail due to size
-        expect(rest_client).to receive(:raw_request) do |method, url, headers, data|
-          data_stream = Zlib::GzipReader.new(StringIO.new(data))
-          data = data_stream.read
-          expect(data).to include('"before":')  # Verify current_resource state is included
-          expect(data).to include('"after":')   # Verify new_resource state is included
-          raise Chef::Exceptions::ValidationFailed, "data too large"
-        end
-
-        # Assert that the post fails due to validation
-        expect { resource_reporter.run_completed(node) }.to raise_error(Chef::Exceptions::ValidationFailed)
-      end
-    end
-
     context "for an unsuccessful run" do
-
       before do
         @backtrace = ["foo.rb:1 in `foo!'", "bar.rb:2 in `bar!", "'baz.rb:3 in `baz!'"]
         node = Chef::Node.new


### PR DESCRIPTION
…ing up build logs

<!--- Provide a short summary of your changes in the Title above -->

## Description
Note: The build isn't technically "broken" without this, but 4MB of data on a single log "line" makes debugging other issues difficult.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
