### PR TITLE
Revert "Removed conflicting openssl installation"

### DIFF
--- a/.expeditor/scripts/prep_and_run_tests.ps1
+++ b/.expeditor/scripts/prep_and_run_tests.ps1
@@ -58,6 +58,7 @@ $env:Path = "$openssl_dir\bin;$ruby_dir\bin;" + $env:Path
 
 Write-Output "Configure bundle to build openssl gem with $openssl_dir"
 bundle config build.openssl --with-openssl-dir=$openssl_dir
+gem install openssl:3.3.0 -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir\include" --with-openssl-lib="$openssl_dir\lib"
 
 Write-Output "OpenSSL directory: $openssl_dir"
 Write-Output "PATH: $env:Path"


### PR DESCRIPTION
## Description
Reverts chef/chef#15482 - We may have removed this too soon. Reverting as only a few builds had the openssl conflict and it appears to be more transient than an actual problem