### PR TITLE
[file] Only evaluate lazy block once for content

### DIFF
--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -197,7 +197,7 @@ class Chef
       # be overridden in subclasses.
       def managing_content?
         return true if new_resource.checksum
-        return true if !new_resource.content.nil? && @action != :create_if_missing
+        return true if new_resource.property_is_set?(:content) && @action != :create_if_missing
 
         false
       end

--- a/lib/chef/provider/file/content.rb
+++ b/lib/chef/provider/file/content.rb
@@ -24,9 +24,10 @@ class Chef
     class File
       class Content < Chef::FileContentManagement::ContentBase
         def file_for_provider
-          if @new_resource.content
+          content = @new_resource.content
+          if content
             tempfile = Chef::FileContentManagement::Tempfile.new(@new_resource).tempfile
-            tempfile.write(@new_resource.content)
+            tempfile.write(content)
             tempfile.close
             tempfile
           else

--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -824,7 +824,7 @@ shared_examples_for "a file provider with content field" do
     end
     it "should be true when creating a file with content" do
       provider.action = :create
-      allow(resource).to receive(:content).and_return("flurbleblobbleblooble")
+      resource.content("flurbleblobbleblooble")
       allow(resource).to receive(:checksum).and_return(nil)
       expect(provider.send(:managing_content?)).to be_truthy
     end
@@ -839,6 +839,16 @@ shared_examples_for "a file provider with content field" do
       allow(resource).to receive(:content).and_return("flurbleblobbleblooble")
       allow(resource).to receive(:checksum).and_return(nil)
       expect(provider.send(:managing_content?)).to be_falsey
+    end
+    it "does not evaluate a lazy content block when checking managing_content?" do
+      provider.action = :create
+      call_count = 0
+      resource.content Chef::DelayedEvaluator.new { call_count += 1; "hello" }
+      allow(resource).to receive(:checksum).and_return(nil)
+
+      provider.send(:managing_content?)
+
+      expect(call_count).to eq(0)
     end
   end
 end

--- a/spec/unit/provider/file/content_spec.rb
+++ b/spec/unit/provider/file/content_spec.rb
@@ -100,6 +100,23 @@ describe Chef::Provider::File::Content do
 
   end
 
+  describe "when the resource has lazy content" do
+    let(:new_resource) do
+      resource = Chef::Resource::File.new("seattle.txt")
+      resource.path(resource_path)
+      resource
+    end
+
+    it "evaluates the lazy block only once" do
+      call_count = 0
+      new_resource.content Chef::DelayedEvaluator.new { call_count += 1; "hello" }
+
+      content.tempfile
+
+      expect(call_count).to eq(1)
+    end
+  end
+
   describe "when the resource does not have a content property set" do
 
     before do


### PR DESCRIPTION
## Description
This is to address #15713, where lazy evaluation occurs multiple times during the course of a run when doing something like:
```
file '/tmp/foo' do
  content lazy { something_expensive }
end
```

With this change, that lazy evaluation only happens once, when it's writing the temporary file for comparison

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
