### PR TITLE
Remove direct dependency on activesupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       chef-config (= 18.8.61)
       chef-utils (= 18.8.61)
       chef-vault
-      chef-zero (>= 15.0.21)
+      chef-zero (>= 15.0.21, < 15.2)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
@@ -81,7 +81,7 @@ PATH
       chef-powershell (~> 18.6.0)
       chef-utils (= 18.8.61)
       chef-vault
-      chef-zero (>= 15.0.21)
+      chef-zero (>= 15.0.21, < 15.2)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
       erubis (~> 2.7)
@@ -147,18 +147,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.3)
-      base64
-      benchmark (>= 0.3)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     appbundler (0.13.4)
@@ -186,7 +174,6 @@ GEM
     aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
-    benchmark (0.4.1)
     bigdecimal (3.1.9)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
@@ -221,8 +208,7 @@ GEM
       erubi (>= 1.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 2.0)
-    chef-zero (15.0.21)
-      activesupport (>= 7, < 8.1)
+    chef-zero (15.1.0)
       ffi-yajl (>= 2.2, < 4.0)
       hashie (>= 2.0, < 6.0)
       mixlib-log (>= 2.0, < 4.0)
@@ -240,7 +226,6 @@ GEM
       rubocop (= 1.25.1)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.3)
     cookstyle (7.32.8)
       rubocop (= 1.25.1)
     corefoundation (0.3.13)
@@ -251,7 +236,6 @@ GEM
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     domain_name (0.6.20240107)
-    drb (2.2.3)
     ed25519 (1.3.0)
     erubi (1.13.1)
     erubis (2.7.0)
@@ -282,8 +266,6 @@ GEM
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.14.7)
-      concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
     inspec-core (5.23.6)
       addressable (~> 2.4)
@@ -331,7 +313,6 @@ GEM
       logger
       mime-types-data (~> 3.2015)
     mime-types-data (3.2025.0204)
-    minitest (5.25.5)
     mixlib-archive (1.3.3)
       mixlib-log
     mixlib-authentication (3.0.10)
@@ -426,7 +407,6 @@ GEM
     rubyntlm (0.6.5)
       base64
     rubyzip (2.4.1)
-    securerandom (0.4.1)
     semverse (3.0.2)
     sslshake (1.3.1)
     strings (0.2.1)
@@ -474,8 +454,6 @@ GEM
       pastel (~> 0.8)
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unf_ext (0.0.8.2)
     unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.6.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7" # template resource / cookbook syntax check
   s.add_dependency "diff-lcs", ">= 1.2.4", "!= 1.4.0", "< 1.6.0" # 1.4 breaks output. Used in lib/chef/util/diff
   s.add_dependency "ffi-libarchive", "~> 1.0", ">= 1.0.3" # archive_file resource
