### PR TITLE
Pin to beta version of InSpec 7 against main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "cheffish", ">= 17"
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec-core-bin", "~> 7.0.38.beta" # need to provide the binaries for inspec
+  gem "inspec-core-bin", "= 7.0.38.beta" # need to provide the binaries for inspec
   gem "chef-vault"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ PATH
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
-      inspec-core (~> 7.0.38.beta)
+      inspec-core (= 7.0.38.beta)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
@@ -90,7 +90,7 @@ PATH
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (~> 2.2)
       iniparse (~> 1.4)
-      inspec-core (~> 7.0.38.beta)
+      inspec-core (= 7.0.38.beta)
       iso8601 (>= 0.12.1, < 0.14)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
@@ -537,7 +537,7 @@ DEPENDENCIES
   ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5)
-  inspec-core-bin (~> 7.0.38.beta)
+  inspec-core-bin (= 7.0.38.beta)
   ohai!
   openssl (= 3.3.0)
   pry (= 0.13.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-shellout", "~> 3.3.8"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 19.0"
-  s.add_dependency "inspec-core", "~> 7.0.38.beta"
+  s.add_dependency "inspec-core", "= 7.0.38.beta"
 
   s.add_dependency "ffi", ">= 1.15.5"
   s.add_dependency "ffi-yajl", "~> 2.2"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Taking a step back to solve the `.beta` pin on `main` first. InSpec non-beta release requires additional dependencies to be released and the Ruby 3.4 version (#15369) of this is breaking on kitchen-tests

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
