### PR TITLE
dependabot - disabled all target branches but chef-18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  target-branch: "main"
-  directory: "/omnibus"
-  schedule:
-    interval: daily
-    time: "06:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  labels:
-  - "Type: Chore"
+# - package-ecosystem: bundler
+#   target-branch: "main"
+#   directory: "/omnibus"
+#   schedule:
+#     interval: daily
+#     time: "06:00"
+#     timezone: America/Los_Angeles
+#   open-pull-requests-limit: 10
+#   labels:
+#   - "Type: Chore"
 - package-ecosystem: bundler
   target-branch: "chef-18"
   directory: "/omnibus"
@@ -20,23 +20,23 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - "Type: Chore"
-- package-ecosystem: bundler
-  target-branch: "chef-17"
-  directory: "/omnibus"
-  schedule:
-    interval: daily
-    time: "06:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  labels:
-  - "Type: Chore"
-- package-ecosystem: bundler
-  target-branch: "chef-16"
-  directory: "/omnibus"
-  schedule:
-    interval: daily
-    time: "06:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  labels:
-  - "Type: Chore"
+# - package-ecosystem: bundler
+#   target-branch: "chef-17"
+#   directory: "/omnibus"
+#   schedule:
+#     interval: daily
+#     time: "06:00"
+#     timezone: America/Los_Angeles
+#   open-pull-requests-limit: 10
+#   labels:
+#   - "Type: Chore"
+# - package-ecosystem: bundler
+#   target-branch: "chef-16"
+#   directory: "/omnibus"
+#   schedule:
+#     interval: daily
+#     time: "06:00"
+#     timezone: America/Los_Angeles
+#   open-pull-requests-limit: 10
+#   labels:
+#   - "Type: Chore"


### PR DESCRIPTION
## Description
Even if we have multiple target branches defined, Dependabot still scans only "main". We are disabling all other branches but "chef-18" to get a proper, one time dependency scan. After the reading is done we will revert the change.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
