### PR TITLE
Fix JSON::GeneratorError if a large binary file fed to ResourceReporter

### DIFF
--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -36,7 +36,7 @@ class Chef
 
       # if the "before" hash is too large, we need to truncate it to avoid 413 errors
       # 640K ought be enough for every Windows registry entry
-      as_hash["before"]   = {} if as_hash["before"].to_json.length > 657920
+      as_hash["before"]   = {} if as_hash["before"].to_s.bytesize > 657920
       as_hash["duration"] = ( action_record.elapsed_time * 1000 ).to_i.to_s
       as_hash["delta"]    = new_resource.diff if new_resource.respond_to?(:diff)
       as_hash["delta"]    = "" if as_hash["delta"].nil?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
