### PR TITLE
Automatically skip version bumps if CI files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,16 @@
 documentation:
   - changed-files:
       - any-glob-to-any-file:
-        - 'README.md'
-        - 'CODE_OF_CONDUCT.md'
-        - 'CONTRIBUTING.md'
-        - 'lib/chef/resource/**/*'
+          - README.md
+          - CODE_OF_CONDUCT.md
+          - CONTRIBUTING.md
+          - lib/chef/resource/**/*
+
+"Expeditor: Skip All":
+  - changed-files:
+      - all-globs-to-all-files:
+          - "{.expeditor,.buildkite,.github,kitchen-tests,test-kitchen}/**"
+          - NOTICE
+          - LICENSE
+          - dangerfile.js
+          - dobi.yaml


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Repeated build fix changes advance the patch version unless you remember to "Expeditor: Skip All"... this prevents that automatically.

Also NOTICE and LICENSE updates may need to reference a version and bumping on merge defeats that purpose.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
