### PR TITLE
Bump chef-licensing to 1.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ PATH
       aws-sdk-secretsmanager (~> 1.46)
       bcrypt_pbkdf (~> 1.0)
       chef-config (= 19.1.130)
-      chef-licensing (>= 0.7.5)
+      chef-licensing (~> 1.3)
       chef-utils (= 19.1.130)
       chef-vault
       chef-zero (~> 15.1.0)
@@ -91,7 +91,7 @@ PATH
       aws-sdk-secretsmanager (~> 1.46)
       bcrypt_pbkdf (~> 1.0)
       chef-config (= 19.1.130)
-      chef-licensing (>= 0.7.5)
+      chef-licensing (~> 1.3)
       chef-powershell (~> 18.6.6)
       chef-utils (= 19.1.130)
       chef-vault
@@ -203,13 +203,12 @@ GEM
     chef-gyoku (1.5.0)
       builder (>= 2.1.2)
       rexml (~> 3.4)
-    chef-licensing (1.3.0)
+    chef-licensing (1.3.4)
       chef-config (>= 15)
-      faraday (>= 1, < 2)
+      faraday (>= 1, < 3)
       faraday-http-cache
-      faraday_middleware (~> 1.0)
       mixlib-log (~> 3.0)
-      ostruct (~> 0.1.0)
+      ostruct (~> 0.6.0)
       pstore (~> 0.1.1)
       tty-prompt (~> 0.23)
       tty-spinner (~> 0.9.3)
@@ -253,7 +252,7 @@ GEM
       uuidtools (~> 2.1)
       webrick
     coderay (1.1.3)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.6)
     cookstyle (8.5.2)
       rubocop (= 1.81.6)
     corefoundation (0.3.13)
@@ -269,15 +268,16 @@ GEM
     ed25519 (1.4.0)
     erubi (1.13.1)
     erubis (2.7.0)
-    faraday (1.2.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
-    faraday_middleware (1.2.1)
-      faraday (~> 1.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     fauxhai-ng (9.3.0)
       net-ssh
     ffi (1.16.3)
@@ -332,7 +332,7 @@ GEM
     ipaddress (0.8.3)
     iso8601 (0.13.0)
     jmespath (1.6.2)
-    json (2.16.0)
+    json (2.18.0)
     language_server-protocol (3.17.0.5)
     libyajl2 (2.1.0)
     license-acceptance (2.1.13)
@@ -372,6 +372,8 @@ GEM
     net-ftp (0.3.9)
       net-protocol
       time
+    net-http (0.8.0)
+      uri (>= 0.11.1)
     net-protocol (0.2.2)
       timeout
     net-scp (4.1.0)
@@ -383,7 +385,7 @@ GEM
     nori (2.7.0)
       bigdecimal
     openssl (3.3.2)
-    ostruct (0.1.0)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
@@ -445,7 +447,6 @@ GEM
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     rubyntlm (0.6.5)
       base64
     rubyzip (2.4.1)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -73,7 +73,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aws-sdk-s3", "~> 1.91" # s3 recipe-url support
   s.add_dependency "aws-sdk-secretsmanager", "~> 1.46"
   s.add_dependency "vault", "~> 0.18.2" # hashi vault official client gem
-  s.add_dependency "chef-licensing", ">= 0.7.5"
+  s.add_dependency "chef-licensing", "~> 1.3"
 
   s.bindir = "bin"
   s.executables = %w{ }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Update open ended dependency in gemspec for chef-licensing gem to pessimistic, bump chef-licensing gem to 1.3.4 to fix  following warnings, also for FIPS compliance fix added [here](https://github.com/chef/chef-licensing/pull/217):
```
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
```
can be confirmed via any of the pipeline logs, if they are still being seen in the logs. e.g in verify pipeline we could see [this](https://buildkite.com/chef-oss/chef-chef-main-verify/builds/21578#019b2625-4e6e-4d3d-8bfc-bbf89e574a75/706-707)

```
bundle update chef-licensing
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using concurrent-ruby 1.3.6 (was 1.3.5)
Using faraday 2.14.0 (was 1.2.0)
Using ostruct 0.6.3 (was 0.1.0)
Fetching json 2.18.0 (was 2.16.0)
Installing json 2.18.0 (was 2.16.0) with native extensions
Fetching chef-licensing 1.3.4 (was 1.3.0)
Installing chef-licensing 1.3.4 (was 1.3.0)
Bundle updated!
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
