### PR TITLE
FIPS mode testing using habitat package of openssl and infra client

### DIFF
--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -31,9 +31,13 @@ jobs:
     runs-on: [self-hosted, x64, Linux, ubuntu-2404-pro-fips-tester]
     env:
       HAB_ORIGIN: gha # Set the dummy origin for this Github actions CI flow
-      HAB_BLDR_CHANNEL: base-2025 # Explicitly set the builder channel
-      HAB_REFRESH_CHANNEL: base-2025 # Explicitly set the refresh channel
+      # HAB_BLDR_CHANNEL: base-2025 # Explicitly set the builder channel
+      # HAB_REFRESH_CHANNEL: base-2025 # Explicitly set the refresh channel
+      HAB_BLDR_CHANNEL: fips-testing
+      HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: fips-testing
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: base-2025
       HAB_AUTH_TOKEN: ${{ secrets.HAB_AUTH_TOKEN }}
+      CHEF_LICENSE_KEY: ${{ secrets.CHEF_LICENSE_KEY }}
     steps:
       - name: 'Clean up any previous installs'
         id: cleanup
@@ -63,24 +67,18 @@ jobs:
           # Export the keys for later use
           hab origin key export "$HAB_ORIGIN" > "$HAB_ORIGIN-key.tar.gz"
 
-      - name: Build Habitat Package
+      - name: Build Habitat Package for Chef Infra Client
         run: |
           # Build the Habitat package
           hab pkg build .
           source ./results/last_build.env
           cp "./results/$pkg_artifact" chef-infra-client-latest.hart
 
-      - name: Set up HAB token file
-        run: |
-          # Create a token file for habitat operations
-          echo "${{ secrets.HAB_AUTH_TOKEN }}" > hab_token
-          chmod 600 hab_token
-
       - name: Install Chef Infra Client Habitat Package
         run: |
           # Import the previously exported key
           cat "$HAB_ORIGIN-key.tar.gz" | sudo hab origin key import
-          sudo hab pkg install ./chef-infra-client-latest.hart --auth "$(cat hab_token)"
+          sudo hab pkg install ./chef-infra-client-latest.hart --auth "${{ secrets.HAB_AUTH_TOKEN }}"
           # Verify installation
           sudo hab pkg exec $HAB_ORIGIN/chef-infra-client chef-client -v
 
@@ -96,15 +94,146 @@ jobs:
             exit 1
           fi
 
-      - name: Run chef-client with FIPS
+      - name: Run Chef Infra Client and verify FIPS enforcement
         run: |
-          sudo hab pkg exec $HAB_ORIGIN/chef-infra-client chef-client -v
+          echo "========================================"
+          echo "Starting FIPS Verification Tests"
+          echo "========================================"
+          echo ""
 
