### PR TITLE
Add support for secrets in credentials file

### DIFF
--- a/chef-config/lib/chef-config/exceptions.rb
+++ b/chef-config/lib/chef-config/exceptions.rb
@@ -23,5 +23,8 @@ module ChefConfig
   class ConfigurationError < ArgumentError; end
   class InvalidPath < StandardError; end
   class UnparsableConfigOption < StandardError; end
+  class NoCredentialsFound < StandardError; end
 
+  class UnsupportedSecretsProvider < ConfigurationError; end
+  class UnresolvedSecret < ConfigurationError; end
 end

--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -194,7 +194,6 @@ module ChefConfig
 
         # Lazy require due to Gem being part of Chef and rarely used functionality
         require "vault" unless defined? Vault
-        logger.debug("Connecting to HashiCorp Vault at #{vault_config[:address]}...")
         @vault ||= Vault::Client.new(vault_config)
 
         secret = secrets_config["secret"]

--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -128,7 +128,7 @@ module ChefConfig
       # @param profile [String] Profile to resolve secrets in.
       # @return [Hash]
       def resolve_secrets(profile)
-	return unless credentials_config
+	      return unless credentials_config
 
         secrets = credentials_config[profile].filter { |k, v| v.is_a?(Hash) && v.keys.include?("secret") }
         return if secrets.empty?

--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -26,6 +26,8 @@ module ChefConfig
     # @since 13.7
     # @api internal
     module Credentials
+      attr_reader :credentials_config
+
       # Compute the active credentials profile name.
       #
       # The lookup order is argument (from --profile), environment variable
@@ -73,7 +75,7 @@ module ChefConfig
         return nil unless File.file?(credentials_file)
 
         begin
-          Tomlrb.load_file(credentials_file)
+          @credentials_config = Tomlrb.load_file(credentials_file)
         rescue => e
           # TOML's error messages are mostly rubbish, so we'll just give a generic one
           message = "Unable to parse Credentials file: #{credentials_file}\n"
@@ -90,17 +92,122 @@ module ChefConfig
       # @return [void]
       def load_credentials(profile = nil)
         profile = credentials_profile(profile)
-        cred_config = parse_credentials_file
-        return if cred_config.nil? # No credentials, nothing to do here.
 
-        if cred_config[profile].nil?
+        parse_credentials_file
+        return if credentials_config.nil? # No credentials, nothing to do here.
+
+        if credentials_config[profile].nil?
           # Unknown profile name. For "default" just silently ignore, otherwise
           # raise an error.
           return if profile == "default"
 
           raise ChefConfig::ConfigurationError, "Profile #{profile} doesn't exist. Please add it to #{credentials_file_path}."
         end
