### PR TITLE
Removed conflicting openssl installation

### DIFF
--- a/.expeditor/scripts/prep_and_run_tests.ps1
+++ b/.expeditor/scripts/prep_and_run_tests.ps1
@@ -58,7 +58,6 @@ $env:Path = "$openssl_dir\bin;$ruby_dir\bin;" + $env:Path
 
 Write-Output "Configure bundle to build openssl gem with $openssl_dir"
 bundle config build.openssl --with-openssl-dir=$openssl_dir
-gem install openssl:3.3.0 -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir\include" --with-openssl-lib="$openssl_dir\lib"
 
 Write-Output "OpenSSL directory: $openssl_dir"
 Write-Output "PATH: $env:Path"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This addition was needed in the past but now it's version causes gem and bundler errors all over the place for Windows unit and Functional tests. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
