### PR TITLE
Downgrade openssl gem to be consistent with ruby package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?
 
 # required for FIPS or bundler will pick up default openssl
 install_if -> { !Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" } } do
-  gem "openssl", "= 3.3.2"
+  gem "openssl", "= 3.3.1"
 end
 
 if File.exist?(File.expand_path("chef-bin", __dir__))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,7 +389,7 @@ GEM
     netrc (0.11.0)
     nori (2.7.0)
       bigdecimal
-    openssl (3.3.2)
+    openssl (3.3.1)
     ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -572,7 +572,7 @@ DEPENDENCIES
   ffi (>= 1.15.5, < 1.18.0)
   inspec-core-bin (= 7.0.95)
   ohai!
-  openssl (= 3.3.2)
+  openssl (= 3.3.1)
   pry (~> 0.15.2)
   pry-byebug
   pry-stack_explorer


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Prevent `C:/hab/pkgs/core/ruby3_4-plus-devkit/3.4.8/20260114093730/lib/ruby/3.4.0/rubygems/specification.rb:2232:in 'Gem::Specification#check_version_conflict': can't activate openssl-3.3.2, already activated openssl-3.3.1 (Gem::LoadError)`

A `bundle install` was used for manual downgrade so no `bundle update --conservative`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
