### PR TITLE
Correcting an issue with nils causing havoc

### DIFF
--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -90,6 +90,7 @@ class Chef
           ohai_plugin_path = Chef::Config[:ohai_segment_plugin_path]
           if ohai_plugin_path && Dir.exist?(ohai_plugin_path) && !Dir.empty?(ohai_plugin_path)
             # Configure Ohai to load plugins from the cookbook segment path
+             ohai.config[:plugin_path] ||= []
             ohai.config[:plugin_path] << ohai_plugin_path
             logger.trace("Added cookbook plugin path to ohai: #{ohai_plugin_path}")
           end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The update from https://github.com/chef/chef/pull/15115 didn't properly account for a nil to creep into the path which leads to a failure on line 94 of the ohai.rb file. Here we account for that by creating an array first

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
