### PR TITLE
[Chef::Property][get_value,set_value,value_is_set?] Only call instance_variable_name once

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -655,8 +655,8 @@ class Chef
 
     # @api private
     def get_value(resource)
-      if instance_variable_name
-        resource.instance_variable_get(instance_variable_name)
+      if (i = instance_variable_name)
+        resource.instance_variable_get(i)
       else
         resource.send(name)
       end
@@ -664,8 +664,8 @@ class Chef
 
     # @api private
     def set_value(resource, value)
-      if instance_variable_name
-        resource.instance_variable_set(instance_variable_name, value)
+      if (i = instance_variable_name)
+        resource.instance_variable_set(i, value)
       else
         resource.send(name, value)
       end
@@ -673,8 +673,8 @@ class Chef
 
     # @api private
     def value_is_set?(resource)
-      if instance_variable_name
-        resource.instance_variable_defined?(instance_variable_name)
+      if (i = instance_variable_name)
+        resource.instance_variable_defined?(i)
       else
         true
       end


### PR DESCRIPTION
instance_variable_name creates objects, and they can add up when you call it a million times or more.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
