### PR TITLE
Update GHA concurrency group

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: danger-${{ github.ref }}
+  group: danger-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -8,7 +8,7 @@ name: func_spec
       - main
 
 concurrency:
-  group: func-spec-${{ github.ref }}
+  group: func-spec-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -10,7 +10,7 @@ name: kitchen
       - main
 
 concurrency:
-  group: kitchen-${{ github.ref }}
+  group: kitchen-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 concurrency:
-  group: labeler-${{ github.ref }}
+  group: labeler--${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 concurrency:
-  group: lint-${{ github.ref }}
+  group: lint-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -12,7 +12,7 @@ name: linux-fips
 permissions: {}
 
 concurrency:
-  group: selfhosted-fips-${{ github.ref }}
+  group: selfhosted-fips-${{ github.ref }} # Since this workflow runs on a self-hosted runner, we want to ensure that only one run executes at a time to avoid conflicts on the runner
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -11,7 +11,7 @@ on:
       types: [opened, synchronize, reopened]
 
 concurrency:
-  group: sonarqube-${{ github.ref }}
+  group: sonarqube-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -8,7 +8,7 @@ name: unit_specs
       - main
 
 concurrency:
-  group: unit-specs-${{ github.ref }}
+  group: unit-specs-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -12,7 +12,7 @@ name: windows-fips
 permissions: {}
 
 concurrency:
-  group: windows-fips-${{ github.ref }}
+  group: windows-fips-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Update concurrency group for GHA jobs because current setup of using github.ref as group ends creating a group by base branch name against which a pr is created so other PRs against same branch end up getting their jobs cancelled.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
