### PR TITLE
Java sous chefs for partials

### DIFF
--- a/kitchen-tests/Policyfile.rb
+++ b/kitchen-tests/Policyfile.rb
@@ -16,3 +16,4 @@ run_list "end_to_end::default"
 # cookbook 'example_cookbook', path: '../cookbooks/example_cookbook'
 
 cookbook "end_to_end", path: "cookbooks/end_to_end"
+cookbook "java"

--- a/kitchen-tests/cookbooks/end_to_end/metadata.rb
+++ b/kitchen-tests/cookbooks/end_to_end/metadata.rb
@@ -10,6 +10,7 @@ depends          "openssh"
 depends          "resolver"
 depends          "users"
 depends          "git"
+depends          "java"
 
 supports         "ubuntu"
 supports         "debian"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_java.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_java.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook:: end_to_end
+# Recipe:: _java
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#
+
+node.default["java"]["install_flavor"] = "openjdk"
+node.default["java"]["jdk_version"] = "11"
+
+include_recipe "java::default"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -221,6 +221,7 @@ include_recipe "::_alternatives"
 include_recipe "::_cron" unless amazon? && node["platform_version"] >= "2023" # TODO: look into cron.d template file issue with resource
 include_recipe "::_ohai_hint"
 include_recipe "::_openssl"
+include_recipe "::_java"
 include_recipe "::_tests" # comment out if it generates UTF-8 error
 include_recipe "::_mount"
 include_recipe "::_ifconfig"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Try the sous-chefs Java cookbook to see if it flags the partial path problem with hab builds. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
