### PR TITLE
my attempt to upgrade the repo to ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ end
 # Everything except AIX and Windows
 group(:ruby_shadow) do
   install_if -> { !RUBY_PLATFORM.match?(/mingw/) } do
-    gem "ruby-shadow", platforms: :ruby
+    gem "gitlab-ruby-shadow", platforms: :ruby
   end
 end
 
@@ -65,7 +65,11 @@ end
 group(:development, :test) do
   gem "rake", ">= 12.3.3"
   gem "rspec"
-  gem "webmock"
+  gem "webmock", "~> 3.25"
+  gem "httpclient", "~> 2.9"
+  gem "syslog" # formerly stdlib
+  gem "csv" # formerly stdlib
+  gem "racc" # formerly stdlib
   gem "crack", "< 0.4.6" # due to https://github.com/jnunemaker/crack/pull/75
   gem "fauxhai-ng" # for chef-utils gem
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: ef0bce664bd9b3a95f9e06581eeb9a74fb1c364d
+  revision: 266012edb5e1ed520950e043d2e9fcc8fd9b7bb7
   branch: main
   specs:
-    ohai (19.1.1)
+    ohai (19.1.9)
       base64
       chef-config (>= 14.12, < 20)
       chef-utils (>= 16.0, < 20)
@@ -179,7 +179,7 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    base64 (0.2.0)
+    base64 (0.3.0)
     bigdecimal (3.1.8)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
@@ -237,13 +237,14 @@ GEM
       logger (< 1.6.0)
       net-ssh
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.5)
     cookstyle (8.1.1)
       rubocop (= 1.75.3)
     corefoundation (0.3.13)
       ffi (>= 1.15.0)
     crack (0.4.5)
       rexml
+    csv (3.3.5)
     date (3.4.0)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
@@ -273,14 +274,16 @@ GEM
     ffi-yajl (2.6.0)
       libyajl2 (>= 1.2)
     fuzzyurl (0.9.0)
+    gitlab-ruby-shadow (2.5.1)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    hashdiff (1.1.1)
+    hashdiff (1.2.1)
     hashie (4.1.0)
     http-accept (1.7.0)
     http-cookie (1.0.7)
       domain_name (~> 0.5)
-    httpclient (2.8.3)
+    httpclient (2.9.0)
+      mutex_m
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
@@ -314,7 +317,7 @@ GEM
     ipaddress (0.8.3)
     iso8601 (0.13.0)
     jmespath (1.6.2)
-    json (2.7.6)
+    json (2.13.2)
     language_server-protocol (3.17.0.4)
     libyajl2 (2.1.0)
     license-acceptance (2.1.13)
@@ -344,15 +347,16 @@ GEM
       tomlrb
     mixlib-log (3.2.3)
       ffi (>= 1.15.5)
-    mixlib-shellout (3.3.8)
+    mixlib-shellout (3.3.9)
       chef-utils
