### PR TITLE
Purging any omnibus references in the codebase - part1

### DIFF
--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -103,10 +103,10 @@ for gem in ${external_gems[@]}; do
     echo "    - apt-get update -y"
     # cspell:disable-next-line
     echo "    - apt-get install -y graphviz"
-    echo "    - bundle config set --local without omnibus_package"
+    echo "    - bundle config set --local without hab_package"
   else
     echo "    - export PATH=\"/root/.rbenv/shims:/opt/chef/bin:${PATH}\""
-    echo "    - bundle config set --local without omnibus_package"
+    echo "    - bundle config set --local without hab_package"
     echo "    - bundle config set --local path 'vendor/bundle'"
   fi
   echo "    - bundle install --jobs=3 --retry=3"

--- a/.expeditor/scripts/bk_win_functional.ps1
+++ b/.expeditor/scripts/bk_win_functional.ps1
@@ -20,7 +20,7 @@ Write-Output "--- configure winrm"
 winrm quickconfig -q
 
 Write-Output "--- bundle install"
-bundle config set --local without 'omnibus_package'
+bundle config set --local without 'hab_package'
 bundle install --jobs=3 --retry=3
 if (-not $?) { throw "Unable to install gem dependencies" }
 

--- a/.expeditor/scripts/bk_win_prep.ps1
+++ b/.expeditor/scripts/bk_win_prep.ps1
@@ -11,7 +11,7 @@ bundle --version
 if (-not $?) { throw "Can't run Bundler. Is it installed?" }
 
 echo "--- bundle install"
-bundle config set --local without omnibus_package
+bundle config set --local without hab_package
 bundle config set --local path 'vendor/bundle'
 bundle install --jobs=3 --retry=3
 if (-not $?) { throw "Unable to install gem dependencies" }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
   cookstyle:
     runs-on: ubuntu-latest
     env:
-      BUNDLE_WITHOUT: ruby_shadow:omnibus_package
+      BUNDLE_WITHOUT: ruby_shadow:hab_package
     steps:
       - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ else
   gem "chef-bin" # rubocop:disable Bundler/DuplicatedGem
 end
 
-group(:omnibus_package) do
+group(:hab_package) do
   gem "appbundler"
   gem "rb-readline"
   gem "inspec-core-bin", "= 7.0.107" # need to provide the binaries for inspec
@@ -41,7 +41,7 @@ end
 
 gem "repl_type_completor", "~> 0.1.12" # deprecation warnings in chef-shell
 
-group(:omnibus_package, :pry) do
+group(:hab_package, :pry) do
   # Locked because pry-byebug is broken with 13+.
   # some work is ongoing? https://github.com/deivid-rodriguez/pry-byebug/issues/343
   gem "pry", "~> 0.15.2"

--- a/knife/Gemfile
+++ b/knife/Gemfile
@@ -12,7 +12,7 @@ group(:development, :test) do # testing only , but why didn't this need to expli
   gem "chef-bin", path: "../chef-bin"
 end
 
-group(:omnibus_package, :pry) do
+group(:hab_package, :pry) do
   gem "pry"
   gem "pry-byebug"
   gem "pry-stack_explorer"


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description

Rename the 'omnibus_package' group in Gemfile and update all its references accordingly since any `bundle install` actually installs all the groups unless `bundle config --without` set to exclude a group, so the gems in that group are still being used in a way even in habitat packaging.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
