### PR TITLE
remove activesupport from chef main

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,6 @@ PATH
   remote: .
   specs:
     chef (19.1.125)
-      activesupport (~> 7.2.2.2)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
@@ -85,7 +84,6 @@ PATH
       uri (~> 1.0.4)
       vault (~> 0.18.2)
     chef (19.1.125-universal-mingw-ucrt)
-      activesupport (~> 7.2.2.2)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
@@ -162,18 +160,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2.2)
-      base64
-      benchmark (>= 0.3)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     appbundler (0.13.4)
@@ -263,7 +249,6 @@ GEM
       webrick
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.4)
     cookstyle (8.5.2)
       rubocop (= 1.81.6)
     corefoundation (0.3.13)
@@ -276,7 +261,6 @@ GEM
     debug_inspector (1.2.0)
     diff-lcs (1.6.2)
     domain_name (0.6.20240107)
-    drb (2.2.3)
     ed25519 (1.4.0)
     erubi (1.13.1)
     erubis (2.7.0)
@@ -309,8 +293,6 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
-    i18n (1.14.7)
-      concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
     inspec-core (7.0.95)
       addressable (~> 2.4)
@@ -364,7 +346,6 @@ GEM
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2025.0924)
-    minitest (5.26.2)
     mixlib-archive (1.3.3)
       mixlib-log
     mixlib-authentication (3.0.10)
@@ -463,7 +444,6 @@ GEM
     rubyntlm (0.6.5)
       base64
     rubyzip (2.4.1)
-    securerandom (0.4.1)
     semverse (3.0.2)
     socksify (1.8.1)
     sslshake (1.3.1)
@@ -517,8 +497,6 @@ GEM
       pastel (~> 0.8)
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unf_ext (0.0.9.1)
     unf_ext (0.0.9.1-x64-mingw-ucrt)
     unicode-display_width (2.6.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -66,9 +66,6 @@ Gem::Specification.new do |s|
   s.add_dependency "uri", "~> 1.0.4" # CVE-2025-61594 fixed in >= 1.0.4
   s.add_dependency "corefoundation", "~> 0.3.4" # macos_userdefaults resource
 
-  # this is temporary until activesupport is removed from chef-licensing/chef-zero/oc-chef-pedant and published
-  s.add_dependency "activesupport", "~> 7.2.2.2"
-
   s.add_dependency "proxifier2", "~> 1.1"
 
   s.add_dependency "aws-sdk-s3", "~> 1.91" # s3 recipe-url support


### PR DESCRIPTION
## Description
This PR implements the changes for CHEF-28002 to remove the activesupport dependency from chef-main.
- Removed activesupport (~> 7.2.2.2) dependency from chef.gemspec
- Updated Gemfile.lock to remove activesupport and its transitive dependencies
- Updated chef-zero pin from ~> 15.0.21 to ~> 15.1.0 in chef.gemspec and Gemfile.lock

## Related Issue
 CHEF-28002

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