-          #*** Uncomment the below lines to check for FIPS mode in chef-client logs once OpenSSL has FIPS mode enabled
-          # output=$(sudo hab pkg exec $HAB_ORIGIN/chef-infra-client chef-client -l debug 2>&1 | grep "FIPS")
-          # if [[ $output == *"OpenSSL FIPS 140 mode enabled"* ]]; then
-          #   echo "✅ Chef Infra Client is running in FIPS mode"
-          # else
-          #   echo "❌ FIPS mode not detected"
-          #   exit 1
-          # fi
+          sudo hab pkg exec $HAB_ORIGIN/chef-infra-client chef-client -z --chef-license accept
+
+          # ============================================
+          # Test 1: MD5 (should FAIL in FIPS mode)
+          # ============================================
+          echo "--- Test 1: MD5 Digest (should FAIL in FIPS mode) ---"
+          mkdir -p /tmp/test_cookbook_md5/recipes
+          cat > /tmp/test_cookbook_md5/recipes/default.rb << 'EOF'
+          file "/tmp/test_md5" do
+            content lazy { OpenSSL::Digest::MD5.hexdigest("test") }
+          end
+          EOF
+
+          sudo bash -c "
+            set -o pipefail
+            hab pkg exec $HAB_ORIGIN/chef-infra-client -- chef-client -z \
+              --config-option cookbook_path=/tmp \
+              -o test_cookbook_md5 2>&1 | tee /tmp/chef-client-md5.log
+            echo \$? > /tmp/chef-exit-code-md5.txt
+          " || true
+
+          EXIT_CODE_MD5=$(cat /tmp/chef-exit-code-md5.txt)
+          echo ""
+
+          # ============================================
+          # Test 2: SHA256 (should SUCCEED in FIPS mode)
+          # ============================================
+          echo "--- Test 2: SHA256 Digest (should SUCCEED in FIPS mode) ---"
+          mkdir -p /tmp/test_cookbook_sha256/recipes
+          cat > /tmp/test_cookbook_sha256/recipes/default.rb << 'EOF'
+          file "/tmp/test_sha256" do
+            content lazy { OpenSSL::Digest::SHA256.hexdigest("test") }
+          end
+          EOF
+
+          sudo bash -c "
+            set -o pipefail
+            hab pkg exec $HAB_ORIGIN/chef-infra-client -- chef-client -z \
+              --config-option cookbook_path=/tmp \
+              -o test_cookbook_sha256 2>&1 | tee /tmp/chef-client-sha256.log
+            echo \$? > /tmp/chef-exit-code-sha256.txt
+          " || true
+
+          EXIT_CODE_SHA256=$(cat /tmp/chef-exit-code-sha256.txt)
+          echo ""
+
+          # ============================================
+          # Evaluate Results
+          # ============================================
+          echo "========================================"
+          echo "FIPS Verification Test Results"
+          echo "========================================"
+          echo ""
+
+          # Check Test 1: MD5 should fail
+          echo "Test 1 - MD5 Result:"
+          if [ $EXIT_CODE_MD5 -ne 0 ]; then
+            # MD5 failed, now check if it's due to FIPS
+            if grep -qi "Digest" /tmp/chef-client-md5.log && grep -qi "initialization" /tmp/chef-client-md5.log; then
+              echo "*** PASS: MD5 blocked by FIPS (exit code: $EXIT_CODE_MD5) ***"
+              MD5_TEST_PASSED=true
+            else
+              echo "*** FAIL: MD5 failed (exit code: $EXIT_CODE_MD5) but not due to FIPS/Digest error ***"
+              echo ""
+              echo "--- MD5 Log excerpt ---"
+              tail -50 /tmp/chef-client-md5.log
+              echo "--- End MD5 log ---"
+              exit 1
+            fi
+          else
+            echo "*** FAIL: MD5 succeeded (exit code: 0) - FIPS not enforced ***"
+            echo ""
+            echo "--- MD5 Log excerpt ---"
+            tail -50 /tmp/chef-client-md5.log
+            echo "--- End MD5 log ---"
+            exit 1
+          fi
+          echo ""
+
+          # Check Test 2: SHA256 should succeed
+          echo "Test 2 - SHA256 Result:"
+          if [ $EXIT_CODE_SHA256 -eq 0 ]; then
+            echo "*** PASS: SHA256 allowed by FIPS (exit code: $EXIT_CODE_SHA256) ***"
+            SHA256_TEST_PASSED=true
+          else
+            echo "*** FAIL: SHA256 failed (exit code: $EXIT_CODE_SHA256) - FIPS blocking approved algorithm ***"
+            echo ""
+            echo "--- SHA256 Log excerpt ---"
+            tail -50 /tmp/chef-client-sha256.log
+            echo "--- End SHA256 log ---"
+            exit 1
+          fi
+          echo ""
+
+          # Final summary
+          if [ "$MD5_TEST_PASSED" = true ] && [ "$SHA256_TEST_PASSED" = true ]; then
+            echo "========================================"
+            echo "*** ALL TESTS PASSED: FIPS mode is correctly enforced ***"
+            echo "   - MD5 blocked ✓"
+            echo "   - SHA256 allowed ✓"
+            echo "========================================"
+            exit 0
+          else
+            echo "========================================"
+            echo "*** TESTS FAILED ***"
+            echo "========================================"
+            exit 1
+          fi
+
+      # This is self-hosted runner, so we need to clean up after ourselves
+      - name: 'Cleanup self-hosted runner'
+        if: always()  # Run even if previous steps fail
+        run: |
+          echo "=== Cleaning up test artifacts ==="
+
+          # Remove test cookbooks and files
+          sudo rm -rf /tmp/test_cookbook_md5 /tmp/test_cookbook_sha256
+          sudo rm -f /tmp/test_md5 /tmp/test_sha256
+          sudo rm -f /tmp/chef-client-*.log
+          sudo rm -f /tmp/chef-exit-code-*.txt
+          sudo rm -f /tmp/client.rb
+
+          # Remove the installed Chef Infra Client package(s) from /hab/pkgs
+          sudo rm -rf /hab/pkgs/$HAB_ORIGIN/chef-infra-client || true
+
+          # Clean up Habitat build artifacts
+          sudo rm -rf /hab/cache/artifacts/$HAB_ORIGIN-chef-infra-client-*.hart || true
+
+          # Remove origin keys
+          sudo rm -f /hab/cache/keys/$HAB_ORIGIN-*.* || true
+
+          # Clean up any Chef local-mode cache
+          sudo rm -rf /root/.chef/local-mode-cache || true
+          sudo rm -rf /var/chef || true
+
+          echo "=== Cleanup complete ==="

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -34,9 +34,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       HAB_ORIGIN: gha # Set the dummy origin for this Github actions CI flow
-      HAB_BLDR_CHANNEL: base-2025
-      HAB_REFRESH_CHANNEL: base-2025
+      # HAB_BLDR_CHANNEL: base-2025 # Explicitly set the builder channel
+      # HAB_REFRESH_CHANNEL: base-2025 # Explicitly set the refresh channel
+      HAB_BLDR_CHANNEL: fips-testing
+      HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: fips-testing
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: base-2025
+      HAB_STUDIO_SECRET_HAB_PREFER_LOCAL_CHEF_DEPS: true
       HAB_AUTH_TOKEN: ${{ secrets.HAB_AUTH_TOKEN }}
