### PR TITLE
fix irb errors in functional tests

### DIFF
--- a/chef-bin/bin/chef-shell
+++ b/chef-bin/bin/chef-shell
@@ -22,7 +22,6 @@ Encoding.default_external = Encoding::UTF_8
 
 require "irb"
 require "irb/completion"
-require "irb/ext/save-history"
 
 $:.unshift(File.expand_path(File.join(__dir__, "..", "lib")))
 

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -58,9 +58,11 @@ module Shell
   # Start the irb REPL with chef-shell's customizations
   def self.start
     setup_logger
-    # FUGLY HACK: irb gives us no other choice.
-    irb_help = [:help, :irb_help, IRB::ExtendCommandBundle::NO_OVERRIDE]
-    IRB::ExtendCommandBundle.instance_variable_get(:@ALIASES).delete(irb_help)
+
+    IRB::Command.register(
+      :help,
+      proc { Shell::Options.print_help }
+    )
 
     parse_opts
     Chef::Config[:shell_config] = options.config


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
`irb` 1.14.x included in ruby 3.4 also includes these updates:

- `save-history` extension was moved to core irb. this change meant that there is no `save-history` to load at that path and what we need is now included by default. https://github.com/ruby/irb/pull/613

- we can't modify aliases anymore, but `irb` now provides apis to override commands by registering them again. https://github.com/ruby/ruby/blob/d2930f8e7a5db8a7337fa43370940381b420cc3e/lib/irb/command.rb#L16-L21
https://docs.ruby-lang.org/en/3.3/IRB/Command.html 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
