### PR TITLE
Downgrade bundler due to platform loss and conservative update chef

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GIT
 PATH
   remote: .
   specs:
-    chef (19.1.103)
+    chef (19.1.109)
       activesupport (~> 7.2.2.2)
       addressable
       aws-sdk-s3 (~> 1.91)
@@ -83,7 +83,7 @@ PATH
       unf_ext (~> 0.0.8.2)
       uri (~> 1.0.3)
       vault (~> 0.18.2)
-    chef (19.1.103-universal-mingw-ucrt)
+    chef (19.1.109-universal-mingw-ucrt)
       activesupport (~> 7.2.2.2)
       addressable
       aws-sdk-s3 (~> 1.91)
@@ -587,4 +587,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.6.9
+   2.5.23

--- a/chef-universal-mingw-ucrt.gemspec
+++ b/chef-universal-mingw-ucrt.gemspec
@@ -15,7 +15,7 @@ gemspec.add_dependency "wmi-lite", "~> 1.0"
 gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
 gemspec.add_dependency "iso8601", ">= 0.12.1", "< 0.14" # validate 0.14 when it comes out
 gemspec.add_dependency "win32-certstore", "~> 0.6.15" # 0.5+ required for specifying user vs. system store
-gemspec.add_dependency "chef-powershell", "~> 18.6.0" # The guts of the powershell_exec code have been moved to its own gem, chef-powershell. It's part of the chef-powershell-shim repo.
+gemspec.add_dependency "chef-powershell", "~> 18.6.6" # The guts of the powershell_exec code have been moved to its own gem, chef-powershell. It's part of the chef-powershell-shim repo.
 
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
```
❯ bundle update --conservative chef
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Resolving dependencies...
Using chef 19.1.109 (was 19.1.103) from source at `.`
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
