### PR TITLE
Pick up ffi-yajl that correctly loads ext

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,10 +287,10 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
-    ffi-yajl (2.7.6)
+    ffi-yajl (2.7.7)
       libyajl2 (>= 2.1)
       yajl
-    ffi-yajl (2.7.6-universal-mingw-ucrt)
+    ffi-yajl (2.7.7-universal-mingw-ucrt)
       libyajl2 (>= 2.1)
       yajl
     fuzzyurl (0.9.0)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

In version 2.7.6, loading `ffi-yajl` on Windows with `FORCE_FFI_YAJL` env set to `"ext"`  triggers the following error.

```
'Kernel#require': cannot load such file -- ffi_yajl/ext/dlopen (LoadError)
```

Reproduction case:

```powershell
gem install -v 2.7.7
$env:FORCE_FFI_YAJL="ext"
ruby -e "require 'ffi_yajl'; FFI_Yajl::Parser.parse('{_}')"
```

`bundle update`:
```sh
❯ bundle update --conservative ffi-yajl
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Resolving dependencies...
Fetching ffi-yajl 2.7.7 (was 2.7.6)
Installing ffi-yajl 2.7.7 (was 2.7.6) with native extensions
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
