### PR TITLE
Add repl_type_completor due to deprecation warnings with the default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ group(:omnibus_package) do
   gem "chef-vault"
 end
 
+gem "repl_type_completor", "~> 0.1.12" # deprecation warnings in chef-shell
+
 group(:omnibus_package, :pry) do
   # Locked because pry-byebug is broken with 13+.
   # some work is ongoing? https://github.com/deivid-rodriguez/pry-byebug/issues/343

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,7 +419,12 @@ GEM
     rainbow (3.1.1)
     rake (13.3.1)
     rb-readline (0.5.5)
+    rbs (3.10.2)
+      logger
     regexp_parser (2.11.3)
+    repl_type_completor (0.1.12)
+      prism (~> 1.0)
+      rbs (>= 2.7.0, < 4.0.0)
     rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -573,6 +578,7 @@ DEPENDENCIES
   pry-stack_explorer
   rake (>= 12.3.3)
   rb-readline
+  repl_type_completor (~> 0.1.12)
   rest-client!
   rspec
   webmock


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Prevent the following deprecation warning
```
(irb):14:in 'block in Kernel#TypeName':   11: C:/hab/pkgs/core/ruby3_4-plus-devkit/3.4.8/20260114093730/lib/ruby/gems/3.4.0/gems/repl_type_completor-0.1.9/lib/repl_type_completor/type_analyzer.rb:61:in 'block in ReplTypeCompletor::TypeAnalyzer#evaluate_statements_node' (StructuredWarnings::StandardWarning)
```

