### PR TITLE
Preserve environment secrets which are being reset due to sudo on linux fips pipeline

### DIFF
--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -78,9 +78,9 @@ jobs:
         run: |
           # Import the previously exported key
           cat "$HAB_ORIGIN-key.tar.gz" | sudo hab origin key import
-          sudo hab pkg install ./chef-infra-client-latest.hart --auth "${{ secrets.HAB_AUTH_TOKEN }}"
+          sudo -E hab pkg install ./chef-infra-client-latest.hart --auth "${{ secrets.HAB_AUTH_TOKEN }}"
           # Verify installation
-          sudo hab pkg exec $HAB_ORIGIN/chef-infra-client chef-client -v
+          sudo -E hab pkg exec $HAB_ORIGIN/chef-infra-client chef-client -v
 
       - name: 'Verify FIPS is enabled on the system'
         run: |
@@ -101,7 +101,7 @@ jobs:
           echo "========================================"
           echo ""
 
-          sudo hab pkg exec $HAB_ORIGIN/chef-infra-client chef-client -z --chef-license accept
+          sudo -E hab pkg exec $HAB_ORIGIN/chef-infra-client chef-client -z --chef-license accept
 
           # ============================================
           # Test 1: MD5 (should FAIL in FIPS mode)
@@ -114,7 +114,7 @@ jobs:
           end
           EOF
 
-          sudo bash -c "
+          sudo -E bash -c "
             set -o pipefail
             hab pkg exec $HAB_ORIGIN/chef-infra-client -- chef-client -z \
               --config-option cookbook_path=/tmp \
@@ -136,7 +136,7 @@ jobs:
           end
           EOF
 
-          sudo bash -c "
+          sudo -E bash -c "
             set -o pipefail
             hab pkg exec $HAB_ORIGIN/chef-infra-client -- chef-client -z \
               --config-option cookbook_path=/tmp \


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
Preserve environment secrets which are being reset due to sudo on linux fips pipeline

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
