### PR TITLE
Fix GH Labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,7 @@
 documentation:
-  - 'README.md'
-  - 'CODE_OF_CONDUCT.md'
-  - 'CONTRIBUTING.md'
-  - 'lib/chef/resource/**/*'
+  - changed-files:
+      - any-glob-to-any-file:
+        - 'README.md'
+        - 'CODE_OF_CONDUCT.md'
+        - 'CONTRIBUTING.md'
+        - 'lib/chef/resource/**/*'

--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           # This seems to be working lately even for external
           # contributors, so maybe we don't need to exclude it?
-          checks_exclude: ".*(SonarCloud Code Analysis|dokr_lnx_arm64).*"
+          checks_exclude: ".*(SonarCloud Code Analysis|dokr_lnx_arm64|triage).*"
           # Retry every minute for 30 minutes...
           retries: 30
           verbose: true


### PR DESCRIPTION
# Description

The config format for the labeler changed, but it didn't get
caught in the upgrade PR. This fixes it.

NOTE: because labeler uses pull_request_target, the config isn't
seem by the current PR. This is just "by design" so that PRs can't
change how their PRs are labeled.

Thus I've removed the labeler from required checks, for now.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
