### PR TITLE
Add licensing check when chef gem when it is required

### DIFF
--- a/lib/chef.rb
+++ b/lib/chef.rb
@@ -34,3 +34,15 @@ require_relative "chef/event_dispatch/dsl"
 require_relative "chef/chef_class"
 
 require_relative "chef/target_io"
+
+require_relative "chef/licensing"
+require_relative "chef/context"
+
+if ChefUtils::Dist::Infra::EXEC == "chef"
+  # Switch to workstation entitlement if running in Test Kitchen context
+  Chef::Context.switch_to_workstation_entitlement if Chef::Context.test_kitchen_context?
+
+  # Fetch and persist license when Chef is loaded as a library
+  # This ensures licensing is checked even when not using Chef::Application
+  Chef::Licensing.fetch_and_persist
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
When someone installs chef gem, doing a `require "chef"` should throw license requirement

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
