### PR TITLE
Expeditor: stop working on chef-17 branch

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -82,10 +82,6 @@ release_branches:
       version_constraint: 19*
   - chef-18:
       version_constraint: 18*
-  - chef-17:
-      version_constraint: 17*
-  # - chef-16:
-  #     version_constraint: 16*
 
 changelog:
   rollup_header: Changes not yet released to stable


### PR DESCRIPTION
There's no reason for expeditor to be looking at the 17 branch anymore.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
