### PR TITLE
Catch accidental changes to the chef gems in Gemfile.lock

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -6,8 +6,8 @@ async function checkChefGemVersions() {
         return
     }
 
-    const diff = await danger.git.diffForFile("Gemfile.lock")
-    if (!diff) {
+    const versionsComparison = await danger.git.diffForFile("Gemfile.lock")
+    if (!versionsComparison) {
         return
     }
 
@@ -15,7 +15,7 @@ async function checkChefGemVersions() {
     const changedGems = []
 
     // Check if any of the chef gem version lines were modified
-    diff.diff.split('\n').forEach(line => {
+    versionsComparison.diff.split('\n').forEach(line => {
         // Look for lines that start with +/- and contain gem version info
         if ((line.startsWith('+') || line.startsWith('-')) && !line.startsWith('+++') && !line.startsWith('---')) {
             chefGems.forEach(gem => {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Occasionally chef gem specs in the Gemfile.lock get modified to be out of sync with the current version. This will flag PRs that have that problem. Can be appeased by `manual-update` in the PR description.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