-        apply_credentials(cred_config[profile], profile)
+
+        resolve_secrets(profile)
+
+        apply_credentials(credentials_config[profile], profile)
+      end
+
+      GLOBAL_CONFIG_HASHES = %w{ default_secrets_provider }.freeze
+
+      # Extract global (non-profile) settings from credentials file.
+      #
+      # @since 19.1
+      # @return [Hash]
+      def global_options
+        globals = credentials_config.filter{ |_, v| v.is_a? String }
+        globals.merge! credentials_config.filter { |k,_| GLOBAL_CONFIG_HASHES.include? k }
+      end
+
+      SUPPORTED_SECRETS_PROVIDERS = %w{ hashicorp-vault }.freeze
+
+      # Resolve all secrets in a credentials file
+      #
+      # @since 19.1
+      # @param profile [String] Profile to resolve secrets in.
+      # @return [Hash]
+      def resolve_secrets(profile)
+        secrets = credentials_config[profile].filter { |k,v| v.is_a?(Hash) && v.keys.include?("secret") }
+        return if secrets.empty?
+
+        secrets.each do |option, secrets_config|
+          unless valid_secrets_provider?(secrets_config)
+            raise UnsupportedSecretsProvider.new("Unsupported credentials secrets provider on '#{option}' for profile '#{profile}'")
+          end
+
+          secrets_config.merge!(default_secrets_provider)
+
+          resolved_value = resolve_secret(secrets_config)
+          raise UnresolvedSecret.new("Could not resolve secret '#{option}' for profile '#{profile}'") if resolved_value.nil?
+
+          credentials_config[profile][option] = resolved_value
+        end
+      end
+
+      # Check, if referenced secrets provider is supported.
+      #
+      # @since 19.1
+      # @param secrets_config [Hash] Parsed contents of a secret in a profile.
+      # @return [true, false]
+      def valid_secrets_provider?(secrets_config)
+        provider_config = secrets_config["secrets_provider"] || default_secrets_provider
+        provider = provider_config["name"]
+
+        provider && SUPPORTED_SECRETS_PROVIDERS.include?(provider)
+      end
+
+      def default_secrets_provider
+        global_options["default_secrets_provider"]
+      end
+
+      # Resolve a specific secret.
+      #
+      # To be replaced later by a Train-like framework to support multiple backends.
+      #
+      # @since 19.1
+      # @param secrets_config [Hash] Parsed contents of a secret in a profile.
+      # @return [String]
+      def resolve_secret(secrets_config)
+        resolve_secret_hashicorp(secrets_config)
+      end
+
+      # Resolver logic for Hashicorp Vault.
+      #
+      # Local lazy loading of Gems which are not part of chef-config or chef-utils,
+      # but chef itself to be switched by a unified secrets mechanism for credentials
+      # and Chef DSL later. Showstopper mitigation for 19 GA.
+      #
+      # @since 19.1
+      # @param secrets_config [Hash] Parsed contents of a secret in a profile.
+      # @return [String]
+      def resolve_secret_hashicorp(secrets_config)
+        vault_config = secrets_config.transform_keys(&:to_sym)
+        vault_config[:address] = vault_config[:endpoint]
+
+        # Lazy require due to Gem being part of Chef and rarely used functionality
+        require 'vault' unless defined? Vault
+        @vault ||= Vault::Client.new(vault_config)
+
+        secret = secrets_config["secret"]
+        engine = vault_config[:engine] || "secret"
+        engine_type = vault_config[:engine_type] || "kv2"
+        secret_value = case engine_type
+                       when "kv", "kv1"
+                         @vault.logical.read("#{engine_type}/#{secret}")
+                       when "kv2"
+                         @vault.kv(engine).read(secret)&.data
+                       else
+                         raise UnsupportedSecretsProvider.new("No support for secrets engine #{engine_type}")
+                       end
+
+        # Always JSON for Hashicorp Vault, but this is future compatible to other providers
+        if secret_value.is_a?(Hash)
+          require 'jmespath' unless defined? ::JMESPath
+          ::JMESPath.search(secrets_config["field"], secret_value)
+        else
+          secret_value
+        end
       end
     end
   end

--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -116,8 +116,8 @@ module ChefConfig
       # @since 19.1
       # @return [Hash]
       def global_options
-        globals = credentials_config.filter{ |_, v| v.is_a? String }
-        globals.merge! credentials_config.filter { |k,_| GLOBAL_CONFIG_HASHES.include? k }
+        globals = credentials_config.filter { |_, v| v.is_a? String }
+        globals.merge! credentials_config.filter { |k, _| GLOBAL_CONFIG_HASHES.include? k }
       end
 
       SUPPORTED_SECRETS_PROVIDERS = %w{ hashicorp-vault }.freeze
@@ -128,7 +128,9 @@ module ChefConfig
       # @param profile [String] Profile to resolve secrets in.
       # @return [Hash]
       def resolve_secrets(profile)
-        secrets = credentials_config[profile].filter { |k,v| v.is_a?(Hash) && v.keys.include?("secret") }
+	return unless credentials_config
+
+        secrets = credentials_config[profile].filter { |k, v| v.is_a?(Hash) && v.keys.include?("secret") }
         return if secrets.empty?
 
         secrets.each do |option, secrets_config|
@@ -186,7 +188,7 @@ module ChefConfig
         vault_config[:address] = vault_config[:endpoint]
 
         # Lazy require due to Gem being part of Chef and rarely used functionality
