### PR TITLE
[chef-18] Backport: GHA runner updates and fix for chef-workstation install

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: danger/danger-js@11.3.1
         with:
           args: "--verbose --text-only -f"

--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -21,7 +21,7 @@ jobs:
         ruby: ['3.1']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -35,12 +35,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, macos-15, macos-latest]
+        os: [macos-14, macos-15, macos-26]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: ['3.1']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/kitchen-fips.yml
+++ b/.github/workflows/kitchen-fips.yml
@@ -20,7 +20,7 @@ jobs:
         ruby: ['3.1']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: 'Install Chef/Ohai from Omnitruck'
       id: install_chef
       run: |

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -21,16 +21,18 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - windows-2025 - no kitchen support yet
+          - windows-2025
           - windows-2022
     runs-on: ${{ matrix.os }}
     env:
       CHEF_LICENSE: accept-no-persist
       KITCHEN_LOCAL_YAML: kitchen.exec.windows.yml
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install Chef
-      uses: actionshub/chef-install@3.0.0
+      uses: actionshub/chef-install@main
+      with:
+        version: "25.5.1084"
     - name: Kitchen Test
       run: kitchen test end-to-end-${{ matrix.os }}
 
@@ -39,18 +41,20 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
     runs-on: ${{ matrix.os }}
     env:
       CHEF_LICENSE: accept-no-persist
       KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
             clean: true
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@main
+        with:
+          version: "25.5.1084"
       - name: Kitchen Test
         run: kitchen test end-to-end-${{ matrix.os }}
 
@@ -61,17 +65,20 @@ jobs:
         os:
           - macos-14
           - macos-15
+          - macos-26
     runs-on: ${{ matrix.os }}
     env:
       CHEF_LICENSE: accept-no-persist
       KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: true
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@main
+        with:
+          version: "25.5.1084"
       - name: Kitchen Test
         run: kitchen test end-to-end-${{ matrix.os }}
 
@@ -102,9 +109,11 @@ jobs:
       KITCHEN_LOCAL_YAML: kitchen.dokken.yml
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@main
+        with:
+          version: "25.5.1084"
       - name: Kitchen Test
         run: kitchen test end-to-end-${{ matrix.os }}
 
@@ -138,7 +147,7 @@ jobs:
       CHEF_LICENSE: accept-no-persist
       KITCHEN_LOCAL_YAML: kitchen.linux.ci.yml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Vagrant and VirtualBox
         run: |
           wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
@@ -150,6 +159,8 @@ jobs:
           sudo vagrant --version
           sudo VBoxManage --version
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@main
+        with:
+          version: "25.5.1084"
       - name: Kitchen Test
         run: export LOGNAME=$USER && kitchen test end-to-end-${{ matrix.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       BUNDLE_WITHOUT: ruby_shadow:omnibus_package
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1
@@ -30,7 +30,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: |
           curl --location 'https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt' --output chef_dictionary.txt
       - uses: streetsidesoftware/cspell-action@v2.12.0

--- a/.github/workflows/selfhosted-fips.yml
+++ b/.github/workflows/selfhosted-fips.yml
@@ -45,7 +45,7 @@ jobs:
           fi
           set -e
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
             clean: false
       - name: 'Install Chef/Ohai from Omnitruck'

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ false }}
     runs-on: ip-range-controlled
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -15,7 +15,7 @@ jobs:
   unit:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         clean: true
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
update GHA runners to latest versions and remove deprecated runner versions.

Latest chef-workstation release with latest test-kitchen breaks exec driver used by windows and macos kitchen tests

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
