### PR TITLE
Hold ffi-yajl for external tests

### DIFF
--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -22,7 +22,7 @@ build_dir = Dir.pwd
 env = {
   "GEMFILE_MOD" => "gem 'chef', path: '#{build_dir}'; " \
     "gem 'ohai', git: 'https://github.com/chef/ohai.git', branch: 'main'; " \
-    "gem 'ffi-yajl', '2.6.0'",
+    "gem 'ffi-yajl', '2.6.0'", # hold ffi-yajl back until chef/chef Gemfile.lock is upgraded to 2.7.5 or later
   "CHEF_LICENSE" => "accept-no-persist",
 }
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Due to hab package conflicts and significant changes in ffi-yajl between 2.6.0 and 2.7.5, we need to hold ffi-yajl back in the chef Gemfile.lock. Unfortunately, that also means that `run_external_test` needs a hint about the ffi-yajl as well.

Log of the failure:
```

Scenario: Searching for a cookbook by partial name  # features/commands/search.feature:9
--
STDERR: failed to load the ffi-yajl c-extension, falling back to ffi interface
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<Chef::Exceptions::InvalidCookbookVersion: '1' does not match 'x.y.z' or 'x.y'>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /tmp/chef-external-test20260106-16282-5ahyvc/spec/unit/berkshelf/validator_spec.rb:27:in 'block (3 levels) in <top (required)>'.
/root/.rbenv/versions/3.4.2/bin/ruby -S bundle exec cucumber
failed to load the ffi-yajl c-extension, falling back to ffi interface
rake aborted!
SignalException: SIGTERM (SignalException)
/root/.rbenv/versions/3.4.2/bin/bundle:25:in 'Kernel#load'
/root/.rbenv/versions/3.4.2/bin/bundle:25:in '<main>'
Tasks: TOP => default => features
(See full trace by running task with --trace)
---- End output of bundle exec rake ----
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
