### PR TITLE
The bin_t strategy works, but why not just go through hab itself

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,7 @@ GEM
     fauxhai-ng (9.3.0)
       net-ssh
     ffi (1.17.4)
+    ffi (1.17.4-arm64-darwin)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -574,7 +575,7 @@ DEPENDENCIES
   crack (~> 1.0.1)
   ed25519 (~> 1.2)
   fauxhai-ng
-  ffi (>= 1.15.5)
+  ffi (>= 1.15.5, < 1.18.0)
   inspec-core-bin (= 7.0.107)
   ohai!
   openssl (= 3.3.1)

--- a/lib/chef/resource/chef_client_cron.rb
+++ b/lib/chef/resource/chef_client_cron.rb
@@ -128,7 +128,7 @@ class Chef
         description: "Append to the log file instead of overwriting the log file on each run."
 
       property :chef_binary_path, String,
-        default: lazy { Chef::ResourceHelpers::PathHelpers.chef_client_hab_binary_path },
+        default: lazy { Chef::ResourceHelpers::PathHelpers.chef_client_hab_package_binary_path },
         description: "The path to the #{ChefUtils::Dist::Infra::CLIENT} binary."
 
       property :daemon_options, Array,

--- a/lib/chef/resource/chef_client_hab_ca_cert.rb
+++ b/lib/chef/resource/chef_client_hab_ca_cert.rb
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-require "pathname" unless defined?(Pathname)
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 
 class Chef
@@ -99,13 +98,8 @@ class Chef
           return @hab_cacerts_pkg_path if @hab_cacerts_pkg_path
 
           # Find the current running version of chef to get THAT version's cacerts package.
-          current_chef_path = Chef::ResourceHelpers::PathHelpers.chef_client_hab_package_binary_path
           current_hab_path = Chef::ResourceHelpers::PathHelpers.hab_executable_binary_path
-
-          # Extract package ident from path: /hab/pkgs/chef/chef-infra-client/VERSION/RELEASE/bin/chef-client
-          # or: C:\hab\pkgs\chef\chef-infra-client\VERSION\RELEASE\bin\chef-client.exe
-          # Result should be: chef/chef-infra-client/VERSION/RELEASE
-          package_ident = ::File.join(Pathname.new(current_chef_path).each_filename.to_a[2..5])
+          package_ident = Chef::ResourceHelpers::PathHelpers.chef_client_hab_package_ident
 
           ca_pkg = shell_out("#{current_hab_path} pkg dependencies #{package_ident}")
           if ca_pkg.error?

--- a/lib/chef/resource/chef_client_launchd.rb
+++ b/lib/chef/resource/chef_client_launchd.rb
@@ -85,7 +85,7 @@ class Chef
 
       property :chef_binary_path, String,
         description: "The path to the #{ChefUtils::Dist::Infra::CLIENT} binary.",
-        default: lazy { Chef::ResourceHelpers::PathHelpers.chef_client_hab_binary_path }
+        default: lazy { Chef::ResourceHelpers::PathHelpers.chef_client_hab_package_binary_path }
 
       property :daemon_options, Array,
         description: "An array of options to pass to the #{ChefUtils::Dist::Infra::CLIENT} command.",

--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -90,7 +90,7 @@ class Chef
 
       property :chef_binary_path, String,
         description: "The path to the #{ChefUtils::Dist::Infra::CLIENT} binary.",
-        default: lazy { Chef::ResourceHelpers::PathHelpers.chef_client_hab_binary_path }
+        default: lazy { Chef::ResourceHelpers::PathHelpers.chef_client_hab_package_binary_path }
 
       property :daemon_options, Array,
         description: "An array of options to pass to the #{ChefUtils::Dist::Infra::CLIENT} command.",

--- a/lib/chef/resource/helpers/path_helpers.rb
+++ b/lib/chef/resource/helpers/path_helpers.rb
@@ -1,4 +1,5 @@
 require "chef/mixin/which"
+require "pathname" unless defined?(Pathname)
 
 class Chef
   module ResourceHelpers
