### PR TITLE
Clean up binstub pathing and include default path

### DIFF
--- a/habitat/binstub_patch.bat
+++ b/habitat/binstub_patch.bat
@@ -1,31 +1,71 @@
+@ECHO OFF
+
 REM skip this if hab pkg exec has already done it, APPBUNDLER_ALLOW_RVM will be set if hab pkg exec
 IF NOT DEFINED APPBUNDLER_ALLOW_RVM (
   REM Get the drive letter of the current batch file
   SET "BINSTUB_DRIVE=%~d0"
 
-  REM Prepend vendor path to PATH if it exists
+  REM Prepend vendor path to PATH if it exists (using full path with drive)
   IF EXIST "%~dp0..\vendor" (
-    SET "PATH=%BINSTUB_DRIVE%%~p0..\vendor;%PATH%"
+    SET "PATH=%~dp0..\vendor;%PATH%"
   )
 
   IF EXIST "%~dp0..\RUNTIME_ENVIRONMENT" (
-    FOR /F "usebackq tokens=* delims=" %%A IN ("%~dp0..\RUNTIME_ENVIRONMENT") DO (
-      SET "line=%%A"
-      REM Skip empty lines and comments
-      IF NOT "!line!"=="" (
-        IF NOT "!line:~0,1!"=="#" (
-          REM Check if this is a PATH variable assignment
-          SET "var=%%A"
-          IF "!var:~0,5!"=="PATH=" (
-            REM Extract the PATH value and prepend drive letter
-            SET "pathval=!var:~5!"
-            SET "PATH=%BINSTUB_DRIVE%!pathval!;%PATH%"
+    REM Process each line from RUNTIME_ENVIRONMENT
+    FOR /F "usebackq tokens=1* delims==" %%A IN ("%~dp0..\RUNTIME_ENVIRONMENT") DO (
+      REM Skip comments (lines starting with #)
+      SET "varname=%%A"
+      SET "firstchar=%%A"
+      SET "firstchar=!firstchar:~0,1!"
+      IF NOT "!firstchar!"=="#" (
+        SET "varvalue=%%B"
+        IF NOT "!varvalue!"=="" (
+          REM Check if this is PATH
+          IF /I "%%A"=="PATH" (
+            REM Process PATH value - add drive letter to paths starting with backslash
+            CALL :ProcessPath "%%B"
           ) ELSE (
-            REM For other variables, prepend drive letter if it's a path-like value
-            SET "%%A"
+            REM For other variables, add drive letter if starts with backslash
+            SET "testchar=%%B"
+            SET "testchar=!testchar:~0,1!"
+            IF "!testchar!"=="\" (
+              SET "%%A=%BINSTUB_DRIVE%%%B"
+            ) ELSE (
+              SET "%%A=%%B"
+            )
           )
         )
       )
     )
   )
+
+  SET "APPBUNDLER_ALLOW_RVM=true"
 )
+
+REM Continue to the rest of the script (this file is patched into other batch files)
+GOTO :SkipBinstubFunctions
+
+:ProcessPath
+SET "origpath=%~1"
+SET "newpath="
+:pathloop
+FOR /F "tokens=1* delims=;" %%X IN ("%origpath%") DO (
+  SET "segment=%%X"
+  SET "testchar=%%X"
+  SET "testchar=!testchar:~0,1!"
+  IF "!testchar!"=="\" (
+    SET "segment=%BINSTUB_DRIVE%%%X"
+  )
+  IF "%newpath%"=="" (
+    SET "newpath=!segment!"
+  ) ELSE (
+    SET "newpath=!newpath!;!segment!"
+  )
+  SET "origpath=%%Y"
+  IF NOT "%%Y"=="" GOTO pathloop
+)
+SET "PATH=%newpath%;%PATH%"
+GOTO :EOF
+
+:SkipBinstubFunctions
+REM Binstub functions defined above, continue with the rest of the script

--- a/habitat/binstub_patch.bat
+++ b/habitat/binstub_patch.bat
@@ -1,12 +1,29 @@
 REM skip this if hab pkg exec has already done it, APPBUNDLER_ALLOW_RVM will be set if hab pkg exec
 IF NOT DEFINED APPBUNDLER_ALLOW_RVM (
+  REM Get the drive letter of the current batch file
+  SET "BINSTUB_DRIVE=%~d0"
+
+  REM Prepend vendor path to PATH if it exists
+  IF EXIST "%~dp0..\vendor" (
+    SET "PATH=%BINSTUB_DRIVE%%~p0..\vendor;%PATH%"
+  )
+
   IF EXIST "%~dp0..\RUNTIME_ENVIRONMENT" (
     FOR /F "usebackq tokens=* delims=" %%A IN ("%~dp0..\RUNTIME_ENVIRONMENT") DO (
       SET "line=%%A"
       REM Skip empty lines and comments
       IF NOT "!line!"=="" (
         IF NOT "!line:~0,1!"=="#" (
-          SET "%%A"
+          REM Check if this is a PATH variable assignment
+          SET "var=%%A"
+          IF "!var:~0,5!"=="PATH=" (
+            REM Extract the PATH value and prepend drive letter
+            SET "pathval=!var:~5!"
+            SET "PATH=%BINSTUB_DRIVE%!pathval!;%PATH%"
+          ) ELSE (
+            REM For other variables, prepend drive letter if it's a path-like value
+            SET "%%A"
+          )
         )
       )
     )

--- a/habitat/binstub_patch.bat
+++ b/habitat/binstub_patch.bat
@@ -62,7 +62,7 @@ FOR /F "tokens=1* delims=;" %%X IN ("%origpath%") DO (
     SET "newpath=!newpath!;!segment!"
   )
   SET "origpath=%%Y"
-  IF NOT "%%Y"=="" GOTO pathloop
+  IF NOT "%%Y"=="" GOTO :pathloop
 )
 SET "PATH=%newpath%;%PATH%"
 GOTO :EOF


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Include explicit drive letter and include the original path for binstubbing.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
