### PR TITLE
remove old net-imap

### DIFF
--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -51,24 +51,21 @@ platforms:
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
   - name: amazonlinux-2023
     driver:
       image: dokken/amazonlinux-2023
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
   - name: debian-12
     driver:
       image: dokken/debian-12
-      pid_one_command:
-        - /bin/systemd
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -y
         - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
@@ -76,8 +73,7 @@ platforms:
   - name: debian-11
     driver:
       image: dokken/debian-11
-      pid_one_command:
-        - /bin/systemd
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -y
         - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
@@ -85,8 +81,7 @@ platforms:
   - name: centos-7
     driver:
       image: dokken/centos-7
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN yum -y install e2fsprogs
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
@@ -96,8 +91,7 @@ platforms:
   - name: almalinux-8
     driver:
       image: dokken/almalinux-8
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
@@ -106,8 +100,7 @@ platforms:
   - name: almalinux-9
     driver:
       image: dokken/almalinux-9
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN mkdir /etc/sysconfig/network-scripts # missing from the alma image
@@ -116,8 +109,7 @@ platforms:
   - name: almalinux-10
     driver:
       image: dokken/almalinux-10
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN mkdir /etc/sysconfig/network-scripts
@@ -126,8 +118,7 @@ platforms:
   - name: rockylinux-8
     driver:
       image: dokken/rockylinux-8
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN mkdir -p /etc/sysconfig/network-scripts
@@ -136,8 +127,7 @@ platforms:
   - name: rockylinux-9
     driver:
       image: dokken/rockylinux-9
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN mkdir -p /etc/sysconfig/network-scripts
@@ -146,8 +136,7 @@ platforms:
   - name: rockylinux-10
     driver:
       image: dokken/rockylinux-10
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN mkdir -p /etc/sysconfig/network-scripts
@@ -156,8 +145,7 @@ platforms:
   - name: oraclelinux-7
     driver:
       image: dokken/oraclelinux-7
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN yum -y install e2fsprogs
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
@@ -168,8 +156,7 @@ platforms:
   - name: oraclelinux-8
     driver:
       image: dokken/oraclelinux-8
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN dnf -y reinstall systemd
@@ -179,8 +166,7 @@ platforms:
   - name: oraclelinux-9
     driver:
       image: dokken/oraclelinux-9
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN dnf -y reinstall systemd
@@ -190,8 +176,7 @@ platforms:
   - name: oraclelinux-10
     driver:
       image: dokken/oraclelinux-10
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN dnf -y install e2fsprogs
         - RUN dnf -y reinstall systemd
@@ -201,8 +186,7 @@ platforms:
   - name: fedora-40
     driver:
       image: dokken/fedora-40
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
         - RUN dnf -y install python3-libdnf python3-dnf
@@ -210,8 +194,7 @@ platforms:
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
         - RUN dnf -y install python3-libdnf python3-dnf
@@ -219,8 +202,7 @@ platforms:
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
-      pid_one_command:
-        - /bin/systemd
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -y
         - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource
@@ -228,8 +210,7 @@ platforms:
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
-      pid_one_command:
-        - /bin/systemd
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -y
         - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
@@ -237,8 +218,7 @@ platforms:
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
-      pid_one_command:
-        - /bin/systemd
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -y
         - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
@@ -246,8 +226,7 @@ platforms:
   - name: ubuntu-24.04
     driver:
       image: dokken/ubuntu-24.04
-      pid_one_command:
-        - /bin/systemd
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -y
         - RUN /usr/bin/apt-get install ifupdown -y # we need this for /etc/network/interfaces & ifconfig resource testing
@@ -255,8 +234,7 @@ platforms:
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command:
-        - /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN /usr/bin/zypper --non-interactive update
         - RUN /usr/bin/zypper --non-interactive install net-tools-deprecated # we need this for /etc/network/interfaces & ifconfig resource testing


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Add code to remove vulnerable versions of `net-imap`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
