### PR TITLE
Revert "updating paths to prevent execitions (#15699)"

### DIFF
--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Fetch PR head
         run: git fetch origin ${{ github.event.pull_request.head.sha }}
 
+        # NOTE!!
+        #   Do NOT add other paths here. This is not a general "security"
+        #   check, this is a check to make sure new secrets are not added
+        #   to pull_request_target PRs. That is the ONLY purpose.
       - name: Detect workflow file changes
         id: diff
         run: |
@@ -36,7 +40,7 @@ jobs:
           CHANGED=$(git diff --name-only \
             ${{ github.event.pull_request.base.sha }} \
             ${{ github.event.pull_request.head.sha }} \
-            | grep -E '^(\.github/|habitat/|\.expeditor/|\.buildkite/|[Gg]emfile$|[Rr]akefile$|Dockerfile$|.*\.gemspec$)' || true)
+            | grep '^.github/workflows/' || true)
 
           if [ -n "$CHANGED" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This change was made erroneously as far as I (and @tpowell-progress) can tell.

The point of the gate is to prevent GH secrets from being added to
kitchen workflows which use `pull_request_target`.

Changing these other files cannot add new secrets to these workflows,
and thus do not need to be a part of this gating.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
