### PR TITLE
Updating Chef-Zero

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ PATH
       chef-config (= 18.7.30)
       chef-utils (= 18.7.30)
       chef-vault
-      chef-zero (>= 15.0.17)
+      chef-zero (>= 15.0.21)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
@@ -86,7 +86,7 @@ PATH
       chef-powershell (~> 18.1.0)
       chef-utils (= 18.7.30)
       chef-vault
-      chef-zero (>= 15.0.17)
+      chef-zero (>= 15.0.21)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
@@ -217,13 +217,14 @@ GEM
       erubi (>= 1.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 2.0)
-    chef-zero (15.0.17)
-      activesupport (~> 7.0, < 7.1)
-      ffi-yajl (~> 2.2)
-      hashie (>= 2.0, < 5.0)
+    chef-zero (15.0.21)
+      activesupport (>= 7, < 8.1)
+      ffi-yajl (>= 2.2, < 4.0)
+      hashie (>= 2.0, < 6.0)
       mixlib-log (>= 2.0, < 4.0)
-      rack (~> 3.1, >= 3.1.10)
+      rack (~> 3.1, >= 3.1.16)
       rackup (~> 2.2, >= 2.2.1)
+      unf_ext (~> 0.0.8)
       uuidtools (~> 2.1)
       webrick
     cheffish (17.1.8)
@@ -380,7 +381,7 @@ GEM
       pry (~> 0.13)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (3.1.12)
+    rack (3.1.16)
     rackup (2.2.1)
       rack (>= 3)
     rainbow (3.1.1)
@@ -538,4 +539,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.7
+   2.3.27

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7" # template resource / cookbook syntax check
   s.add_dependency "diff-lcs", ">= 1.2.4", "!= 1.4.0", "< 1.6.0" # 1.4 breaks output. Used in lib/chef/util/diff
   s.add_dependency "ffi-libarchive", "~> 1.0", ">= 1.0.3" # archive_file resource
-  s.add_dependency "chef-zero", ">= 15.0.17"
+  s.add_dependency "chef-zero", ">= 15.0.21"
   s.add_dependency "chef-vault" # chef-vault resources and helpers
 
   s.add_dependency "plist", "~> 3.2" # launchd, dscl/mac user, macos_userdefaults, osx_profile and plist resources


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating Chef-Zero to pull in an updated rack gem. < 3.1.12 has a CVE in it.

```
❯ bundle update --conservative chef-zero rack
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies....
Using rake 13.2.1
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      stringio (>= 0)
      Available/installed versions of this gem:
      - 3.1.7
      - 3.0.1.2
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
Using concurrent-ruby 1.3.5
Using minitest 5.25.5
Using public_suffix 6.0.1
Using mixlib-cli 2.1.8
Using ast 2.4.2
Using aws-eventstream 1.3.0
Using aws-partitions 1.1048.0
Using base64 0.2.0
Using debug_inspector 1.2.0
Using builder 3.3.0
Using bundler 2.3.7
Using byebug 11.1.3
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using libyajl2 2.1.0
Using bigdecimal 3.1.9
Using jmespath 1.6.2
Using ffi 1.16.3
Using unf_ext 0.0.8.2
Using uuidtools 2.2.0
Using webrick 1.9.1
Fetching rack 3.1.16 (was 3.1.12)
Using hashie 4.1.0
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using iniparse 1.5.0
Using parallel 1.26.3
Using racc 1.8.1
Using rainbow 3.1.1
Using regexp_parser 2.10.0
Using rexml 3.4.0
Using unicode-display_width 2.6.0
Using uri 1.0.2
Using json 2.10.0
Using logger 1.5.3
Using tty-color 0.6.0
Using ruby-progressbar 1.13.0
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using tty-screen 0.8.2
Using wisper 2.0.1
Using method_source 1.1.0
Using strings-ansi 0.2.0
Using parslet 2.0.0
Using coderay 1.1.3
Using rspec-support 3.12.2
Using rubyzip 2.4.1
Using semverse 3.0.2
Using sslshake 1.3.1
Using multipart-post 2.4.1
Using thor 1.2.2
Using mixlib-authentication 3.0.10
Using timeout 0.4.3
Using date 3.4.1
Using net-ssh 7.3.0
Using ipaddress 0.8.3
Using wmi-lite 1.0.7
Using plist 3.7.2
Using syslog-logger 1.6.8
Using http-accept 1.7.0
Using proxifier2 1.1.0
Using domain_name 0.6.20240107
Using netrc 0.11.0
Using mime-types-data 3.2025.0204
Using erubi 1.13.1
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using multi_json 1.15.0
Using ed25519 1.3.0
Using rb-readline 0.5.5
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using hashdiff 1.1.1
Using i18n 1.14.7
Using tzinfo 2.0.6
Using chef-utils 18.7.30 from source at `chef-utils`
Using addressable 2.8.7
Using aws-sigv4 1.11.0
Using binding_of_caller 1.0.1
Using mixlib-config 3.0.27
Using ffi-yajl 2.6.0
Using rubyntlm 0.6.5
Using nori 2.7.0
Using mixlib-log 3.1.2.1
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.3
Using gssapi 1.3.1
Using parser 3.3.7.1
Using net-http 0.6.0
Using pastel 0.8.0
Using tty-reader 0.9.0
Using chef-gyoku 1.4.1
Using crack 0.4.5
Using strings 0.2.1
Using pry 0.13.0
Using rspec-core 3.12.3
Using rspec-expectations 3.12.4
Using rspec-mocks 3.12.7
Using net-protocol 0.2.2
Using time 0.4.1
Using net-scp 4.1.0
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using http-cookie 1.0.8
Using mime-types 3.6.0
Using logging 2.4.0
Using mixlib-shellout 3.3.6
Using aws-sdk-core 3.218.1
Using activesupport 7.0.8.7
Using vault 0.18.2
Using mixlib-archive 1.1.7
Using rubocop-ast 1.38.0
Using faraday-net_http 3.4.0
Using tty-prompt 0.23.1
Using webmock 3.25.0
Using tty-box 0.7.0
Using tty-table 0.12.0
Using pry-stack_explorer 0.6.1
Using pry-byebug 3.10.1
Using rspec-its 1.3.1
Using rspec 3.12.0
Using appbundler 0.13.4
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Using aws-sdk-kms 1.98.0
Using aws-sdk-secretsmanager 1.112.0
Using chef-config 18.7.30 from source at `chef-config`
Using train-core 3.12.13
Using net-ftp 0.3.8
Using chef-winrm 2.3.11
Using rubocop 1.25.1
Using faraday 2.12.2
Using license-acceptance 2.1.13
Using aws-sdk-s3 1.180.0
Using chef-telemetry 1.1.1
Using ohai 18.2.5 from https://github.com/chef/ohai.git (at 18-stable@58ee0df)
Using chef-winrm-fs 1.3.7
Using cookstyle 7.32.8
Using chefstyle 2.2.3
Using faraday-follow_redirects 0.3.0
Using train-rest 0.5.0
Using chef-winrm-elevated 1.2.5
Using inspec-core 5.22.80
Using train-winrm 0.2.17
Using inspec-core-bin 5.22.80
Installing rack 3.1.16 (was 3.1.12)
Using rackup 2.2.1
Fetching chef-zero 15.0.21 (was 15.0.17)
Installing chef-zero 15.0.21 (was 15.0.17)
Using chef 18.7.30 from source at `.`
Using cheffish 17.1.8
Using chef-bin 18.7.30 from source at `chef-bin` and installing its executables
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