-        require 'vault' unless defined? Vault
+        require "vault" unless defined? Vault
         @vault ||= Vault::Client.new(vault_config)
 
         secret = secrets_config["secret"]
@@ -203,7 +205,7 @@ module ChefConfig
 
         # Always JSON for Hashicorp Vault, but this is future compatible to other providers
         if secret_value.is_a?(Hash)
-          require 'jmespath' unless defined? ::JMESPath
+          require "jmespath" unless defined? ::JMESPath
           ::JMESPath.search(secrets_config["field"], secret_value)
         else
           secret_value

--- a/chef-config/lib/chef-config/mixin/train_transport.rb
+++ b/chef-config/lib/chef-config/mixin/train_transport.rb
@@ -95,7 +95,7 @@ module ChefConfig
           elsif File.exist?(config.platform_specific_path("#{ChefConfig::Config.etc_chef_dir}/#{profile}/credentials"))
             config.platform_specific_path("#{ChefConfig::Config.etc_chef_dir}/#{profile}/credentials")
           else
-            super
+            PathHelper.home(ChefUtils::Dist::Infra::USER_CONF_DIR, "target_credentials").freeze
           end
 
         raise ArgumentError, "No credentials file found for target '#{profile}'" unless credentials_file

--- a/chef-config/lib/chef-config/mixin/train_transport.rb
+++ b/chef-config/lib/chef-config/mixin/train_transport.rb
@@ -48,7 +48,7 @@ module ChefConfig
         if !credentials_config.nil? && !credentials_config[profile].nil?
           credentials_config[profile].transform_keys(&:to_sym) # return symbolized keys to match Train.options()
         else
-          raise NoCredentialsFound.new("No credentials found for profile '#{profile}'")
+          nil
         end
       end
 
@@ -119,7 +119,7 @@ module ChefConfig
         # Load the credentials file, and place any valid settings into the train configuration
         credentials = load_credentials(tm_config.host)
 
-        protocol = credentials[:transport_protocol] || tm_config.protocol
+        protocol = credentials&.dig(:transport_protocol) || tm_config.protocol
         train_config = tm_config.to_hash.select { |k| Train.options(protocol).key?(k) }
         logger.trace("Using target mode options from #{ChefUtils::Dist::Infra::PRODUCT} config file: #{train_config.keys.join(", ")}") if train_config
 

--- a/chef-config/lib/chef-config/mixin/train_transport.rb
+++ b/chef-config/lib/chef-config/mixin/train_transport.rb
@@ -78,9 +78,10 @@ module ChefConfig
       #
       # Credentials file preference:
       #
-      # 1) target_mode.credentials_file
-      # 2) /etc/chef/TARGET_MODE_HOST/credentials
-      # 3) #credentials_file_path from parent ($HOME/.chef/credentials)
+      # 1) environment variable CHEF_CREDENTIALS_FILE
+      # 2) target_mode.credentials_file
+      # 3) /etc/chef/TARGET_MODE_HOST/credentials
+      # 4) user configuration ($HOME/.chef/target_credentials)
       #
       def credentials_file_path
         tm_config = config.target_mode

--- a/chef-config/spec/unit/credentials_spec.rb
+++ b/chef-config/spec/unit/credentials_spec.rb
@@ -19,7 +19,7 @@ require "spec_helper"
 require "chef-config/config"
 require "chef-config/mixin/credentials"
 
-module Vault;
+module Vault
   class Client; end
 end
 
@@ -85,7 +85,7 @@ RSpec.describe ChefConfig::Mixin::Credentials do
   end
 
   describe "#valid_secrets_provider?" do
-    context "when global, valid configuration was provided" do #!
+    context "when global, valid configuration was provided" do
       let(:global_options) { { "default_secrets_provider" => { "name" => "hashicorp-vault", "endpoint" => "https://198.51.100.5:8200", "token" => "hvs.1234567890" } } }
       let(:secrets_config) { { "secret" => "/chef/sudo_password", "field" => "password" } }
 
