### PR TITLE
fix errors on habitat/verify

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -11,7 +11,7 @@ steps:
 
 - label: ":linux: Validate Linux"
   commands:
-    - sudo .expeditor/scripts/habitat-test.sh $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUX
+    - sudo -E .expeditor/scripts/habitat-test.sh $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUX
   expeditor:
     executor:
       linux:

--- a/.expeditor/scripts/habitat-test.ps1
+++ b/.expeditor/scripts/habitat-test.ps1
@@ -1,6 +1,19 @@
 param ($WindowsArtifact = $(throw "WindowsArtifact parameter is required."))
 $ErrorActionPreference = 'Stop'
 
+# Read the CHEF_LICENSE_SERVER value from chef_license_server_url.txt
+# Ideally, this value would have been read from a centralized environment such as a GitHub environment,
+# Buildkite environment, or a vault, allowing for seamless updates without requiring a pull request for changes.
+try {
+  $licenseFile = Join-Path -Path $PSScriptRoot -ChildPath 'chef_license_server_url.txt'
+  $licenseServerUrl = Get-Content -Path $licenseFile -ErrorAction Stop | Select-Object -First 1
+  $env:CHEF_LICENSE_SERVER = $licenseServerUrl.Trim()
+  Write-Host "--- Set CHEF_LICENSE_SERVER to '$($env:CHEF_LICENSE_SERVER)' from $licenseFile"
+}
+catch {
+	Write-Warning "Failed to read chef_license_server_url.txt: $($_.Exception.Message)"
+}
+
 $ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
 & "$ScriptRoute"
 # . ./scripts/ensure-minimum-viable-hab.ps1

--- a/.expeditor/scripts/habitat-test.ps1
+++ b/.expeditor/scripts/habitat-test.ps1
@@ -8,10 +8,9 @@ try {
   $licenseFile = Join-Path -Path $PSScriptRoot -ChildPath 'chef_license_server_url.txt'
   $licenseServerUrl = Get-Content -Path $licenseFile -ErrorAction Stop | Select-Object -First 1
   $env:CHEF_LICENSE_SERVER = $licenseServerUrl.Trim()
-  Write-Host "--- Set CHEF_LICENSE_SERVER to '$($env:CHEF_LICENSE_SERVER)' from $licenseFile"
 }
 catch {
-	Write-Warning "Failed to read chef_license_server_url.txt: $($_.Exception.Message)"
+	Write-Host "Failed to read chef_license_server_url.txt: $($_.Exception.Message)"
 }
 
 $ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))

--- a/.expeditor/scripts/habitat-test.sh
+++ b/.expeditor/scripts/habitat-test.sh
@@ -9,7 +9,12 @@ fi
 
 LINUX_ARTIFACT="$1"
 
+# Read the CHEF_LICENSE_SERVER value from chef_license_server_url.txt
+# Ideally, this value would have been read from a centralized environment such as a GitHub environment,
+# Buildkite environment, or a vault, allowing for seamless updates without requiring a pull request for changes.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Use SCRIPT_DIR to refer to files relative to the script’s location
+export CHEF_LICENSE_SERVER=$(cat "$SCRIPT_DIR/chef_license_server_url.txt")
 
 echo "--- Installing habitat using ${SCRIPT_DIR}/install-hab.sh"
 "${SCRIPT_DIR}/install-hab.sh" "x86_64-linux"

