### PR TITLE
Disable no-op omnibus nightlies that run

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -21,10 +21,11 @@ rubygems:
 
 # At the given time, trigger the following scheduled workloads
 # https://expeditor.chef.io/docs/getting-started/subscriptions/#scheduling-workloads
-schedules:
-  - name: nightly_build_main
-    description: "Run a nightly build in the Buildkite pipeline"
-    cronline: "0 6 * * *"
+# For the moment, nightly builds do nothing useful because omnibus builds are disabled
+#schedules:
+#  - name: nightly_build_main
+#    description: "Run a nightly build in the Buildkite pipeline"
+#    cronline: "0 6 * * *"
 
 pipelines:
   - verify:
@@ -296,6 +297,7 @@ subscriptions:
   - workload: ruby_gem_published:train-winrm-*
     actions:
       - bash:.expeditor/update_dep.sh
-  - workload: schedule_triggered:chef/chef:main:nightly_build_main:*
-    actions:
-      - trigger_pipeline:validate/adhoc
+# now that omnibus is not part of the build, we're working to redefine what the nightly should be
+#  - workload: schedule_triggered:chef/chef:main:nightly_build_main:*
+#    actions:
+#      - trigger_pipeline:validate/adhoc


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
With omnibus and chef-foundation removed, the nightlies no longer mean anything in their current form. Temporarily disabling them in lieu of a future workflow.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