+      CHEF_LICENSE_KEY: ${{ secrets.CHEF_LICENSE_KEY }}
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v6
@@ -63,7 +68,7 @@ jobs:
           # Generate the origin key for signing packages
           hab origin key generate "$env:HAB_ORIGIN"
 
-      - name: 'Build Habitat Package'
+      - name: 'Build Habitat Package of Chef Infra Client'
         run: |
           # Build the package for current checkout
           hab pkg build .
@@ -114,16 +119,149 @@ jobs:
             Exit 1
           }
 
-      - name: 'Run chef-client with FIPS'
+      - name: 'Run Chef Infra Client and verify FIPS enforcement'
         run: |
-          # Verify FIPS mode is active
-          hab pkg exec $env:HAB_ORIGIN/chef-infra-client chef-client --version
+          Write-Host "========================================"
+          Write-Host "Starting FIPS Verification Tests"
+          Write-Host "========================================"
+          Write-Host ""
 
-          #*** Uncomment the below lines to check for FIPS mode in chef-client logs once OpenSSL has FIPS mode enabled
-          # $output = hab pkg exec $env:HAB_ORIGIN/chef-infra-client chef-client -l debug --no-color 2>&1 | Select-String "FIPS"
-          # if ($output -match "OpenSSL FIPS 140 mode enabled") {
-          #   Write-Host "✅ Chef Infra Client is running in FIPS mode"
-          # } else {
-          #   Write-Host "❌ FIPS mode not detected"
-          #   Exit 1
-          # }
+          hab pkg exec $env:HAB_ORIGIN/chef-infra-client -- chef-client -z --chef-license accept
+
+          # ============================================
+          # Test 1: MD5 (should FAIL in FIPS mode)
+          # ============================================
+          Write-Host "--- Test 1: MD5 Digest (should FAIL in FIPS mode) ---"
+          New-Item -ItemType Directory -Force -Path "C:\temp" | Out-Null
+          New-Item -ItemType Directory -Force -Path "$env:TEMP\test_cookbook_md5\recipes" | Out-Null
+          @"
+          file 'C:\temp\test_md5' do
+            content lazy { OpenSSL::Digest::MD5.hexdigest('test') }
+          end
+          "@ | Set-Content -Path "$env:TEMP\test_cookbook_md5\recipes\default.rb"
+
+          $logPathMD5 = "$env:TEMP\chef-client-md5.log"
+          $exitCodeMD5 = 0
+          try {
+            hab pkg exec $env:HAB_ORIGIN/chef-infra-client -- chef-client -z `
+              --config-option "cookbook_path=$env:TEMP" `
+              -o test_cookbook_md5 2>&1 | Tee-Object -FilePath $logPathMD5
+            $exitCodeMD5 = $LASTEXITCODE
+          } catch {
+            $exitCodeMD5 = 1
+            $_ | Out-File -Append -FilePath $logPathMD5
+          }
+          Write-Host ""
+
+          # ============================================
+          # Test 2: SHA256 (should SUCCEED in FIPS mode)
+          # ============================================
+          Write-Host "--- Test 2: SHA256 Digest (should SUCCEED in FIPS mode) ---"
+          New-Item -ItemType Directory -Force -Path "$env:TEMP\test_cookbook_sha256\recipes" | Out-Null
+          @"
+          file 'C:\temp\test_sha256' do
+            content lazy { OpenSSL::Digest::SHA256.hexdigest('test') }
+          end
+          "@ | Set-Content -Path "$env:TEMP\test_cookbook_sha256\recipes\default.rb"
+
+          $logPathSHA256 = "$env:TEMP\chef-client-sha256.log"
+          $exitCodeSHA256 = 0
+          try {
+            hab pkg exec $env:HAB_ORIGIN/chef-infra-client -- chef-client -z `
+              --config-option "cookbook_path=$env:TEMP" `
+              -o test_cookbook_sha256 2>&1 | Tee-Object -FilePath $logPathSHA256
+            $exitCodeSHA256 = $LASTEXITCODE
+          } catch {
+            $exitCodeSHA256 = 1
+            $_ | Out-File -Append -FilePath $logPathSHA256
+          }
+          Write-Host ""
+
+          # ============================================
+          # Evaluate Results
+          # ============================================
+          Write-Host "========================================"
+          Write-Host "FIPS Verification Test Results"
+          Write-Host "========================================"
+          Write-Host ""
+
+          # Check Test 1: MD5 should fail
+          Write-Host "Test 1 - MD5 Result:"
+          $MD5TestPassed = $false
+          if ($exitCodeMD5 -ne 0) {
+            # MD5 failed, now check if it's due to FIPS
+            $logContentMD5 = Get-Content $logPathMD5 -Raw
+            if ($logContentMD5 -match "(?i)Digest" -and $logContentMD5 -match "(?i)initialization") {
+              Write-Host "*** PASS: MD5 blocked by FIPS (exit code: $exitCodeMD5) ***"
+              $MD5TestPassed = $true
+            } else {
+              Write-Host "*** FAIL: MD5 failed (exit code: $exitCodeMD5) but not due to FIPS/Digest error ***"
+              Write-Host ""
+              Write-Host "--- MD5 Log excerpt ---"
+              Get-Content $logPathMD5 -Tail 50
+              Write-Host "--- End MD5 log ---"
+              exit 1
+            }
+          } else {
+            Write-Host "*** FAIL: MD5 succeeded (exit code: 0) - FIPS not enforced ***"
+            Write-Host ""
+            Write-Host "--- MD5 Log excerpt ---"
+            Get-Content $logPathMD5 -Tail 50
+            Write-Host "--- End MD5 log ---"
+            exit 1
+          }
+          Write-Host ""
+
+          # Check Test 2: SHA256 should succeed
+          Write-Host "Test 2 - SHA256 Result:"
+          $SHA256TestPassed = $false
+          if ($exitCodeSHA256 -eq 0) {
+            Write-Host "*** PASS: SHA256 allowed by FIPS (exit code: $exitCodeSHA256) ***"
+            $SHA256TestPassed = $true
+          } else {
+            Write-Host "*** FAIL: SHA256 failed (exit code: $exitCodeSHA256) - FIPS blocking approved algorithm ***"
+            Write-Host ""
+            Write-Host "--- SHA256 Log excerpt ---"
+            Get-Content $logPathSHA256 -Tail 50
+            Write-Host "--- End SHA256 log ---"
+            exit 1
+          }
+          Write-Host ""
+
+          # Final summary
+          if ($MD5TestPassed -and $SHA256TestPassed) {
+            Write-Host "========================================"
+            Write-Host "*** ALL TESTS PASSED: FIPS mode is correctly enforced ***"
+            Write-Host "   - MD5 blocked ✓"
+            Write-Host "   - SHA256 allowed ✓"
+            Write-Host "========================================"
+            exit 0
+          } else {
+            Write-Host "========================================"
+            Write-Host "*** TESTS FAILED ***"
+            Write-Host "========================================"
+            exit 1
+          }
+
+      - name: 'Cleanup artifacts on runner'
+        if: always()
+        run: |
+          Write-Host "=== Cleaning up test artifacts ==="
+
+          # Remove the entire C:\temp directory (includes test_md5, test_sha256, etc.)
+          Remove-Item -Path "C:\temp" -Recurse -Force -ErrorAction SilentlyContinue
+
+          # Remove test cookbooks from TEMP
+          Remove-Item -Path "$env:TEMP\test_cookbook_md5" -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path "$env:TEMP\test_cookbook_sha256" -Recurse -Force -ErrorAction SilentlyContinue
+
+          # Remove log files
+          Remove-Item -Path "$env:TEMP\chef-client-md5.log" -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path "$env:TEMP\chef-client-sha256.log" -Force -ErrorAction SilentlyContinue
+
+          # Clean up Habitat artifacts
+          Remove-Item -Path "hab_token" -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path "$env:HAB_ORIGIN-key.tar.gz" -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path "chef-infra-client-latest.hart" -Force -ErrorAction SilentlyContinue
+
+          Write-Host "=== Cleanup complete ==="

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -1306,7 +1306,9 @@ module ChefConfig
     # sure Chef runs do not crash.
     # @api private
     def self.enable_fips_mode
