### PR TITLE
Add bundler to hab package's vendor/gems

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -105,6 +105,15 @@ do_prepare() {
     bundle config --local silence_root_warning 1
   )
 
+  # Needed for appbundler-updater to work properly
+  build_line "Extracting bundler version from Gemfile.lock"
+  BUNDLER_VERSION=$(grep -A 1 "BUNDLED WITH" "$CACHE_PATH/Gemfile.lock" | tail -n 1 | tr -d '[:space:]')
+  if [ -z "$BUNDLER_VERSION" ]; then
+    exit_with "Failed to extract bundler version from Gemfile.lock" 1
+  fi
+  build_line "Installing bundler version $BUNDLER_VERSION"
+  gem install bundler --version "$BUNDLER_VERSION" --no-document
+
   build_line "Setting link for /usr/bin/env to 'coreutils'"
   if [ ! -f /usr/bin/env ]; then
     ln -s "$(pkg_interpreter_for core/coreutils bin/env)" /usr/bin/env


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
We use appbundle-updater in kitchen tests to update installed habitat package of Infra client to a commit SHA. First bundle install is run to install the gems. Recently we added a [bug fix](https://github.com/chef/chef/pull/15038) related to `ffi` not loading when hab package is run. But this change had a side effect causing bundler no longer existing at `vendor/gems` directory of habitat package. Due to this appbundle-updater will fail to apply commit SHA to installed package. To fix it we tried modifying the script to use [packaged ruby's bundler directly ](https://github.com/chef/appbundle-updater/pull/120/files), but this even if it works without error fails to update the package. Found that it is due to how habitat environment sets up GEH_HOME and GEM_PATH to `vendor/bin` due to which if bundler is not invoked from the habitat package itself, all the bundle updates get applied to the path where bundler exists instead of applying it to the habitat package. Hence we add back bundler explicitly to get things working again when updating an installed package to a commit SHA.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
