### PR TITLE
make sure the right paths get put in the native ffi gem runpath

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1190,6 +1190,7 @@
     "rname",
     "roundrobin",
     "rpartition",
+    "rpath",
     "rpmdb",
     "rpmdep",
     "rpmds",

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -97,6 +97,7 @@ do_prepare() {
         --with-xslt-dir=$(pkg_path_for libxslt) \
         --with-xml2-include=$(pkg_path_for libxml2)/include/libxml2 \
         --with-xml2-lib=$(pkg_path_for libxml2)/lib"
+    bundle config --local build.ffi "-Wl,-rpath,'${LD_RUN_PATH}'"
     bundle config --local jobs "$(nproc)"
     bundle config --local without server docgen maintenance pry travis integration ci
     bundle config --local shebang "$(pkg_path_for "$_chef_client_ruby")/bin/ruby"


### PR DESCRIPTION
If I run `hab pkg exec chef/chef-infra-client/19.1.14/20250404144140 irb` and then `require "ffi-libarchive"`, I get an error that it is unable to load ffi-libarchive because libarchive cannot be found. With the change here, the require succeeds.