### PR TITLE
Remove dependency on .present? from activesupport

### DIFF
--- a/knife/lib/chef/knife/bootstrap.rb
+++ b/knife/lib/chef/knife/bootstrap.rb
@@ -23,7 +23,6 @@ require "license_acceptance/cli_flags/mixlib_cli"
 require "chef/json_compat" unless defined?(Chef::JSONCompat) # can't be lazy loaded since it's used in options
 require "chef/utils/licensing_config"
 require "chef/utils/licensing_handler"
-require "active_support/core_ext/object/blank"
 
 module LicenseAcceptance
   autoload :Acceptor, "license_acceptance/acceptor"

--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -67,7 +67,7 @@ begin
     desc "Run chef's node and role unit specs with activesupport loaded"
     RSpec::Core::RakeTask.new(:activesupport) do |t|
       t.verbose = false
-      t.rspec_opts = %w{--require active_support/core_ext --profile}
+      t.rspec_opts = %w{--profile}
       # Only node_spec and role_spec specifically have issues, target those tests
       t.pattern = FileList["spec/unit/node_spec.rb", "spec/unit/role_spec.rb"]
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Fix the following failure by removing usage of `.present?` in `knife`
```text
Failures:
--
  |  
  | 1) Chef::Knife::Bootstrap#run performs the steps we expect to run a bootstrap
  | Failure/Error: knife.run
  |  
  | NoMethodError:
  | undefined method `present?' for nil:NilClass
  |  
  | return if config[:license_type].present?
  | ^^^^^^^^^
  | # ./lib/chef/knife/bootstrap.rb:1210:in `warn_license_usage'
  | # ./lib/chef/knife/bootstrap.rb:582:in `run'
  | # ./spec/unit/knife/bootstrap_spec.rb:1727:in `block (3 levels) in <top (required)>'
  | # ./spec/knife_spec_helper.rb:207:in `block (2 levels) in <top (required)>'
  | # ./vendor/bundle/ruby/3.1.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```

Per https://github.com/CocoaPods/CocoaPods/issues/12089#issuecomment-1768713084 the `active_support` extensions are not loaded by default. While this could be fixed with an extra require, the larger issue is that this usage of `.present?` is the only one in the Chef client code base (and removed in Chef 18), so I've opted to avoid the volatility of `activesupport` in a project which otherwise doesn't track the Rails ecosystem closely.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
