### PR TITLE
Updating for CVE-2025-14762

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ PATH
   specs:
     chef (18.10.47)
       addressable
-      aws-sdk-s3 (~> 1.91)
+      aws-sdk-s3 (~> 1.218.0)
       aws-sdk-secretsmanager (~> 1.46)
       chef-config (= 18.10.47)
       chef-utils (= 18.10.47)
@@ -76,7 +76,7 @@ PATH
       vault (>= 0.18.2, < 0.21.0)
     chef (18.10.47-universal-mingw-ucrt)
       addressable
-      aws-sdk-s3 (~> 1.91)
+      aws-sdk-s3 (~> 1.218.0)
       aws-sdk-secretsmanager (~> 1.46)
       chef-config (= 18.10.47)
       chef-powershell (~> 18.6.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "proxifier2", "~> 1.1"
 
-  s.add_dependency "aws-sdk-s3", "~> 1.91" # s3 recipe-url support
+  s.add_dependency "aws-sdk-s3", "~> 1.218.0" # s3 recipe-url support
   s.add_dependency "aws-sdk-secretsmanager", "~> 1.46"
   s.add_dependency "vault", ">= 0.18.2", "< 0.21.0" # hashi vault official client gem
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The Aws-sdk-s3 gem < 1.208 are susceptible to a couple of different CVE's
- GHSA-wx95-c6cv-8532
- CVE-2025-14762

This PR bumps our version dependency to 1.218.x which is safe to use.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
