### PR TITLE
Fix CI Pipelines by using apt properly

### DIFF
--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -37,7 +37,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install native deps (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -43,7 +43,9 @@ jobs:
           clean: true
       - name: Install native deps (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
You have to run `apt update` before `apt install ...`, otherwise
you're using stale metadata.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
