### PR TITLE
Use chef/ vs. removed skylerto/ package in hab for tests

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_config.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_config.rb
@@ -10,7 +10,7 @@ ruby_block "wait-for-svc-default-startup" do
   retry_delay 1
 end
 
-habitat_service "skylerto/splunkforwarder"
+habitat_service "chef/splunkforwarder"
 
 habitat_config "splunkforwarder.default" do
   config(

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
@@ -2,6 +2,6 @@ habitat_install "default" do
   license "accept"
 end
 
-habitat_package "skylerto/splunkforwarder" do
+habitat_package "chef/splunkforwarder" do
   version "7.0.3/20180418161444"
 end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_service.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_service.rb
@@ -11,7 +11,7 @@ ruby_block "wait-for-svc-default-startup" do
   retry_delay 1
 end
 
-habitat_service "skylerto/splunkforwarder" do
+habitat_service "chef/splunkforwarder" do
   gateway_auth_token "secret"
 end
 
@@ -23,11 +23,11 @@ ruby_block "wait-for-splunkforwarder-start" do
     sleep 3
   end
   action :nothing
-  subscribes :run, "habitat_service[skylerto/splunkforwarder]", :immediately
+  subscribes :run, "habitat_service[chef/splunkforwarder]", :immediately
 end
 
-habitat_service "skylerto/splunkforwarder unload" do
-  service_name "skylerto/splunkforwarder"
+habitat_service "chef/splunkforwarder unload" do
+  service_name "chef/splunkforwarder"
   gateway_auth_token "secret"
   action :unload
 end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_user_toml.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_user_toml.rb
@@ -20,4 +20,4 @@ habitat_user_toml "splunkforwarder" do
   )
 end
 
-habitat_service "skylerto/splunkforwarder"
+habitat_service "chef/splunkforwarder"

--- a/kitchen-tests/test/integration/end-to-end/habitat_win_package/default_spec.rb
+++ b/kitchen-tests/test/integration/end-to-end/habitat_win_package/default_spec.rb
@@ -12,12 +12,12 @@ describe command("C:\\habitat\\hab.exe -V") do
   its("exit_status") { should eq 0 }
 end
 
-describe directory("C:\\hab\\pkgs\\skylerto\\splunkforwarder") do
+describe directory("C:\\hab\\pkgs\\chef\\splunkforwarder") do
   it { should exist }
 end
 
 # TODO: Same issue as above
-describe command("C:\\habitat\\hab.exe pkg path skylerto/splunkforwarder") do
+describe command("C:\\habitat\\hab.exe pkg path chef/splunkforwarder") do
   its("exit_status") { should eq 0 }
-  its("stdout") { should match(/C:\\hab\\pkgs\\skylerto\\splunkforwarder/) }
+  its("stdout") { should match(/C:\\hab\\pkgs\\chef\\splunkforwarder/) }
 end

--- a/kitchen-tests/test/integration/end-to-end/habitat_win_service/default_spec.rb
+++ b/kitchen-tests/test/integration/end-to-end/habitat_win_service/default_spec.rb
@@ -1,4 +1,4 @@
-describe directory("C:\\hab\\pkgs\\skylerto\\splunkforwarder") do
+describe directory("C:\\hab\\pkgs\\chef\\splunkforwarder") do
   it { should exist }
 end
 

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -1100,7 +1100,7 @@ describe Chef::Node::Attribute do
           "c" => 4,
       }
       attributes = Chef::Node::Attribute.new(nil, default_hash, override_hash, nil)
-      expect(attributes.to_s).to eq('{"a"=>1, "b"=>3, "c"=>4}')
+      expect(attributes).to match({ "a" => 1, "b" => 3, "c" => 4 })
     end
   end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Cleanup of packages in bldr.sh removed skylerto/splunkforwarder package being used for a test. Restore of the package was done to chef/splunkforwarder. This PR corrects the package name to reflect the new location.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
