### PR TITLE
bump ffi-yajl to 2.7.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,8 +286,12 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
-    ffi-yajl (2.6.0)
-      libyajl2 (>= 1.2)
+    ffi-yajl (2.7.6)
+      libyajl2 (>= 2.1)
+      yajl
+    ffi-yajl (2.7.6-universal-mingw-ucrt)
+      libyajl2 (>= 2.1)
+      yajl
     fuzzyurl (0.9.0)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
@@ -540,6 +544,7 @@ GEM
       structured_warnings
     wisper (2.0.1)
     wmi-lite (1.0.7)
+    yajl (0.3.4)
 
 PLATFORMS
   arm64-darwin-21


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Bump of `ffi-yajl` gem to get rid of deprecation warnings fixed with [`warning: undefining the allocator of T_DATA class FFI_Yajl::Ext::Encoder::YajlGen`](https://github.com/chef/ffi-yajl/issues/123) 

```sh
❯ bundle update --conservative ffi-yajl
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Resolving dependencies...
Fetching ffi-yajl 2.7.6 (was 2.6.0)
Installing ffi-yajl 2.7.6 (was 2.6.0) with native extensions
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
