### PR TITLE
Pinning Hab package versions

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,3 +1,9 @@
+export HAB_BLDR_CHANNEL="base-2025"
+export HAB_ORIGIN="chef"
+export HAB_REFRESH_CHANNEL="stable"
+export CHEF_LICENSE="accept-silent"
+hab origin key generate chef
+
 _chef_client_ruby="core/ruby31"
 pkg_name="chef-infra-client"
 pkg_origin="chef"
@@ -13,19 +19,29 @@ pkg_build_deps=(
   core/gcc
   core/git
 )
+# After updating a number of packages for chef-19, we have huge list of dependency version conflicts.
+# Below, we explicitly set the habitat packages to use the versions from the chef/chef-infra-client 18.9.4 package.
 pkg_deps=(
-  core/glibc
+  core/acl/2.3.1
+  core/glibc/2.35
+  core/attr/2.5.1
+  core/cacerts/2021.10.26
+  core/coreutils/8.32
+  core/gcc-libs/9.5.0
+  core/grep/3.7
+  core/libcap/2.60
+  core/libffi/3.4.2
+  core/linux-headers/4.20.17
+  core/ncurses/6.2
+  core/readline/8.1
   $_chef_client_ruby
   core/libxml2
   core/libxslt
   core/libiconv
-  core/xz
-  core/zlib
-  core/openssl
-  core/cacerts
-  core/libffi
-  core/coreutils
-  core/libarchive
+  core/xz/5.2.5
+  core/zlib/1.3
+  core/openssl/1.0.2zl
+  core/libarchive/3.8.1/20250728145737
 )
 pkg_svc_user=root
 
@@ -93,7 +109,9 @@ do_prepare() {
 do_build() {
   ( cd "$CACHE_PATH" || exit_with "unable to enter hab-cache directory" 1
     build_line "Installing gem dependencies ..."
-    bundle install --jobs=3 --retry=3
+    export BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
+    export BUNDLE_FORCE_RUBY_PLATFORM=true
+    bundle install --jobs=3 --retry=3 --verbose
     build_line "Installing gems from git repos properly ..."
     ruby ./post-bundle-install.rb
     build_line "Installing this project's gems ..."

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -13,9 +13,9 @@ $pkg_bin_dirs=@(
 )
 $pkg_deps=@(
   "core/cacerts"
-  "core/openssl"
-  "core/libarchive"
-  "core/zlib"
+  "core/openssl/1.1.1w"
+  "core/libarchive/3.7.2"
+  "core/zlib/1.3"
   "chef/ruby31-plus-devkit"
   "chef/chef-powershell-shim"
   "core/visual-cpp-redist-2015/14.0.24215/20240108064521"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We updated a number of habitat packages for Chef-19. That resulted in chef-18 hab builds pulling in all the latest tools and dying immediately because of version conflicts and mismatched openssl, et al. Here we pin the plan files to versions used by the released chef-18 packages to make it clear what version of what app we need.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
