### PR TITLE
[chef18]Remove msys installed openssl on windows

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -51,6 +51,9 @@ dependency "more-ruby-cleanup"
 # introduced for rexml cleanup
 dependency "remove-old-gems"
 
+# remove unused Ruby DevKit OpenSSL binary from embedded msys on Windows
+dependency "remove-vulnerable-msys-artifacts"
+
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]
   compression_level 1

--- a/omnibus/config/software/remove-vulnerable-msys-artifacts.rb
+++ b/omnibus/config/software/remove-vulnerable-msys-artifacts.rb
@@ -1,0 +1,21 @@
+require "fileutils"
+
+name "remove-vulnerable-msys-artifacts"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+build do
+  block "Removing unused MSYS OpenSSL binary" do
+    next unless windows?
+
+    msys_openssl = "#{install_dir}/embedded/msys64/usr/bin/openssl.exe"
+
+    if File.exist?(msys_openssl)
+      puts "Deleting #{msys_openssl}"
+      FileUtils.rm_f(msys_openssl)
+    else
+      puts "MSYS OpenSSL binary not found at #{msys_openssl}. Skipping."
+    end
+  end
+end


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
Remove unused openssl.exe being installed by msys on windows as it is not used by chef18 and has vulnerability as well.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
