### PR TITLE
fix: multiple apt_repos with same key url should be signed-by

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_apt.rb
@@ -38,3 +38,11 @@ apt_repository "test" do
   signed_by true
   key "https://ftp-master.debian.org/keys/archive-key-12.asc"
 end
+
+apt_repository "test-with-same-key" do
+  uri "http://ftp.be.debian.org/debian/"
+  distribution "bookworm-updates"
+  components %w{main contrib non-free}
+  signed_by true
+  key "https://ftp-master.debian.org/keys/archive-key-12.asc"
+end

--- a/kitchen-tests/test/integration/end-to-end/_apt.rb
+++ b/kitchen-tests/test/integration/end-to-end/_apt.rb
@@ -1,0 +1,6 @@
+# Check if an apt_repository using the same key url as a previous apt_repository, actually has a working key.
+if os.debian?
+  describe command("gpg --no-default-keyring --keyring /etc/apt/keyrings/test-with-same-key.gpg --list-keys") do
+    its(:stdout) { should match(/Debian Archive Automatic Signing Key/) }
+  end
+end

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -334,7 +334,6 @@ class Chef
               sensitive new_resource.sensitive
               action :create
               verify "gpg --homedir #{tmp_dir} %{path}"
-              notifies :delete, "file[#{keyfile_path}]", :immediately
               notifies :run, "execute[import #{keyfile_path}]", :immediately
             end
 
@@ -347,6 +346,7 @@ class Chef
 
             file keyfile_path do
               mode "0644"
+              notifies :run, "execute[import #{keyfile_path}]", :before unless ::File.exist?(keyfile_path)
             end
           else
             declare_resource(key_resource_type(key), keyfile_path) do


### PR DESCRIPTION
Currently, when having multiple apt_repository resources that use the same key url (e.g. Debian bookworm, bookworm-updates and bookworm-backports), only the first apt_repository resource that gets executed will have its key imported into a keyring.

The other apt_repository resources using the same key will not get their keyrings imported, as the remote_file is up to date.

By notifying the import if the key does not exist, we work around this problem.

I also removed the `:delete` notification of the keyring file when the `remote_file` resource changes, as it caused unwanted deletes of the actual keyring file _after_ the `gpg --import`.
This doesn't break anything, as `gpg --import` does not require the keyring file to be missing, it just imports the new key in the same file if it exists.
