### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           # This seems to be working lately even for external
           # contributors, so maybe we don't need to exclude it?
-          checks_exclude: "SonarCloud Code Analysis"
+          checks_exclude: ".*(SonarCloud Code Analysis|dokr_lnx_arm64).*"
           # Retry every minute for 30 minutes...
           retries: 30
+          verbose: true

--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -63,7 +63,7 @@ jobs:
 
       # BlackDuck SAST (Polaris) and SCA scans (requires a build or download to do SAST)
       # requires these secrets: POLARIS_SERVER_URL, POLARIS_ACCESS_TOKEN
-      perform-blackduck-polaris: true
+      perform-blackduck-polaris: false
       polaris-application-name: "Chef-Agents"  # one of these: Chef-Agents, Chef-Automate, Chef-Chef360, Chef-Habitat, Chef-Infrastructure-Server, Chef-Shared-Services, Chef-Other
       polaris-project-name: 'chef-19'
       # polaris-blackduck-executable: 'path/to/blackduck/binary'
@@ -99,7 +99,7 @@ jobs:
       # generate and export Software Bill of Materials (SBOM) in various formats
       generate-sbom: true
       export-github-sbom: true      # SPDX JSON artifact on job instance
-      perform-blackduck-sca-scan: true # combined with generate sbom & generate github-sbom, also needs version above
+      perform-blackduck-sca-scan: false # combined with generate sbom & generate github-sbom, also needs version above
       blackduck-project-group-name: 'Chef-Agents' # typically one of (Chef), Chef-Agents, Chef-Automate, Chef-Chef360, Chef-Habitat, Chef-Infrastructure-Server, Chef-Shared-Services'
       blackduck-project-name: 'chef' # BlackDuck project name, typically the repository name
       generate-blackduck-sbom: true # obsolete, use perform-blackduck-sca-scan instead

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -347,18 +347,20 @@ jobs:
       matrix:
         os:
           - almalinux-9
-          - almalinux-10
-          - debian-11
-          - debian-12
-          - debian-13
-          - fedora-42
-          - opensuse-leap-15
-          - oraclelinux-8
-          - oraclelinux-9
-          - rockylinux-9
-          - rockylinux-10
-          - ubuntu-2204
-          - ubuntu-2404
+          # Commenting most of these out until at least one
+          # works. Also excluding from allchecks.
+          #- almalinux-10
+          #- debian-11
+          #- debian-12
+          #- debian-13
+          #- fedora-42
+          #- opensuse-leap-15
+          #- oraclelinux-8
+          #- oraclelinux-9
+          #- rockylinux-9
+          #- rockylinux-10
+          #- ubuntu-2204
+          #- ubuntu-2404
     runs-on: ubuntu-24.04-arm
     env:
       FORCE_FFI_YAJL: ext


### PR DESCRIPTION
# Description

* Remove all but one of the new, and broken, arm tests, and then
  exclude that one from allchecks
* Remove the Blackduck tests that don't work on forks. Security needs
  to actually get a story around their tests before enforcing them
  on everyone.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
