### PR TITLE
Disable vm_lnx_x86_64 due to GA instability

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -115,48 +115,48 @@ jobs:
       - name: Kitchen Test
         run: kitchen test end-to-end-${{ matrix.os }}
 
-  vm_lnx_x86_64:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - amazonlinux-2
-          - amazonlinux-2023
-          - almalinux-8
-          - almalinux-9
-          - debian-11
-          - debian-12
-          - fedora-40
-          # - fedora-latest
-#          - freebsd-13 runner is broken
-          - freebsd-14
-          - opensuse-leap-15
-          - oracle-7
-          - oracle-8
-          - oracle-9
-          - rockylinux-8
-          - rockylinux-9
-#          - ubuntu-1804 EOL and errors occurring
-          - ubuntu-2004
-          - ubuntu-2204
-          - ubuntu-2404
-    runs-on: ubuntu-22.04
-    env:
-      CHEF_LICENSE: accept-no-persist
-      KITCHEN_LOCAL_YAML: kitchen.linux.ci.yml
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install Vagrant and VirtualBox
-        run: |
-          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          cat files/oracle_vbox_2016.asc | gpg --dearmor | sudo tee /usr/share/keyrings/oracle-virtualbox-2016.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
-          sudo apt-get update
-          sudo apt-get install -y vagrant virtualbox-7.1
-          sudo vagrant --version
-          sudo VBoxManage --version
-      - name: Install Chef
-        uses: actionshub/chef-install@main
-      - name: Kitchen Test
-        run: export LOGNAME=$USER && kitchen test end-to-end-${{ matrix.os }}
+#  vm_lnx_x86_64:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os:
+#          - amazonlinux-2
+#          - amazonlinux-2023
+#          - almalinux-8
+#          - almalinux-9
+#          - debian-11
+#          - debian-12
+#          - fedora-40
+#          # - fedora-latest
+##          - freebsd-13 runner is broken
+#          - freebsd-14
+#          - opensuse-leap-15
+#          - oracle-7
+#          - oracle-8
+#          - oracle-9
+#          - rockylinux-8
+#          - rockylinux-9
+##          - ubuntu-1804 EOL and errors occurring
+#          - ubuntu-2004
+#          - ubuntu-2204
+#          - ubuntu-2404
+#    runs-on: ubuntu-22.04
+#    env:
+#      CHEF_LICENSE: accept-no-persist
+#      KITCHEN_LOCAL_YAML: kitchen.linux.ci.yml
+#    steps:
+#      - uses: actions/checkout@v5
+#      - name: Install Vagrant and VirtualBox
+#        run: |
+#          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+#          cat files/oracle_vbox_2016.asc | gpg --dearmor | sudo tee /usr/share/keyrings/oracle-virtualbox-2016.gpg
+#          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+#          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+#          sudo apt-get update
+#          sudo apt-get install -y vagrant virtualbox-7.1
+#          sudo vagrant --version
+#          sudo VBoxManage --version
+#      - name: Install Chef
+#        uses: actionshub/chef-install@main
+#      - name: Kitchen Test
+#        run: export LOGNAME=$USER && kitchen test end-to-end-${{ matrix.os }}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
GitHub Actions VMs are timing out on booting. Disable until we can have a more permanent fix.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
