### PR TITLE
Remove manipulation of the removed @ALIASES instance var

### DIFF
--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -57,6 +57,14 @@ module Shell
   def self.start
     setup_logger
 
+    # @ALIASES was removed from irb in v1.13.0, but chef-shell can still be run in contexts that
+    # use the Ruby 3.1.x default of irb v1.4.1
+    if IRB::ExtendCommandBundle.instance_variables.include? :@ALIASES
+      # FUGLY HACK: irb gives us no other choice.
+      irb_help = [:help, :irb_help, IRB::ExtendCommandBundle::NO_OVERRIDE]
+      IRB::ExtendCommandBundle.instance_variable_get(:@ALIASES).delete(irb_help)
+    end
+
     parse_opts
     Chef::Config[:shell_config] = options.config
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
`@ALIASES` was removed from `ExtendCommandBundle` between `irb` `v1.12.0` and `v1.13.0`. If there's a situation in which `chef-shell` is run against a ruby with the 3.1.x irb default or any other `irb` version prior to v1.13.0, the deletion has been preserved.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
