### PR TITLE
Why can't Kitchen Fips find the rest-client branch?

### DIFF
--- a/.github/workflows/kitchen-fips.yml
+++ b/.github/workflows/kitchen-fips.yml
@@ -55,6 +55,11 @@ jobs:
         # libyajl2 build if already present. gem install seems to build anyway.
         gem uninstall -I libyajl2
 
+        # appbundler is not finding the correct branch for rest-client. Here we clean the bundle to force it
+        Write-Host "Forcing a bundle clean to ensure we get the correct rest-client version"
+        bundle clean --force
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
         gem install appbundler appbundle-updater --no-doc
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
         appbundle-updater chef chef $env:GITHUB_SHA --tarball --github $env:GITHUB_REPOSITORY


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Kitchen FIPS tests are failing on Windows. Tests fail when appbundler attempts to pull down a current version of the rest-client. It says that the branch we reference does not exist; which is incorrect.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
