### PR TITLE
[Chef-18] Fix kitchen test homebrew_package failure on post-install hook by

### DIFF
--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -198,7 +198,7 @@ class Chef
           # the package provider can magically handle that
           shell_out_cmd = options[:allow_failure] ? :shell_out : :shell_out!
 
-          output = send(shell_out_cmd, homebrew_bin_path, *command, user: homebrew_uid, login: true, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
+          output = send(shell_out_cmd, homebrew_bin_path, *command, user: homebrew_uid, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
           output.stdout.chomp
         end
       end


### PR DESCRIPTION
removing login: true from the shell out cmd (added in #14544)

<!--- Provide a short summary of your changes in the Title above -->

## Description
Attempt to fix homebrew issue with kitchen-tests that manifests on the post-install:

```
Warning: The post-install step did not complete successfully
---- End output of ["/opt/homebrew/bin/brew", "install", "dos2unix"] ----
Ran ["/opt/homebrew/bin/brew", "install", "dos2unix"] returned 1
/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/mixlib-shellout-3.3.9/lib/mixlib/shellout.rb:304:in `invalid!'
/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/mixlib-shellout-3.3.9/lib/mixlib/shellout.rb:291:in `error!'
/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/mixlib-shellout-3.3.9/lib/mixlib/shellout/helper.rb:130:in `shell_out_compacted!'
/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/mixlib-shellout-3.3.9/lib/mixlib/shellout/helper.rb:54:in `shell_out!'
/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.139/lib/chef/provider/package/homebrew.rb:201:in `brew_cmd_output'
/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.139/lib/chef/provider/package/homebrew.rb:66:in `install_package'
/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.139/lib/chef/provider/package.rb:120:in `block (3 levels) in <class:Package>'
/opt/chef/embedded/lib/ruby/gems/3.1.0/gems/chef-19.1.139/lib/chef/provider/package.rb:267:in `multipackage_api_adapter'
```

Upon debugging the shell out commands and results, the following symptoms were found:
* In kitchen-tests: `/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.8/bin/ruby: no -I allowed while running setgid (SecurityError)`
* And locally, `<Mixlib::ShellOut#7000: command: '["/opt/homebrew/bin/brew", "info", "--json=v1", "dos2unix"]' process_status: #<Process::Status: pid 25604 exit 1> stdout: '' stderr: '/Users/powell/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/mixlib-shellout-3.3.9/lib/mixlib/shellout/unix.rb:162:in `groups=': Operation not permitted (Errno::EPERM)`

## Related Issue
[Homebrew package resource fails postinstall tasks with `setgid (SecurityError)`](https://github.com/chef/chef/issues/14885) which points to [Fix issues with multiple homebrew binaries](https://github.com/chef/chef/pull/14544)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
