### PR TITLE
Updating the openssl gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
     FileUtils.cp_r assemblies, ruby_exe_dir, verbose: false unless ENV["_BUNDLER_WINDOWS_DLLS_COPIED"]
     ENV["_BUNDLER_WINDOWS_DLLS_COPIED"] = "1"
   end
-  
+
   # Pin date gem for UCRT compatibility
   if RUBY_PLATFORM.include?("ucrt")
     gem "date", "~> 3.3.3"  # Use a version compatible with UCRT

--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
   end
   
   # Pin date gem for UCRT compatibility
-  if RUBY_PLATFORM.include?('ucrt')
+  if RUBY_PLATFORM.include?("ucrt")
     gem "date", "~> 3.3.3"  # Use a version compatible with UCRT
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?
 
 # required for FIPS or bundler will pick up default openssl
 install_if -> { RUBY_PLATFORM !~ /darwin/ } do
-  gem "openssl", "= 3.2.0"
+  gem "openssl", "= 3.3.0"
 end
 
 if File.exist?(File.expand_path("chef-bin", __dir__))
@@ -91,5 +91,10 @@ if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
     assemblies = Dir.glob(File.expand_path("distro/ruby_bin_folder/#{ENV["PROCESSOR_ARCHITECTURE"]}", __dir__) + "**/*")
     FileUtils.cp_r assemblies, ruby_exe_dir, verbose: false unless ENV["_BUNDLER_WINDOWS_DLLS_COPIED"]
     ENV["_BUNDLER_WINDOWS_DLLS_COPIED"] = "1"
+  end
+  
+  # Pin date gem for UCRT compatibility
+  if RUBY_PLATFORM.include?('ucrt')
+    gem "date", "~> 3.3.3"  # Use a version compatible with UCRT
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       ffi (>= 1.15.0)
     crack (0.4.5)
       rexml
-    date (3.4.1)
+    date (3.3.4)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     domain_name (0.6.20240107)
@@ -362,7 +362,7 @@ GEM
     netrc (0.11.0)
     nori (2.7.0)
       bigdecimal
-    openssl (3.2.0)
+    openssl (3.3.0)
     parallel (1.26.3)
     parser (3.3.7.1)
       ast (~> 2.4.1)
@@ -524,12 +524,13 @@ DEPENDENCIES
   cheffish (>= 17)
   chefstyle
   crack (< 0.4.6)
+  date (~> 3.3.3)
   ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5, <= 1.17.0)
   inspec-core-bin (>= 5, < 6)
   ohai!
-  openssl (= 3.2.0)
+  openssl (= 3.3.0)
   pry (= 0.13.0)
   pry-byebug
   pry-stack_explorer


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating the Openssl gem to prepare for moving to a new Ruby version

