### PR TITLE
Chocolatey custom url bug

### DIFF
--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -131,7 +131,12 @@ class Chef
         # note that Invoke-Expression is being called on the downloaded script (outer parens),
         # not triggering the script download (inner parens)
         converge_if_changed do
-          powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))").error!
+          if new_resource.download_url
+            Chef::Log.info("Using a custom download URL for Chocolatey installation.")
+            powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{new_resource.download_url}'))").error!
+          else
+            powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))").error!
+          end
         end
       end
 

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -18,134 +18,162 @@
 require "spec_helper"
 
 describe Chef::Resource::ChocolateyInstaller do
-  include RecipeDSLHelper
+  describe "When installing from Chocolatey" do
+    include RecipeDSLHelper
 
-  let(:resource) { Chef::Resource::ChocolateyInstaller.new("fakey_fakerton") }
-  let(:config) do
-    <<-CONFIG
-      <?xml version="1.0" encoding="utf-8"?>
-      <chocolatey xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <config>
-          <add key="containsLegacyPackageInstalls" value="true" description="Install has packages installed prior to 0.9.9 series." />
-        </config>
-        <sources>
-          <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" bypassProxy="false" selfService="false" adminOnly="false" priority="0" />
-        </sources>
-        <features>
-          <feature name="checksumFiles" enabled="true" setExplicitly="false" description="Checksum files when pulled in from internet (based on package)." />
-        </features>
-        <apiKeys />
-      </chocolatey>
-    CONFIG
-  end
-
-  # we save off the ENV and set ALLUSERSPROFILE so these specs will work on *nix and non-C drive Windows installs
-  before(:each) do
-    @original_env = ENV.to_hash
-    ENV["ALLUSERSPROFILE"] = "C:\\ProgramData"
-  end
-
-  after(:each) do
-    ENV.clear
-    ENV.update(@original_env)
-  end
-
-  describe "Basic Resource Settings" do
-    context "on windows", :windows_only do
-      it "supports :install, :uninstall, :upgrade actions" do
-        expect { resource.action :install }.not_to raise_error
-        expect { resource.action :uninstall }.not_to raise_error
-        expect { resource.action :upgrade }.not_to raise_error
-      end
+    let(:resource) { Chef::Resource::ChocolateyInstaller.new("fakey_fakerton") }
+    let(:config) do
+      <<-CONFIG
+        <?xml version="1.0" encoding="utf-8"?>
+        <chocolatey xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <config>
+            <add key="containsLegacyPackageInstalls" value="true" description="Install has packages installed prior to 0.9.9 series." />
+          </config>
+          <sources>
+            <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" bypassProxy="false" selfService="false" adminOnly="false" priority="0" />
+          </sources>
+          <features>
+            <feature name="checksumFiles" enabled="true" setExplicitly="false" description="Checksum files when pulled in from internet (based on package)." />
+          </features>
+          <apiKeys />
+        </chocolatey>
+      CONFIG
     end
-  end
 
-  describe "Basic chocolatey settings" do
-    context "on windows", :windows_only do
-      it "has a resource name of :chocolatey_installer" do
-        expect(resource.resource_name).to eql(:chocolatey_installer)
-      end
-
-      it "sets the default action as :install" do
-        expect(resource.action).to eql([:install])
-      end
-
-      it "supports :install and :uninstall actions" do
-        expect { resource.action :install }.not_to raise_error
-        expect { resource.action :uninstall }.not_to raise_error
-      end
-
-      it "does not support bologna install options" do
-        expect { resource.action :foo }.to raise_error(Chef::Exceptions::ValidationFailed)
-      end
+    # we save off the ENV and set ALLUSERSPROFILE so these specs will work on *nix and non-C drive Windows installs
+    before(:each) do
+      @original_env = ENV.to_hash
+      ENV["ALLUSERSPROFILE"] = "C:\\ProgramData"
     end
-  end
 
-  describe "Installing chocolatey" do
-    context "on windows", :windows_only do
-      it "can install Chocolatey with parameters" do
-        resource.chocolatey_version = "1.4.0"
-        expect { resource.action :install }.not_to raise_error
-      end
-
-      it "logs a warning if a chocolatey install cannot be found" do
-        allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
-        expect { Chef::Log.warn("Chocolatey is already uninstalled.") }.not_to output.to_stderr
-      end
+    after(:each) do
+      ENV.clear
+      ENV.update(@original_env)
     end
-  end
 
-  describe "Chocolatey is idempotent because" do
-    context "on windows", :windows_only do
-      it "it does not install choco again if it is already installed" do
-        install_choco
-        chocolatey_installer "install" do
-          action :install
-        end.should_not_be_updated
-      end
-    end
-  end
-
-  describe "upgrading choco versions" do
-
-    context "on windows", :windows_only do
-      describe "when the versions do not match" do
-        it "upgrades if the proposed version is newer" do
-          allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("1.2.2"))
-          allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new("4.2.2"))
+    describe "Basic Resource Settings" do
+      context "on windows", :windows_only do
+        it "supports :install, :uninstall, :upgrade actions" do
+          expect { resource.action :install }.not_to raise_error
+          expect { resource.action :uninstall }.not_to raise_error
           expect { resource.action :upgrade }.not_to raise_error
