### PR TITLE
Removing the Powershell package for now

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -18,7 +18,7 @@ $pkg_deps=@(
   "core/xz"
   "core/libarchive"
   "core/ruby3_4-plus-devkit/3.4.8"
-  # "chef/chef-powershell-shim" - Rmoved for the first Chef-19 release
+  # "chef/chef-powershell-shim" - Removed for the first Chef-19 release
   # "core/visual-cpp-redist-2022" - Removed for the first Chef-19 release because of license issues
 )
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We did not fully integrate the chef-powershell hab package into the build which also added the visual cpp package to make the PowerShell package work. Since we are removing powershell habitat package, we are also removing visual cpp package which also takes care of licensing issues with visual cpp package. 

NOTE: We are removing both temporarily until this can all get resolved. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
