### PR TITLE
Fix snap tests on chef-18 (#15118)

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_snap.rb
@@ -12,42 +12,129 @@ snap_package "core" do
   channel "stable"
   retries 2
   retry_delay 15
+  notifies :run, "execute[wait_for_snapd]", :immediately
 end
 
-snap_package "hello" do
-  # there was originally a 5 second sleep before this
-  action :install
+# Add a sleep to ensure snapd is fully ready
+execute "wait_for_snapd" do
+  command "sleep 10"
+  action :nothing
+  notifies :install, "snap_package[hello-install]", :immediately
+end
+
+snap_package "hello-install" do
+  package_name "hello"
+  action :nothing
   channel "stable"
-  retries 2
-  retry_delay 15
+  retries 3
+  retry_delay 30
+  notifies :run, "execute[wait_after_install]", :immediately
 end
 
-snap_package "hello" do
-  action :upgrade
+# Wait between operations to avoid conflicts
+execute "wait_after_install" do
+  command "sleep 5"
+  action :nothing
+  notifies :upgrade, "snap_package[hello-upgrade]", :immediately
+end
+
+snap_package "hello-upgrade" do
+  package_name "hello"
+  action :nothing
   channel "edge"
+  retries 3
+  retry_delay 30
+  notifies :run, "execute[wait_after_upgrade]", :immediately
 end
 
-snap_package "hello" do
-  action :remove
+# Wait between operations
+execute "wait_after_upgrade" do
+  command "sleep 5"
+  action :nothing
+  notifies :remove, "snap_package[hello-remove]", :immediately
 end
 
-snap_package "hello"
-
-snap_package "hello" do
-  action :purge
+snap_package "hello-remove" do
+  package_name "hello"
+  action :nothing
+  retries 3
+  retry_delay 30
+  notifies :run, "execute[wait_after_remove]", :immediately
 end
 
-snap_package "hello" do
+# Wait before reinstall
+execute "wait_after_remove" do
+  command "sleep 5"
+  action :nothing
+  notifies :install, "snap_package[hello-reinstall]", :immediately
+end
+
+snap_package "hello-reinstall" do
+  package_name "hello"
+  action :nothing
+  retries 3
+  retry_delay 30
+  notifies :run, "execute[wait_before_purge]", :immediately
+end
+
+# Wait before purge
+execute "wait_before_purge" do
+  command "sleep 5"
+  action :nothing
+  notifies :purge, "snap_package[hello-purge]", :immediately
+end
+
+snap_package "hello-purge" do
+  package_name "hello"
+  action :nothing
+  retries 3
+  retry_delay 30
+  notifies :run, "execute[wait_before_devmode]", :immediately
+end
+
+# Wait before devmode install
+execute "wait_before_devmode" do
+  command "sleep 5"
+  action :nothing
+  notifies :install, "snap_package[hello-devmode]", :immediately
+end
+
+snap_package "hello-devmode" do
+  package_name "hello"
+  action :nothing
   options ["devmode"]
+  retries 3
+  retry_delay 30
+  notifies :run, "execute[wait_before_final_remove]", :immediately
 end
 
-snap_package "hello" do
-  action :remove
+# Wait before final remove
+execute "wait_before_final_remove" do
+  command "sleep 5"
+  action :nothing
+  notifies :remove, "snap_package[hello-final-remove]", :immediately
 end
 
-snap_package %w{hello expect} do
+snap_package "hello-final-remove" do
+  package_name "hello"
+  action :nothing
+  retries 3
+  retry_delay 30
+  notifies :run, "execute[wait_before_multi_install]", :immediately
+end
+
+# Wait before multi-package install
+execute "wait_before_multi_install" do
+  command "sleep 10"
+  action :nothing
+  notifies :install, "snap_package[multi-package]", :immediately
+end
+
+snap_package "multi-package" do
+  package_name %w{hello expect}
+  action :nothing
   # this action seems to be finicky after the removal
   # action
-  retries 2
+  retries 3
   retry_delay 60
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Attempt to prevent the following issue in kitchen-tests in CI:

```
 Running handlers:
       [2025-07-17T13:16:11+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2025-07-17T13:16:11+00:00] ERROR: Exception handlers complete
       Infra Phase failed. 243 resources updated in 08 minutes 02 seconds
       [2025-07-17T13:16:11+00:00] FATAL: Stacktrace dumped to /opt/kitchen/cache/chef-stacktrace.out
       [2025-07-17T13:16:11+00:00] FATAL: ---------------------------------------------------------------------------------------
       [2025-07-17T13:16:11+00:00] FATAL: PLEASE PROVIDE THE CONTENTS OF THE stacktrace.out FILE (above) IF YOU FILE A BUG REPORT
       [2025-07-17T13:16:11+00:00] FATAL: ---------------------------------------------------------------------------------------
       [2025-07-17T13:16:11+00:00] FATAL: RuntimeError: snap_package[hello] (end_to_end::_snap line 17) had an error: RuntimeError: status: Conflict, kind: snap-change-conflict, message: snap "hello" has "install-snap" change in progress
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package/snap.rb:215:in `get_id_from_async_response'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package/snap.rb:275:in `block in install_snaps'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package/snap.rb:273:in `each'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package/snap.rb:273:in `install_snaps'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package/snap.rb:74:in `install_package'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package.rb:120:in `block (3 levels) in <class:Package>'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package.rb:267:in `multipackage_api_adapter'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package.rb:119:in `block (2 levels) in <class:Package>'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/mixin/why_run.rb:51:in `add_action'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider.rb:293:in `converge_by'
       /opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.54/lib/chef/provider/package.rb:118:in `block in <class:Package>'
       (eval):2:in `block in action_install'
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
