### PR TITLE
Bump openssl gem to 3.3.0 to appease the kitchen-tests for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?
 
 # required for FIPS or bundler will pick up default openssl
 install_if -> { !Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" } } do
-  gem "openssl", "= 3.2.0"
+  gem "openssl", "= 3.3.0"
 end
 
 if File.exist?(File.expand_path("chef-bin", __dir__))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,8 @@ GEM
     fauxhai-ng (9.3.0)
       net-ssh
     ffi (1.17.2)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x64-mingw-ucrt)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -366,7 +368,7 @@ GEM
     netrc (0.11.0)
     nori (2.7.0)
       bigdecimal
-    openssl (3.2.0)
+    openssl (3.3.0)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -539,7 +541,7 @@ DEPENDENCIES
   ffi (>= 1.15.5)
   inspec-core-bin (~> 7.0.38.beta)
   ohai!
-  openssl (= 3.2.0)
+  openssl (= 3.3.0)
   pry (= 0.13.0)
   pry-byebug
   pry-stack_explorer

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -146,7 +146,7 @@ function Invoke-Build {
         $env:_BUNDLER_WINDOWS_DLLS_COPIED = "1"
 
         $openssl_dir = "$(Get-HabPackagePath core/openssl)"
-        gem install openssl:3.2.0 -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
+        gem install openssl:3.3.0 -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
 
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
         bundle install --jobs=3 --retry=3


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
No `bundle update --conservative` on this but a manual bump of `openssl` gem to 3.3.0

```sh
Fetching https://github.com/chef/rest-client
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies.....
Using rake 13.2.1
Using concurrent-ruby 1.3.5
Using public_suffix 6.0.1
Using minitest 5.25.5
Using ast 2.4.2
Using aws-eventstream 1.3.0
Using mixlib-cli 2.1.8
Using aws-partitions 1.1048.0
Using base64 0.2.0
Using jmespath 1.6.2
Using debug_inspector 1.2.0
Using builder 3.3.0
Using bundler 2.3.27
Using byebug 11.1.3
Using fuzzyurl 0.9.0
Using bigdecimal 3.1.9
Using tomlrb 1.3.0
Using libyajl2 2.1.0
Using hashie 4.1.0
Using ffi 1.16.3
Using rack 3.1.16
Using unf_ext 0.0.8.2
Using webrick 1.9.1
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using chef-vault 4.1.11
Using uuidtools 2.2.0
Using iniparse 1.5.0
Using parallel 1.26.3
Using racc 1.8.1
Using rainbow 3.1.1
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.6.0
Using uri 1.0.3
Using json 2.13.2
Using logger 1.5.3
Using regexp_parser 2.10.0
Using rexml 3.4.0
Using tty-color 0.6.0
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using tty-screen 0.8.2
Using wisper 2.0.1
Using method_source 1.1.0
Using multipart-post 2.4.1
Using strings-ansi 0.2.0
Using parslet 2.0.0
Using coderay 1.1.3
Using rubyzip 2.4.1
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.2.2
Using net-ssh 7.3.0
Using mixlib-authentication 3.0.10
Using timeout 0.4.3
Using date 3.4.1
Using rspec-support 3.12.2
Using plist 3.7.2
Using wmi-lite 1.0.7
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using http-accept 2.1.1
Using ipaddress 0.8.3
Using domain_name 0.6.20240107
Using mime-types-data 3.2025.0204
Using netrc 0.11.0
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using erubi 1.13.1
Using multi_json 1.15.0
Using ed25519 1.3.0
Using rb-readline 0.5.5
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using i18n 1.14.7
Using hashdiff 1.1.1
Using tzinfo 2.0.6
Using chef-utils 18.8.1 from source at `chef-utils`
Using aws-sigv4 1.11.0
Using addressable 2.8.7
Using binding_of_caller 1.0.1
Using mixlib-config 3.0.27
Using ffi-yajl 2.6.0
Using mixlib-log 3.1.2.1
Using rackup 2.2.1
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.3
Using gssapi 1.3.1
Using nori 2.7.0
Using parser 3.3.7.1
Using rubyntlm 0.6.5
Using net-http 0.6.0
Using tty-reader 0.9.0
Using chef-gyoku 1.4.1
Using crack 0.4.5
Using strings 0.2.1
Using pry 0.13.0
Using rspec-core 3.12.3
Using rspec-expectations 3.12.4
Using pastel 0.8.0
Using rspec-mocks 3.12.7
Using net-scp 4.1.0
Using net-protocol 0.2.2
Using time 0.4.1
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using mime-types 3.6.0
Using logging 2.4.0
Using activesupport 7.0.8.7
Using mixlib-shellout 3.3.6
Using http-cookie 1.0.8
Using aws-sdk-core 3.218.1
Using vault 0.18.2
Using rubocop-ast 1.38.0
Using faraday-net_http 3.4.0
Using pry-byebug 3.10.1
Using mixlib-archive 1.1.7
Using pry-stack_explorer 0.6.1
Using rspec-its 1.3.1
Using tty-box 0.7.0
Using tty-prompt 0.23.1
Using webmock 3.25.0
Using rspec 3.12.0
Using appbundler 0.13.4
Using chef-config 18.8.1 from source at `chef-config`
Using chef-zero 15.0.21
Using train-core 3.12.13
Using net-ftp 0.3.8
Using chef-winrm 2.3.11
Using aws-sdk-kms 1.98.0
Using aws-sdk-secretsmanager 1.112.0
Using rubocop 1.25.1
Using faraday 2.12.2
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@4f8417a)
Using tty-table 0.12.0
Using aws-sdk-s3 1.180.0
Using chef-telemetry 1.1.1
Using cookstyle 7.32.8
Using license-acceptance 2.1.13
Using ohai 18.2.5 from https://github.com/chef/ohai.git (at 18-stable@58ee0df)
Using faraday-follow_redirects 0.3.0
Using chef-winrm-fs 1.3.7
Using cheffish 17.1.8
Using chefstyle 2.2.3
Using inspec-core 5.22.80
Using chef-winrm-elevated 1.2.5
Using inspec-core-bin 5.22.80
Using train-winrm 0.2.17
Using train-rest 0.5.0
Using chef 18.8.1 from source at `.`
Using chef-bin 18.8.1 from source at `chef-bin` and installing its executables
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
