### PR TITLE
[Chef 18] Support JSON recipes

### DIFF
--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -18,6 +18,7 @@
 #
 
 autoload :YAML, "yaml"
+require_relative "json_compat"
 require_relative "dsl/recipe"
 require_relative "mixin/from_file"
 require_relative "mixin/deprecation"
@@ -96,6 +97,25 @@ class Chef
       res = ::YAML.safe_load(string, permitted_classes: [Date])
       unless res.is_a?(Hash) && res.key?("resources")
         raise ArgumentError, "YAML recipe '#{source_file}' must contain a top-level 'resources' hash (YAML sequence), i.e. 'resources:'"
+      end
+
+      from_hash(res)
+    end
+
+    def from_json_file(filename)
+      self.source_file = filename
+      if File.file?(filename) && File.readable?(filename)
+        json_contents = IO.read(filename)
+        from_json(json_contents)
+      else
+        raise IOError, "Cannot open or read file '#{filename}'!"
+      end
+    end
+
+    def from_json(string)
+      res = JSONCompat.from_json(string)
+      unless res.is_a?(Hash) && res.key?("resources")
+        raise ArgumentError, "JSON recipe '#{source_file}' must contain a top-level 'resources' hash"
       end
 
       from_hash(res)

--- a/spec/unit/cookbook_version_spec.rb
+++ b/spec/unit/cookbook_version_spec.rb
@@ -96,6 +96,45 @@ describe Chef::CookbookVersion do
     end
   end
 
+  describe "#recipe_json_filenames_by_name" do
+    let(:cookbook_version) { Chef::CookbookVersion.new("mycb", "/tmp/mycb") }
+
+    def files_for_recipe(extension)
+      [
+        { name: "recipes/default.#{extension}", full_path: "/home/user/repo/cookbooks/test/recipes/default.#{extension}" },
+        { name: "recipes/other.#{extension}", full_path: "/home/user/repo/cookbooks/test/recipes/other.#{extension}" },
+      ]
+    end
+
+    %w{json}.each do |extension|
+
+      context "and JSON files are present including a recipes/default.#{extension}" do
+        before(:each) do
+          allow(cookbook_version).to receive(:files_for).with("recipes").and_return(files_for_recipe(extension))
+        end
+
+        context "and manifest does not include a root_files/recipe.#{extension}" do
+          it "returns all JSON recipes with a correct default of default.#{extension}" do
+            expect(cookbook_version.recipe_json_filenames_by_name).to eq({ "default" => "/home/user/repo/cookbooks/test/recipes/default.#{extension}",
+                                                                        "other" => "/home/user/repo/cookbooks/test/recipes/other.#{extension}" })
+          end
+        end
+
+        context "and manifest also includes a root_files/recipe.#{extension}" do
+          let(:root_files) { [{ name: "root_files/recipe.#{extension}", full_path: "/home/user/repo/cookbooks/test/recipe.#{extension}" } ] }
+          before(:each) do
+            allow(cookbook_version.cookbook_manifest).to receive(:root_files).and_return(root_files)
+          end
+
+          it "returns all JSON recipes with a correct default of recipe.#{extension}" do
+            expect(cookbook_version.recipe_json_filenames_by_name).to eq({ "default" => "/home/user/repo/cookbooks/test/recipe.#{extension}",
+                                                                         "other" => "/home/user/repo/cookbooks/test/recipes/other.#{extension}" })
+          end
+        end
+      end
+    end
+  end
+
   describe "with a cookbook directory named tatft" do
     MD5 = /[0-9a-f]{32}/.freeze
 


### PR DESCRIPTION
This uses the same underlying `from_hash` mechanism as YAML recipes, so the schemas are fundamentally the same.

(see main branch PR for discussion #15094 )

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
