### PR TITLE
Fix ffi-libarchive load error from habitat package on windows

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1197,6 +1197,7 @@
     "rpmvercmp",
     "rquery",
     "rsakey",
+    "RTLD",
     "RSAT",
     "RUNFULLSCREEN",
     "runid",

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -16,6 +16,7 @@ $pkg_bin_dirs=@(
 $pkg_deps=@(
   "core/cacerts"
   "core/openssl"
+  "core/zlib"
   "core/libarchive"
   "chef/ruby31-plus-devkit"
   "chef/chef-powershell-shim"
@@ -45,7 +46,9 @@ function Invoke-SetupEnvironment {
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
 
     Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath openssl)/bin"
+    Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath zlib)/bin"
     Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath visual-cpp-redist-2015)/bin"
+    Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$(Get-HabPackagePath libarchive)/bin"
 }
 
 function Invoke-Download() {

--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -70,8 +70,7 @@ begin
   # ffi-libarchive must be eager loaded see: https://github.com/chef/chef/issues/12228
   require "ffi-libarchive" unless defined?(Archive::Reader)
 rescue LoadError => e
-  STDERR.puts "ffi-libarchive could not be loaded: #{e.message}"
-  STDERR.puts "libarchive is probably not installed on system, archive_file will not be available"
+  STDERR.puts "ffi-libarchive could not be loaded. libarchive is probably not installed on system, archive_file will not be available"
 end
 
 class Chef

--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -21,10 +21,57 @@
 require_relative "../resource"
 require "fileutils" unless defined?(FileUtils)
 begin
+  # The explicit call to FFI::DynamicLibrary.open was added to address an issue specific to the Habitat packaging of Chef Infra Client on windows.
+  # In the Habitat environment, the libarchive library (archive.dll) is installed in a non-standard location that is not included
+  # in the default search paths used by the FFI gem to locate dynamic libraries. The default search paths for FFI are:
+  #   - <system library path>
+  #   - /usr/lib
+  #   - /usr/local/lib
+  #   - /opt/local/lib
+  # These paths do not account for the Habitat package structure, where libraries are installed in isolated directories under
+  # the Habitat package path (e.g., C:/hab/pkgs/core/libarchive/<version>/bin on Windows).
+  #
+  # Without explicitly loading archive.dll using FFI::DynamicLibrary.open, the ffi-libarchive gem fails to locate and load the library,
+  # resulting in runtime errors when attempting to use the archive_file resource.
+  #
+  # This code dynamically determines the path to archive.dll using the Habitat CLI (`hab pkg path core/libarchive`) and explicitly
+  # loads the library using FFI::DynamicLibrary.open. This ensures that the library is correctly loaded in the Habitat environment.
+  #
+  # Note: This logic is gated by a check for Habitat-specific environment variables (HAB_CACHE_SRC_PATH or HAB_PKG_PATH) to ensure
+  # that it is only applied in Habitat runs. For other environments (e.g., Omnibus, plain gem installations, or git checkouts),
+  # the default behavior of FFI is sufficient, as the libraries are installed in standard locations or embedded paths that are
+  # included in the default search paths.
+  if RUBY_PLATFORM.match?(/mswin|mingw|windows/) && (ENV["HAB_CACHE_SRC_PATH"] || ENV["HAB_PKG_PATH"])
+    require "ffi" unless defined?(FFI)
+    require "open3" unless defined?(Open3)
+    # Dynamically determine the path to the core/libarchive package
+    stdout, stderr, status = Open3.capture3("hab pkg path core/libarchive")
+    unless status.success?
+      Chef::Log.debug("Failed to determine Habitat libarchive path: #{stderr}")
+      return
+    end
+
+    habitat_libarchive_path = File.join(stdout.strip.tr("\\", "/"), "bin")
+    unless Dir.exist?(habitat_libarchive_path)
+      Chef::Log.debug("Habitat libarchive path not found: #{habitat_libarchive_path}")
+      return
+    end
+
+    archive_dll_path = File.join(habitat_libarchive_path, "archive.dll")
+    unless File.exist?(archive_dll_path)
+      Chef::Log.debug("archive.dll not found in Habitat path: #{habitat_libarchive_path}")
+      return
+    end
+
+    FFI::DynamicLibrary.open(archive_dll_path, FFI::DynamicLibrary::RTLD_LAZY) # Explicitly load the DLL
+    Chef::Log.debug("Explicitly loaded archive.dll from Habitat path: #{archive_dll_path}")
+  end
+
   # ffi-libarchive must be eager loaded see: https://github.com/chef/chef/issues/12228
   require "ffi-libarchive" unless defined?(Archive::Reader)
-rescue LoadError
-  STDERR.puts "ffi-libarchive could not be loaded, libarchive is probably not installed on system, archive_file will not be available"
+rescue LoadError => e
+  STDERR.puts "ffi-libarchive could not be loaded: #{e.message}"
+  STDERR.puts "libarchive is probably not installed on system, archive_file will not be available"
 end
 
 class Chef


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Include libarchive in DLL search path for windows habitat package which otherwise throws error `ffi-libarchive could not be loaded, libarchive is probably not installed on system, archive_file will not be available`

Additional error backtrace:

```
hab pkg exec chef/chef-infra-client irb
irb(main):001:0> require "ffi-libarchive"
C:/hab/pkgs/chef/chef-infra-client/19.1.58/20250722210356/vendor/gems/ffi-1.17.2-x64-mingw-ucrt/lib/ffi/dynamic_library.rb:94:in `load_library': Could not open library 'libarchive.so.13': Failed with error 126: The specified module could no (LoadError)
.
Could not open library 'libarchive.so.13.dll': Failed with error 126: The specified module could not be found.
.
Could not open library 'libarchive.13': Failed with error 126: The specified module could not be found.
.
Could not open library 'libarchive.13.dll': Failed with error 126: The specified module could not be found.
.
Could not open library 'libarchive-13': Failed with error 126: The specified module could not be found.
.
Could not open library 'libarchive-13.dll': Failed with error 126: The specified module could not be found.
.
Could not open library 'libarchive.so': Failed with error 126: The specified module could not be found.
.
Could not open library 'libarchive.so.dll': Failed with error 126: The specified module could not be found.
.
Could not open library 'libarchive': Failed with error 126: The specified module could not be found.
.
Could not open library 'libarchive.dll': Failed with error 126: The specified module could not be found.
.
Could not open library 'archive': Failed with error 126: The specified module could not be found.
.
Could not open library 'archive.dll': Failed with error 126: The specified module could not be found.
.
Searched in <system library path>
        from C:/hab/pkgs/chef/chef-infra-client/19.1.58/20250722210356/vendor/gems/ffi-1.17.2-x64-mingw-ucrt/lib/ffi/library.rb:95:in `block in ffi_lib'
        from C:/hab/pkgs/chef/chef-infra-client/19.1.58/20250722210356/vendor/gems/ffi-1.17.2-x64-mingw-ucrt/lib/ffi/library.rb:94:in `map'
        from C:/hab/pkgs/chef/chef-infra-client/19.1.58/20250722210356/vendor/gems/ffi-1.17.2-x64-mingw-ucrt/lib/ffi/library.rb:94:in `ffi_lib'
        from C:/hab/pkgs/chef/chef-infra-client/19.1.58/20250722210356/vendor/gems/ffi-libarchive-1.1.14/lib/ffi-libarchive/archive.rb:11:in `<module:C>'
        from C:/hab/pkgs/chef/chef-infra-client/19.1.58/20250722210356/vendor/gems/ffi-libarchive-1.1.14/lib/ffi-libarchive/archive.rb:4:in `<module:Archive>'
        from C:/hab/pkgs/chef/chef-infra-client/19.1.58/20250722210356/vendor/gems/ffi-libarchive-1.1.14/lib/ffi-libarchive/archive.rb:3:in `<top (required)>'
        from <internal:C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from C:/hab/pkgs/chef/chef-infra-client/19.1.58/20250722210356/vendor/gems/ffi-libarchive-1.1.14/lib/ffi-libarchive.rb:56:in `<top (required)>'
        from <internal:C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
        from <internal:C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
        from <internal:C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
        from (irb):1:in `<main>'
        from C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/bin/irb:33:in `load'
        from C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/bin/irb:33:in `<main>'
<internal:C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- ffi-libarchive (LoadError)
        from <internal:C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from (irb):1:in `<main>'
        from C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/bin/irb:33:in `load'
        from C:/hab/pkgs/chef/ruby31-plus-devkit/3.1.7/20250714120059/bin/irb:33:in `<main>'
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
