### PR TITLE
feat: refactor habitat resources 

### DIFF
--- a/lib/chef/provider/package/habitat.rb
+++ b/lib/chef/provider/package/habitat.rb
@@ -49,7 +49,7 @@ class Chef
 
         def install_package(names, versions)
           # License acceptance needed outside of local Chef Client
-          shell_out!("hab license accept") if Chef::Config.target_mode?
+          shell_out!("#{ChefUtils::Dist::Habitat::EXEC} license accept") if Chef::Config.target_mode?
 
           names.zip(versions).map do |n, v|
             opts = ["pkg", "install", "--channel", new_resource.channel, "--url", new_resource.bldr_url]

--- a/lib/chef/resource/habitat/_habitat_shared.rb
+++ b/lib/chef/resource/habitat/_habitat_shared.rb
@@ -17,9 +17,9 @@
 def hab(*command)
   # Windows shell_out does not support arrays, so manually cleaning and joining
   hab_cmd = if windows?
-              (["hab"] + command).flatten.compact.join(" ")
+              ([ChefUtils::Dist::Habitat::EXEC] + command).flatten.compact.join(" ")
             else
-              (["hab"] + command)
+              ([ChefUtils::Dist::Habitat::EXEC] + command)
             end
   shell_out!(hab_cmd)
 rescue Errno::ENOENT

--- a/lib/chef/resource/habitat/habitat_base.rb
+++ b/lib/chef/resource/habitat/habitat_base.rb
@@ -1,0 +1,22 @@
+
+require_relative "../../resource"
+require "chef-utils/dist" unless defined?(ChefUtils::Dist)
+
+class Chef
+  class Resource
+    class HabitatBase < Chef::Resource
+      property :bldr_url, String, default: node['habitat']['bldr_url'] || "https://bldr.habitat.sh",
+      description: "The habitat builder url where packages will be downloaded from. **Defaults to public Habitat Builder**"
+
+      property :channel, String, default: node['habitat']['channel'] || "stable",
+      description: "The release channel to install your package from."
+
+      property :auth_token, String, default: node['habitat']['auth_token'] || Nil,
+      description: "Auth token for installing a package."
+
+      action_class do
+        use "habitat_shared"
+      end
+    end
+  end
+end

--- a/lib/chef/resource/habitat/habitat_package.rb
+++ b/lib/chef/resource/habitat/habitat_package.rb
@@ -102,13 +102,13 @@ class Chef
       ```
       DOC
 
-      property :bldr_url, String, default: "https://bldr.habitat.sh",
+      property :bldr_url, String, default: node['habitat']['bldr_url'] || "https://bldr.habitat.sh",
       description: "The habitat builder url where packages will be downloaded from. **Defaults to public Habitat Builder**"
 
-      property :channel, String, default: "stable",
+      property :channel, String, default: node['habitat']['channel'] || "stable",
       description: "The release channel to install your package from."
 
-      property :auth_token, String,
+      property :auth_token, String, default: node['habitat']['auth_token'] || Nil,
       description: "Auth token for installing a package from a private organization on Habitat builder."
 
       property :binlink, [true, false, :force], default: false,

--- a/lib/chef/resource/habitat/habitat_sup.rb
+++ b/lib/chef/resource/habitat/habitat_sup.rb
@@ -15,11 +15,11 @@
 # limitations under the License.
 #
 
-require_relative "../../resource"
+require_relative "habitat_base"
 
 class Chef
   class Resource
-    class HabitatSup < Chef::Resource
+    class HabitatSup < Chef::Resource::HabitatBase
 
       provides(:habitat_sup, target_mode: true) do |_node|
         false
@@ -100,9 +100,6 @@ class Chef
       ```
       DOC
 
-      property :bldr_url, String,
-      description: "The Habitat Builder URL for the `habitat_package` resource, if needed."
-
       property :permanent_peer, [true, false], default: false,
       description: "Only valid for `:run` action, passes `--permanent-peer` to the hab command."
 
