### PR TITLE
remove lables as those are not supported for build workloads

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -129,10 +129,7 @@ subscriptions:
   # Trigger docker build once habitat/build pipeline completes and packages are available in unstable
   - workload: buildkite_build_passed:{{agent_id}}:habitat/build:*
     actions:
-      - trigger_pipeline:docker/build:
-          ignore_labels:
-            - "Expeditor: Skip Docker Build"
-            - "Expeditor: Skip All"
+      - trigger_pipeline:docker/build
 
   # Automatically promote the Habitat packages from unstable to current upon successful build of habitat/build
   - workload: buildkite_hab_build_group_published:{{agent_id}}:*


### PR DESCRIPTION
## Description

removing labels as the ignore_labels filter only works with pull_request_merged workloads not with buildkite_build workloads

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