+      # Enable FIPS mode in OpenSSL.
       OpenSSL.fips_mode = true
+
       require "digest" unless defined?(Digest)
       require "digest/sha1" unless defined?(Digest::SHA1)
       require "digest/md5" unless defined?(Digest::MD5)
@@ -1314,8 +1316,6 @@ module ChefConfig
       # amount of log spam and warnings.
       Digest.send(:remove_const, "SHA1") if Digest.const_defined?(:SHA1)
       Digest.const_set(:SHA1, OpenSSL::Digest::SHA1)
-      OpenSSL::Digest.send(:remove_const, "MD5") if OpenSSL::Digest.const_defined?(:MD5)
-      OpenSSL::Digest.const_set(:MD5, Digest::MD5)
       ChefConfig.logger.debug "FIPS mode is enabled."
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

1. Adding Github actions pipeline to test this functionality  on both windows and linux. 
On those systems we turn on FIPS at the OS level. Build and install habitat package of infra client and run a recipe which makes use of MD5 hash. Infra client recipe run SHOULD FAIL with an Openssl Digest error as MD5 is blocked by FIPS. So the pipeline should go green when infra client recipe run actually fails in this case. Similarly if Openssh digest SHA256 is used, the recipe should run successfully. We are deliberately testing for positive case as well in pipeline because previously in manual testing we saw openssl throwing digest errors, but for all the digests when the provider was not currently getting loaded, giving us false positive.

2. Bug fix: In fips mode, OpenSSL::Digest::MD5 was redirected to ruby's Digest::MD5 which is not correct, since md5 is one of the non permitted algorithms in fips mode.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
