### PR TITLE
Disable nightly builds in chef-17

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -17,10 +17,11 @@ rubygems:
   - chef-bin
   - chef-utils
 
-schedules:
-  - name: adhoc_build_chef_17
-    description: "Run an adhoc build for chef-17, twice a week in the Buildkite pipeline"
-    cronline: "30 9 * * 0,3"
+# no active contributions, so disable
+#schedules:
+#  - name: adhoc_build_chef_17
+#    description: "Run an adhoc build for chef-17, twice a week in the Buildkite pipeline"
+#    cronline: "30 9 * * 0,3"
 
 pipelines:
   - verify:
@@ -247,6 +248,3 @@ subscriptions:
   - workload: ruby_gem_published:fauxhai-ng-*
     actions:
       - bash:.expeditor/update_dep.sh
-  - workload: schedule_triggered:chef/chef:chef-17:adhoc_build_chef_17:*
-    actions:
-      - trigger_pipeline:omnibus/adhoc


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Given that there are no active PRs to chef-17, disable nightlies.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
