### PR TITLE
Remove macos-15-intel due to corefoundation gem issue

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -36,28 +36,28 @@ jobs:
     - name: Kitchen Test
       run: kitchen verify ${{ matrix.os }}
 
-  mac_x86_64:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-15-intel
-    runs-on: ${{ matrix.os }}
-    env:
-      CHEF_LICENSE: accept-no-persist
-      KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v5
-        with:
-            clean: true
-      - name: Install Chef
-        uses: actionshub/chef-install@main
-        with:
-          version: "25.5.1084"
-      - name: Kitchen Test
-        run: kitchen verify ${{ matrix.os }}
-
+#  mac_x86_64:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os:
+#          - macos-15-intel
+#    runs-on: ${{ matrix.os }}
+#    env:
+#      CHEF_LICENSE: accept-no-persist
+#      KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
+#    steps:
+#      - name: Check out code
+#        uses: actions/checkout@v5
+#        with:
+#            clean: true
+#      - name: Install Chef
+#        uses: actionshub/chef-install@main
+#        with:
+#          version: "25.5.1084"
+#      - name: Kitchen Test
+#        run: kitchen verify ${{ matrix.os }}
+#
   mac_arm64:
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Intel Macs are no longer officially supported, and corefoundation is breaking on a kitchen-test. Disabling for now (pending cleanup later)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
