### PR TITLE
Enforce description content for PRs

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -64,7 +64,7 @@ if (danger.git.modified_files.includes("Gemfile.lock") &&
 }
 
 // Check if PR description has been properly filled out
-function checkPRDescription() {
+async function checkPRDescription() {
     const body = danger.github.pr.body || ""
 
     if (danger.github.pr.user.type === "Bot") {
@@ -101,4 +101,4 @@ function checkPRDescription() {
 schedule(checkChefGemVersions())
 
 // Check PR description
-checkPRDescription()
+schedule(checkPRDescription())


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Pull requests are often opened up without editing the description to describe intent behind the pull request. This change to danger simply detects that you have changed the comment about the description.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
