### PR TITLE
Don't depend on core_ext loading for rspec

### DIFF
--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -67,7 +67,7 @@ begin
     desc "Run chef's node and role unit specs with activesupport loaded"
     RSpec::Core::RakeTask.new(:activesupport) do |t|
       t.verbose = false
-      t.rspec_opts = %w{--require active_support/core_ext --profile}
+      t.rspec_opts = %w{--profile}
       # Only node_spec and role_spec specifically have issues, target those tests
       t.pattern = FileList["spec/unit/node_spec.rb", "spec/unit/role_spec.rb"]
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
`active_support/core_ext` being added specifically for tests has triggered problems in the past, with false negatives on using things like string modifiers from Rails' `active_support` breaking scenarios in which active_support isn't being loaded.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
