### PR TITLE
fix(apt_repository): Use import instead of dearmor to import key from url

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -335,15 +335,14 @@ class Chef
               action :create
               verify "gpg --homedir #{tmp_dir} %{path}"
               notifies :delete, "file[#{keyfile_path}]", :immediately
-              notifies :run, "execute[dearmor #{keyfile_path}]", :immediately
+              notifies :run, "execute[import #{keyfile_path}]", :immediately
             end
 
-            execute "dearmor #{keyfile_path}" do
-              command [ "gpg", "--batch", "--yes", "--dearmor", "-o", keyfile_path, keyfile_tmp_path ]
+            execute "import #{keyfile_path}" do
+              command [ "gpg", "--import", "--batch", "--yes", "--no-default-keyring", "--keyring", keyfile_path, keyfile_tmp_path ]
               default_env true
               sensitive new_resource.sensitive
               action :nothing
-              only_if { !::File.exist?(keyfile_path) || ::File.read(keyfile_path).include?("-----BEGIN PGP PUBLIC KEY BLOCK-----") }
             end
 
             file keyfile_path do


### PR DESCRIPTION
By using gpg --import instead of --dearmor, we can incrementally add new keys to the keyring, instead of replacing it each time we process an item from the array.

Maybe it would be better to have some kind of cleanup of old keys, but that seems really complicated to get right, and this is strictly better than only using the last item of the array.

I suppose another possibility is we could have a single keyring for each file, and then add multiple `signed-by` attributes, one for each key file. 



<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes: #15208

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