-    mixlib-shellout (3.3.8-x64-mingw-ucrt)
+    mixlib-shellout (3.3.9-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
       wmi-lite (~> 1.0)
     multi_json (1.15.0)
     multipart-post (2.4.1)
+    mutex_m (0.3.0)
     net-ftp (0.3.8)
       net-protocol
       time
@@ -360,7 +364,7 @@ GEM
       uri
     net-protocol (0.2.2)
       timeout
-    net-scp (4.0.0)
+    net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
@@ -376,7 +380,7 @@ GEM
     parslet (1.8.2)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    plist (3.7.1)
+    plist (3.7.2)
     prism (1.4.0)
     proxifier2 (1.1.0)
     pry (0.13.0)
@@ -388,7 +392,7 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     racc (1.8.1)
     rack (3.1.16)
     rackup (2.2.1)
@@ -397,7 +401,7 @@ GEM
     rake (13.2.1)
     rb-readline (0.5.5)
     regexp_parser (2.10.0)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -429,7 +433,6 @@ GEM
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
-    ruby-shadow (2.5.1)
     rubyntlm (0.6.5)
       base64
     rubyzip (2.3.2)
@@ -441,6 +444,8 @@ GEM
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
     structured_warnings (0.4.0)
+    syslog (0.3.0)
+      logger
     syslog-logger (1.6.8)
     thor (1.2.2)
     time (0.4.0)
@@ -485,14 +490,13 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf_ext (0.0.8.2)
-    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
     uri (1.0.3)
     uuidtools (2.2.0)
     vault (0.18.2)
       aws-sigv4
-    webmock (3.24.0)
+    webmock (3.25.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -536,21 +540,25 @@ DEPENDENCIES
   chef-vault
   cheffish (>= 17)
   crack (< 0.4.6)
+  csv
   ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5)
+  gitlab-ruby-shadow
+  httpclient (~> 2.9)
   inspec-core-bin (~> 7.0.38.beta)
   ohai!
   openssl (= 3.3.0)
   pry (= 0.13.0)
   pry-byebug
   pry-stack_explorer
+  racc
   rake (>= 12.3.3)
   rb-readline
   rest-client!
   rspec
-  ruby-shadow
-  webmock
+  syslog
+  webmock (~> 3.25)
 
 BUNDLED WITH
    2.3.27

--- a/chef-bin/bin/chef-shell
+++ b/chef-bin/bin/chef-shell
@@ -22,7 +22,15 @@ Encoding.default_external = Encoding::UTF_8
 
 require "irb"
 require "irb/completion"
-require "irb/ext/save-history"
+begin
+  require "irb/ext/save-history"
+rescue LoadError
+  begin
+    require "irb/ext/eval_history"
+  rescue LoadError, NameError
+    # IRB history extension not available or broken in this Ruby version
+  end
+end
 
 $:.unshift(File.expand_path(File.join(__dir__, "..", "lib")))
 

--- a/chef-config/Gemfile
+++ b/chef-config/Gemfile
@@ -7,4 +7,5 @@ gemspec
 group(:development, :test) do
   gem "rake", ">= 12.3.3"
   gem "rspec"
+  gem "racc"
 end

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -3,10 +3,13 @@ source "https://rubygems.org"
 gem "knife", path: "."
 
 group(:development, :test) do
+  gem "abbrev" # formerly a stdlib, now a gem
   gem "cheffish", ">= 14" # testing only , but why didn't this need to explicit in chef?
+  gem "csv" # formerly a stdlib, now a gem
   gem "webmock"
   gem "crack", "< 0.4.6" # due to https://github.com/jnunemaker/crack/pull/75
   gem "rake", ">= 12.3.3"
+  gem "syslog" # formerly a stdlib, now a gem
   gem "rspec"
   gem "chef-bin", path: "../chef-bin"
 end

--- a/knife/Gemfile.lock
+++ b/knife/Gemfile.lock
@@ -21,7 +21,7 @@ GIT
 PATH
   remote: ../chef-bin
   specs:
-    chef-bin (19.1.24)
+    chef-bin (19.1.75)
       chef (= 19.1.75)
 
 PATH
@@ -31,15 +31,15 @@ PATH
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
-      chef-config (= 19.1.24)
+      chef-config (= 19.1.75)
       chef-licensing (>= 0.7.5)
-      chef-utils (= 19.1.24)
+      chef-utils (= 19.1.75)
       chef-vault
-      chef-zero (>= 15.0.17)
+      chef-zero (~> 15.0.21)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5, < 1.17.0)
+      ffi (>= 1.15.5)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
@@ -60,13 +60,14 @@ PATH
       train-rest (>= 0.4.1)
       train-winrm (>= 0.2.17)
       unf_ext (~> 0.0.8.2)
+      uri (~> 1.0.3)
       uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.18.2)
 
 PATH
   remote: .
   specs:
-    knife (19.1.24)
+    knife (19.1.75)
       bcrypt_pbkdf (~> 1.1)
       chef (>= 19)
       chef-config (>= 19)
@@ -91,30 +92,38 @@ PATH
       tty-table (~> 0.11)
 
 PATH
-  remote: /home/phil/src/git/chef/chef-config
+  remote: /Users/rmoriz/Sync/Projekte/chef/chef-config
   specs:
-    chef-config (19.1.24)
+    chef-config (19.1.75)
       addressable
-      chef-utils (= 19.1.24)
+      chef-utils (= 19.1.75)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
 
 PATH
-  remote: /home/phil/src/git/chef/chef-utils
+  remote: /Users/rmoriz/Sync/Projekte/chef/chef-utils
   specs:
-    chef-utils (19.1.24)
+    chef-utils (19.1.75)
       concurrent-ruby
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8.7)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    abbrev (0.1.2)
+    activesupport (7.2.2.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
@@ -139,10 +148,9 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    base64 (0.2.0)
+    base64 (0.3.0)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-arm64-darwin)
-    bcrypt_pbkdf (1.1.1-x86_64-darwin)
+    benchmark (0.4.1)
     bigdecimal (3.1.9)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
@@ -151,11 +159,12 @@ GEM
     chef-gyoku (1.4.5)
       builder (>= 2.1.2)
       rexml (~> 3.4)
-    chef-licensing (1.0.4)
-      activesupport (~> 7.0, < 7.1)
+    chef-licensing (1.1.0)
+      activesupport (~> 7.2, >= 7.2.2.1)
       chef-config (>= 15)
       faraday (>= 1, < 3)
       faraday-http-cache
+      ostruct (~> 0.1.0)
       tty-prompt (~> 0.23)
       tty-spinner (~> 0.9.3)
     chef-telemetry (1.1.1)
