### PR TITLE
temporarily pin berkshelf in verify

### DIFF
--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -126,7 +126,7 @@ for gem in ${external_gems[@]}; do
       echo "    - bundle exec tasks/bin/run_external_test chef/knife-windows main rake spec"
       ;;
     "berkshelf")
-      echo "    - bundle exec tasks/bin/run_external_test chef/berkshelf main rake"
+      echo "    - bundle exec tasks/bin/run_external_test chef/berkshelf 61c6c77e4aea00ed6be0af64c6f7260226cc1bdd rake" # temporary pin to get past verify
       ;;
     *)
       echo -e "\n Gem $gem is not valid\n" >&2


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
pinning berkshelf to an older commit to get past broken verify pipeline builds. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
