### PR TITLE
Added -a or --all-users to show all user details in user list command

### DIFF
--- a/knife/lib/chef/knife/user_list.rb
+++ b/knife/lib/chef/knife/user_list.rb
@@ -30,12 +30,27 @@ class Chef
       banner "knife user list (options)"
 
       option :with_uri,
-        short: "-w",
-        long: "--with-uri",
-        description: "Show corresponding URIs."
+             short: "-w",
+             long: "--with-uri",
+             description: "Show corresponding URIs."
+
+      option :all_users,
+             short: "-a",
+             long: "--all-users",
+             description: "Show all user details."
 
       def run
-        output(format_list_for_display(Chef::UserV1.list))
+        users = Chef::UserV1.list(config[:all_users])
+        if config[:all_users]
+          # When showing all user details, convert UserV1 objects to hashes for display
+          detailed_users = {}
+          users.each do |name, user|
+            detailed_users[name] = user.to_h
+          end
+          output(detailed_users)
+        else
+          output(format_list_for_display(users))
+        end
       end
 
     end

--- a/knife/spec/unit/knife/user_list_spec.rb
+++ b/knife/spec/unit/knife/user_list_spec.rb
@@ -34,23 +34,53 @@ describe Chef::Knife::UserList do
     @rest = double("Chef::ServerAPI")
     allow(Chef::ServerAPI).to receive(:new).and_return(@rest)
     allow(@rest).to receive(:get).with("users").and_return(users)
+    allow(Chef::UserV1).to receive(:list).with(nil).and_return(users)
   end
 
   describe "with no arguments" do
-    it "lists all non users" do
+    it "lists all users" do
       expect(knife.ui).to receive(:output).with(%w{user1 user2})
       knife.run
     end
-
   end
 
   describe "with all_users argument" do
-    before do
-      knife.config[:all_users] = true
+    let(:user1_object) do
+      u = Chef::UserV1.new
+      u.username "user1"
+      u.email "user1@example.com"
+      u.display_name "User One"
+      u
     end
 
-    it "lists all users including hidden users" do
-      expect(knife.ui).to receive(:output).with(%w{user1 user2})
+    let(:user2_object) do
+      u = Chef::UserV1.new
+      u.username "user2"
+      u.email "user2@example.com"
+      u.display_name "User Two"
+      u
+    end
+
+    let(:inflated_users) do
+      {
+        "user1" => user1_object,
+        "user2" => user2_object,
+      }
+    end
+
+    before do
+      knife.config[:all_users] = true
+      allow(Chef::UserV1).to receive(:list).with(true).and_return(inflated_users)
+    end
+
+    it "lists all users with full details" do
+      expect(knife.ui).to receive(:output) do |arg|
+        expect(arg).to be_a(Hash)
+        expect(arg.keys).to contain_exactly("user1", "user2")
+        expect(arg["user1"]["username"]).to eq("user1")
+        expect(arg["user1"]["email"]).to eq("user1@example.com")
+        expect(arg["user2"]["username"]).to eq("user2")
+      end
       knife.run
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Added the -a/--all-users flag to the knife user list command to display detailed user information including email, display name, first name, and last name.

Issue
[[CHEF-28966](https://progresssoftware.atlassian.net/browse/CHEF-28966)] - Missing all users flag in knife user list command

Description
The knife user list command previously only displayed usernames. This change adds an -a/--all-users option (similar to knife org list -a) that shows comprehensive user details.

https://progresssoftware.atlassian.net/browse/CHEF-28966
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

<img width="1576" height="1058" alt="Screenshot 2025-12-08 at 3 37 45 PM" src="https://github.com/user-attachments/assets/ed443ca5-879c-4fd3-82c6-f18e878b440b" />


[CHEF-28966]: https://progresssoftware.atlassian.net/browse/CHEF-28966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