```
❯ bundle install
Bundler 2.6.9 is running, but your lockfile was generated with 2.5.23. Installing Bundler 2.5.23 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.5.23
Installing bundler 2.5.23
Fetching https://github.com/chef/rest-client
Fetching https://github.com/chef/cheffish.git
Fetching https://github.com/chef/ohai.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Fetching rake 13.3.1
Installing rake 13.3.1
Fetching public_suffix 7.0.0
Fetching mixlib-cli 2.1.8
Fetching concurrent-ruby 1.3.6
Fetching ast 2.4.3
Fetching aws-eventstream 1.4.0
Fetching aws-partitions 1.1188.0
Fetching base64 0.3.0
Fetching bigdecimal 3.3.1
Fetching jmespath 1.6.2
Fetching logger 1.7.0
Installing public_suffix 7.0.0
Fetching bcrypt_pbkdf 1.1.2
Installing mixlib-cli 2.1.8
Fetching benchmark 0.5.0
Installing concurrent-ruby 1.3.6
Installing ast 2.4.3
Fetching debug_inspector 1.2.0
Installing aws-eventstream 1.4.0
Fetching builder 3.3.0
Fetching byebug 12.0.0
Installing aws-partitions 1.1188.0
Fetching fuzzyurl 0.9.0
Installing base64 0.3.0
Fetching tomlrb 1.3.0
Installing fuzzyurl 0.9.0
Fetching uri 1.0.4
Installing jmespath 1.6.2
Installing logger 1.7.0
Fetching json 2.18.0
Fetching ffi 1.17.3 (arm64-darwin)
Installing bcrypt_pbkdf 1.1.2 with native extensions
Installing benchmark 0.5.0
Installing debug_inspector 1.2.0 with native extensions
Fetching ostruct 0.6.3
Installing builder 3.3.0
Installing bigdecimal 3.3.1 with native extensions
Installing byebug 12.0.0 with native extensions
Installing tomlrb 1.3.0
Fetching pstore 0.1.4
Fetching tty-color 0.6.0
Installing uri 1.0.4
Installing json 2.18.0 with native extensions
Fetching tty-cursor 0.7.1
Installing ostruct 0.6.3
Installing ffi 1.17.3 (arm64-darwin)
Installing tty-color 0.6.0
Installing pstore 0.1.4
Fetching tty-screen 0.8.2
Fetching wisper 2.0.1
Installing tty-cursor 0.7.1
Installing tty-screen 0.8.2
Fetching libyajl2 2.1.0
Fetching yajl 0.3.4
Fetching hashie 5.0.0
Installing wisper 2.0.1
Fetching rack 3.2.4
Installing libyajl2 2.1.0 with native extensions
Fetching unf_ext 0.0.9.1
Installing yajl 0.3.4
Fetching uuidtools 2.2.0
Installing hashie 5.0.0
Fetching webrick 1.9.2
Installing rack 3.2.4
Fetching csv 3.3.5
Installing unf_ext 0.0.9.1 with native extensions
Installing uuidtools 2.2.0
Fetching diff-lcs 1.6.2
Installing webrick 1.9.2
Installing csv 3.3.5
Fetching ed25519 1.4.0
Fetching erubis 2.7.0
Installing diff-lcs 1.6.2
Installing ed25519 1.4.0 with native extensions
Fetching iniparse 1.5.0
Installing erubis 2.7.0
Installing iniparse 1.5.0
Fetching language_server-protocol 3.17.0.5
Installing language_server-protocol 3.17.0.5
Fetching lint_roller 1.1.0
Fetching parallel 1.27.0
Fetching rainbow 3.1.1
Fetching regexp_parser 2.11.3
Installing lint_roller 1.1.0
Fetching prism 1.6.0
Fetching ruby-progressbar 1.13.0
Installing parallel 1.27.0
Fetching unicode-display_width 2.6.0
Fetching strings-ansi 0.2.0
Installing rainbow 3.1.1
Fetching unicode_utils 1.4.0
Installing regexp_parser 2.11.3
Fetching method_source 1.1.0
Installing prism 1.6.0 with native extensions
Installing ruby-progressbar 1.13.0
Fetching multipart-post 2.4.1
Installing unicode-display_width 2.6.0
Installing strings-ansi 0.2.0
Fetching parslet 2.0.0
Fetching coderay 1.1.3
Installing unicode_utils 1.4.0
Installing method_source 1.1.0
Installing multipart-post 2.4.1
Fetching rspec-support 3.13.6
Fetching rubyzip 2.4.1
Installing parslet 2.0.0
Fetching semverse 3.0.2
Installing coderay 1.1.3
Installing rspec-support 3.13.6
Installing rubyzip 2.4.1
Fetching sslshake 1.3.1
Installing semverse 3.0.2
Fetching thor 1.4.0
Fetching net-ssh 7.3.0
Installing sslshake 1.3.1
Fetching mixlib-authentication 3.0.10
Fetching timeout 0.4.4
Fetching date 3.5.0
Installing thor 1.4.0
Installing net-ssh 7.3.0
Installing mixlib-authentication 3.0.10
Fetching ipaddress 0.8.3
Fetching plist 3.7.2
Installing timeout 0.4.4
Fetching wmi-lite 1.0.7
Installing date 3.5.0 with native extensions
Installing ipaddress 0.8.3
Fetching proxifier2 1.1.0
Installing plist 3.7.2
Fetching syslog-logger 1.6.8
Fetching http-accept 2.1.1
Installing wmi-lite 1.0.7
Installing proxifier2 1.1.0
Fetching domain_name 0.6.20240107
Fetching mime-types-data 3.2025.0924
Installing syslog-logger 1.6.8
Fetching netrc 0.11.0
Installing http-accept 2.1.1
Fetching erubi 1.13.1
Installing domain_name 0.6.20240107
Fetching little-plugger 1.1.4
Fetching multi_json 1.17.0
Installing mime-types-data 3.2025.0924
Fetching socksify 1.8.1
Installing netrc 0.11.0
Fetching chef-ruby-shadow 3.0.0
Installing erubi 1.13.1
Fetching hashdiff 1.2.1
Installing little-plugger 1.1.4
Fetching rb-readline 0.5.5
Installing multi_json 1.17.0
Installing socksify 1.8.1
Fetching addressable 2.8.8
Fetching aws-sigv4 1.12.1
Installing chef-ruby-shadow 3.0.0 with native extensions
Installing hashdiff 1.2.1
Installing rb-readline 0.5.5
Installing addressable 2.8.8
Installing aws-sigv4 1.12.1
Fetching rubyntlm 0.6.5
Fetching parser 3.3.10.0
Fetching syslog 0.3.0
Fetching rbs 3.10.2
Installing rubyntlm 0.6.5
Fetching mixlib-config 3.0.27
Installing syslog 0.3.0 with native extensions
Installing parser 3.3.10.0
Installing mixlib-config 3.0.27
Fetching net-http 0.8.0
Installing rbs 3.10.2 with native extensions
Installing net-http 0.8.0
Fetching pastel 0.8.0
Fetching tty-spinner 0.9.3
Installing pastel 0.8.0
Installing tty-spinner 0.9.3
Fetching tty-reader 0.9.0
Fetching mixlib-log 3.2.3
Installing tty-reader 0.9.0
Installing mixlib-log 3.2.3
Fetching corefoundation 0.3.13
Fetching ffi-libarchive 1.1.14
Installing corefoundation 0.3.13
Fetching gssapi 1.3.1
Installing ffi-libarchive 1.1.14
Fetching rackup 2.2.1
Installing gssapi 1.3.1
Installing rackup 2.2.1
Fetching binding_of_caller 1.0.1
Fetching ffi-yajl 2.7.6
Installing binding_of_caller 1.0.1
Fetching strings 0.2.1
Installing ffi-yajl 2.7.6 with native extensions
Installing strings 0.2.1
Fetching rspec-core 3.13.6
Installing rspec-core 3.13.6
Fetching rspec-expectations 3.13.5
Fetching rspec-mocks 3.13.7
Installing rspec-expectations 3.13.5
Fetching pry 0.15.2
Fetching net-protocol 0.2.2
Installing rspec-mocks 3.13.7
Fetching net-scp 4.1.0
Installing pry 0.15.2
Installing net-protocol 0.2.2
Fetching net-sftp 4.0.0
Fetching fauxhai-ng 9.3.0
Installing net-scp 4.1.0
Installing net-sftp 4.0.0
Fetching chef-gyoku 1.5.0
Fetching httpclient 2.9.0
Installing fauxhai-ng 9.3.0
Installing chef-gyoku 1.5.0
Fetching http-cookie 1.1.0
Fetching mime-types 3.7.0
Fetching logging 2.4.0
Installing http-cookie 1.1.0
Installing httpclient 2.9.0
Installing mime-types 3.7.0
Fetching mixlib-shellout 3.3.9
Fetching vault 0.18.2
Installing logging 2.4.0
Fetching faraday-net_http 3.4.2
Installing mixlib-shellout 3.3.9
Fetching tty-prompt 0.23.1
Fetching mixlib-archive 1.3.3
Installing vault 0.18.2
Installing faraday-net_http 3.4.2
Fetching tty-box 0.7.0
Fetching tty-table 0.12.0
Fetching aws-sdk-core 3.239.2
Fetching nori 2.7.0
Fetching crack 1.0.1
Installing tty-prompt 0.23.1
Fetching rspec-its 2.0.0
Installing mixlib-archive 1.3.3
Fetching rspec 3.13.2
Installing tty-box 0.7.0
Fetching pry-byebug 3.11.0
Installing tty-table 0.12.0
Fetching pry-stack_explorer 0.6.1
Installing aws-sdk-core 3.239.2
Installing nori 2.7.0
Installing crack 1.0.1
Fetching time 0.4.1
Fetching chef-vault 4.2.5
Installing rspec-its 2.0.0
Installing rspec 3.13.2
Fetching appbundler 0.13.4
Fetching train-core 3.14.1
Installing pry-byebug 3.11.0
Installing pry-stack_explorer 0.6.1
Fetching faraday 2.14.0
Fetching license-acceptance 2.1.13
Installing time 0.4.1
Fetching chef-winrm 2.4.4
Fetching webmock 3.26.1
Installing chef-vault 4.2.5
Installing appbundler 0.13.4
Fetching chef-telemetry 1.1.1
Fetching net-ftp 0.3.9
Installing train-core 3.14.1
Fetching aws-sdk-kms 1.118.0
Installing faraday 2.14.0
Installing license-acceptance 2.1.13
Fetching aws-sdk-secretsmanager 1.124.0
Installing chef-winrm 2.4.4
Fetching train-rest 0.5.0
Installing webmock 3.26.1
Installing chef-telemetry 1.1.1
Fetching faraday-http-cache 2.5.1
Fetching faraday-follow_redirects 0.3.0
Installing net-ftp 0.3.9
Fetching chef-winrm-fs 1.4.2
Installing aws-sdk-kms 1.118.0
Installing aws-sdk-secretsmanager 1.124.0
Fetching aws-sdk-s3 1.205.0
Installing train-rest 0.5.0
Installing faraday-http-cache 2.5.1
Fetching chef-licensing 1.3.4
Installing faraday-follow_redirects 0.3.0
Installing chef-winrm-fs 1.4.2
Fetching chef-winrm-elevated 1.2.5
Installing aws-sdk-s3 1.205.0
Installing chef-licensing 1.3.4
Installing chef-winrm-elevated 1.2.5
Fetching train-winrm 0.4.0
Installing train-winrm 0.4.0
Fetching chef-zero 15.1.0
Installing chef-zero 15.1.0
Fetching rubocop-ast 1.48.0
Fetching repl_type_completor 0.1.12
Installing rubocop-ast 1.48.0
Installing repl_type_completor 0.1.12
Fetching rubocop 1.81.6
Installing rubocop 1.81.6
Fetching cookstyle 8.5.2
Installing cookstyle 8.5.2
Fetching inspec-core 7.0.95
Installing inspec-core 7.0.95
Fetching inspec-core-bin 7.0.95
Installing inspec-core-bin 7.0.95
Bundle complete! 24 Gemfile dependencies, 162 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
