### PR TITLE
More gemspec fixes for dependabot

### DIFF
--- a/chef-universal-mingw-ucrt.gemspec
+++ b/chef-universal-mingw-ucrt.gemspec
@@ -1,4 +1,6 @@
-gemspec = instance_eval(File.read(File.expand_path("chef.gemspec", __dir__)))
+# rubocop:disable Chef/Ruby/GemspecLicense
+# License is in the included gemspec.
+gemspec = Gem::Specification.load(File.expand_path("chef.gemspec", __dir__))
 
 gemspec.platform = Gem::Platform.new(%w{universal mingw-ucrt})
 

--- a/knife/knife.gemspec
+++ b/knife/knife.gemspec
@@ -15,9 +15,13 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.1.0"
 
-  s.add_dependency "chef-config", ">= #{Chef::Knife::VERSION.split(".").first}"
-  s.add_dependency "chef-utils", ">= #{Chef::Knife::VERSION.split(".").first}"
-  s.add_dependency "chef", ">= #{Chef::Knife::VERSION.split(".").first}"
+  # Dependabot swallows the require_relative above, so Chef::Knife::VERSION
+  # may not be defined. Fall back to a hardcoded major version so the
+  # gemspec can still be evaluated.
+  major = defined?(Chef::Knife::VERSION) ? Chef::Knife::VERSION.split(".").first : "19"
+  s.add_dependency "chef-config", ">= #{major}"
+  s.add_dependency "chef-utils", ">= #{major}"
+  s.add_dependency "chef", ">= #{major}"
   s.add_dependency "train-core", "~> 3.13", ">= 3.13.4" # Updated to be compatible with InSpec 7
   s.add_dependency "train-winrm", ">= 0.2.17"
   s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"


### PR DESCRIPTION
# Description

Dependabot is a bit tricky, it's static analyzer does a bunch of weird stuff.

* It replaces `File.read(...)` with `"1.1.0"`, so in chef-universal-mingw-ucrt.gemspec we now use Gemspec loader
* In knife, the `require_relative` gets dropped so its nil, so in that case we fake the value (which won't change anything, those are tied to major version of chef and won't be auto-bumped anyway)

I tested with the CLI and dependabot can now parse all our gem files.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
