### PR TITLE
Disable testing 'HEAD' as a tag name

### DIFF
--- a/spec/functional/resource/git_spec.rb
+++ b/spec/functional/resource/git_spec.rb
@@ -261,11 +261,9 @@ describe Chef::Resource::Git do
     end
   end
 
-  context "when dealing with a repo with a degenerate tag named 'HEAD'" do
+  context "when dealing with a repo with a degenerate tag named 'HEAD'", not_supported_on_windows: true, git_no_tag_head: true do
     before do
-      unless ChefUtils.windows?
-        shell_out!("git", "tag", "-m \"degenerate tag\"", "HEAD", "ed181b3419b6f489bedab282348162a110d6d3a1", cwd: origin_repo)
-      end
+      shell_out!("git", "tag", "-m \"degenerate tag\"", "HEAD", "ed181b3419b6f489bedab282348162a110d6d3a1", cwd: origin_repo)
     end
 
     it "checks out the (master) HEAD revision and ignores the tag" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -145,6 +145,7 @@ RSpec.configure do |config|
   # config.filter_run_excluding :fips_mode if windows?
 
   config.filter_run_excluding windows_only: true unless windows?
+  config.filter_run_excluding git_no_tag_head: true if git_version_ge?("2.48.0")
   config.filter_run_excluding not_supported_on_windows: true if windows?
   config.filter_run_excluding not_supported_on_windows_11: true if windows_11?
   config.filter_run_excluding not_supported_on_macos: true if macos?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -288,3 +288,18 @@ def hab_test?
 
   @hab_test = ENV["HAB_TEST"] =~ /true/i ? true : false
 end
+
+def git_version_ge?(version)
+  result = ShellHelpers.shell_out("git --version")
+  return false unless result.exitstatus == 0
+
+  # Parse version from output like "git version 2.32.0"
+  match = result.stdout.match(/git version (\d+\.\d+\.\d+)/)
+  return false unless match
+
+  current_version = Gem::Version.new(match[1])
+  required_version = Gem::Version.new(version)
+  current_version >= required_version
+rescue
+  false
+end


### PR DESCRIPTION
Fix Git functional test for systems with newer Git versions

## Description

Fixed failing Git functional test on our Amazon Linux 2023 builder and other systems with newer Git versions >= 2.48.0 by skipping the test on systems with git >= 2.48.0 and on Windows. Trying to modify the HEAD tag on these systems will already trigger an error.

The test was attempting to create a Git tag named `HEAD` to verify that Chef's Git resource correctly handles edge cases where a tag name might conflict with a special reference. However, newer versions of Git (as found on Amazon Linux 2023) no longer allow creating tags with reserved names like `HEAD`, causing the test to fail with:

```sh

1) Chef::Resource::Git when dealing with a repo with a degenerate tag named 'HEAD' checks out the (master) HEAD revision and ignores the tag
--
Failure/Error: shell_out!("git", "tag", "-m \"degenerate tag\"", "HEAD", "ed181b3419b6f489bedab282348162a110d6d3a1", cwd: origin_repo)
 
Mixlib::ShellOut::ShellCommandFailed:
Expected process to exit with [0], but received '128'
---- Begin output of ["git", "tag", "-m \"degenerate tag\"", "HEAD", "ed181b3419b6f489bedab282348162a110d6d3a1"] ----
STDOUT:
STDERR: fatal: 'HEAD' is not a valid tag name.
---- End output of ["git", "tag", "-m \"degenerate tag\"", "HEAD", "ed181b3419b6f489bedab282348162a110d6d3a1"] ----
Ran ["git", "tag", "-m \"degenerate tag\"", "HEAD", "ed181b3419b6f489bedab282348162a110d6d3a1"] returned 128

```

## Related Issue

Fixes test failures on Amazon Linux 2023 CI builds.

Test originally added on [Support annotated tags in the git provider](https://github.com/chef/chef/commit/8093045e9ce178bd82773ab3659787f48cfc0172)

[git tag HEAD rejected](https://github.com/git/git/commit/bbd445d5efd415d43ac6102a3e9541b9ac4f0329) commit

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
