### PR TITLE
Hab 2.0 is busted? Downgrading all the things

### DIFF
--- a/.expeditor/scripts/chef_adhoc_build.ps1
+++ b/.expeditor/scripts/chef_adhoc_build.ps1
@@ -4,15 +4,11 @@
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-# Install Habitat for Windows - equivalent to install-hab.sh x86_64-linux
-Write-Host "--- :habicat: Installing Habitat for Windows"
-try {
-    Set-ExecutionPolicy Bypass -Scope Process -Force
-    iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
-} catch {
-    Write-Host "$($_ | Format-List * -Force | Out-String)"
-    throw "Unable to install Habitat"
-}
+# Ensure Habitat 1.6.1245 is installed on Windows
+$ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
+& "$ScriptRoute"
+
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 $env:Path += ";C:\buildkite-agent\bin"
 
 Write-Host "Verifying we have access to buildkite-agent"

--- a/.expeditor/scripts/validate_adhoc_build.ps1
+++ b/.expeditor/scripts/validate_adhoc_build.ps1
@@ -22,6 +22,48 @@ Write-Host "--- Downloading package artifact"
 $env:PKG_ARTIFACT = $(buildkite-agent meta-data get "INFRA_HAB_ARTIFACT_WINDOWS")
 buildkite-agent artifact download "$env:PKG_ARTIFACT" .
 
+$requiredHabVersionString = "1.6.1245"
+$requiredHabVersion = [Version]$requiredHabVersionString
+$currentHabVersion = $null
+
+try {
+	$habVersionOutput = hab --version
+	if ($habVersionOutput) {
+		$currentHabVersion = [Version]($habVersionOutput.Split(" ")[1].Split("/")[0])
+	}
+} catch {
+	Write-Host "--- :habicat: Unable to determine Habitat version, forcing install of $requiredHabVersionString"
+}
+
+if ($currentHabVersion -ne $requiredHabVersion) {
+	Write-Host "--- :habicat: Habitat version '$currentHabVersion' detected, forcing install of $requiredHabVersionString"
+	Set-ExecutionPolicy Bypass -Scope Process -Force
+
+	$habCommand = Get-Command hab -ErrorAction SilentlyContinue
+	if ($habCommand) {
+		$habPath = $habCommand.Source | Split-Path -Parent
+		if ($habPath) {
+			Remove-Item -Path $habPath -Recurse -Force -ErrorAction Continue
+			Write-Host "--- :habicat: Deleted Habitat from $habPath"
+		}
+	}
+
+	$installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
+	$installScriptPath = Join-Path $env:TEMP "hab-install-$requiredHabVersionString.ps1"
+
+	Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
+	try {
+		& $installScriptPath -Version $requiredHabVersionString
+		if (-not $?) { throw "Failed to install Habitat $requiredHabVersionString" }
+	}
+	finally {
+		Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue
+	}
+
+	$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+	$env:Path += ";C:\buildkite-agent\bin"
+}
+
 Write-Host ":key: Downloading origin key"
 hab origin key download $env:HAB_ORIGIN
 if (-not $?) { throw "Unable to download origin key" }

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Install Habitat CLI
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1 -OutFile install-habitat.ps1
-          .\install-habitat.ps1
+          $env:HAB_VERSION = "1.6.1245"
+          & "${{ github.workspace }}\.expeditor\scripts\ensure-minimum-viable-hab.ps1"
           $env:PATH = "C:\Program Files\Habitat;C:\hab\bin;C:\opscode\chef-workstation\bin;C:\opscode\chef-workstation\embedded\bin;" + $env:PATH
           echo "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           hab license accept

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: 'Install Habitat CLI'
         run: |
-          # Download and install Habitat CLI
-          Invoke-WebRequest -Uri https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1 -OutFile install-habitat.ps1
-          .\install-habitat.ps1
+          # Ensure pinned Habitat version on Windows CI
+          $env:HAB_VERSION = "1.6.1245"
+          & "${{ github.workspace }}\.expeditor\scripts\ensure-minimum-viable-hab.ps1"
           # Add hab to PATH
           $env:PATH = "C:\Program Files\Habitat;" + $env:PATH
           # Use GitHub's special environment file to persist the PATH across steps


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Currently, there is a threading/race condition problem with hab 2.0 on Windows only where it can't delete folders required for clean-up. Here we add a mechanism to support a desired Hab version so we can be consistent across all the builder types.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
