### PR TITLE
fix chef-workstation install

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -114,8 +114,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Install Chef
         uses: actionshub/chef-install@main
-        with:
-          version: "25.5.1084"
       - name: Kitchen Test
         run: kitchen verify ${{ matrix.os }}
 
@@ -161,8 +159,6 @@ jobs:
           sudo VBoxManage --version
       - name: Install Chef
         uses: actionshub/chef-install@main
-        with:
-          version: "25.5.1084"
       - name: Kitchen Test
         run: |
           # To debug, uncomment these

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -30,7 +30,9 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Install Chef
-      uses: actionshub/chef-install@3.0.0
+      uses: actionshub/chef-install@main
+      with:
+        version: "25.5.1084"
     - name: Kitchen Test
       run: kitchen verify ${{ matrix.os }}
 
@@ -50,7 +52,9 @@ jobs:
         with:
             clean: true
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@main
+        with:
+          version: "25.5.1084"
       - name: Kitchen Test
         run: kitchen verify ${{ matrix.os }}
 
@@ -72,7 +76,9 @@ jobs:
         with:
           clean: true
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@main
+        with:
+          version: "25.5.1084"
       - name: Kitchen Test
         run: kitchen verify ${{ matrix.os }}
 
@@ -107,7 +113,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@main
+        with:
+          version: "25.5.1084"
       - name: Kitchen Test
         run: kitchen verify ${{ matrix.os }}
 
@@ -152,7 +160,9 @@ jobs:
           sudo vagrant --version
           sudo VBoxManage --version
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@main
+        with:
+          version: "25.5.1084"
       - name: Kitchen Test
         run: |
           # To debug, uncomment these


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Latest chef-workstation release with latest test-kitchen breaks exec driver used by windows and macos kitchen tests

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
