### PR TITLE
Backport - Added -a or --all-users to show all user details in user list command

### DIFF
--- a/knife/lib/chef/knife/user_list.rb
+++ b/knife/lib/chef/knife/user_list.rb
@@ -34,8 +34,22 @@ class Chef
         long: "--with-uri",
         description: "Show corresponding URIs."
 
+      option :all_users,
+             short: "-a",
+             long: "--all-users",
+             description: "Show all user details."
       def run
-        output(format_list_for_display(Chef::UserV1.list))
+        users = Chef::UserV1.list(config[:all_users])
+        if config[:all_users]
+          # When showing all user details, convert UserV1 objects to hashes for display
+          detailed_users = {}
+          users.each do |name, user|
+            detailed_users[name] = user.to_h
+          end
+          output(detailed_users)
+        else
+          output(format_list_for_display(users))
+        end
       end
 
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Added the -a/--all-users flag to the knife user list command to display detailed user information including email, display name, first name, and last name.

Issue
[[CHEF-28966](https://progresssoftware.atlassian.net/browse/CHEF-28966)] - Missing all users flag in knife user list command

Description
The knife user list command previously only displayed usernames. This change adds an -a/--all-users option (similar to knife org list -a) that shows comprehensive user details.

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
<img width="1576" height="1058" alt="Screenshot 2025-12-08 at 3 37 45 PM" src="https://github.com/user-attachments/assets/4da4e4ce-523f-400b-a72a-b01bdfc9af25" />


[CHEF-28966]: https://progresssoftware.atlassian.net/browse/CHEF-28966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