-  s.add_dependency "chef-zero", ">= 15.0.21"
+  s.add_dependency "chef-zero", ">= 15.0.21", "< 15.2"
   s.add_dependency "chef-vault" # chef-vault resources and helpers
 
   s.add_dependency "plist", "~> 3.2" # launchd, dscl/mac user, macos_userdefaults, osx_profile and plist resources


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
```
❯ bundle update --conservative chef-zero
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies....
Using rake 13.2.1
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      stringio (>= 0)
      Available/installed versions of this gem:
      - 3.1.8
      - 3.1.7
      - 3.0.1.2
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
Using mixlib-cli 2.1.8
Using concurrent-ruby 1.3.5
Using ast 2.4.3
Using aws-eventstream 1.3.0
Using aws-partitions 1.1048.0
Using base64 0.2.0
Using jmespath 1.6.2
Using bigdecimal 3.1.9
Using debug_inspector 1.2.0
Using builder 3.3.0
Using public_suffix 6.0.2
Using bundler 2.3.27
Using byebug 11.1.3
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using libyajl2 2.1.0
Using fuzzyurl 0.9.0
Using hashie 5.0.0
Using ffi 1.16.3
Using diff-lcs 1.5.1
Using erubis 2.7.0
Using iniparse 1.5.0
Using rack 3.2.4
Using racc 1.8.1
Using rainbow 3.1.1
Using regexp_parser 2.11.3
Using rexml 3.4.4
Using prism 1.5.1
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.6.0
Using uri 1.0.4
Using json 2.15.1
Using logger 1.5.3
Using unf_ext 0.0.8.2
Using uuidtools 2.2.0
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using parallel 1.27.0
Using wisper 2.0.1
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 2.0.0
Using coderay 1.1.3
Using webrick 1.9.1
Using rspec-support 3.13.6
Using rubyzip 2.4.1
Using semverse 3.0.2
Using sslshake 1.3.1
Using tty-screen 0.8.2
Using thor 1.4.0
Using net-ssh 7.3.0
Using timeout 0.4.3
Using mixlib-authentication 3.0.10
Using ipaddress 0.8.3
Using date 3.4.1
Using wmi-lite 1.0.7
Using syslog-logger 1.6.8
Using http-accept 2.1.1
Using plist 3.7.2
Using proxifier2 1.1.0
Using domain_name 0.6.20240107
Using mime-types-data 3.2025.0204
Using netrc 0.11.0
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using erubi 1.13.1
Using multi_json 1.17.0
Using ed25519 1.3.0
Using hashdiff 1.1.1
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using rb-readline 0.5.5
Using chef-utils 18.8.61 from source at `chef-utils`
Using mixlib-config 3.0.27
Using ffi-yajl 2.6.0
Using mixlib-log 3.1.2.1
Using ffi-libarchive 1.1.3
Using gssapi 1.3.1
Using addressable 2.8.7
Using aws-sigv4 1.11.0
Using binding_of_caller 1.0.1
Using rackup 2.2.1
Using parser 3.3.9.0
Using net-http 0.6.0
Using strings 0.2.1
Using chef-gyoku 1.4.1
Using crack 0.4.5
Using pastel 0.8.0
Using pry 0.13.0
Using corefoundation 0.3.13
Using http-cookie 1.0.8
Using mime-types 3.6.0
Using net-scp 4.1.0
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using nori 2.7.0
Using mixlib-shellout 3.3.9
Using aws-sdk-core 3.218.1
Using faraday-net_http 3.4.1
Using tty-box 0.7.0
Using vault 0.18.2
Using pry-stack_explorer 0.6.1
Using webmock 3.25.0
Using rubyntlm 0.6.5
Using time 0.4.1
Using appbundler 0.13.4
Using rubocop-ast 1.47.1
Using logging 2.4.0
Using pry-byebug 3.10.1
Using aws-sdk-kms 1.98.0
Using aws-sdk-secretsmanager 1.112.0
Using chef-config 18.8.61 from source at `chef-config`
Using tty-reader 0.9.0
Using rspec-core 3.13.5
Using rspec-expectations 3.13.5
Using rspec-mocks 3.13.5
Using train-core 3.13.4
Using tty-table 0.12.0
Using mixlib-archive 1.3.3
Using net-protocol 0.2.2
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@3e962d5)
Using faraday 2.14.0
Fetching chef-zero 15.1.0 (was 15.0.26)
Using rspec 3.13.1
Using rspec-its 2.0.0
Using net-ftp 0.3.8
Using faraday-follow_redirects 0.4.0
Using rubocop 1.25.1
Using chef-winrm 2.3.11
Using aws-sdk-s3 1.180.0
Using cookstyle 7.32.8
Using tty-prompt 0.23.1
Using chef-winrm-fs 1.3.7
Using chefstyle 2.2.3
Using license-acceptance 2.1.13
Using chef-winrm-elevated 1.2.5
Using train-winrm 0.2.17
Using ohai 18.2.8 from https://github.com/chef/ohai.git (at 18-stable@1941699)
Using chef-telemetry 1.1.1
Using inspec-core 5.23.6
Using inspec-core-bin 5.23.6
Using train-rest 0.5.0
Installing chef-zero 15.1.0 (was 15.0.26)
Using chef 18.8.61 from source at `.`
Using cheffish 17.1.8
Using chef-bin 18.8.61 from source at `chef-bin` and installing its executables
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
