### PR TITLE
Use selinux_fcontext to fix selinux problems with chef_client_systemd_timer with /hab path

### DIFF
--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -111,6 +111,13 @@ class Chef
         introduced: "18.5"
 
       action :add, description: "Add a systemd timer that runs #{ChefUtils::Dist::Infra::PRODUCT}." do
+        selinux_fcontext "/hab/pkgs/chef/chef-infra-client/.*/bin(/.*)?" do
+          secontext "bin_t"
+          action :manage
+          only_if "which getenforce"
+          only_if { new_resource.chef_binary_path.include?("/hab/") }
+        end
+
         systemd_unit "#{new_resource.job_name}.service" do
           content service_content
           action :create

--- a/spec/unit/resource/chef_client_systemd_timer_spec.rb
+++ b/spec/unit/resource/chef_client_systemd_timer_spec.rb
@@ -112,4 +112,30 @@ describe Chef::Resource::ChefClientSystemdTimer do
       expect(provider.service_content["Service"]["CPUQuota"]).to eq("50%")
     end
   end
+
+  describe "selinux_fcontext for Habitat binary path" do
+    before do
+      allow(provider).to receive(:declare_resource)
+    end
+
+    context "when chef_binary_path is a Habitat path" do
+      it "includes a selinux_fcontext resource in the :add action" do
+        allow(resource).to receive(:chef_binary_path).and_return("/hab/pkgs/chef/chef-infra-client/19.2.7/20250122151044/bin/chef-client")
+        expect(provider).to receive(:declare_resource).with(:selinux_fcontext, "/hab/pkgs/chef/chef-infra-client/.*/bin(/.*)?", anything)
+        expect(provider).to receive(:declare_resource).with(:systemd_unit, "chef-client.service", anything)
+        expect(provider).to receive(:declare_resource).with(:systemd_unit, "chef-client.timer", anything)
+        provider.action_add
+      end
+    end
+
+    context "when chef_binary_path is not a Habitat path" do
+      it "does not include a selinux_fcontext resource in the :add action" do
+        allow(resource).to receive(:chef_binary_path).and_return("/usr/local/bin/chef-client")
+        allow(provider).to receive(:declare_resource).with(:selinux_fcontext, anything, anything)
+        expect(provider).to receive(:declare_resource).with(:systemd_unit, "chef-client.service", anything)
+        expect(provider).to receive(:declare_resource).with(:systemd_unit, "chef-client.timer", anything)
+        provider.action_add
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Use `selinux_fcontext` to update selinux of hab-based executable

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