-          allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("4.2.2"))
-          expect(resource.get_choco_version).to eql(Gem::Version.new("4.2.2"))
-        end
-      end
-      describe "when the versions match" do
-        it "does not upgrade if the old version is identical" do
-          allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("2.2.2"))
-          allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new("2.2.2"))
-          expect { resource.action :upgrade }.not_to raise_error
-          expect(resource).not_to be_updated
         end
       end
     end
-  end
 
-  describe "Uninstalling chocolatey" do
-    context "on windows", :windows_only do
-      it "doesn't error out uninstalling chocolatey if chocolatey is not installed" do
-        allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
-        expect { resource.action :uninstall }.not_to raise_error
+    describe "Basic chocolatey settings" do
+      context "on windows", :windows_only do
+        it "has a resource name of :chocolatey_installer" do
+          expect(resource.resource_name).to eql(:chocolatey_installer)
+        end
+
+        it "sets the default action as :install" do
+          expect(resource.action).to eql([:install])
+        end
+
+        it "supports :install and :uninstall actions" do
+          expect { resource.action :install }.not_to raise_error
+          expect { resource.action :uninstall }.not_to raise_error
+        end
+
+        it "does not support bologna install options" do
+          expect { resource.action :foo }.to raise_error(Chef::Exceptions::ValidationFailed)
+        end
       end
+    end
+
+    describe "Installing chocolatey" do
+      context "on windows", :windows_only do
+        it "can install Chocolatey with parameters" do
+          resource.chocolatey_version = "1.4.0"
+          expect { resource.action :install }.not_to raise_error
+        end
+
+        it "logs a warning if a chocolatey install cannot be found" do
+          allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
+          expect { Chef::Log.warn("Chocolatey is already uninstalled.") }.not_to output.to_stderr
+        end
+      end
+    end
+
+    describe "Chocolatey is idempotent because" do
+      context "on windows", :windows_only do
+        it "it does not install choco again if it is already installed" do
+          install_choco
+          chocolatey_installer "install" do
+            action :install
+          end.should_not_be_updated
+        end
+      end
+    end
+
+    describe "upgrading choco versions" do
+
+      context "on windows", :windows_only do
+        describe "when the versions do not match" do
+          it "upgrades if the proposed version is newer" do
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("1.2.2"))
+            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new("4.2.2"))
+            expect { resource.action :upgrade }.not_to raise_error
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("4.2.2"))
+            expect(resource.get_choco_version).to eql(Gem::Version.new("4.2.2"))
+          end
+        end
+        describe "when the versions match" do
+          it "does not upgrade if the old version is identical" do
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("2.2.2"))
+            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new("2.2.2"))
+            expect { resource.action :upgrade }.not_to raise_error
+            expect(resource).not_to be_updated
+          end
+        end
+      end
+    end
+
+    describe "Uninstalling chocolatey" do
+      context "on windows", :windows_only do
+        it "doesn't error out uninstalling chocolatey if chocolatey is not installed" do
+          allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
+          expect { resource.action :uninstall }.not_to raise_error
+        end
+      end
+    end
+
+    def install_choco
+      require "chef-powershell"
+      include ChefPowerShell::ChefPowerShellModule::PowerShellExec
+      powershell_code = <<-CODE
+        Set-ExecutionPolicy Bypass -Scope Process -Force;
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+        iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+      CODE
+      powershell_exec(powershell_code)
     end
   end
 
-  def install_choco
-    require "chef-powershell"
-    include ChefPowerShell::ChefPowerShellModule::PowerShellExec
-    powershell_code = <<-CODE
-      Set-ExecutionPolicy Bypass -Scope Process -Force;
-      [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-      iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-    CODE
-    powershell_exec(powershell_code)
+  describe "When installing from a custom URL" do
+    include RecipeDSLHelper
+
+    let(:resource) { Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom") }
+
+    # we save off the ENV and set ALLUSERSPROFILE so these specs will work on *nix and non-C drive Windows installs
+    before(:each) do
+      @original_env = ENV.to_hash
+      ENV["ALLUSERSPROFILE"] = "C:\\ProgramData"
+    end
+
+    after(:each) do
+      ENV.clear
+      ENV.update(@original_env)
+    end
+
+    describe "Installing chocolatey" do
+      context "on windows", :windows_only do
+        it "can install Chocolatey with a custom download URL" do
+          resource.download_url = "https://some.custom.url/install.ps1"
+          expect { resource.action :install }.not_to raise_error
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The choco install resource let's you specify a download_url so you can download the choco installer in air-gapped environments or when you have your own choco server or whatever. The code was not correctly honoring that and was instead always trying to install choco from chocolatey.org. This corrects that. I updated the spec file to make sure a custom url worked too. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