@@ -135,12 +135,11 @@ RSpec.describe ChefConfig::Mixin::Credentials do
     end
 
     context "without default secrets provider being set" do
-      let(:global_options) { }
+      let(:global_options) {}
 
       context "for a secret of type string" do
         let(:secrets_result) { "secret" }
         let(:secrets_config) { { "secrets_provider" => { "name" => "hashicorp-vault" }, "secret" => "/chef/sudo_password" } }
-
 
         it "returns the complete value" do
           expect(test_obj.resolve_secret(secrets_config)).to eq("secret")

--- a/chef-config/spec/unit/credentials_spec.rb
+++ b/chef-config/spec/unit/credentials_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe ChefConfig::Mixin::Credentials do
 
   describe "#valid_secrets_provider?" do
     context "when global, valid configuration was provided" do #!
-      let(:global_options) { { "default_secrets_provider" => { "name" => 'hashicorp-vault', "endpoint" => 'https://198.51.100.5:8200', "token" => "hvs.1234567890" } } }
+      let(:global_options) { { "default_secrets_provider" => { "name" => "hashicorp-vault", "endpoint" => "https://198.51.100.5:8200", "token" => "hvs.1234567890" } } }
       let(:secrets_config) { { "secret" => "/chef/sudo_password", "field" => "password" } }
 
       it "returns true" do
@@ -96,7 +96,7 @@ RSpec.describe ChefConfig::Mixin::Credentials do
     end
 
     context "when global, invalid configuration was provided" do
-      let(:global_options) { { "default_secrets_provider" => { "name" => 'hashicorp-consul' } } }
+      let(:global_options) { { "default_secrets_provider" => { "name" => "hashicorp-consul" } } }
       let(:secrets_config) { { "secret" => "/chef/sudo_password", "field" => "password" } }
 
       it "returns false" do
@@ -106,7 +106,7 @@ RSpec.describe ChefConfig::Mixin::Credentials do
     end
 
     context "when global, invalid configuration is overridden with a correct value" do
-      let(:global_options) { { "default_secrets_provider" => { "name" => 'hashicorp-consul' } } }
+      let(:global_options) { { "default_secrets_provider" => { "name" => "hashicorp-consul" } } }
       let(:secrets_config) { { "secrets_provider" => { "name" => "hashicorp-vault" }, "secret" => "/chef/sudo_password", "field" => "password" } }
 
       it "returns false" do
@@ -148,8 +148,8 @@ RSpec.describe ChefConfig::Mixin::Credentials do
       end
 
       context "for a secret of type hash" do
-        let(:secrets_result) { { "password" => "secret"} }
-        let(:secrets_config) { { "secrets_provider" => { "name" => "hashicorp-vault", "endpoint" => 'https://198.51.100.5:8200', "token" => "hvs.1234567890" }, "secret" => "/chef/sudo_password", "field" => "password" } }
+        let(:secrets_result) { { "password" => "secret" } }
+        let(:secrets_config) { { "secrets_provider" => { "name" => "hashicorp-vault", "endpoint" => "https://198.51.100.5:8200", "token" => "hvs.1234567890" }, "secret" => "/chef/sudo_password", "field" => "password" } }
 
         it "returns the correct subkey" do
           expect(test_obj.resolve_secret(secrets_config)).to eq("secret")
@@ -158,7 +158,7 @@ RSpec.describe ChefConfig::Mixin::Credentials do
     end
 
     context "with default secrets provider being set" do
-      let(:global_options) { { "default_secrets_provider" => { "name" => 'hashicorp-vault', "endpoint" => 'https://198.51.100.5:8200', "token" => "hvs.1234567890" } } }
+      let(:global_options) { { "default_secrets_provider" => { "name" => "hashicorp-vault", "endpoint" => "https://198.51.100.5:8200", "token" => "hvs.1234567890" } } }
 
       context "for a secret of type string" do
         let(:secrets_result) { "secret" }
