### PR TITLE
Disable pre build tests for ssl hack

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -180,7 +180,7 @@ RSpec.configure do |config|
   config.filter_run_excluding openssl_gte_101: true unless openssl_gte_101?
   config.filter_run_excluding openssl_lt_101: true unless openssl_lt_101?
   config.filter_run_excluding aes_256_gcm_only: true unless aes_256_gcm?
-  config.filter_run_excluding validate_only: true unless ENV["BUILDKITE_BUILD_URL"] =~ /validate/
+  config.filter_run_excluding validate_only: true unless ENV["BUILDKITE_BUILD_URL"] =~ /validate/ && ENV.fetch("BUILDKITE_LABEL", "") !~ /(Integration |Functional |Unit )/
   config.filter_run_excluding broken: true
   config.filter_run_excluding not_wpar: true unless wpar?
   config.filter_run_excluding not_supported_on_s390x: true unless s390x?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Unit/Functional/Integration tests won't have a ruby with the ssl_env_hack on it.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
