### PR TITLE
[ChefRepositoryFileSystemCookbookEntry] Add `any_children?` method

### DIFF
--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_dir.rb
@@ -100,10 +100,6 @@ class Chef
             raise
           end
 
-          def children
-            super.select { |entry| !(entry.dir? && entry.children.size == 0 ) }
-          end
-
           def can_have_child?(name, is_dir)
             if is_dir && !%w{ root_files .. . }.include?(name)
               # Only the given directories will be uploaded.
@@ -132,7 +128,7 @@ class Chef
           end
 
           def can_upload?
-            File.exist?(uploaded_cookbook_version_path) || children.size > 0
+            File.exist?(uploaded_cookbook_version_path) || any_children?
           end
 
           protected

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_entry.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_entry.rb
@@ -90,6 +90,18 @@ class Chef
             true
           end
 
+          # This is a lighter (than `#children.size == 0`) existence check.
+          # return earlier where we only care if 1 or more children exist
+          def any_children?
+            Dir.entries(file_path).any? { |child_name|
+              (child = make_child_entry(child_name)) &&
+                can_have_child?(child.name, child.dir?) &&
+                !(child.dir? && !child.any_children? )
+            }
+          rescue Errno::ENOENT
+            raise Chef::ChefFS::FileSystem::NotFoundError.new(self, $!)
+          end
+
           def write_pretty_json
             false
           end


### PR DESCRIPTION
## Description
This is kind of a "Facebook-scale" issue, but when you have *lots* of cookbooks and files, creating big arrays of child objects that are checked only for non-zero lengths can add whole seconds to Chef Zero cookbook resolution. Instead of creating the big arrays, simply detect if there's at least one child and return accordingly.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
