### PR TITLE
Fix dearmoring idempotency

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
@@ -27,5 +27,14 @@ apt_repository "test" do
   uri "http://ftp.be.debian.org/debian/"
   distribution "bookworm"
   components %w{main contrib non-free}
+  signed_by true
+  key "https://ftp-master.debian.org/keys/archive-key-12.asc"
+end
+
+apt_repository "test" do
+  uri "http://ftp.be.debian.org/debian/"
+  distribution "bookworm"
+  components %w{main contrib non-free}
+  signed_by true
   key "https://ftp-master.debian.org/keys/archive-key-12.asc"
 end

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -284,7 +284,7 @@ class Chef
         # @raise [Chef::Exceptions::FileNotFound] Key isn't remote or found in the current run
         #
         # @return [Symbol] :remote_file or :cookbook_file
-        def key_type(uri)
+        def key_resource_type(uri)
           if uri.start_with?("http")
             :remote_file
           elsif has_cookbook_file?(uri)
@@ -307,39 +307,46 @@ class Chef
         # @return [void]
         def install_key_from_uri(key)
           key_name = key.gsub(/[^0-9A-Za-z\-]/, "_")
-          keyfile_path = ::File.join(Chef::Config[:file_cache_path], key_name)
+          keyfile_tmp_path = ::File.join(Chef::Config[:file_cache_path], key_name)
+          keyfile_path = keyring_path
           tmp_dir = Dir.mktmpdir(".gpg")
           at_exit { FileUtils.remove_entry(tmp_dir) }
 
           if new_resource.signed_by
-            keyfile_path = keyring_path
-
             directory "/etc/apt/keyrings" do
               mode "0755"
             end
-          end
 
-          declare_resource(key_type(key), keyfile_path) do
-            source key
-            mode "0644"
-            sensitive new_resource.sensitive
-            action :create
-            verify "gpg --homedir #{tmp_dir} %{path}"
-          end
+            declare_resource(key_resource_type(key), keyfile_tmp_path) do
+              source key
+              mode "0644"
+              sensitive new_resource.sensitive
+              action :create
+              verify "gpg --homedir #{tmp_dir} %{path}"
+              notifies :delete, "file[#{keyfile_path}]", :immediately
+              notifies :run, "execute[dearmor #{keyfile_path}]", :immediately
+            end
 
-          # If signed by is true, then we don't need to
-          # add to the default keyring. Instead make sure it's dearmored
-          if new_resource.signed_by
-            execute "gpg dearmor key" do
-              input ::File.read(keyfile_path)
-              command [ "gpg", "--batch", "--yes", "--dearmor", "-o", keyfile_path ]
+            execute "dearmor #{keyfile_path}" do
+              command [ "gpg", "--batch", "--yes", "--dearmor", "-o", keyfile_path, keyfile_tmp_path ]
               default_env true
               sensitive new_resource.sensitive
-              action :run
-              only_if { ::File.read(keyfile_path).include?("-----BEGIN PGP PUBLIC KEY BLOCK-----") }
-              notifies :run, "execute[apt-cache gencaches]", :immediately
+              action :nothing
+              only_if { !::File.exist?(keyfile_path) || ::File.read(keyfile_path).include?("-----BEGIN PGP PUBLIC KEY BLOCK-----") }
+            end
+
+            file keyfile_path do
+              mode "0644"
             end
           else
+            declare_resource(key_resource_type(key), keyfile_path) do
+              source key
+              mode "0644"
+              sensitive new_resource.sensitive
+              action :create
+              verify "gpg --homedir #{tmp_dir} %{path}"
+            end
+
             execute "apt-key add #{keyfile_path}" do
               command [ "apt-key", "add", keyfile_path ]
               default_env true

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -165,17 +165,17 @@ C5986B4F1257FFA86632CBA746181433FBB75451
 
   describe "#key_type" do
     it "returns :remote_file with an http URL" do
-      expect(provider.key_type("https://www.chef.io/key")).to eq(:remote_file)
+      expect(provider.key_resource_type("https://www.chef.io/key")).to eq(:remote_file)
     end
 
     it "returns :cookbook_file with a chef managed file" do
       expect(provider).to receive(:has_cookbook_file?).and_return(true)
-      expect(provider.key_type("/foo/bar.key")).to eq(:cookbook_file)
+      expect(provider.key_resource_type("/foo/bar.key")).to eq(:cookbook_file)
     end
 
     it "throws exception if an unknown file specified" do
       expect(provider).to receive(:has_cookbook_file?).and_return(false)
-      expect { provider.key_type("/foo/bar.key") }.to raise_error(Chef::Exceptions::FileNotFound)
+      expect { provider.key_resource_type("/foo/bar.key") }.to raise_error(Chef::Exceptions::FileNotFound)
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
...also rename `key_type` to `key_resource_type`

This is a hand-edited conflict resolution of a `cherry-pick` of https://github.com/chef/chef/pull/15044 PR merge, otherwise `TargetIO::` will be reintroduced to `chef-18`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
