### PR TITLE
CVE-2025-61594 remove old uri as well

### DIFF
--- a/post-bundle-install.rb
+++ b/post-bundle-install.rb
@@ -114,7 +114,7 @@ default_gem_list.each do |gem_name, version|
   puts "Checking #{gem_name} gem installation..."
   gem_info = `gem info #{gem_name}`
 
-  if gem_info.include?("default):") && gem_info.include?(/#{gem_name} \([0-9., ]*#{version}[0-9., ]*\)/)
+  if gem_info.include?("default):") && gem_info.match?(/#{gem_name} \([0-9., ]*#{version}[0-9., ]*\)/)
     # Extract the default gem path
     default_path = gem_info.match(/default\): (.+)$/)[1]
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
CVE-2025-61594 has been patched by upgrading the uri gem to 1.0.4, but vulnerable version 0.12.4 still has its gemspec in default specifications. Remove similar to how `resolv` default was handled.

## Related Issue

[CVE-2025-61594](https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
