### PR TITLE
[chef-17] Backport Actions DCO check to chef-17

### DIFF
--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -1,0 +1,20 @@
+name: All checks pass
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+jobs:
+  allchecks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+    steps:
+      - uses: wechuli/allcheckspassed@v1
+        with:
+          # This seems to be working lately even for external
+          # contributors, so maybe we don't need to exclude it?
+          checks_exclude: ".*(SonarCloud Code Analysis|dokr_lnx_arm64).*"
+          # Retry every minute for 30 minutes...
+          retries: 30
+          verbose: true

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,22 @@
+name: DCO Check
+on: [pull_request]
+
+permissions: {}
+
+jobs:
+  dco_check_job:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    name: DCO Check
+    steps:
+    - name: Get PR Commits
+      uses: tim-actions/get-pr-commits@master
+      id: 'get-pr-commits'
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: tim-actions/dco@master
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
# Description

Backport Actions DCO so we can nuke webhook DCO

Also adding allchecks while we're here.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
