### PR TITLE
Bump chef-licensing to 1.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,11 +203,10 @@ GEM
     chef-gyoku (1.5.0)
       builder (>= 2.1.2)
       rexml (~> 3.4)
-    chef-licensing (1.3.0)
+    chef-licensing (1.3.1)
       chef-config (>= 15)
-      faraday (>= 1, < 2)
+      faraday (>= 1, < 3)
       faraday-http-cache
-      faraday_middleware (~> 1.0)
       mixlib-log (~> 3.0)
       ostruct (~> 0.1.0)
       pstore (~> 0.1.1)
@@ -276,8 +275,6 @@ GEM
       faraday (>= 1, < 3)
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
-    faraday_middleware (1.2.1)
-      faraday (~> 1.0)
     fauxhai-ng (9.3.0)
       net-ssh
     ffi (1.16.3)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -73,7 +73,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aws-sdk-s3", "~> 1.91" # s3 recipe-url support
   s.add_dependency "aws-sdk-secretsmanager", "~> 1.46"
   s.add_dependency "vault", "~> 0.18.2" # hashi vault official client gem
-  s.add_dependency "chef-licensing", ">= 0.7.5"
+  s.add_dependency "chef-licensing", "~> 1.3"
 
   s.bindir = "bin"
   s.executables = %w{ }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Update open ended dependency in gemspec for chef-licensing gem to pessimistic, bump chef-licensing gem to 1.3.1 to fix warnings below:
```
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
```
can be confirmed via any of the pipeline logs, if they are still being seen in the logs. e.g in verify pipeline we could see [this](https://buildkite.com/chef-oss/chef-chef-main-verify/builds/21578#019b2625-4e6e-4d3d-8bfc-bbf89e574a75/706-707)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
