### PR TITLE
Updating uri to get past a CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,7 @@ GEM
     unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
-    uri (0.13.1)
+    uri (1.0.3)
     uuidtools (2.2.0)
     vault (0.18.2)
       aws-sigv4

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -62,6 +62,7 @@ Gem::Specification.new do |s|
   s.add_dependency "syslog-logger", "~> 1.6"
   s.add_dependency "uuidtools", ">= 2.1.5", "< 3.0" # osx_profile resource
   s.add_dependency "unf_ext", "~> 0.0.8.2" # older platforms
+  s.add_dependency "uri", "~> 1.0.3" # This is used by net-http. We are forcing a version to get past a CVE in 1.0.2
   s.add_dependency "corefoundation", "~> 0.3.4" # macos_userdefaults resource
 
   s.add_dependency "proxifier2", "~> 1.1"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
URI is a transitive dependency from net-http. They have not updated in a bit and URI has a CVE. We are forcing a version update here to get past that until net-http gets a new version that includes this update.

$ gem update --conservative uri
Updating installed gems
Updating uri
Successfully installed uri-1.0.3
Gems updated: uri

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
