### PR TITLE
Bump ctke to pick up latest kitchen-dokken

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -329,7 +329,7 @@ jobs:
           # kitchen test end-to-end-${{ matrix.os }}
 
           # Run recipe convergence only
-          kitchen converge -l debug end-to-end-${{ matrix.os }}
+          kitchen converge end-to-end-${{ matrix.os }}
           kitchen destroy end-to-end-${{ matrix.os }}
 
 #  vm_lnx_x86_64:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Bump kitchen-chef-enterprise to pick up 

https://github.com/test-kitchen/kitchen-dokken/pull/368 

which should resolve 

```
>>>>>>     Failed to complete #create action: [{"message":"invalid JSON: json: cannot unmarshal string into Go struct field CreateRequest.Config.Cmd of type []string"}
```

Due to GHA runners bumping from Docker Server 28.0.4 to Docker Server 29.1.5


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
