### PR TITLE
Updating Omnibus dependencies, they are super stale

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,10 +18,10 @@ GIT
       chef-utils (>= 15.4)
       contracts (>= 0.16.0, < 0.17.0)
       ffi-yajl (~> 2.2)
-      license_scout (~> 1.3.17)
+      license_scout (~> 1.4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       mixlib-versioning
-      ohai (>= 16, < 19)
+      ohai (>= 18.2.6, < 19)
       pedump
       rexml (~> 3.4)
       ruby-progressbar (~> 1.7)
@@ -30,14 +30,13 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     ast (2.4.2)
-    awesome_print (1.9.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1146.0)
-    aws-sdk-core (3.229.0)
+    aws-partitions (1.1213.0)
+    aws-sdk-core (3.242.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -45,8 +44,8 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.110.0)
-      aws-sdk-core (~> 3, >= 3.228.0)
+    aws-sdk-kms (1.121.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
       aws-sigv4 (~> 1.5)
     aws-sdk-s3 (1.116.0)
       aws-sdk-core (~> 3, >= 3.127.0)
@@ -72,7 +71,7 @@ GEM
       retryable (>= 2.0, < 4.0)
       solve (~> 4.0)
       thor (>= 0.20)
-    bigdecimal (3.2.2)
+    bigdecimal (4.0.1)
     builder (3.3.0)
     chef (18.5.0)
       addressable
@@ -181,7 +180,7 @@ GEM
     citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.6)
     contracts (0.16.1)
     cookstyle (7.32.8)
       rubocop (= 1.25.1)
@@ -206,8 +205,12 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
-    ffi-yajl (2.6.0)
-      libyajl2 (>= 1.2)
+    ffi-yajl (2.7.7)
+      libyajl2 (>= 2.1)
+      yajl
+    ffi-yajl (2.7.7-universal-mingw-ucrt)
+      libyajl2 (>= 2.1)
+      yajl
     fuzzyurl (0.9.0)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
@@ -244,11 +247,11 @@ GEM
       train-core (~> 3.12.13)
       tty-prompt (~> 0.17)
       tty-table (~> 0.10)
-    iostruct (0.5.0)
+    iostruct (0.7.0)
     ipaddress (0.8.3)
     iso8601 (0.13.0)
     jmespath (1.6.2)
-    json (2.13.2)
+    json (2.18.1)
     kitchen-vagrant (2.0.1)
       test-kitchen (>= 1.4, < 4)
     libyajl2 (2.1.0)
@@ -257,7 +260,7 @@ GEM
       tomlrb (>= 1.2, < 3.0)
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
-    license_scout (1.3.18)
+    license_scout (1.4.2)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)
@@ -285,14 +288,9 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.9)
-    mixlib-shellout (3.3.9)
+    mixlib-shellout (3.4.10)
       chef-utils
-    mixlib-shellout (3.3.9-universal-mingw32)
-      chef-utils
-      ffi-win32-extensions (~> 1.0.3)
-      win32-process (~> 0.9)
-      wmi-lite (~> 1.0)
-    mixlib-shellout (3.3.9-x64-mingw-ucrt)
+    mixlib-shellout (3.4.10-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
       win32-process (~> 0.9)
@@ -321,7 +319,7 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    ohai (18.2.6)
+    ohai (18.2.8)
       chef-config (>= 14.12, < 19)
       chef-utils (>= 16.0, < 19)
       ffi (~> 1.9, <= 1.17.0)
@@ -341,11 +339,9 @@ GEM
     parslet (1.8.2)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pedump (0.6.10)
-      awesome_print
-      iostruct (>= 0.0.4)
-      multipart-post (>= 2.0.0)
-      rainbow
+    pedump (0.7.6)
+      iostruct (>= 0.7.0)
+      logger
       zhexdump (>= 0.0.2)
     plist (3.7.2)
     proxifier2 (1.1.0)
@@ -375,7 +371,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retryable (3.0.5)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -527,6 +523,7 @@ GEM
       winrm (~> 2.0)
     wisper (2.0.1)
     wmi-lite (1.0.7)
+    yajl (0.3.4)
     zhexdump (0.3.0)
 
 PLATFORMS


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Omnibus dependencies are super stale. We primarily need to pull in updates for license_scout to pick up changes for the mime_types gem which causes errors in the verify pipeline because support for that gem in license_scout is missing.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
