### PR TITLE
Catch accidental changes to the chef gems in Gemfile.lock (#15446)

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,5 +1,42 @@
 import { danger, fail, markdown, message, peril, schedule, warn } from 'danger'
 
+// Check if chef gem versions have been modified in Gemfile.lock
+async function checkChefGemVersions() {
+    if (!danger.git.modified_files.includes("Gemfile.lock")) {
+        return
+    }
+
+    const versionsComparison = await danger.git.diffForFile("Gemfile.lock")
+    if (!versionsComparison) {
+        return
+    }
+
+    const chefGems = ['chef (', 'chef-bin (', 'chef-config (', 'chef-utils (']
+    const changedGems = []
+
+    // Check if any of the chef gem version lines were modified
+    versionsComparison.diff.split('\n').forEach(line => {
+        // Look for lines that start with +/- and contain gem version info
+        if ((line.startsWith('+') || line.startsWith('-')) && !line.startsWith('+++') && !line.startsWith('---')) {
+            chefGems.forEach(gem => {
+                if (line.includes(gem) && !changedGems.includes(gem.replace(' (', ''))) {
+                    changedGems.push(gem.replace(' (', ''))
+                }
+            })
+        }
+    })
+
+    if (changedGems.length > 0) {
+        const gemList = changedGems.map(g => `\`${g}\``).join(', ')
+
+        if (danger.github.pr.body && danger.github.pr.body.includes("manual-update")) {
+            message(`✅ This PR modifies version(s) for: ${gemList} in Gemfile.lock. The PR includes 'manual-update' flag, so this is allowed.`)
+        } else {
+            fail(`❌ This PR modifies version(s) for: ${gemList} in Gemfile.lock. Core chef gem versions should not be changed unless this is an intentional version bump. If this is intentional, add 'manual-update' to the PR description to bypass this check.`)
+        }
+    }
+}
+
 // Enforce our Gemfile update policy
 if (danger.git.modified_files.includes("Gemfile.lock") &&
     danger.github.pr.user.type !== "Bot") {
@@ -25,3 +62,6 @@ if (danger.git.modified_files.includes("Gemfile.lock") &&
         }
     }
 }
+
+// Check for chef gem version changes
+schedule(checkChefGemVersions())


### PR DESCRIPTION
* Catch accidental changes to the chef gems in Gemfile.lock

---------

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
