### PR TITLE
[dependabot] Ignore openssl

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,26 @@ updates:
     target-branch: "main"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     labels:
       - "Type: Chore"
+    ignore:
+      # Due to FIPS builds and having to couple the openssl
+      # build itself, we don't let dependabot bump openssl
+      - dependency-name: "openssl"
 
   - package-ecosystem: bundler
     directory: "/"
     target-branch: "chef-18"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     labels:
       - "Type: Chore"
+    ignore:
+      # Due to FIPS builds and having to couple the openssl
+      # build itself, we don't let dependabot bump openssl
+      - dependency-name: "openssl"
 
   - package-ecosystem: bundler
     directory: "/omnibus"


### PR DESCRIPTION
At least for now. Though it'd be good to get this working
properly with automation.

Also bump the limits so we can catch up easier and make sure that
Ohai is gonna be in the list.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