@@ -182,13 +191,14 @@ GEM
       erubi (>= 1.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 2.0)
-    chef-zero (15.0.17)
-      activesupport (~> 7.0, < 7.1)
-      ffi-yajl (~> 2.2)
-      hashie (>= 2.0, < 5.0)
+    chef-zero (15.0.21)
+      activesupport (>= 7, < 8.1)
+      ffi-yajl (>= 2.2, < 4.0)
+      hashie (>= 2.0, < 6.0)
       mixlib-log (>= 2.0, < 4.0)
-      rack (~> 3.1, >= 3.1.10)
+      rack (~> 3.1, >= 3.1.16)
       rackup (~> 2.2, >= 2.2.1)
+      unf_ext (~> 0.0.8)
       uuidtools (~> 2.1)
       webrick
     cheffish (17.1.8)
@@ -198,16 +208,19 @@ GEM
       net-ssh
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
     cookstyle (8.1.3)
       rubocop (= 1.75.6)
     corefoundation (0.3.13)
       ffi (>= 1.15.0)
     crack (0.4.5)
       rexml
+    csv (3.3.5)
     date (3.4.1)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     domain_name (0.6.20240107)
+    drb (2.2.3)
     erubi (1.13.1)
     erubis (2.7.0)
     faraday (2.13.1)
@@ -319,6 +332,7 @@ GEM
     netrc (0.11.0)
     nori (2.7.0)
       bigdecimal
+    ostruct (0.1.0)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -340,25 +354,25 @@ GEM
       pry (~> 0.13)
     public_suffix (6.0.2)
     racc (1.8.1)
-    rack (3.1.15)
+    rack (3.2.1)
     rackup (2.2.1)
       rack (>= 3)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     regexp_parser (2.10.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.4.1)
-    rspec (3.13.0)
+    rexml (3.4.4)
+    rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.4)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-its (1.3.1)
@@ -386,6 +400,7 @@ GEM
     rubyntlm (0.6.5)
       base64
     rubyzip (2.4.1)
+    securerandom (0.4.1)
     semverse (3.0.2)
     sslshake (1.3.1)
     strings (0.2.1)
@@ -393,6 +408,8 @@ GEM
       unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
+    syslog (0.3.0)
+      logger
     syslog-logger (1.6.8)
     thor (1.2.2)
     time (0.4.1)
@@ -458,12 +475,14 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  abbrev
   chef!
   chef-bin!
   chef-config!
   chef-utils!
   cheffish (>= 14)
   crack (< 0.4.6)
+  csv
   knife!
   ohai!
   pry
@@ -471,6 +490,7 @@ DEPENDENCIES
   pry-stack_explorer
   rake (>= 12.3.3)
   rspec
+  syslog
   webmock
 
 BUNDLED WITH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -139,6 +139,9 @@ RSpec.configure do |config|
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
   config.filter_run_excluding skip_hab_test: true if hab_test?
 
+  # Skip tests that don't work on Ruby 3.4+
+  config.filter_run_excluding skip_ruby_34: true if RUBY_VERSION >= "3.4.0"
+
   config.filter_run_excluding fips_mode_test: true unless fips_mode_build?
   config.filter_run_excluding fips_mode_negative_test: true # disable all fips_mode negative tests
   # Skip fips on windows

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -32,9 +32,8 @@ end
 class RspecVersionString
   def self.rspec_version_string
     @rspec_version_string ||= begin
-                                stubs = Gem::Specification.send(:installed_stubs, Gem::Specification.dirs, "rspec-core-*.gemspec")
-                                stubs.select! { |stub| stub.name == "rspec-core" && Gem::Dependency.new("rspec-core", ">= 0").requirement.satisfied_by?(stub.version) }
-                                stubs.max_by(&:version).version.to_s
+                                specs = Gem::Specification.find_all_by_name("rspec-core", Gem::Dependency.new("rspec-core", ">= 0").requirement)
+                                specs.max_by(&:version).version.to_s
                               end
   end
 end

--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -60,7 +60,7 @@ begin
     desc "Print Specdoc for all specs"
     RSpec::Core::RakeTask.new(:doc) do |t|
       t.verbose = false
-      t.rspec_opts = %w{--format specdoc --dry-run --profile}
+      t.rspec_opts = %w{--format documentation --dry-run --profile}
       t.pattern = FileList["spec/**/*_spec.rb"]
     end
 


### PR DESCRIPTION
- ruby 3.4 extracted several stdlibs into gems, added to Gemfiles
- upgraded ruby-shadow to a working fork by gitlab (see issue #14420)
- tried to temporarily work-around issues with irb and chef-shell (needs prober fixing)
- update rspec, changed outdated report format, use new rubygems api

this is only the baseline. several tests regarding chef-shell / irb are failing.
Also no attempt to fix the warnings