@@ -124,14 +121,8 @@ class Chef
       property :ring, String,
       description: "Only valid for `:run` action, passes `--ring` with the specified ring key name to the hab command."
 
-      property :hab_channel, String,
-      description: "The channel to install Habitat from. Defaults to stable"
-
       property :auto_update, [true, false], default: false,
       description: "Passes `--auto-update`. This will set the Habitat supervisor to automatically update itself any time a stable version has been released."
-
-      property :auth_token, String,
-      description: "Auth token for accessing a private organization on bldr. This value is templated into the appropriate service file."
 
       property :gateway_auth_token, String,
       description: "Auth token for accessing the supervisor's HTTP gateway. This value is templated into the appropriate service file."

--- a/lib/chef/resource/habitat/habitat_sup_systemd.rb
+++ b/lib/chef/resource/habitat/habitat_sup_systemd.rb
@@ -33,13 +33,13 @@ class Chef
         service_environment.push("HAB_SUP_GATEWAY_AUTH_TOKEN=#{new_resource.gateway_auth_token}") if new_resource.gateway_auth_token
         systemd_unit "hab-sup.service" do
           content(Unit: {
-                    Description: "The Habitat Supervisor",
+                    Description: "The #{ChefUtils::Dist::Habitat::PRODUCT} Supervisor",
                   },
                   Service: {
                     LimitNOFILE: new_resource.limit_no_files,
                     Environment: service_environment,
-                    ExecStart: "/bin/hab sup run #{exec_start_options}",
-                    ExecStop: "/bin/hab sup term",
+                    ExecStart: "/bin/#{ChefUtils::Dist::Habitat::EXEC} sup run #{exec_start_options}",
+                    ExecStop: "/bin/#{ChefUtils::Dist::Habitat::EXEC} sup term",
                     Restart: "on-failure",
                   }.compact,
                   Install: {

--- a/lib/chef/resource/habitat/habitat_sup_windows.rb
+++ b/lib/chef/resource/habitat/habitat_sup_windows.rb
@@ -56,7 +56,7 @@ class Chef
           version new_resource.service_version if new_resource.service_version
         end
 
-        execute "hab pkg exec core/windows-service install" do
+        execute "#{ChefUtils::Dist::Habitat::EXEC} pkg exec core/windows-service install" do
           not_if { ::Win32::Service.exists?("Habitat") }
         end
 

--- a/lib/chef/resource/habitat_config.rb
+++ b/lib/chef/resource/habitat_config.rb
@@ -15,13 +15,13 @@
 #
 require_relative "../http"
 require_relative "../json_compat"
-require_relative "../resource"
+require_relative "habitat/habitat_base"
 
 require "tmpdir" unless defined?(Dir::Tmpname)
 
 class Chef
   class Resource
-    class HabitatConfig < Chef::Resource
+    class HabitatConfig < Chef::Resource::HabitatBase
 
       provides :habitat_config, target_mode: true
       target_mode support: :full
@@ -110,10 +110,6 @@ class Chef
             TargetIO::File.unlink(tempname)
           end
         end
-      end
-
-      action_class do
-        use "../resource/habitat/habitat_shared"
       end
     end
   end

--- a/lib/chef/resource/habitat_user_toml.rb
+++ b/lib/chef/resource/habitat_user_toml.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing
 
 require_relative "../resource"
+
 class Chef
   class Resource
     class HabitatUserToml < Chef::Resource


### PR DESCRIPTION
Use ChefUtils::Dist::Habitat constants and allow a more generic configuration for on-prem builder

<!--- Provide a short summary of your changes in the Title above -->

## Description
Actually using an on prem builder require to set environment variables before launching chef or specifying builder/channel/auth token on every resource usage which is tiresome.
This PR is a first draft proposal on an approach to have things factorized in a base where possible and use node attributes as default.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
