### PR TITLE
[File#load_current_resource] assign #path call to variable

### DIFF
--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -71,32 +71,33 @@ class Chef
       end
 
       def load_current_resource
+        new_resource_path = new_resource.path
         # true if there is a symlink and we need to manage what it points at
-        @managing_symlink = file_class.symlink?(new_resource.path) && ( new_resource.manage_symlink_source || new_resource.manage_symlink_source.nil? )
+        @managing_symlink = file_class.symlink?(new_resource_path) && ( new_resource.manage_symlink_source || new_resource.manage_symlink_source.nil? )
 
         # true if there is a non-file thing in the way that we need to unlink first
         @needs_unlinking =
-          if ::TargetIO::File.exist?(new_resource.path)
+          if ::TargetIO::File.exist?(new_resource_path)
             if managing_symlink?
-              !symlink_to_real_file?(new_resource.path)
+              !symlink_to_real_file?(new_resource_path)
             else
-              !real_file?(new_resource.path)
+              !real_file?(new_resource_path)
             end
           else
             false
           end
 
         # true if we are going to be creating a new file
-        @needs_creating = !::TargetIO::File.exist?(new_resource.path) || needs_unlinking?
+        @needs_creating = !::TargetIO::File.exist?(new_resource_path) || needs_unlinking?
 
         # Let children resources override constructing the current_resource
         @current_resource ||= Chef::Resource::File.new(new_resource.name)
-        current_resource.path(new_resource.path)
+        current_resource.path(new_resource_path)
 
         unless needs_creating?
           # we are updating an existing file
           if managing_content?
-            logger.trace("#{new_resource} checksumming file at #{new_resource.path}.")
+            logger.trace("#{new_resource} checksumming file at #{new_resource_path}.")
 
             resource_to_check = current_resource.path
             resource_to_check = ::TargetIO::File.open(current_resource.path) if ChefConfig::Config.target_mode?


### PR DESCRIPTION
## Description
This is a simple optimization to save the value of `#path` for a new resource in the method, since it's not a simple class variable, but actually uses parameter plumbing, which is considerably more expensive.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