--- a/habitat/tests/spec.ps1
+++ b/habitat/tests/spec.ps1
@@ -6,30 +6,24 @@ param (
 # some of the functional tests require that winrm be configured
 winrm quickconfig -quiet
 
-$chef_gem_root = (hab pkg exec $PackageIdentifier gem.cmd which chef | Split-Path | Split-Path)
-try {
-    Push-Location $chef_gem_root
-    $env:PATH = "C:\hab\bin;$env:PATH"
+$env:PATH = "C:\hab\bin;$env:PATH"
 
-    # Put chef's GEM_PATH in the machine environment so that the windows service
-    # tests will be able to consume the win32-service gem
-    $pkgEnv = hab pkg env $PackageIdentifier
-    $gemPath = $pkgEnv | Where-Object { $_.StartsWith("`$env:GEM_PATH=") }
-    SETX GEM_PATH $($gemPath.Split("=")[1]) /m
+# Put chef's GEM_PATH in the machine environment so that the windows service
+# tests will be able to consume the win32-service gem
+$pkgEnv = hab pkg env $PackageIdentifier
+$gemPath = $pkgEnv | Where-Object { $_.StartsWith("`$env:GEM_PATH=") }
+SETX GEM_PATH $($gemPath.Split("=")[1]) /m
 
-    hab pkg binlink --force $PackageIdentifier
+hab pkg binlink --force $PackageIdentifier
 
-    # [System.Environment]::SetEnvironmentVariable("HAB_TEST", "true", "Machine")
-    # [System.Environment]::SetEnvironmentVariable("HAB_TEST", "true", "User")
-    $env:HAB_TEST="true"
+# [System.Environment]::SetEnvironmentVariable("HAB_TEST", "true", "Machine")
+# [System.Environment]::SetEnvironmentVariable("HAB_TEST", "true", "User")
+$env:HAB_TEST="true"
 
-    # TODO need to merge this branch before these will pass, so don't throw errors just yet.
-    hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/unit
-    if (-not $?) { Write-Host "--- :fire: Unit tests failed" }
-    hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/functional
-    if (-not $?) { Write-Host "--- :fire: Functional tests failed" }
-    hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/integration
-    if (-not $?) { Write-Host "--- :fire: Integration tests failed" }
-} finally {
-    Pop-Location
-}
+# TODO need to merge this branch before these will pass, so don't throw errors just yet.
+hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/unit
+if (-not $?) { Write-Host "--- :fire: Unit tests failed" }
+hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/functional
+if (-not $?) { Write-Host "--- :fire: Functional tests failed" }
+hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/integration
+if (-not $?) { Write-Host "--- :fire: Integration tests failed" }

--- a/habitat/tests/spec.ps1
+++ b/habitat/tests/spec.ps1
@@ -22,8 +22,8 @@ $env:HAB_TEST="true"
 
 # TODO need to merge this branch before these will pass, so don't throw errors just yet.
 hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/unit
-if (-not $?) { Write-Host "--- :fire: Unit tests failed" }
+if (-not $?) { throw "--- :fire: Unit tests failed" }
 hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/functional
-if (-not $?) { Write-Host "--- :fire: Functional tests failed" }
+if (-not $?) { throw "--- :fire: Functional tests failed" }
 hab pkg exec $PackageIdentifier rspec -f progress --profile -- ./spec/integration
-if (-not $?) { Write-Host "--- :fire: Integration tests failed" }
+if (-not $?) { throw "--- :fire: Integration tests failed" }

--- a/spec/functional/resource/git_spec.rb
+++ b/spec/functional/resource/git_spec.rb
@@ -263,7 +263,9 @@ describe Chef::Resource::Git do
 
   context "when dealing with a repo with a degenerate tag named 'HEAD'" do
     before do
-      shell_out!("git", "tag", "-m\"degenerate tag\"", "HEAD", "ed181b3419b6f489bedab282348162a110d6d3a1", cwd: origin_repo)
+      unless ChefUtils.windows?
+        shell_out!("git", "tag", "-m \"degenerate tag\"", "HEAD", "ed181b3419b6f489bedab282348162a110d6d3a1", cwd: origin_repo)
+      end
     end
 
     it "checks out the (master) HEAD revision and ignores the tag" do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes a bunch of stuff in habitat/verify pipeline

- The #15301 PR missed the `-E` flag when executing the linux script which is making the installation fail for infra client package in our tests. 
- Missing CHEF_LICENSE_SERVER env was making the tests fail with licensing errors.
- Fixed silent test failures on Windows runners (spec.ps1 in habitat/tests was the culprit)
- Fixed failing tests for git in windows. details in commit message: https://github.com/chef/chef/pull/15303/commits/0e17a4e6860b03ba5837a6e3c694c3209a383e91

Passing build: https://buildkite.com/chef-oss/chef-chef-main-habitat-verify/builds/13 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
