### PR TITLE
Clean up prompt_n deprecation warnings on newer ruby

### DIFF
--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -144,7 +144,7 @@ module Shell
       # remove this clause for any Chef version that has upgraded to ruby >= 3.3.0
       if RUBY_VERSION >= "3.3.0"
         conf.prompt_c       = "#{ChefUtils::Dist::Infra::EXEC}#{leader(m)} > "
-        conf.prompt_n       = "#{ChefUtils::Dist::Infra::EXEC}#{leader(m)} ?> "
+        # prompt_n deprecation warnings as of 3.4.x
         conf.prompt_s       = "#{ChefUtils::Dist::Infra::EXEC}#{leader(m)}%l> "
       else
         # there's a bug if you use a left arrow and the alternative prompts

--- a/spec/unit/shell_spec.rb
+++ b/spec/unit/shell_spec.rb
@@ -67,7 +67,6 @@ describe Shell do
       Shell.irb_conf[:IRB_RC].call(conf)
       if RUBY_VERSION >= "3.3.0"
         expect(conf.prompt_c).to      eq("chef > ")
-        expect(conf.prompt_n).to      eq("chef ?> ")
         expect(conf.prompt_s).to      eq("chef%l> ")
       else
         expect(conf.prompt_c).to      eq("chef (#{Chef::VERSION})> ")
@@ -88,7 +87,6 @@ describe Shell do
       Shell.irb_conf[:IRB_RC].call(conf)
       if RUBY_VERSION >= "3.3.0"
         expect(conf.prompt_c).to eq("chef:recipe > ")
-        expect(conf.prompt_n).to eq("chef:recipe ?> ")
         expect(conf.prompt_s).to eq("chef:recipe%l> ")
       else
         expect(conf.prompt_c).to eq("chef:recipe (#{Chef::VERSION})> ")
@@ -108,7 +106,6 @@ describe Shell do
 
       if RUBY_VERSION >= "3.3.0"
         expect(conf.prompt_c).to eq("chef:attributes > ")
-        expect(conf.prompt_n).to eq("chef:attributes ?> ")
         expect(conf.prompt_s).to eq("chef:attributes%l> ")
       else
         expect(conf.prompt_c).to eq("chef:attributes (#{Chef::VERSION})> ")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Suppress 
`IRB::Context#prompt_n= is deprecated and will be removed in the next major release.`

in >= 3.3.0

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
