### PR TITLE
Cleanup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,25 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  target-branch: "main"
-  directory: "/omnibus"
-  schedule:
-    interval: daily
-    time: "06:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  labels:
-  - "Type: Chore"
-- package-ecosystem: bundler
-  target-branch: "chef-18"
-  directory: "/omnibus"
-  schedule:
-    interval: daily
-    time: "06:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  labels:
-  - "Type: Chore"
-- package-ecosystem: bundler
-  target-branch: "chef-17"
-  directory: "/omnibus"
-  schedule:
-    interval: daily
-    time: "06:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  labels:
-  - "Type: Chore"
+  - &base
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "Type: Chore"
+
+  - &bundler_base
+    <<: *base
+    package-ecosystem: bundler
+    directory: "/"
+    target-branch: "main"
+
+  - <<: *bundler_base
+    target-branch: "chef-18"
+
+  - <<: *bundler_base
+    directory: "/omnibus"
+    target-branch: "chef-18"
+
+  - <<: *base
+    package-ecosystem: github-actions
+    directory: "/"


### PR DESCRIPTION
# Description

- Enable dependabot for our main ruby deps
- Remove dependabot for /omnibus on main, it doesn't exist anymore
- Add Github actions block
- Use some anchors to clean things up

Signed-off-by: Phil Dibowitz <phil@ipom.com>
