### PR TITLE
Change Fedora package provider to use 'fedora_derived'

### DIFF
--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -32,7 +32,7 @@ class Chef
       provides :package, platform_family: "rhel", platform_version: ">= 8"
 
       # fedora >= 22 uses DNF
-      provides :package, platform: "fedora", platform_version: ">= 22"
+      provides :package, platform_family: "fedora_derived", platform_version: ">= 22"
 
       # amazon will eventually use DNF
       provides :package, platform: "amazon" do


### PR DESCRIPTION
Fedora derivatives may not get the proper provider mapping, and have yum selected instead of dnf.

<!--- Provide a short summary of your changes in the Title above -->

## Description
When the openssh cookbook requests

```package node['openssh']['package_name'] unless node['openssh']['package_name'].empty?  ```

The provider mapping pins it as a yum distro, when fedora and derivs are dnf -- and at f43, even removed the yum libs so there's no way it can do yum.

Chef Version
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/15703

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist

[x] here's a patch
[x] consider applying it
[x] enjoy
[x] I don't need to sign an oath to donate code

