### PR TITLE
fix: apt_repository gpg key import for newer APT versions

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -309,6 +309,15 @@ class Chef
           "/etc/apt/keyrings/#{new_resource.repo_name}.gpg"
         end
 
+        # Get the current APT version, this is important for creating keyring files,
+        # on newer APT versions these need to be an _older_ GnuPG format due to "sqv"
+        # being used to verify
+        #
+        # @return [Integer]
+        def apt_version
+          @apt_version ||= shell_out("apt -v").stdout.strip[/([0-9]\.?){3}/, 0].to_i
+        end
+
         # Fetch the key using either cookbook_file or remote_file, validate it,
         # and install it with apt-key add
         # @param [String] key the key to install
@@ -320,6 +329,7 @@ class Chef
           key_name = key.gsub(/[^0-9A-Za-z\-]/, "_")
           keyfile_tmp_path = ::File.join(Chef::Config[:file_cache_path], key_name)
           keyfile_path = keyring_path
+          gpg_keyring_prefix = apt_version > 2 ? "gnupg-ring:" : ""
           tmp_dir = TargetIO::Dir.mktmpdir(".gpg")
           at_exit { TargetIO::FileUtils.remove_entry(tmp_dir) }
 
@@ -338,7 +348,7 @@ class Chef
             end
 
             execute "import #{keyfile_path}" do
-              command [ "gpg", "--import", "--batch", "--yes", "--no-default-keyring", "--keyring", keyfile_path, keyfile_tmp_path ]
+              command [ "gpg", "--import", "--batch", "--yes", "--no-default-keyring", "--keyring", "#{gpg_keyring_prefix}#{keyfile_path}", keyfile_tmp_path ]
               default_env true
               sensitive new_resource.sensitive
               action :nothing


### PR DESCRIPTION
A normal `gpg --import` creates a GnuPG keybox database file, which, for previous Debian versions, was not a problem for APT.

On newer Debian versions (e.g. 13/Trixie), however, APT uses `sqv` to verify the keys, which seems not to be compatible with the GnuPG keybox database file.

```
Sub-process /usr/bin/sqv returned an error code (1), error message is:
Error: Failed to parse keyring "/etc/apt/keyrings/om-debian.gpg"  Caused
by:     0: Reading "/etc/apt/keyrings/om-debian.gpg": EOF     1: EOF
```

The solution is to import to a `OpenPGP Public Key Version 4` ring file, which does work.

https://github.com/chef/chef/pull/15218#issuecomment-3224592196