### PR TITLE
[Chef18] Raise FileTypeMismatch when directory :create encounters a file

### DIFF
--- a/lib/chef/provider/directory.rb
+++ b/lib/chef/provider/directory.rb
@@ -66,6 +66,17 @@ class Chef
         end
 
         requirements.assert(:create) do |a|
+          a.assertion do
+            if ::File.exist?(new_resource.path)
+              ::File.directory?(new_resource.path)
+            else
+              true
+            end
+          end
+          a.failure_message(Chef::Exceptions::FileTypeMismatch, "Cannot create #{new_resource} at #{new_resource.path} because a file already exists at that path")
+        end
+
+        requirements.assert(:create) do |a|
           parent_directory = ::File.dirname(new_resource.path)
           a.assertion do
             if new_resource.recursive

--- a/spec/unit/provider/directory_spec.rb
+++ b/spec/unit/provider/directory_spec.rb
@@ -201,6 +201,17 @@ describe Chef::Provider::Directory do
       end
     end
 
+    describe "when a file exists at the directory path" do
+      before do
+        FileUtils.rmdir tmp_dir
+        FileUtils.touch tmp_dir
+      end
+
+      it "raises an exception" do
+        expect { directory.run_action(:create) }.to raise_error(Chef::Exceptions::FileTypeMismatch)
+      end
+    end
+
     describe "on macOS" do
       before do
         allow(ChefUtils).to receive(:macos?).and_return(true)


### PR DESCRIPTION
When the directory resource's :create action is run and a file (not a directory) already exists at the specified path, raise a Chef::Exceptions::FileTypeMismatch exception instead of silently proceeding.

This is consistent with the :delete action which already raises an exception when encountering a file at the directory path.

This could fail runs that previously succeeded, but would make the `directory` resource more correct.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
