### PR TITLE
Use pull_request_target to run kitchen tests in the context of main

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -88,6 +88,7 @@ jobs:
 
   # end-to-end recipe testing using test-kitchen-enterprise and habitat package of Infra Client
   docr_lnx_x86_64:
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-run')
     name: dokr_lnx_x86_64_hab
     strategy:
       fail-fast: false

--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -4,7 +4,9 @@ permissions:
   contents: read
 
 "on":
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -15,9 +17,12 @@ concurrency:
 
 jobs:
   linux:
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe-to-run')
     strategy:
       fail-fast: false
-    runs-on: [self-hosted, x64, Linux, ubuntu-2404-pro-fips-tester]
+      matrix:
+        platform: [self-hosted, x64, Linux, ubuntu-2404-pro-fips-tester]
+    runs-on: ${{ matrix.platform }}
     env:
       HAB_ORIGIN: gha # Set the dummy origin for this Github actions CI flow
       HAB_BLDR_CHANNEL: base-2025 # Explicitly set the builder channel

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -4,7 +4,9 @@ permissions:
   contents: read
 
 "on":
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -15,6 +17,7 @@ concurrency:
 
 jobs:
   windows:
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe-to-run')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
[GitHub Actions improvements for fork and pull request workflows](https://github.blog/news-insights/product-news/github-actions-improvements-for-fork-and-pull-request-workflows/):

> In order to solve this, we’ve added a new `pull_request_target` event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
