### PR TITLE
[CHEF-21785] Updated the knife ec backup to preserve the frozen cookbook status

### DIFF
--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -312,6 +312,7 @@ class Chef
                     new_dest_parent.create_child_from(src_entry)
                     ui.output "Created #{dest_path}" if ui
                   end
+                  create_cookbook_status_file(src_entry, dest_entry)
                   return
                 end
 
@@ -331,6 +332,7 @@ class Chef
                       error ||= child_error
                     end
                   end
+                  create_cookbook_status_file(src_entry, new_dest_dir)
                 else
                   if options[:dry_run]
                     ui.output "Would create #{dest_path}" if ui
@@ -355,6 +357,7 @@ class Chef
                     ui.output "Updated #{dest_path}" if ui
                   end
                 end
+                create_cookbook_status_file(src_entry, dest_entry)
                 return
               end
 
@@ -368,6 +371,7 @@ class Chef
                       error ||= child_error
                     end
                   end
+                  create_cookbook_status_file(src_entry, dest_entry)
                 else
                   # If they are different types.
                   ui.error("File #{src_path} is a directory while file #{dest_path} is a regular file\n") if ui
@@ -439,6 +443,12 @@ class Chef
           parent
         end
 
+        def create_cookbook_status_file(src_entry, dest_entry)
+          if src_entry.is_a?(Chef::ChefFS::FileSystem::ChefServer::CookbookDir)
+            status_file = dest_entry.child("status.json")
+            status_file.write({ "frozen": src_entry.cookbook_frozen? }.to_json)
+          end
+        end
       end
     end
   end

--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -446,7 +446,8 @@ class Chef
         def create_cookbook_status_file(src_entry, dest_entry)
           if src_entry.is_a?(Chef::ChefFS::FileSystem::ChefServer::CookbookDir)
             status_file = dest_entry.child("status.json")
-            status_file.write({ "frozen": src_entry.cookbook_frozen? }.to_json)
+            frozen_status = src_entry.cookbook_frozen? || false
+            status_file.write({ "frozen": frozen_status }.to_json)
           end
         end
       end

--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_dir.rb
@@ -204,6 +204,10 @@ class Chef
               end
             end
           end
+
+          def cookbook_frozen?
+            @frozen ||= (chef_object&.frozen_version? || false)
+          end
         end
       end
     end

--- a/spec/unit/chef_fs/file_system_spec.rb
+++ b/spec/unit/chef_fs/file_system_spec.rb
@@ -19,6 +19,7 @@
 require "spec_helper"
 require "chef/chef_fs/file_system"
 require "chef/chef_fs/file_pattern"
+require "chef/chef_fs/file_system/chef_server/cookbook_dir"
 
 describe Chef::ChefFS::FileSystem, ruby: ">= 3.0" do
   include FileSystemSupport
@@ -147,4 +148,63 @@ describe Chef::ChefFS::FileSystem, ruby: ">= 3.0" do
   end
 
   # Need to add the test case for copy_to method - not able to do the implimentation with Dir.mktmpdir
+
+  describe ".create_cookbook_status_file" do
+    let(:chef_server_cookbook_dir) { double("Chef::ChefFS::FileSystem::ChefServer::CookbookDir") }
+    let(:local_cookbook_dir) { double("LocalCookbookDir") }
+    let(:status_file) { double("StatusFile") }
+    let(:non_cookbook_dir) { double("RegularDir") }
+
+    before do
+      allow(Chef::ChefFS::FileSystem).to receive(:create_cookbook_status_file).and_call_original
+    end
+
+    context "when source is a CookbookDir" do
+      before do
+        allow(chef_server_cookbook_dir).to receive(:is_a?).with(Chef::ChefFS::FileSystem::ChefServer::CookbookDir).and_return(true)
+        allow(local_cookbook_dir).to receive(:child).with("status.json").and_return(status_file)
+      end
+
+      it "creates status.json file with frozen: true when cookbook is frozen" do
+        allow(chef_server_cookbook_dir).to receive(:cookbook_frozen?).and_return(true)
+        expect(status_file).to receive(:write).with('{"frozen":true}')
+
+        Chef::ChefFS::FileSystem.send(:create_cookbook_status_file, chef_server_cookbook_dir, local_cookbook_dir)
+      end
+
+      it "creates status.json file with frozen: false when cookbook is not frozen" do
+        allow(chef_server_cookbook_dir).to receive(:cookbook_frozen?).and_return(false)
+        expect(status_file).to receive(:write).with('{"frozen":false}')
+
+        Chef::ChefFS::FileSystem.send(:create_cookbook_status_file, chef_server_cookbook_dir, local_cookbook_dir)
+      end
+    end
+
+    context "when source is not a CookbookDir" do
+      before do
+        allow(non_cookbook_dir).to receive(:is_a?).with(Chef::ChefFS::FileSystem::ChefServer::CookbookDir).and_return(false)
+      end
+
+      it "does not create status.json file" do
+        expect(local_cookbook_dir).not_to receive(:child)
+        expect(status_file).not_to receive(:write)
+
+        Chef::ChefFS::FileSystem.send(:create_cookbook_status_file, non_cookbook_dir, local_cookbook_dir)
+      end
+    end
+
+    context "when cookbook_frozen? returns nil" do
+      before do
+        allow(chef_server_cookbook_dir).to receive(:is_a?).with(Chef::ChefFS::FileSystem::ChefServer::CookbookDir).and_return(true)
+        allow(chef_server_cookbook_dir).to receive(:cookbook_frozen?).and_return(nil)
+        allow(local_cookbook_dir).to receive(:child).with("status.json").and_return(status_file)
+      end
+
+      it "creates status.json file with frozen: false when cookbook_frozen? returns nil" do
+        expect(status_file).to receive(:write).with('{"frozen":false}')
+
+        Chef::ChefFS::FileSystem.send(:create_cookbook_status_file, chef_server_cookbook_dir, local_cookbook_dir)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Issue:
During the chef server migration, the frozen cookbook information is not transmitted to the new chef server. This is not a bug, actually a missed feature in the backup/restore functionality. In https://github.com/chef/chef/pull/14947, @PrajaktaPurohit introduced three options to implement this feature. The majority of people opted for option 3, and this PR implements option 3 of the knife ec backup side.

The changes introduced in this PR:
- During the knife ec backup process, a file called status.json will be created in the backup folder, which contains the frozen status of the cookbook. 

The restore part then will read the status.json file and update the cookbook with the frozen status. This is implemented in this PR:


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