@@ -170,7 +170,7 @@ RSpec.describe ChefConfig::Mixin::Credentials do
       end
 
       context "for a secret of type hash" do
-        let(:secrets_result) { { "password" => "secret"} }
+        let(:secrets_result) { { "password" => "secret" } }
         let(:secrets_config) { { "secret" => "/chef/sudo_password", "field" => "password" } }
 
         it "returns the correct subkey" do

--- a/chef-config/spec/unit/credentials_spec.rb
+++ b/chef-config/spec/unit/credentials_spec.rb
@@ -1,0 +1,182 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-config/config"
+require "chef-config/mixin/credentials"
+
+module Vault;
+  class Client; end
+end
+
+RSpec.describe ChefConfig::Mixin::Credentials do
+
+  let(:test_class) { Class.new { include ChefConfig::Mixin::Credentials } }
+  subject(:test_obj) { test_class.new }
+
+  describe "#credentials_profile" do
+    context "when an explicit profile is given" do
+      it "passes it through" do
+        expect(test_obj.credentials_profile("webserver")).to eq("webserver")
+      end
+    end
+
+    context "when an environment variable is set" do
+      before(:all) do
+        @original_env = ENV.to_hash
+      end
+
+      after(:all) do
+        ENV.clear
+        ENV.update(@original_env)
+      end
+
+      before(:each) do
+        ENV["CHEF_PROFILE"] = "acme-server"
+      end
+
+      it "picks the profile correctly" do
+        expect(test_obj.credentials_profile).to eq("acme-server")
+      end
+    end
+
+    context "when no profile is given" do
+      it "picks the default one" do
+        expect(test_obj.credentials_profile).to eq("default")
+      end
+    end
+  end
+
+  describe "#resolve_secrets" do
+    context "when no credentials were loaded" do
+      it "returns" do
+        allow(test_obj).to receive(:credentials_config).and_return(nil)
+        expect(test_obj.resolve_secrets("dummy")).to eq(nil)
+      end
+    end
+
+    context "when credentials do not contain specified profile" do
+      it "raises an error" do
+        allow(test_obj).to receive(:credentials_config).and_return({ "webserver" => {} })
+        expect { test_obj.resolve_secrets("dummy") }.to raise_error(ChefConfig::NoCredentialsFound, /No credentials found for profile/)
+      end
+    end
+
+    context "when no secrets were referenced in profile" do
+      it "returns" do
+        allow(test_obj).to receive(:credentials_config).and_return({ "webserver2" => {} })
+        expect(test_obj.resolve_secrets("webserver2")).to eq(nil)
+      end
+    end
+  end
+
+  describe "#valid_secrets_provider?" do
+    context "when global, valid configuration was provided" do #!
+      let(:global_options) { { "default_secrets_provider" => { "name" => 'hashicorp-vault', "endpoint" => 'https://198.51.100.5:8200', "token" => "hvs.1234567890" } } }
+      let(:secrets_config) { { "secret" => "/chef/sudo_password", "field" => "password" } }
+
+      it "returns true" do
+        allow(test_obj).to receive(:global_options).and_return(global_options)
+        expect(test_obj.valid_secrets_provider?(secrets_config)).to be(true)
+      end
+    end
+
+    context "when global, invalid configuration was provided" do
+      let(:global_options) { { "default_secrets_provider" => { "name" => 'hashicorp-consul' } } }
+      let(:secrets_config) { { "secret" => "/chef/sudo_password", "field" => "password" } }
+
+      it "returns false" do
+        allow(test_obj).to receive(:global_options).and_return(global_options)
+        expect(test_obj.valid_secrets_provider?(secrets_config)).to be(false)
+      end
+    end
+
+    context "when global, invalid configuration is overridden with a correct value" do
+      let(:global_options) { { "default_secrets_provider" => { "name" => 'hashicorp-consul' } } }
+      let(:secrets_config) { { "secrets_provider" => { "name" => "hashicorp-vault" }, "secret" => "/chef/sudo_password", "field" => "password" } }
+
+      it "returns false" do
+        allow(test_obj).to receive(:global_options).and_return(global_options)
+        expect(test_obj.valid_secrets_provider?(secrets_config)).to be(true)
+      end
+    end
+  end
+
+  describe "#resolve_secret" do
+    before do
+      allow(test_obj).to receive(:global_options).and_return(global_options)
+
+      # Simulate "vault" gem
+      allow(test_obj).to receive(:require).with("vault")
+      vault_double = double("Vault::Client")
+      allow(vault_double).to receive_message_chain("logical.read") { secrets_result }
+      allow(vault_double).to receive_message_chain("kv.read.data") { secrets_result }
+      test_obj.instance_variable_set(:@vault, vault_double)
+
+      # Simulate "jmespath" gem
+      allow(test_obj).to receive(:require).with("jmespath")
+      jmespath_double = double("JMESPath")
+      allow(jmespath_double).to receive_message_chain("search") { search_for = secrets_config["field"]; secrets_result[search_for] }
+      stub_const("::JMESPath", jmespath_double)
+    end
+
+    context "without default secrets provider being set" do
+      let(:global_options) { }
+
+      context "for a secret of type string" do
+        let(:secrets_result) { "secret" }
+        let(:secrets_config) { { "secrets_provider" => { "name" => "hashicorp-vault" }, "secret" => "/chef/sudo_password" } }
+
+
+        it "returns the complete value" do
+          expect(test_obj.resolve_secret(secrets_config)).to eq("secret")
+        end
+      end
+
+      context "for a secret of type hash" do
+        let(:secrets_result) { { "password" => "secret"} }
+        let(:secrets_config) { { "secrets_provider" => { "name" => "hashicorp-vault", "endpoint" => 'https://198.51.100.5:8200', "token" => "hvs.1234567890" }, "secret" => "/chef/sudo_password", "field" => "password" } }
+
+        it "returns the correct subkey" do
+          expect(test_obj.resolve_secret(secrets_config)).to eq("secret")
+        end
+      end
+    end
+
+    context "with default secrets provider being set" do
+      let(:global_options) { { "default_secrets_provider" => { "name" => 'hashicorp-vault', "endpoint" => 'https://198.51.100.5:8200', "token" => "hvs.1234567890" } } }
+
+      context "for a secret of type string" do
+        let(:secrets_result) { "secret" }
+        let(:secrets_config) { { "secret" => "/chef/sudo_password" } }
+
+        it "returns the complete value" do
+          expect(test_obj.resolve_secret(secrets_config)).to eq("secret")
+        end
+      end
+
+      context "for a secret of type hash" do
+        let(:secrets_result) { { "password" => "secret"} }
+        let(:secrets_config) { { "secret" => "/chef/sudo_password", "field" => "password" } }
+
+        it "returns the correct subkey" do
+          expect(test_obj.resolve_secret(secrets_config)).to eq("secret")
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/train_transport_spec.rb
+++ b/spec/unit/train_transport_spec.rb
@@ -35,7 +35,7 @@ describe Chef::TrainTransport do
     end
 
     it "returns nil if there is no match" do
