### PR TITLE
Why is the Server service not running on that node?

### DIFF
--- a/.expeditor/scripts/prep_and_run_tests.ps1
+++ b/.expeditor/scripts/prep_and_run_tests.ps1
@@ -210,6 +210,9 @@ if ( $RakeTest -match 'functional' ) {
       Write-Host "Current service status: $($service.Status)" -ForegroundColor Cyan
       Write-Host "Current startup type: $($serviceWMI.StartMode)" -ForegroundColor Cyan
 
+      Write-Host "Getting current Service logs for diagnostics..." -ForegroundColor Yellow
+      Get-ServiceLogs
+
       # Check if service is disabled and enable it
       if ($serviceWMI.StartMode -eq "Disabled") {
           Write-Host "Service is disabled. Attempting to enable..." -ForegroundColor Yellow


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
On any of the windows testers in the verify pipeline, the Server service appears to be failing/failed/not started/not running, any of the above. This results in an absurd number of failures in tests. Here we attempt to ensure that the service is running and fail hard and fast if it can't be started. 

if this doesn't work, the next step will be to add code to scan the event logs for failure messages related to that service and see if we can discover what might be going wrong.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
