### PR TITLE
Fix rhsm register status detection

### DIFF
--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -176,8 +176,8 @@ class Chef
         # @return [Boolean] is the node registered with RHSM. Return true ONLY if the status is "Current"
         #
         def registered_with_rhsm?
-	  @rhsm_status_stdout ||= shell_out("subscription-manager status").stdout
-	  @rhsm_status_stdout.include?("Overall Status: Current")
+          @rhsm_status_stdout ||= shell_out("subscription-manager status").stdout
+          @rhsm_status_stdout.include?("Overall Status: Current")
         end
 
         #


### PR DESCRIPTION
Issue with rhsm_register chef resource: rhsm_register.rb not reflecting latest satellite update

## Description
There is an issue with the rhsm_register chef resource. Recently in RedHat Satellite service, the command: "subscription-manager status" o/p changed. 

Previously, an unregistered system returned the status line as:
Overall Status: Unknown

Now it returns:
Overall Status: Not registered

So, the best solution is to ignore all possible failure states and only check for the single, known success state. The status for a correctly registered system is: Overall Status: Current. This means: consider the node registered if and only if the status is 'Current'.", thereby whitelisting the issue.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
