### PR TITLE
cleaning up lint_roller after cookstyle installs

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -169,6 +169,10 @@ function Invoke-Build {
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
         bundle install --jobs=3 --retry=3
         if (-not $?) { throw "unable to install gem dependencies" }
+
+        Write-BuildLine " ** Cleaning up lint_roller Gemfile.lock"
+        ruby .\scripts\cleanup_lint_roller.rb
+
         Write-BuildLine " ** 'rake install' any gem sourced as a git reference so they'll look like regular gems."
         foreach($git_gem in (Get-ChildItem "$env:GEM_HOME/bundler/gems")) {
             try {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -128,6 +128,8 @@ do_build() {
     build_line "Installing gems from git repos properly ..."
     ruby ./post-bundle-install.rb
 
+    ruby ./scripts/cleanup_lint_roller.rb
+
     build_line "Installing this project's gems ..."
     bundle exec rake install:local
   )

--- a/scripts/cleanup_lint_roller.rb
+++ b/scripts/cleanup_lint_roller.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# Removes stray Gemfile.lock shipped inside the lint_roller gem to appease scanners.
+require "rubygems"
+
+def cleanup_lint_roller_lockfile
+  puts "Cleaning up lint_roller Gemfile.lock..."
+  specs = Gem::Specification.find_all_by_name("lint_roller")
+  if specs.empty?
+    puts "  No lint_roller gem installed"
+    return
+  end
+
+  specs.each do |spec|
+    gemfile_lock_path = File.join(spec.gem_dir, "Gemfile.lock")
+    if File.exist?(gemfile_lock_path)
+      puts "  Removing #{gemfile_lock_path}"
+      File.delete(gemfile_lock_path)
+      puts "  Successfully removed lint_roller Gemfile.lock"
+    else
+      puts "  No Gemfile.lock found in #{spec.gem_dir}"
+    end
+  end
+rescue StandardError => e
+  warn "  Warning: Failed to clean up lint_roller Gemfile.lock: #{e.message}"
+end
+
+cleanup_lint_roller_lockfile


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
When we install Cookstyle, it pulls in Rubocop and gives us a transitive dependency on lint_roller. That gem has unexpectedly included it's gemfile.lock which causes issues with Trivvy and Blackduck. There is a bug [here](https://github.com/standardrb/lint_roller/issues/21) that discusses the issue further and a PR [here](https://github.com/standardrb/lint_roller/pull/22) that fixes it. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
