### PR TITLE
Fix IPv6 crash in proxy no_proxy matching

### DIFF
--- a/chef-config/lib/chef-config/mixin/fuzzy_hostname_matcher.rb
+++ b/chef-config/lib/chef-config/mixin/fuzzy_hostname_matcher.rb
@@ -42,6 +42,11 @@ module ChefConfig
         # Do greedy matching by adding wildcard if it is not specified
         match = "*" + match unless match.start_with?("*")
         Fuzzyurl.matches?(Fuzzyurl.mask(hostname: match), hostname)
+      rescue ArgumentError
+        # Fuzzyurl cannot parse certain URL formats, notably IPv6 addresses
+        # (bare, bracketed, or embedded in URLs). When parsing fails, the URL
+        # cannot match a no_proxy pattern, so return false.
+        false
       end
 
     end

--- a/chef-config/spec/unit/fuzzy_hostname_matcher_spec.rb
+++ b/chef-config/spec/unit/fuzzy_hostname_matcher_spec.rb
@@ -1,0 +1,70 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "spec_helper"
+require "chef-config/mixin/fuzzy_hostname_matcher"
+
+RSpec.describe ChefConfig::Mixin::FuzzyHostnameMatcher do
+  let(:matcher) do
+    Class.new { include ChefConfig::Mixin::FuzzyHostnameMatcher }.new
+  end
+
+  describe "#fuzzy_hostname_match?" do
+    it "matches a hostname with a wildcard pattern" do
+      expect(matcher.fuzzy_hostname_match?("foo.example.com", "example.com")).to be true
+    end
+
+    it "does not match unrelated hostnames" do
+      expect(matcher.fuzzy_hostname_match?("foo.example.com", "other.com")).to be false
+    end
+
+    it "returns false for bare IPv6 addresses instead of raising" do
+      expect(matcher.fuzzy_hostname_match?("2001:db8::1", "example.com")).to be false
+    end
+
+    it "returns false for bracketed IPv6 addresses instead of raising" do
+      expect(matcher.fuzzy_hostname_match?("[2001:db8::1]", "example.com")).to be false
+    end
+
+    it "returns false for IPv6 URLs instead of raising" do
+      expect(matcher.fuzzy_hostname_match?("https://[2001:db8::1]/path", "example.com")).to be false
+    end
+  end
+
+  describe "#fuzzy_hostname_match_any?" do
+    it "returns false when hostname is nil" do
+      expect(matcher.fuzzy_hostname_match_any?(nil, "example.com")).to be false
+    end
+
+    it "returns false when matches is nil" do
+      expect(matcher.fuzzy_hostname_match_any?("foo.example.com", nil)).to be false
+    end
+
+    it "matches against comma-separated patterns" do
+      expect(matcher.fuzzy_hostname_match_any?("foo.example.com", "other.com, example.com")).to be true
+    end
+
+    it "returns false for IPv6 URLs with hostname no_proxy patterns" do
+      ipv6_url = "https://[2001:db8:abcd:ef01::1]/organizations/o3"
+      no_proxy = "gateway.example.net,internal.example.com"
+      expect(matcher.fuzzy_hostname_match_any?(ipv6_url, no_proxy)).to be false
+    end
+
+    it "returns false for bare IPv6 with hostname no_proxy patterns" do
+      expect(matcher.fuzzy_hostname_match_any?("2001:db8::1", "example.com,other.net")).to be false
+    end
+  end
+end


### PR DESCRIPTION
  fuzzyurl 0.9.0 cannot parse IPv6 addresses (bare, bracketed, or in URLs), causing ArgumentError in
  fuzzy_hostname_match? when Chef connects to a server via IPv6 and checks the no_proxy config.

  Add rescue ArgumentError to return false (no proxy match), which is the only correct answer when the URL
  cannot be parsed.

  ## Description

  When Chef connects to a server using an IPv6 address, the `fuzzy_hostname_match?` method raises
  `ArgumentError` because `fuzzyurl` 0.9.0 cannot parse IPv6 in any form (bare, bracketed, or in URLs). This
  crashes Chef during the infra phase before any recipes run.

  The fix adds `rescue ArgumentError` to return `false` — if fuzzyurl can't parse the URL, it can't match a
  `no_proxy` pattern, so "no match" is the only correct answer.

  ## Related Issue

  No existing issue. Discovered in production when connecting to Chef servers via IPv6.

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Chore (non-breaking change that does not add functionality or fix an issue)

  ## Checklist:

  - [x] I have read the **CONTRIBUTING** document.
  - [ ] I have run the pre-merge tests locally and they pass.
  - [ ] I have updated the documentation accordingly.
  - [x] I have added tests to cover my changes.
  - [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in
  the Description above.
  - [x] All new and existing tests passed.
  - [x] All commits have been signed-off for [the Developer Certificate of
  Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