$ bundle install
Fetching https://github.com/chef/ruby-shadow
Fetching https://github.com/chef/rest-client
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Fetching rake 13.2.1
Installing rake 13.2.1
Using ffi 1.16.3 (x64-mingw-ucrt)
Fetching concurrent-ruby 1.3.5
Fetching minitest 5.25.5
Fetching public_suffix 6.0.1
Fetching mixlib-cli 2.1.8
Fetching wmi-lite 1.0.7
Fetching aws-eventstream 1.3.0
Fetching ast 2.4.2
Fetching aws-partitions 1.1048.0
Installing ast 2.4.2
Installing aws-eventstream 1.3.0
Installing aws-partitions 1.1048.0
Installing wmi-lite 1.0.7
Installing minitest 5.25.5
Installing mixlib-cli 2.1.8
Installing public_suffix 6.0.1
Fetching base64 0.2.0
Fetching jmespath 1.6.2
Fetching bigdecimal 3.1.9
Fetching debug_inspector 1.2.0
Installing concurrent-ruby 1.3.5
Fetching builder 3.3.0
Using bundler 2.3.27
Fetching byebug 11.1.3
Fetching fuzzyurl 0.9.0
Installing debug_inspector 1.2.0 with native extensions
Installing jmespath 1.6.2
Installing base64 0.2.0
Installing builder 3.3.0
Fetching tomlrb 1.3.0
Installing bigdecimal 3.1.9 with native extensions
Installing fuzzyurl 0.9.0
Installing byebug 11.1.3 with native extensions
Fetching libyajl2 2.1.0
Installing tomlrb 1.3.0
Fetching chef-vault 4.1.11
Fetching hashie 4.1.0
Fetching rack 3.1.16
Installing libyajl2 2.1.0 with native extensions
Installing chef-vault 4.1.11
Installing hashie 4.1.0
Installing rack 3.1.16
Fetching unf_ext 0.0.8.2 (x64-mingw-ucrt)
Fetching uuidtools 2.2.0
Fetching webrick 1.9.1
Fetching diff-lcs 1.5.1
Installing uuidtools 2.2.0
Installing webrick 1.9.1
Installing unf_ext 0.0.8.2 (x64-mingw-ucrt)
Installing diff-lcs 1.5.1
Fetching erubis 2.7.0
Installing erubis 2.7.0
Fetching iniparse 1.5.0
Installing iniparse 1.5.0
Fetching parallel 1.26.3
Using racc 1.8.1
Using rainbow 3.1.1
Using regexp_parser 2.10.0
Fetching rexml 3.4.0
Installing parallel 1.26.3
Using ruby-progressbar 1.13.0
Fetching unicode-display_width 2.6.0
Using uri 1.0.3
Fetching json 2.10.0
Installing rexml 3.4.0
Installing unicode-display_width 2.6.0
Installing json 2.10.0 with native extensions
Fetching logger 1.5.3
Installing logger 1.5.3
Fetching tty-color 0.6.0
Fetching strings-ansi 0.2.0
Installing tty-color 0.6.0
Installing strings-ansi 0.2.0
Fetching unicode_utils 1.4.0
Installing unicode_utils 1.4.0
Fetching tty-cursor 0.7.1
Installing tty-cursor 0.7.1
Fetching tty-screen 0.8.2
Fetching wisper 2.0.1
Installing tty-screen 0.8.2
Using method_source 1.1.0
Fetching multipart-post 2.4.1
Installing wisper 2.0.1
Installing multipart-post 2.4.1
Fetching parslet 2.0.0
Using coderay 1.1.3
Fetching rspec-support 3.12.2
Installing parslet 2.0.0
Installing rspec-support 3.12.2
Fetching rubyzip 2.4.1
Fetching semverse 3.0.2
Installing rubyzip 2.4.1
Installing semverse 3.0.2
Fetching sslshake 1.3.1
Fetching thor 1.2.2
Installing thor 1.2.2
Installing sslshake 1.3.1
Fetching net-ssh 7.3.0
Fetching iso8601 0.13.0
Fetching mixlib-authentication 3.0.10
Fetching timeout 0.4.3
Installing mixlib-authentication 3.0.10
Installing iso8601 0.13.0
Installing net-ssh 7.3.0
Installing timeout 0.4.3
Fetching date 3.3.4 (was 3.4.1)
Fetching ipaddress 0.8.3
Fetching plist 3.7.2
Installing date 3.3.4 (was 3.4.1) with native extensions
Installing plist 3.7.2
Installing ipaddress 0.8.3
Fetching proxifier2 1.1.0
Installing proxifier2 1.1.0
Fetching syslog-logger 1.6.8
Using http-accept 1.7.0
Using domain_name 0.6.20240107
Fetching mime-types-data 3.2025.0204
Installing syslog-logger 1.6.8
Using netrc 0.11.0
Installing mime-types-data 3.2025.0204
Fetching erubi 1.13.1
Installing erubi 1.13.1
Fetching httpclient 2.8.3
Fetching little-plugger 1.1.4
Fetching multi_json 1.15.0
Installing little-plugger 1.1.4
Installing httpclient 2.8.3
Fetching win32-api 1.10.1 (universal-mingw32)
Installing multi_json 1.15.0
Installing win32-api 1.10.1 (universal-mingw32)
Fetching structured_warnings 0.4.0
Installing structured_warnings 0.4.0
Fetching ed25519 1.3.0
Fetching hashdiff 1.1.1
Fetching openssl 3.3.0 (was 3.2.0)
Fetching rb-readline 0.5.5
Installing ed25519 1.3.0 with native extensions
Installing hashdiff 1.1.1
Installing rb-readline 0.5.5
Installing openssl 3.3.0 (was 3.2.0) with native extensions
Fetching ffi-win32-extensions 1.0.4
Fetching win32-process 0.10.0
Installing ffi-win32-extensions 1.0.4
Installing win32-process 0.10.0
Fetching mixlib-log 3.1.2.1
Fetching corefoundation 0.3.13
Installing mixlib-log 3.1.2.1
Installing corefoundation 0.3.13
Fetching ffi-libarchive 1.1.3
Fetching gssapi 1.3.1
Installing ffi-libarchive 1.1.3
Installing gssapi 1.3.1
Fetching win32-ipc 0.7.0
Installing win32-ipc 0.7.0
Fetching win32-eventlog 0.6.3
Fetching win32-mmap 0.4.2
Installing win32-eventlog 0.6.3
Installing win32-mmap 0.4.2
Fetching aws-sigv4 1.11.0
Using addressable 2.8.7
Fetching rubyntlm 0.6.5
Installing aws-sigv4 1.11.0
Installing rubyntlm 0.6.5
Fetching mixlib-config 3.0.27
Installing mixlib-config 3.0.27
Fetching i18n 1.14.7
Fetching tzinfo 2.0.6
Installing i18n 1.14.7
Installing tzinfo 2.0.6
Using chef-utils 18.7.32 from source at `chef-utils`
Fetching rackup 2.2.1
Fetching parser 3.3.7.1
Installing rackup 2.2.1
Fetching net-http 0.6.0
Installing parser 3.3.7.1
Installing net-http 0.6.0
Fetching chef-gyoku 1.4.1
Installing chef-gyoku 1.4.1
Fetching crack 0.4.5
Fetching pastel 0.8.0
Installing crack 0.4.5
Fetching binding_of_caller 1.0.1
Installing pastel 0.8.0
Installing binding_of_caller 1.0.1
Fetching strings 0.2.1
Fetching pry 0.13.0
Installing strings 0.2.1
Installing pry 0.13.0
Fetching tty-reader 0.9.0
Installing tty-reader 0.9.0
Fetching rspec-core 3.12.3
Fetching rspec-expectations 3.12.4
Installing rspec-expectations 3.12.4
Installing rspec-core 3.12.3
Fetching rspec-mocks 3.12.7
Fetching net-protocol 0.2.2
Using http-cookie 1.0.8
Fetching net-scp 4.1.0
Installing rspec-mocks 3.12.7
Installing net-scp 4.1.0
Installing net-protocol 0.2.2
Fetching net-sftp 4.0.0
Fetching fauxhai-ng 9.3.0
Installing net-sftp 4.0.0
Fetching mime-types 3.6.0
Installing fauxhai-ng 9.3.0
Fetching logging 2.4.0
Installing mime-types 3.6.0
Installing logging 2.4.0
Fetching win32-taskscheduler 2.0.4
Installing win32-taskscheduler 2.0.4
Fetching ffi-yajl 2.6.0
Fetching win32-service 2.3.2
Installing ffi-yajl 2.6.0 with native extensions
Installing win32-service 2.3.2
Fetching mixlib-archive 1.1.7 (universal-mingw32)
Fetching win32-event 0.6.3
Installing win32-event 0.6.3
Installing mixlib-archive 1.1.7 (universal-mingw32)
Fetching win32-mutex 0.4.3
Installing win32-mutex 0.4.3
Fetching aws-sdk-core 3.218.1
Fetching vault 0.18.2
Installing aws-sdk-core 3.218.1
Installing vault 0.18.2
Fetching mixlib-shellout 3.3.6 (x64-mingw-ucrt)
Installing mixlib-shellout 3.3.6 (x64-mingw-ucrt)
Fetching activesupport 7.0.8.7
Installing activesupport 7.0.8.7
Fetching faraday-net_http 3.4.0
Installing faraday-net_http 3.4.0
Fetching rubocop-ast 1.38.0
Installing rubocop-ast 1.38.0
Fetching webmock 3.25.0
Installing webmock 3.25.0
Fetching tty-box 0.7.0
Fetching tty-table 0.12.0
Installing tty-box 0.7.0
Fetching tty-prompt 0.23.1
Installing tty-table 0.12.0
Installing tty-prompt 0.23.1
Fetching pry-byebug 3.10.1
Installing pry-byebug 3.10.1
Fetching pry-stack_explorer 0.6.1
Fetching rspec-its 1.3.1
Installing pry-stack_explorer 0.6.1
Fetching rspec 3.12.0
Using rest-client 2.1.0 (x64-mingw-ucrt) from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Installing rspec-its 1.3.1
Fetching appbundler 0.13.4
Installing rspec 3.12.0
Installing appbundler 0.13.4
Using chef-config 18.7.32 from source at `chef-config`
Fetching rubocop 1.25.1
Fetching aws-sdk-kms 1.98.0
Fetching aws-sdk-secretsmanager 1.112.0
Installing rubocop 1.25.1
Installing aws-sdk-secretsmanager 1.112.0
Installing aws-sdk-kms 1.98.0
Fetching license-acceptance 2.1.13
Fetching chef-telemetry 1.1.1
Installing license-acceptance 2.1.13
Fetching aws-sdk-s3 1.180.0
Installing chef-telemetry 1.1.1
Installing aws-sdk-s3 1.180.0
Fetching cookstyle 7.32.8
Fetching chefstyle 2.2.3
Installing cookstyle 7.32.8
Installing chefstyle 2.2.3
Fetching time 0.4.1
Installing time 0.4.1
Fetching net-ftp 0.3.8
Installing net-ftp 0.3.8
Fetching faraday 2.12.2
Fetching train-core 3.12.13
Installing faraday 2.12.2
Installing train-core 3.12.13
Fetching train-rest 0.5.0
Fetching faraday-follow_redirects 0.3.0
Installing train-rest 0.5.0
Installing faraday-follow_redirects 0.3.0
Fetching inspec-core 5.22.80
Installing inspec-core 5.22.80
Fetching inspec-core-bin 5.22.80
Installing inspec-core-bin 5.22.80
Using ohai 18.2.5 from https://github.com/chef/ohai.git (at 18-stable@58ee0df)
Fetching chef-powershell 18.1.0
Fetching chef-zero 15.0.21
Installing chef-zero 15.0.21
Fetching cheffish 17.1.8
Installing cheffish 17.1.8
Installing chef-powershell 18.1.0
Fetching win32-certstore 0.6.16
Installing win32-certstore 0.6.16
Fetching nori 2.7.0
Installing nori 2.7.0
Fetching chef-winrm 2.3.11
Installing chef-winrm 2.3.11
Fetching chef-winrm-fs 1.3.7
Installing chef-winrm-fs 1.3.7
Fetching chef-winrm-elevated 1.2.5
Installing chef-winrm-elevated 1.2.5
Fetching train-winrm 0.2.17
Installing train-winrm 0.2.17
Using chef 18.7.32 (universal-mingw-ucrt) from source at `.`
Using chef-bin 18.7.32 from source at `chef-bin` and installing its executables
Bundle complete! 25 Gemfile dependencies, 164 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Post-install message from rubyzip:
RubyZip 3.0 is coming!
**********************

The public API of some Rubyzip classes has been modernized to use named
parameters for optional arguments. Please check your usage of the
following classes:
  * `Zip::File`
  * `Zip::Entry`
  * `Zip::InputStream`
  * `Zip::OutputStream`
  * `Zip::DOSTime`

Run your test suite with the `RUBYZIP_V3_API_WARN` environment
variable set to see warnings about usage of the old API. This will
help you to identify any changes that you need to make to your code.
See https://github.com/rubyzip/rubyzip/wiki/Updating-to-version-3.x for
more information.

Please ensure that your Gemfiles and .gemspecs are suitably restrictive
to avoid an unexpected breakage when 3.0 is released (e.g. ~> 2.3.0).
See https://github.com/rubyzip/rubyzip for details. The Changelog also
lists other enhancements and bugfixes that have been implemented since
version 2.3.0.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