@@ -39,10 +40,27 @@ class Chef
         path = File.realpath($PROGRAM_NAME)
         bin = File.basename(path)
 
-        return path.sub(bin, ChefUtils::Dist::Infra::CLIENT) if bin =~ /^chef-[a-z-]+$/
+        if bin =~ /^chef-[a-z-]+$/
+          return path.sub(bin, ChefUtils::Dist::Infra::CLIENT) if ChefUtils.windows?
+
+          return "hab pkg exec #{chef_client_hab_package_ident} #{ChefUtils::Dist::Infra::CLIENT}"
+        end
 
         # Return empty string if no valid path is found
         ""
+      end
+
+      # Returns the Habitat package identifier (origin/name/version/release) for the
+      # currently running Chef Infra Client package.
+      #
+      # @return [String] the hab package ident, e.g. "chef/chef-infra-client/19.10.0/20250822151044",
+      #   or an empty string if not running from a hab package.
+      def chef_client_hab_package_ident
+        path = File.realpath($PROGRAM_NAME)
+        bin = File.basename(path)
+        return "" unless bin =~ /^chef-[a-z-]+$/
+
+        Pathname.new(path).each_filename.to_a[2..5].join("/")
       end
 
       def hab_executable_binary_path

--- a/spec/unit/resource/chef_client_hab_ca_cert_spec.rb
+++ b/spec/unit/resource/chef_client_hab_ca_cert_spec.rb
@@ -41,13 +41,13 @@ describe Chef::Resource::ChefClientHabCaCert do
   end
 
   describe "#ca_cert_path", :linux_only do
-    let(:mock_chef_path) { "/hab/pkgs/chef/chef-infra-client/19.0.0/20250101010101/bin/chef-client" }
     let(:mock_hab_path) { "/hab/bin/hab" }
+    let(:mock_package_ident) { "chef/chef-infra-client/19.0.0/20250101010101" }
     let(:dependencies_output) { "core/cacerts/2023.1.0\nother/dependency" }
     let(:pkg_path_output) { "/hab/pkgs/core/cacerts/2023.1.0\n" }
 
     before do
-      allow(Chef::ResourceHelpers::PathHelpers).to receive(:chef_client_hab_package_binary_path).and_return(mock_chef_path)
+      allow(Chef::ResourceHelpers::PathHelpers).to receive(:chef_client_hab_package_ident).and_return(mock_package_ident)
       allow(Chef::ResourceHelpers::PathHelpers).to receive(:hab_executable_binary_path).and_return(mock_hab_path)
       allow_any_instance_of(Chef::Resource::ChefClientHabCaCert::ActionClass).to receive(:shell_out).with("#{mock_hab_path} pkg dependencies chef/chef-infra-client/19.0.0/20250101010101").and_return(double(stdout: dependencies_output, error?: false))
       allow_any_instance_of(Chef::Resource::ChefClientHabCaCert::ActionClass).to receive(:shell_out).with("#{mock_hab_path} pkg path core/cacerts/2023.1.0").and_return(double(stdout: pkg_path_output, error?: false))
@@ -79,13 +79,13 @@ describe Chef::Resource::ChefClientHabCaCert do
   end
 
   describe "#ca_cert_path", :windows_only do
-    let(:mock_chef_path_windows) { "C:\\hab\\pkgs\\chef\\chef-infra-client\\19.0.0\\20250101010101\\bin\\chef-client.exe" }
+    let(:mock_package_ident_windows) { "chef/chef-infra-client/19.0.0/20250101010101" }
     let(:mock_hab_path_windows) { "C:\\ProgramData\\Habitat\\hab.exe" }
     let(:dependencies_output) { "core/cacerts/2023.1.0\nother/dependency" }
     let(:pkg_path_output) { "/hab/pkgs/core/cacerts/2023.1.0\n" }
 
     before do
