### PR TITLE
[Chef 18 backport] #15349

### DIFF
--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -369,6 +369,16 @@ describe Chef::Provider::Package::Rubygems::AlternateGemEnvironment do
     expect(Gem.platforms).to eq(original_platforms)
   end
 
+  it "uses shell command to avoid embedded Ruby version conflicts" do
+    shell_out_result = OpenStruct.new(stdout: "rematch (3.2.0, 3.1.0, 3.0.0)\n")
+    expect(@gem_env).to receive(:shell_out!).with("/usr/weird/bin/gem list rematch --remote --all ").and_return(shell_out_result)
+
+    gem_dependency = Gem::Dependency.new("rematch", ">= 3.1.0")
+    version = @gem_env.candidate_version_from_remote(gem_dependency)
+
+    expect(version).to eq(Gem::Version.new("3.2.0"))
+  end
+
 end
 
 describe Chef::Provider::Package::Rubygems do


### PR DESCRIPTION
Backports https://github.com/chef/chef/pull/15349

#### fix: use correct Ruby in gem_package resource dependency resolution (#15349)
The `gem_package` resource in Chef Infra Client had a bug where it
used Chef's embedded Ruby for dependency resolution instead of the
target Ruby environment specified by the `gem_binary` property.
This caused failures when installing gems that require a newer
Ruby version than Chef's embedded Ruby.

The issue was in the `AlternateGemEnvironment` class in
`lib/chef/provider/package/rubygems.rb`. When using an alternate gem
binary (via the `gem_binary` property), the class correctly used shell
commands for most operations but still relied on the
`candidate_version_from_remote` method to call the parent class's
dependency resolution logic.

The parent class's dependency resolution used Ruby's
`Gem::DependencyInstaller` API, which operates within the current Ruby
environment (Chef's embedded Ruby) rather than the target Ruby
environment.

We overrode the `candidate_version_from_remote` method in the
`AlternateGemEnvironment` class to use shell commands instead of the
Ruby API for dependency resolution.

Resolves #15199

Signed-off-by: Frederik Thuysbaert <frederik.thuysbaert@combell.group>

---------