### PR TITLE
CVE-2025-61770 bundle update --conservative rack to 3.2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,7 +420,7 @@ GEM
     pstore (0.1.4)
     public_suffix (6.0.2)
     racc (1.8.1)
-    rack (3.2.1)
+    rack (3.2.4)
     rackup (2.2.1)
       rack (>= 3)
     rainbow (3.1.1)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
```
❯ bundle update --conservative rack
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Resolving dependencies...
Using rack 3.2.4 (was 3.2.1)
Using chef 19.1.107 (was 19.1.103) from source at `.`
Bundle updated!
```

## Related Issue

* [CVE-2025-61770](https://nvd.nist.gov/vuln/detail/CVE-2025-61770) - [3.1.0, 3.1.17) and [3.2.0, 3.2.2) vulnerable


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
