### PR TITLE
[PythonHelper#query] Move build_query outside of with_helper block

### DIFF
--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -145,8 +145,8 @@ class Chef
           end
 
           def query(action, parameters)
+            json = build_query(action, parameters)
             with_helper do
-              json = build_query(action, parameters)
               Chef::Log.trace "sending '#{json}' to python helper"
               outpipe.puts json
               outpipe.flush


### PR DESCRIPTION
Signed-off-by: David Crosby <dcrosby@fb.com>

## Description
with_helper has a retry, and we're not expecting `json` to change over multiple iterations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