-      expect(transport.load_credentials("router.unicorns.com")).to raise_error(ChefConfig::NoCredentialsFound)
+      expect(transport.load_credentials("router.unicorns.com")).to be_nil
     end
 
     # [foo.example.org]   => {"foo"=>{"example"=>{"org"=>{}}}}
@@ -45,7 +45,7 @@ describe Chef::TrainTransport do
       allow(transport).to receive(:parse_credentials_file).and_return({ "foo" => { "example" => { "org" => {} } } })
       expect(Chef::Log).to receive(:warn).with(/as a Hash/)
       expect(Chef::Log).to receive(:warn).with(/Hostnames must be surrounded by single quotes/)
-      expect(transport.load_credentials("foo.example.org")).to raise_error(ChefConfig::NoCredentialsFound)
+      expect(transport.load_credentials("foo.example.org")).to be_nil
     end
   end
 

--- a/spec/unit/train_transport_spec.rb
+++ b/spec/unit/train_transport_spec.rb
@@ -53,6 +53,26 @@ describe Chef::TrainTransport do
     let(:config_cred_file_path) { "/somewhere/credentials" }
     let(:host_cred_file_path) { Chef::Platform.windows? ? "C:\\chef\\foo.example.org\\credentials" : "/etc/chef/foo.example.org/credentials" }
 
