### PR TITLE
Updating to latest Ohai

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 1941699de82df98ad51f8b8c4b24dca5b0b81bf2
+  revision: 6dac7dc7189de48b04352ab750956279c794301d
   branch: 18-stable
   specs:
-    ohai (18.2.8)
+    ohai (18.2.13)
       chef-config (>= 14.12, < 19)
       chef-utils (>= 16.0, < 19)
       ffi (~> 1.9, <= 1.17.0)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Ohai has had some updates and tweaks and we are pulling them in here before the release.

$ bundle update --conservative ohai
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies....
Using rake 13.2.1
Using public_suffix 6.0.2
Using mixlib-cli 2.1.8
Using concurrent-ruby 1.3.5
Using ffi 1.16.3 (x64-mingw-ucrt)
Using wmi-lite 1.0.7
Using ast 2.4.3
Using bundler 2.3.27
Using aws-eventstream 1.3.0
Using aws-partitions 1.1048.0
Using base64 0.2.0
Using jmespath 1.6.2
Using bigdecimal 3.1.9
Using debug_inspector 1.2.0
Using builder 3.3.0
Using byebug 11.1.3
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using hashie 5.0.0
Using libyajl2 2.1.0
Using unf_ext 0.0.8.2 (x64-mingw-ucrt)
Using rack 3.2.4
Using uuidtools 2.2.0
Using webrick 1.9.1
Using erubis 2.7.0
Using iniparse 1.5.0
Using diff-lcs 1.5.1
Using parallel 1.27.0
Using racc 1.8.1
Using rexml 3.4.4
Using rainbow 3.1.1
Using regexp_parser 2.11.3
Using prism 1.5.1
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.6.0
Using uri 1.0.4
Using logger 1.5.3
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using unicode_utils 1.4.0
Using tty-cursor 0.7.1
Using tty-screen 0.8.2
Using json 2.15.1
Using wisper 2.0.1
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 2.0.0
Using coderay 1.1.3
Using rspec-support 3.13.6
Using rubyzip 2.4.1
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.4.0
Using net-ssh 7.3.0
Using iso8601 0.13.0
Using mixlib-authentication 3.0.10
Using timeout 0.4.3
Using date 3.4.1
Using ipaddress 0.8.3
Using plist 3.7.2
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using http-accept 2.1.1
Using domain_name 0.6.20240107
Using mime-types-data 3.2025.0204
Using netrc 0.11.0
Using erubi 1.13.1
Using httpclient 2.8.3
Using little-plugger 1.1.4
Using multi_json 1.17.0
Using chef-utils 18.9.0 from source at `chef-utils`
Using structured_warnings 0.4.0
Using ed25519 1.3.0
Using win32-api 1.10.1 (universal-mingw32)
Using hashdiff 1.1.1
Using rb-readline 0.5.5
Using openssl 3.3.0
Using addressable 2.8.7
Using ffi-win32-extensions 1.0.4
Using win32-process 0.10.0
Using aws-sigv4 1.11.0
Using binding_of_caller 1.0.1
Using mixlib-log 3.1.2.1
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.3
Using gssapi 1.3.1
Using nori 2.7.0
Using rubyntlm 0.6.5
Using win32-ipc 0.7.0
Using win32-eventlog 0.6.3
Using win32-mmap 0.4.2
Using mixlib-config 3.0.27
Using ffi-yajl 2.6.0
Using rackup 2.2.1
Using parser 3.3.9.0
Using chef-gyoku 1.4.1
Using crack 0.4.5
Using net-http 0.6.0
Using pastel 0.8.0
Using strings 0.2.1
Using tty-reader 0.9.0
Using pry 0.13.0
Using rspec-core 3.13.5
Using rspec-expectations 3.13.5
Using rspec-mocks 3.13.5
Using net-scp 4.1.0
Using net-protocol 0.2.2
Using time 0.4.1
Using net-sftp 4.0.0
Using fauxhai-ng 9.3.0
Using http-cookie 1.0.8
Using mime-types 3.6.0
Using logging 2.4.0
Using win32-taskscheduler 2.0.4
Using aws-sdk-core 3.218.1
Using vault 0.18.2
Using win32-service 2.3.2
Using mixlib-archive 1.3.3
Using win32-event 0.6.3
Using win32-mutex 0.4.3
Using chef-powershell 18.6.6
Using chef-zero 15.1.0
Using faraday-net_http 3.4.1
Using tty-box 0.7.0
Using rubocop-ast 1.47.1
Using tty-prompt 0.23.1
Using tty-table 0.12.0
Using pry-byebug 3.10.1
Using pry-stack_explorer 0.6.1
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@3e962d5)
Using webmock 3.25.0
Using rspec 3.13.1
Using rspec-its 2.0.0
Using net-ftp 0.3.8
Using aws-sdk-kms 1.98.0
Using aws-sdk-secretsmanager 1.112.0
Using chef-winrm 2.3.11
Using faraday 2.14.0
Using win32-certstore 0.6.16
Using rubocop 1.25.1
Using license-acceptance 2.1.13
Using aws-sdk-s3 1.180.0
Using chef-winrm-fs 1.3.7
Using faraday-follow_redirects 0.4.0
Using chefstyle 2.2.3
Using cookstyle 7.32.8
Using chef-winrm-elevated 1.2.5
Using train-winrm 0.2.17
Using mixlib-shellout 3.3.9 (x64-mingw-ucrt)
Using cheffish 17.1.8
Using chef-config 18.9.0 from source at `chef-config`
Using appbundler 0.13.4
Using train-core 3.13.4
Using chef-telemetry 1.1.1
Using ohai 18.2.13 (was 18.2.8) from https://github.com/chef/ohai.git (at 18-stable@6dac7dc)
Using inspec-core 5.23.6
Using inspec-core-bin 5.23.6
Using train-rest 0.5.0
Using chef 18.9.0 (universal-mingw-ucrt) from source at `.`
Using chef-bin 18.9.0 from source at `chef-bin` and installing its executables
Bundle updated!

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
