### PR TITLE
Start monitoring fail-after

### DIFF
--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: wechuli/allcheckspassed@v2
         with:
           # SonarCloud - never works for forks
-          # arm64 - still under development
-          # rockylinux-9 - upstream package issues
-          # rockylinux-10 - upstream package issues
+          # arm64 - still under development - fail-after:2026-04-30
+          # rockylinux-9 - upstream package issues - fail-after:2026-04-15
+          # rockylinux-10 - upstream package issues - fail-after:2026-04-15
           checks_exclude: ".*(SonarCloud Code Analysis|dokr_lnx_arm64|rockylinux-9|rockylinux-10).*"
           # Retry every minute for 30 minutes...
           retries: 90

--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -1,0 +1,16 @@
+name: Chronoguard
+on:
+  pull_request:
+    branches: [ main, chef-18 ]
+
+jobs:
+  chronoguard:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jaymzh/chronoguard@main
+        with:
+          files: .github/workflows/allchecks.yml


### PR DESCRIPTION
# Description

Use my new `chronoguard` check to enforce timelimits on checkallchecks exceptions.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
