### PR TITLE
Windows plan dies during removal of devkit tests. 

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -370,10 +370,10 @@ function Invoke-After {
             break
         } catch {
             if ($attempt -lt $maxRetries) {
-                Write-BuildLine " ** Removing $bundlerPath: attempt $attempt failed (git subdirectories may be locked), retrying..."
+                Write-BuildLine " ** Removing ${bundlerPath}: attempt $attempt failed (git subdirectories may be locked), retrying..."
                 Start-Sleep -Seconds 2
             } else {
-                throw "Failed to remove $bundlerPath after $maxRetries attempts: $_"
+                throw "Failed to remove ${bundlerPath} after $maxRetries attempts: $_"
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The Windows plan file pretty often (like 6 out of 7 times) dies during removal of the devkit tests we added. We're adding scaffolding here to stop that from happening

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
