### PR TITLE
[FileAccessControl] Reduce Securable object usage

### DIFF
--- a/lib/chef/file_access_control/unix.rb
+++ b/lib/chef/file_access_control/unix.rb
@@ -77,15 +77,15 @@ class Chef
       end
 
       def should_update_owner?
-        if target_uid.nil?
+        if (target = target_uid).nil?
           # the user has not specified a permission on the new resource, so we never manage it with FAC
           Chef::Log.trace("Found target_uid == nil, so no owner was specified on resource, not managing owner")
           false
-        elsif current_uid.nil?
+        elsif (current = current_uid).nil?
           # the user has specified a permission, and we are creating a file, so always enforce permissions
           Chef::Log.trace("Found current_uid == nil, so we are creating a new file, updating owner")
           true
-        elsif target_uid != current_uid
+        elsif target != current
           # the user has specified a permission, and it does not match the file, so fix the permission
           Chef::Log.trace("Found target_uid != current_uid, updating owner")
           true
@@ -138,15 +138,15 @@ class Chef
       end
 
       def should_update_group?
-        if target_gid.nil?
+        if (target = target_gid).nil?
           # the user has not specified a permission on the new resource, so we never manage it with FAC
           Chef::Log.trace("Found target_gid == nil, so no group was specified on resource, not managing group")
           false
-        elsif current_gid.nil?
+        elsif (current = current_gid).nil?
           # the user has specified a permission, and we are creating a file, so always enforce permissions
           Chef::Log.trace("Found current_gid == nil, so we are creating a new file, updating group")
           true
-        elsif target_gid != current_gid
+        elsif target != current
           # the user has specified a permission, and it does not match the file, so fix the permission
           Chef::Log.trace("Found target_gid != current_gid, updating group")
           true
@@ -189,15 +189,15 @@ class Chef
       end
 
       def should_update_mode?
-        if target_mode.nil?
+        if (target = target_mode).nil?
           # the user has not specified a permission on the new resource, so we never manage it with FAC
           Chef::Log.trace("Found target_mode == nil, so no mode was specified on resource, not managing mode")
           false
-        elsif current_mode.nil?
+        elsif (current = current_mode).nil?
           # the user has specified a permission, and we are creating a file, so always enforce permissions
           Chef::Log.trace("Found current_mode == nil, so we are creating a new file, updating mode")
           true
-        elsif target_mode != current_mode
+        elsif target != current
           # the user has specified a permission, and it does not match the file, so fix the permission
           Chef::Log.trace("Found target_mode != current_mode, updating mode")
           true


### PR DESCRIPTION
## Description
These methods now only call the Chef::Mixin::Securable objects once on the happy path, and also fixes what appears to be a copy-paste error in the gid_from_resource method

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
