### PR TITLE
fix windows runs on adhoc

### DIFF
--- a/.expeditor/scripts/chef_adhoc_build.ps1
+++ b/.expeditor/scripts/chef_adhoc_build.ps1
@@ -31,6 +31,15 @@ hab origin key download $env:HAB_ORIGIN
 hab origin key download $env:HAB_ORIGIN --secret
 if (-not $?) { throw "Unable to download origin key" }
 
+Write-Host "--- :key: Importing origin keys into studio"
+# Import the downloaded keys to make them available in the local studio
+$keyDir = "C:\hab\cache\keys"
+$secretKey = Get-ChildItem "$keyDir\chef-*.sig.key" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$publicKey = Get-ChildItem "$keyDir\chef-*.pub" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if ($secretKey) { Get-Content $secretKey.FullName | hab origin key import }
+if ($publicKey) { Get-Content $publicKey.FullName | hab origin key import }
+if (-not $?) { throw "Unable to import origin keys" }
+
 Write-Host "--- Building Chef Infra Client package"
 hab pkg build . --refresh-channel base-2025
 if (-not $?) { throw "Unable to build package" }


### PR DESCRIPTION
## Description
windows adhoc builds failed validation with 404 errors complaining about missing origin keys. The problem was that habitat's local studio on windows didn't import downloaded keys, causing new key generation on the build step. this made the hart file installation fail in the test stage. this change ensure we import downloaded origin keys into the studio before building.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
