### PR TITLE
Fix invalid TOML in unittest

### DIFF
--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -480,11 +480,10 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
             node_name = 'barney'
             client_key = "barney_rubble.pem"
             chef_server_url = "https://api.chef.io/organizations/bedrock"
-            knife = {
-              secret_file = "/home/barney/.chef/encrypted_data_bag_secret.pem"
-            }
+
             [default.knife]
             ssh_user = "knife_ssh_user"
+            secret_file = "/home/barney/.chef/encrypted_data_bag_secret.pem"
           EOH
           content
         end


### PR DESCRIPTION
Invalid TOML in unit tests breaks newer TOML. Fix it.

Signed-off-by: Phil Dibowitz <phil@ipom.com>