### PR TITLE
Add test of loading of ssl_env_hack.rb and fix.

### DIFF
--- a/post-bundle-install.rb
+++ b/post-bundle-install.rb
@@ -27,3 +27,77 @@ Dir["#{gem_home}/bundler/gems/*"].each do |gempath|
     system("gem install #{gem_name}*.gem --conservative --minimal-deps --no-document") or raise "gem install failed"
   end
 end
+
+def patch_ssl_env_hack(ssl_env_hack)
+  # the constant SSL_ENV_CACERT_PATCH is a proxy for whether the SSL_CERT_FILE environment variable
+  # will be set by the ssl_env_hack.rb file.  This is used to ensure that the CA bundle
+  # is set correctly in omnibus installations of Chef Infra Client if the user is using certs/cacert.pem
+  # instead of cert.pem. Because we're reinstalling openssl gem for 3.x versions, we need to ensure that
+  # openssl.rb requires ssl_env_hack.rb, which will set the SSL_CERT_FILE environment variable
+  ssl_env_hack_patch = <<-PATCH
+  SSL_ENV_CACERT_PATCH=true unless defined?(SSL_ENV_CACERT_PATCH)
+  PATCH
+
+  File.open(ssl_env_hack, "r+") do |f|
+    unpatched_ssl_env_hack_rb = f.read
+    if unpatched_ssl_env_hack_rb =~ /SSL_ENV_CACERT_PATCH/
+      puts "skipping #{ssl_env_hack} as it already has SSL_ENV_CACERT_PATCH"
+      next
+    end
+
+    f.rewind
+    f.write(ssl_env_hack_patch)
+    f.write(unpatched_ssl_env_hack_rb)
+  end
+  puts "patched #{ssl_env_hack} to include SSL_ENV_CACERT_PATCH"
+end
+
+def patch_openssl(openssl)
+  puts openssl
+  File.open(openssl, "r+") do |f|
+    unpatched_openssl_rb = f.read
+    if unpatched_openssl_rb =~ /require\s+['"]ssl_env_hack['"]/
+      puts "skipping #{openssl} as it already has ssl_env_hack"
+      next
+    end
+
+    f.rewind
+    # This is a workaround for the openssl gem not being able to find the CA bundle in omnibus installations
+    # and not setting SSL_CERT_FILE if it's not already set.
+    f.write("\nrequire 'ssl_env_hack'\n")
+    f.write(unpatched_openssl_rb)
+  end
+  puts "patched #{openssl} to include ssl_env_hack"
+end
+
+if RUBY_PLATFORM =~ /mswin|mingw|windows/
+  puts "Patching ssl_env_hack.rb to include SSL_ENV_CACERT_PATCH"
+
+  # ssl_env_hack.rb in chef is superseded by foundation copy in omnibus,
+  # but patch it if it doesn't have SSL_ENV_CACERT_PATCH defined.
+  $:.each do |lib|
+    puts "checking for ssl_env_hack in #{lib}"
+    Dir["#{lib}/**/ssl_env_hack.rb"].each do |ssl_env_hack|
+      puts "found #{ssl_env_hack}"
+      patch_ssl_env_hack(ssl_env_hack)
+      File.readlines(ssl_env_hack).each do |line|
+        puts line
+      end
+    end
+  end
+
+  puts "Found openssl.rb files in the following gem paths:"
+  Dir["#{gem_home}/**/openssl-*/lib/openssl.rb"].each do |openssl|
+    patch_openssl(openssl)
+  end
+
+  puts "Patch openssl.rb in the load path as well"
+  $:.each do |lib|
+    openssl_rb = File.join(lib, "openssl.rb")
+    patch_openssl(openssl_rb) if File.exist?(openssl_rb)
+  end
+
+  puts "Including openssl"
+  require "openssl"
+  puts "::SSL_ENV_CACERT_PATCH is #{defined?(::SSL_ENV_CACERT_PATCH) ? "defined" : "not defined"}"
+end

--- a/spec/integration/client/open_ssl_spec.rb
+++ b/spec/integration/client/open_ssl_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "openssl"
 
 describe "openssl checks" do
   let(:openssl_version_default) do
@@ -16,5 +17,9 @@ describe "openssl checks" do
     example "check #{method}", not_supported_on_macos: true do
       expect(OpenSSL.const_get("OPENSSL_#{method.upcase}")).to match(openssl_version_default), "OpenSSL doesn't match omnibus_overrides.rb"
     end
+  end
+
+  example "check SSL_ENV_HACK", windows_only: true, validate_only: true do
+    expect(defined?(::SSL_ENV_CACERT_PATCH)).to be_truthy, "SSL_ENV_CACERT_PATCH is not defined, did you forget to include the openssl-customization.rb file in your project?"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -180,6 +180,7 @@ RSpec.configure do |config|
   config.filter_run_excluding openssl_gte_101: true unless openssl_gte_101?
   config.filter_run_excluding openssl_lt_101: true unless openssl_lt_101?
   config.filter_run_excluding aes_256_gcm_only: true unless aes_256_gcm?
+  config.filter_run_excluding validate_only: true unless ENV["BUILDKITE_BUILD_URL"] =~ /validate/
   config.filter_run_excluding broken: true
   config.filter_run_excluding not_wpar: true unless wpar?
   config.filter_run_excluding not_supported_on_s390x: true unless s390x?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The ssl_env_hack.rb file that sets SSL_CERT_FILE to `cacert.pem` in Windows isn't getting loaded due to the reinstall of the `openssl` gem. Edit `post-bundle-install.rb` to fix.

* Patch constant SSL_ENV_CACERT_PATCH into all instances of
ssl_env_hack.rb
* Add test for constant that is defined in ssl_env_hack.rb.
* Add ssl_env_hack.rb during post-bundle-install to look for openssl.rb in lib path and gem hierarchies
due to reinstalling openssl gem

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
