### PR TITLE
Ohai custom plug-ins Chef-11588

### DIFF
--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -85,6 +85,16 @@ class Chef
         converge_by("re-run ohai and merge results into node attributes") do
           ohai = ::Ohai::System.new
 
+          # Load any custom plugins from cookbooks if they exist
+          # This ensures that cookbook-provided Ohai plugins are available
+          # when the resource reloads Ohai data
+          ohai_plugin_path = Chef::Config[:ohai_segment_plugin_path]
+          if ohai_plugin_path && Dir.exist?(ohai_plugin_path) && !Dir.empty?(ohai_plugin_path)
+            # Configure Ohai to load plugins from the cookbook segment path
+            ohai.config[:plugin_path] << ohai_plugin_path
+            logger.trace("Added cookbook plugin path to ohai: #{ohai_plugin_path}")
+          end
+
           # If new_resource.plugin is nil, ohai will reload all the plugins
           # Otherwise it will only reload the specified plugin
           # Note that any changes to plugins, or new plugins placed on

--- a/spec/unit/resource/ohai_spec.rb
+++ b/spec/unit/resource/ohai_spec.rb
@@ -108,5 +108,78 @@ describe Chef::Resource::Ohai do
       expect(node[:origdata]).to eq("somevalue")
       expect(node[:newdata]).to eq("somevalue")
     end
+
+    it "loads cookbook plugins when the ohai_segment_plugin_path directory exists and has content" do
+      # Setup mock plugin path
+      plugin_path = "/tmp/chef/ohai/cookbook_plugins"
+      Chef::Config[:ohai_segment_plugin_path] = plugin_path
+
+      # Mock that the directory exists and has content
+      allow(Dir).to receive(:exist?).with(plugin_path).and_return(true)
+      allow(Dir).to receive(:empty?).with(plugin_path).and_return(false)
+
+      # Mock the ohai system
+      ohai_mock = double("Ohai::System")
+      config_mock = double("config")
+      plugin_path_array = []
+
+      allow(ohai_mock).to receive(:config).and_return(config_mock)
+      allow(config_mock).to receive(:[]).with(:plugin_path).and_return(plugin_path_array)
+      allow(ohai_mock).to receive(:all_plugins).with(nil)
+      allow(ohai_mock).to receive(:data).and_return({})
+      allow(Ohai::System).to receive(:new).and_return(ohai_mock)
+
+      provider.run_action(:reload)
+
+      # Verify that the plugin path was added to the ohai config
+      expect(plugin_path_array).to include(plugin_path)
+    end
+
+    it "does not attempt to load cookbook plugins when the ohai_segment_plugin_path directory does not exist" do
+      # Setup mock plugin path that doesn't exist
+      plugin_path = "/tmp/chef/ohai/cookbook_plugins"
+      Chef::Config[:ohai_segment_plugin_path] = plugin_path
+
+      # Mock that the directory doesn't exist
+      allow(Dir).to receive(:exist?).with(plugin_path).and_return(false)
+
+      # Mock the ohai system
+      ohai_mock = double("Ohai::System")
+      config_mock = spy("config")
+
+      allow(ohai_mock).to receive(:config).and_return(config_mock)
+      allow(ohai_mock).to receive(:all_plugins).with(nil)
+      allow(ohai_mock).to receive(:data).and_return({})
+      allow(Ohai::System).to receive(:new).and_return(ohai_mock)
+
+      provider.run_action(:reload)
+
+      # Verify that the plugin path configuration was not accessed since directory doesn't exist
+      expect(config_mock).not_to have_received(:[]).with(:additional_plugin_path)
+    end
+
+    it "does not attempt to load cookbook plugins when the ohai_segment_plugin_path directory is empty" do
+      # Setup mock plugin path that exists but is empty
+      plugin_path = "/tmp/chef/ohai/cookbook_plugins"
+      Chef::Config[:ohai_segment_plugin_path] = plugin_path
+
+      # Mock that the directory exists but is empty
+      allow(Dir).to receive(:exist?).with(plugin_path).and_return(true)
+      allow(Dir).to receive(:empty?).with(plugin_path).and_return(true)
+
+      # Mock the ohai system
+      ohai_mock = double("Ohai::System")
+      config_mock = spy("config")
+
+      allow(ohai_mock).to receive(:config).and_return(config_mock)
+      allow(ohai_mock).to receive(:all_plugins).with(nil)
+      allow(ohai_mock).to receive(:data).and_return({})
+      allow(Ohai::System).to receive(:new).and_return(ohai_mock)
+
+      provider.run_action(:reload)
+
+      # Verify that the plugin path configuration was not accessed since directory is empty
+      expect(config_mock).not_to have_received(:[]).with(:additional_plugin_path)
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The chef ohai resource has an issue where it does not load custom ohai plug-ins. The error the user sees is Attribute Missing but the name that shows up is the name of the plug-in. This corrects that.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
