### PR TITLE
remove uuidtools from lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,6 @@ PATH
       train-winrm (>= 0.2.17)
       unf_ext (~> 0.0.8.2)
       uri (~> 1.0.3)
-      uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.18.2)
     chef (19.1.88-universal-mingw-ucrt)
       addressable
@@ -110,7 +109,6 @@ PATH
       train-winrm (>= 0.2.17)
       unf_ext (~> 0.0.8.2)
       uri (~> 1.0.3)
-      uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.18.2)
       win32-api (~> 1.10.0)
       win32-certstore (~> 0.6.15)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Removing `uuidtools` from Gemfile.lock since it is not used anymore because osx_profile was removed https://github.com/chef/chef/pull/15184

(note `bundle update --conservative` does not apply here [@tpowell-progress])

```
bundle install
```

```
Fetching https://github.com/chef/rest-client
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Fetching rake 13.2.1
Installing rake 13.2.1
Fetching concurrent-ruby 1.3.4
Fetching public_suffix 6.0.1
Fetching minitest 5.25.1
Installing minitest 5.25.1
Installing public_suffix 6.0.1
Fetching mixlib-cli 2.1.8
Fetching ast 2.4.3
Installing concurrent-ruby 1.3.4
Installing mixlib-cli 2.1.8
Fetching aws-eventstream 1.3.0
Installing ast 2.4.3
Fetching aws-partitions 1.1001.0
Fetching jmespath 1.6.2
Installing aws-eventstream 1.3.0
Fetching base64 0.2.0
Installing jmespath 1.6.2
Fetching bigdecimal 3.1.8
Installing base64 0.2.0
Fetching debug_inspector 1.2.0
Installing aws-partitions 1.1001.0
Fetching builder 3.3.0
Installing bigdecimal 3.1.8 with native extensions
Installing debug_inspector 1.2.0 with native extensions
Installing builder 3.3.0
Using bundler 2.3.27
Fetching byebug 11.1.3
Installing byebug 11.1.3 with native extensions
Fetching fuzzyurl 0.9.0
Installing fuzzyurl 0.9.0
Fetching tomlrb 1.3.0
Installing tomlrb 1.3.0
Fetching uri 1.0.3
Installing uri 1.0.3
Fetching json 2.7.6
Installing json 2.7.6 with native extensions
Fetching logger 1.5.3
Installing logger 1.5.3
Fetching tty-color 0.6.0
Installing tty-color 0.6.0
Fetching tty-cursor 0.7.1
Installing tty-cursor 0.7.1
Fetching tty-screen 0.8.2
Installing tty-screen 0.8.2
Fetching wisper 2.0.1
Installing wisper 2.0.1
Fetching chef-vault 4.1.11
Installing chef-vault 4.1.11
Fetching libyajl2 2.1.0
Installing libyajl2 2.1.0 with native extensions
Fetching hashie 4.1.0
Installing hashie 4.1.0
Fetching ffi 1.17.2 (arm64-darwin)
Installing ffi 1.17.2 (arm64-darwin)
Fetching rack 3.1.16
Installing rack 3.1.16
Fetching unf_ext 0.0.8.2
Installing unf_ext 0.0.8.2 with native extensions
Fetching uuidtools 2.2.0
Installing uuidtools 2.2.0
Fetching webrick 1.8.2
Installing webrick 1.8.2
Fetching diff-lcs 1.5.1
Installing diff-lcs 1.5.1
Fetching erubis 2.7.0
Installing erubis 2.7.0
Fetching iniparse 1.5.0
Installing iniparse 1.5.0
Fetching language_server-protocol 3.17.0.4
Fetching lint_roller 1.1.0
Installing language_server-protocol 3.17.0.4
Installing lint_roller 1.1.0
Fetching parallel 1.27.0
Installing parallel 1.27.0
Fetching racc 1.8.1
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Installing racc 1.8.1 with native extensions
Fetching regexp_parser 2.10.0
Installing regexp_parser 2.10.0
Fetching prism 1.4.0
Installing prism 1.4.0 with native extensions
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-display_width 2.6.0
Installing unicode-display_width 2.6.0
Fetching strings-ansi 0.2.0
Installing strings-ansi 0.2.0
Fetching unicode_utils 1.4.0
Installing unicode_utils 1.4.0
Fetching method_source 1.1.0
Installing method_source 1.1.0
Fetching multipart-post 2.4.1
Installing multipart-post 2.4.1
Fetching parslet 1.8.2
Installing parslet 1.8.2
Fetching coderay 1.1.3
Installing coderay 1.1.3
Fetching rspec-support 3.13.1
Installing rspec-support 3.13.1
Fetching rubyzip 2.3.2
Installing rubyzip 2.3.2
Fetching semverse 3.0.2
Installing semverse 3.0.2
Fetching sslshake 1.3.1
Installing sslshake 1.3.1
Fetching thor 1.2.2
Installing thor 1.2.2
Fetching net-ssh 7.3.0
Installing net-ssh 7.3.0
Fetching mixlib-authentication 3.0.10
Installing mixlib-authentication 3.0.10
Fetching timeout 0.4.1
Installing timeout 0.4.1
Fetching date 3.4.0
Installing date 3.4.0 with native extensions
Fetching ipaddress 0.8.3
Installing ipaddress 0.8.3
Fetching plist 3.7.1
Installing plist 3.7.1
Fetching wmi-lite 1.0.7
Installing wmi-lite 1.0.7
Fetching proxifier2 1.1.0
Installing proxifier2 1.1.0
Fetching syslog-logger 1.6.8
Installing syslog-logger 1.6.8
Fetching http-accept 1.7.0
Installing http-accept 1.7.0
Fetching domain_name 0.6.20240107
Installing domain_name 0.6.20240107
Fetching mime-types-data 3.2024.1105
Installing mime-types-data 3.2024.1105
Fetching netrc 0.11.0
Installing netrc 0.11.0
Fetching rexml 3.4.1
Installing rexml 3.4.1
Fetching erubi 1.13.0
Installing erubi 1.13.0
Fetching httpclient 2.8.3
Installing httpclient 2.8.3
Fetching little-plugger 1.1.4
Installing little-plugger 1.1.4
Fetching multi_json 1.15.0
Installing multi_json 1.15.0
Fetching ed25519 1.3.0
Installing ed25519 1.3.0 with native extensions
Fetching hashdiff 1.1.1
Installing hashdiff 1.1.1
Fetching rb-readline 0.5.5
Installing rb-readline 0.5.5
Fetching ruby-shadow 2.5.1
Installing ruby-shadow 2.5.1 with native extensions
Fetching addressable 2.8.7
Installing addressable 2.8.7
Fetching i18n 1.14.6
Fetching tzinfo 2.0.6
Installing i18n 1.14.6
Installing tzinfo 2.0.6
Using chef-utils 19.1.87 from source at `chef-utils`
Fetching aws-sigv4 1.10.1
Fetching rubyntlm 0.6.5
Installing aws-sigv4 1.10.1
Fetching binding_of_caller 1.0.1
Installing rubyntlm 0.6.5
Installing binding_of_caller 1.0.1
Fetching mixlib-config 3.0.27
Fetching net-http 0.4.1
Installing mixlib-config 3.0.27
Fetching pastel 0.8.0
Installing net-http 0.4.1
Fetching tty-spinner 0.9.3
Installing pastel 0.8.0
Fetching tty-reader 0.9.0
Installing tty-spinner 0.9.3
Fetching ffi-yajl 2.6.0
Installing tty-reader 0.9.0
Fetching mixlib-log 3.2.3
Installing mixlib-log 3.2.3
Installing ffi-yajl 2.6.0 with native extensions
Fetching corefoundation 0.3.13
Installing corefoundation 0.3.13
Fetching ffi-libarchive 1.1.14
Installing ffi-libarchive 1.1.14
Fetching gssapi 1.3.1
Installing gssapi 1.3.1
Fetching rackup 2.2.1
Installing rackup 2.2.1
Fetching parser 3.3.8.0
Installing parser 3.3.8.0
Fetching strings 0.2.1
Installing strings 0.2.1
Fetching pry 0.13.0
Installing pry 0.13.0
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Fetching rspec-expectations 3.13.3
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching net-scp 4.0.0
Installing net-scp 4.0.0
Fetching net-sftp 4.0.0
Installing net-sftp 4.0.0
Fetching fauxhai-ng 9.3.0
Installing fauxhai-ng 9.3.0
Fetching net-protocol 0.2.2
Installing net-protocol 0.2.2
Fetching nori 2.7.0
Installing nori 2.7.0
Fetching http-cookie 1.0.7
Installing http-cookie 1.0.7
Fetching mime-types 3.6.0
Installing mime-types 3.6.0
Fetching chef-gyoku 1.4.1
Installing chef-gyoku 1.4.1
Fetching crack 0.4.5
Fetching logging 2.4.0
Installing crack 0.4.5
Fetching time 0.4.0
Installing logging 2.4.0
Installing time 0.4.0
Fetching mixlib-shellout 3.3.8
Fetching activesupport 7.0.8.6
Installing mixlib-shellout 3.3.8
Fetching aws-sdk-core 3.211.0
Installing activesupport 7.0.8.6
Installing aws-sdk-core 3.211.0
Fetching vault 0.18.2
Installing vault 0.18.2
Fetching faraday-net_http 3.3.0
Fetching tty-prompt 0.23.1
Installing faraday-net_http 3.3.0
Fetching mixlib-archive 1.1.7
Installing tty-prompt 0.23.1
Fetching rubocop-ast 1.44.1
Installing mixlib-archive 1.1.7
Fetching tty-box 0.7.0
Installing rubocop-ast 1.44.1
Installing tty-box 0.7.0
Fetching tty-table 0.12.0
Fetching pry-byebug 3.10.1
Installing tty-table 0.12.0
Installing pry-byebug 3.10.1
Fetching pry-stack_explorer 0.6.1
Fetching rspec-its 1.3.1
Installing pry-stack_explorer 0.6.1
Installing rspec-its 1.3.1
Fetching rspec 3.13.0
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@badd0be)
Fetching webmock 3.24.0
Installing rspec 3.13.0
Fetching net-ftp 0.3.8
Installing webmock 3.24.0
Fetching chef-winrm 2.3.11
Installing net-ftp 0.3.8
Fetching appbundler 0.13.4
Installing chef-winrm 2.3.11
Installing appbundler 0.13.4
Using chef-config 19.1.87 from source at `chef-config`
Fetching train-core 3.12.7
Fetching aws-sdk-kms 1.95.0
Installing train-core 3.12.7
Fetching aws-sdk-secretsmanager 1.109.0
Installing aws-sdk-kms 1.95.0
Fetching faraday 2.12.0
Installing aws-sdk-secretsmanager 1.109.0
Fetching license-acceptance 2.1.13
Installing faraday 2.12.0
Installing license-acceptance 2.1.13
Fetching rubocop 1.75.3
Fetching chef-telemetry 1.1.1
Installing chef-telemetry 1.1.1
Fetching chef-winrm-fs 1.3.7
Installing rubocop 1.75.3
Installing chef-winrm-fs 1.3.7
Fetching train-rest 0.5.0
Installing train-rest 0.5.0
Fetching aws-sdk-s3 1.169.0
Installing aws-sdk-s3 1.169.0
Fetching faraday-http-cache 2.5.1
Installing faraday-http-cache 2.5.1
Fetching faraday-follow_redirects 0.3.0
Installing faraday-follow_redirects 0.3.0
Fetching chef-winrm-elevated 1.2.5
Fetching chef-licensing 1.0.4
Installing chef-winrm-elevated 1.2.5
Fetching cookstyle 8.1.1
Installing chef-licensing 1.0.4
Installing cookstyle 8.1.1
Fetching train-winrm 0.2.17
Installing train-winrm 0.2.17
Fetching inspec-core 7.0.38.beta
Installing inspec-core 7.0.38.beta
Fetching inspec-core-bin 7.0.38.beta
Installing inspec-core-bin 7.0.38.beta
Using ohai 19.1.1 from https://github.com/chef/ohai.git (at main@ef0bce6)
Fetching chef-zero 15.0.21
Installing chef-zero 15.0.21
Using chef 19.1.87 from source at `.`
Using chef-bin 19.1.87 from source at `chef-bin` and installing its executables
Fetching cheffish 17.1.8
Installing cheffish 17.1.8
Bundle complete! 23 Gemfile dependencies, 155 gems now installed.
Bundled gems are installed into `./vendor/bundle`
Post-install message from i18n:
PSA: I18n will be dropping support for Ruby < 3.2 in the next major release (April 2025), due to Ruby's end of life for 3.1 and below (https://endoflife.date/ruby). Please upgrade to Ruby 3.2 or newer by April 2025 to continue using future versions of this gem.
Post-install message from rubyzip:
RubyZip 3.0 is coming!
**********************

The public API of some Rubyzip classes has been modernized to use named
parameters for optional arguments. Please check your usage of the
following classes:
  * `Zip::File`
  * `Zip::Entry`
  * `Zip::InputStream`
  * `Zip::OutputStream`

Please ensure that your Gemfiles and .gemspecs are suitably restrictive
to avoid an unexpected breakage when 3.0 is released (e.g. ~> 2.3.0).
See https://github.com/rubyzip/rubyzip for details. The Changelog also
lists other enhancements and bugfixes that have been implemented since
version 2.3.0.
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
