### PR TITLE
Point back hab channel to base-2025 in GHA fips testing pipelines

### DIFF
--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -31,11 +31,8 @@ jobs:
     runs-on: [self-hosted, x64, Linux, ubuntu-2404-pro-fips-tester]
     env:
       HAB_ORIGIN: gha # Set the dummy origin for this Github actions CI flow
-      # HAB_BLDR_CHANNEL: base-2025 # Explicitly set the builder channel
-      # HAB_REFRESH_CHANNEL: base-2025 # Explicitly set the refresh channel
-      HAB_BLDR_CHANNEL: fips-testing
-      HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: fips-testing
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: base-2025
+      HAB_BLDR_CHANNEL: base-2025 # Explicitly set the builder channel
+      HAB_REFRESH_CHANNEL: base-2025 # Explicitly set the refresh channel
       HAB_AUTH_TOKEN: ${{ secrets.HAB_AUTH_TOKEN }}
       HAB_LICENSE: accept-no-persist
       CHEF_LICENSE_KEY: ${{ secrets.CHEF_LICENSE_KEY }}

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -34,12 +34,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       HAB_ORIGIN: gha # Set the dummy origin for this Github actions CI flow
-      # HAB_BLDR_CHANNEL: base-2025 # Explicitly set the builder channel
-      # HAB_REFRESH_CHANNEL: base-2025 # Explicitly set the refresh channel
-      HAB_BLDR_CHANNEL: fips-testing
-      HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: fips-testing
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: base-2025
-      HAB_STUDIO_SECRET_HAB_PREFER_LOCAL_CHEF_DEPS: true
+      HAB_BLDR_CHANNEL: base-2025 # Explicitly set the builder channel
+      HAB_REFRESH_CHANNEL: base-2025 # Explicitly set the refresh channel
       HAB_AUTH_TOKEN: ${{ secrets.HAB_AUTH_TOKEN }}
       HAB_LICENSE: accept-no-persist
       CHEF_LICENSE_KEY: ${{ secrets.CHEF_LICENSE_KEY }}


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
Point habitat builder and refresh channels back to base-2025 which were temporarily set to fips-testing channel for testing GHA fips pipeline only

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
