### PR TITLE
Obvious fix: remove stale TODO

### DIFF
--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -339,7 +339,6 @@ class Chef
         raise ArgumentError, "Invalid value passed for `random_delay`. Please pass seconds as an Integer (e.g. 60) or a String with numeric values only (e.g. '60')." unless numeric_value_in_string?(random_delay)
       end
 
-      # @todo when we drop ruby 2.3 support this should be converted to .match?() instead of =~f
       def validate_start_day(start_day, frequency)
         if start_day && frequency == :none
           raise ArgumentError, "`start_day` property is not supported with frequency: #{frequency}"
@@ -351,7 +350,6 @@ class Chef
         end
       end
 
-      # @todo when we drop ruby 2.3 support this should be converted to .match?() instead of =~
       def validate_start_time(start_time, frequency)
         if start_time
           raise ArgumentError, "`start_time` property is not supported with `frequency :none`" if frequency == :none


### PR DESCRIPTION
This is no longer relevant since the code has changed, plus Ruby 2.7 was dropped in #14260.