### PR TITLE
Adding explicit loads for net/http

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -27,6 +27,7 @@ autoload :URI, "uri"
 module Net
   autoload :HTTP, "net/http"
   autoload :HTTPClientException, "net/http"
+  autoload :Protocol, "net/protocol"
 end
 require_relative "http/basic_client"
 require_relative "config"

--- a/lib/chef/http/basic_client.rb
+++ b/lib/chef/http/basic_client.rb
@@ -23,6 +23,7 @@
 autoload :URI, "uri"
 module Net
   autoload :HTTP, "net/http"
+  autoload :Protocol, "net/protocol"
 end
 require_relative "ssl_policies"
 require_relative "http_request"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
When running run_external_test against chef-zero, we started to get errors about an undefined "Net < Protocol"

Why This Happens Specifically in [run_external_test](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
The issue occurs specifically in the [run_external_test](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) framework because:

Different Load Order: When running external gems through [run_external_test](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), the load order of Chef components differs from standalone gem tests
Bundler Environment: The Bundler.with_unbundled_env call changes the gem loading environment
Dependency Resolution: The external gem (oc-chef-pedant) expects Net::Protocol to be available when it tries to monkey-patch Net::HTTP
Ruby Version Sensitivity: Ruby 3.0+ changed how the Net library loads its subcomponents
Additional Context
From the attachments, I can see that:

oc-chef-pedant is loaded from a git repository at line 1957 in the log
The error occurs when oc-chef-pedant tries to define class HTTP < Protocol
This is a classic Ruby 3.0+ compatibility issue where the Net library structure changed
Expected Outcome
With these changes, Net::Protocol should be properly autoloaded when oc-chef-pedant attempts to access it, resolving the NameError: uninitialized constant Net::Protocol error during the chef-zero external tests.

The fix is minimal and follows Chef's existing patterns for handling Net library autoloads, making it a safe and consistent solution.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
