### PR TITLE
install the required buildx plugin for docker builds

### DIFF
--- a/.expeditor/build-docker-images.sh
+++ b/.expeditor/build-docker-images.sh
@@ -22,10 +22,28 @@ fi
 
 echo "--- Building chef/chef-hab:${version} docker image for ${arch}"
 
-# Enable BuildKit for secret support
+# Ensure docker buildx plugin is available (required for BuildKit --secret support
+# and for the Dockerfile's RUN --mount=type=secret syntax).
+#
+# The Buildkite docker-login plugin sets DOCKER_CONFIG to a temp directory (e.g.
+# /tmp/tmp.XXXXX). Docker CLI resolves plugins from $DOCKER_CONFIG/cli-plugins/,
+# so we must install buildx there — not ~/.docker/ (invisible when DOCKER_CONFIG
+# is overridden) and not /usr/local/lib/docker/ (requires root).
+if ! docker buildx version &>/dev/null; then
+  echo "--- docker buildx not found; installing plugin"
+  BUILDX_VERSION="v0.20.1"
+  BUILDX_PLUGIN_DIR="${DOCKER_CONFIG:-${HOME}/.docker}/cli-plugins"
+  mkdir -p "${BUILDX_PLUGIN_DIR}"
+  curl -fsSL \
+    "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${arch}" \
+    -o "${BUILDX_PLUGIN_DIR}/docker-buildx"
+  chmod +x "${BUILDX_PLUGIN_DIR}/docker-buildx"
+  docker buildx version
+fi
+
 export DOCKER_BUILDKIT=1
 
-# Use --secret instead of --build-arg for sensitive data
+# Use --secret instead of --build-arg for sensitive data (token never baked into layers)
 docker build \
   --build-arg "CHANNEL=${channel}" \
   --build-arg "VERSION=${version}" \


### PR DESCRIPTION
## Description
`docker/build` pipeline is failing with the following error for both AMD and ARM builds:

```bash
ERROR: BuildKit is enabled but the buildx component is missing or broken.
       Install the buildx component to build images with BuildKit:
       https://docs.docker.com/go/buildx/
```

The `build-docker-images.sh` script uses `DOCKER_BUILDKIT=1` with `--secret` (and the `Dockerfile` uses `RUN --mount=type=secret`). This requires the `docker-buildx-plugin`, which is missing from the buildkite runner. Temporarily adding manual buildx installation until this is updated in the images.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