-      allow(Chef::ResourceHelpers::PathHelpers).to receive(:chef_client_hab_package_binary_path).and_return(mock_chef_path_windows)
+      allow(Chef::ResourceHelpers::PathHelpers).to receive(:chef_client_hab_package_ident).and_return(mock_package_ident_windows)
       allow(Chef::ResourceHelpers::PathHelpers).to receive(:hab_executable_binary_path).and_return(mock_hab_path_windows)
       allow(provider).to receive(:shell_out).with("#{mock_hab_path_windows} pkg dependencies chef/chef-infra-client/19.0.0/20250101010101").and_return(double(stdout: dependencies_output, error?: false))
       allow(provider).to receive(:shell_out).with("#{mock_hab_path_windows} pkg path core/cacerts/2023.1.0").and_return(double(stdout: pkg_path_output, error?: false))
@@ -97,7 +97,7 @@ describe Chef::Resource::ChefClientHabCaCert do
   end
 
   describe "action :add", :linux_only do
-    let(:mock_chef_path) { "/hab/pkgs/chef/chef-infra-client/19.0.0/20250101010101/bin/chef-client" }
+    let(:mock_package_ident) { "chef/chef-infra-client/19.0.0/20250101010101" }
     let(:mock_hab_path) { "/hab/bin/hab" }
     let(:dependencies_output) { "core/cacerts/2023.1.0\nother/dependency" }
     let(:pkg_path_output) { "/hab/pkgs/core/cacerts/2023.1.0\n" }
@@ -129,7 +129,7 @@ describe Chef::Resource::ChefClientHabCaCert do
     end
 
     before do
-      allow(Chef::ResourceHelpers::PathHelpers).to receive(:chef_client_hab_package_binary_path).and_return(mock_chef_path)
+      allow(Chef::ResourceHelpers::PathHelpers).to receive(:chef_client_hab_package_ident).and_return(mock_package_ident)
       allow(Chef::ResourceHelpers::PathHelpers).to receive(:hab_executable_binary_path).and_return(mock_hab_path)
       allow(provider).to receive(:shell_out).with("#{mock_hab_path} pkg dependencies chef/chef-infra-client/19.0.0/20250101010101").and_return(double(stdout: dependencies_output, error?: false))
       allow(provider).to receive(:shell_out).with("#{mock_hab_path} pkg path core/cacerts/2023.1.0").and_return(double(stdout: pkg_path_output, error?: false))
@@ -209,7 +209,7 @@ describe Chef::Resource::ChefClientHabCaCert do
   end
 
   describe "action :add", :windows_only do
-    let(:mock_chef_path) { "C:\\hab\\pkgs\\chef\\chef-infra-client\\19.0.0\\20250101010101\\bin\\chef-client.exe" }
+    let(:mock_package_ident) { "chef/chef-infra-client/19.0.0/20250101010101" }
     let(:mock_hab_path) { "C:\\ProgramData\\Habitat\\hab.exe" }
     let(:dependencies_output) { "core/cacerts/2023.1.0\nother/dependency" }
     let(:pkg_path_output) { "/hab/pkgs/core/cacerts/2023.1.0\n" }
@@ -241,7 +241,7 @@ describe Chef::Resource::ChefClientHabCaCert do
     end
 
     before do
-      allow(Chef::ResourceHelpers::PathHelpers).to receive(:chef_client_hab_binary_path).and_return(mock_chef_path)
+      allow(Chef::ResourceHelpers::PathHelpers).to receive(:chef_client_hab_package_ident).and_return(mock_package_ident)
       allow(Chef::ResourceHelpers::PathHelpers).to receive(:hab_executable_binary_path).and_return(mock_hab_path)
       allow(provider).to receive(:shell_out).with("#{mock_hab_path} pkg dependencies chef/chef-infra-client/19.0.0/20250101010101").and_return(double(stdout: dependencies_output, error?: false))
       allow(provider).to receive(:shell_out).with("#{mock_hab_path} pkg path core/cacerts/2023.1.0").and_return(double(stdout: pkg_path_output, error?: false))


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Try to run systemd_timer, launchd, and cron through hab pkg exec

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