+    context "when CHEF_CREDENTIALS_FILE environment variable is set" do
+      before(:all) do
+        @original_env = ENV.to_hash
+      end
+
+      after(:all) do
+        ENV.clear
+        ENV.update(@original_env)
+      end
+
+      before do
+        ENV["CHEF_CREDENTIALS_FILE"] = "/etc/myconfig/targetmode_credentials"
+        allow(::File).to receive(:exist?).and_return(true)
+      end
+
+      it "returns the path if it exists" do
+        expect(transport.credentials_file_path).to eq("/etc/myconfig/targetmode_credentials")
+      end
+    end
+
     context "when a file path is specified by a config" do
       before do
         tm_config = double("Config Context", host: "foo.example.org", credentials_file: config_cred_file_path)

--- a/spec/unit/train_transport_spec.rb
+++ b/spec/unit/train_transport_spec.rb
@@ -81,5 +81,10 @@ describe Chef::TrainTransport do
       allow(File).to receive(:exist?).with(host_cred_file_path).and_return(true)
       expect(transport.credentials_file_path).to eq(host_cred_file_path)
     end
+
+    it "expects target mode credentials in a file called 'target_credentials'" do
+      allow(File).to receive(:exist?).and_return(false)
+      expect { transport.credentials_file_path }.to raise_error(ArgumentError, /Credentials file .* does not exist: .*target_credentials/)
+    end
   end
 end

--- a/spec/unit/train_transport_spec.rb
+++ b/spec/unit/train_transport_spec.rb
@@ -35,7 +35,7 @@ describe Chef::TrainTransport do
     end
 
     it "returns nil if there is no match" do
-      expect(transport.load_credentials("router.unicorns.com")).to be_nil
+      expect(transport.load_credentials("router.unicorns.com")).to raise_error(ChefConfig::NoCredentialsFound)
     end
 
     # [foo.example.org]   => {"foo"=>{"example"=>{"org"=>{}}}}
@@ -45,7 +45,7 @@ describe Chef::TrainTransport do
       allow(transport).to receive(:parse_credentials_file).and_return({ "foo" => { "example" => { "org" => {} } } })
       expect(Chef::Log).to receive(:warn).with(/as a Hash/)
       expect(Chef::Log).to receive(:warn).with(/Hostnames must be surrounded by single quotes/)
-      expect(transport.load_credentials("foo.example.org")).to be_nil
+      expect(transport.load_credentials("foo.example.org")).to raise_error(ChefConfig::NoCredentialsFound)
     end
   end
 


### PR DESCRIPTION
## Description
Enables sensitive credentials to be served from a HashiCorp Vault instance.

Any value inside the `credentials` file can be forwarded to a secrets provider by not providing a literal string, but a map instead:

```toml
sudo_password = {
  secret = "/chef/sudo_password",
  field = "password"
}
```

If the secrets provider returns a plain string, the `field` statement is not needed. Otherwise, it can be used to grab a specific field from the returned value via JMESPath syntax.

You can set a default secrets provider at the top-level of the credentials file. Currently, only `hashicorp-vault` is supported but has to be explicitly referenced for future compatibility. Parameters beyond `name` and `endpoint` match the ones from the [official HashiCorp vault gem](https://github.com/hashicorp/vault-ruby). You can use the same options inside each secret's `secrets_provider` field.

```toml
default_secrets_provider = {
  name = 'hashicorp-vault',
  endpoint = 'https://198.51.100.5:8200',
  token = 'hvs.1234567890'
}

['default']
# ....
```

_This feature is intended to solve a compliance showstopper issue on the Chef 19 release of Target Mode. Support for more powerful features and better structure (clear Gem dependencies, other providers, cleaner implementation) is deferred to a post-GA version._

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
