### PR TITLE
Fix bad platform_family matches

### DIFF
--- a/lib/chef/provider/ifconfig/redhat.rb
+++ b/lib/chef/provider/ifconfig/redhat.rb
@@ -22,7 +22,7 @@ class Chef
   class Provider
     class Ifconfig
       class Redhat < Chef::Provider::Ifconfig
-        provides :ifconfig, platform_family: "fedora_derived", target_mode: true
+        provides :ifconfig, platform_family: %w{fedora rhel amazon}, target_mode: true
 
         def initialize(new_resource, run_context)
           super(new_resource, run_context)

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -38,7 +38,7 @@ class Chef
         use_package_name_for_source
         use_magic_version
 
-        provides :package, platform_family: "fedora_derived"
+        provides :package, platform_family: %w{fedora rhel amazon}
 
         provides :yum_package
 

--- a/lib/chef/provider/package/yum_tm.rb
+++ b/lib/chef/provider/package/yum_tm.rb
@@ -21,7 +21,7 @@ class Chef
   class Provider
     class Package
       class YumTM < Chef::Provider::Package::Yum
-        provides :package, platform_family: "fedora_derived", target_mode: true, agent_mode: false
+        provides :package, platform_family: %w{fedora rhel amazon}, target_mode: true, agent_mode: false
         provides :yum_package, target_mode: true, agent_mode: false
 
         def load_current_resource

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -24,7 +24,7 @@ class Chef
     class YumPackage < Chef::Resource::Package
 
       provides :yum_package, target_mode: true
-      provides :package, platform_family: "fedora_derived"
+      provides :package, platform_family: %w{fedora rhel amazon}
       target_mode support: :full
 
       description "Use the **yum_package** resource to install, upgrade, and remove packages with Yum for the Red Hat and CentOS platforms. The yum_package resource is able to resolve `provides` data for packages much like Yum can do when it is run from the command line. This allows a variety of options for installing packages, like minimum versions, virtual provides, and library names. Note: Support for using file names to install packages (as in `yum_package '/bin/sh'`) is not available because the volume of data required to parse for this is excessive."


### PR DESCRIPTION
# Description

`fedora_derived?` is a helper, fedora_derived is NOT a platform_family.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
