### PR TITLE
[CookbookSynchronizer#remove_deleted_files] Flatten the cache hash structure

### DIFF
--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -231,28 +231,25 @@ class Chef
 
       # First populate files from cache
       cache.find(File.join(%w{cookbooks ** {*,.*}})).each do |cache_file|
-        md = cache_file.match(%r{^cookbooks/([^/]+)/([^/]+)/(.*)})
+        md = cache_file.match(%r{^cookbooks/([^/]+)/([^/]+\/.*)})
         next unless md
 
-        (cookbook_name, segment, file) = md[1..3]
+        (cookbook_name, segment_file) = md[1..2]
         if have_cookbook?(cookbook_name)
-          cache_file_hash[cookbook_name][segment] ||= {}
-          cache_file_hash[cookbook_name][segment]["#{segment}/#{file}"] = cache_file
+          cache_file_hash[cookbook_name]["#{segment_file}"] = cache_file
         end
       end
       # Determine which files don't match manifest
       @cookbooks_by_name.each_key do |cookbook_name|
-        cache_file_hash[cookbook_name].each_key do |segment|
-          manifest_segment = cookbook_segment(cookbook_name, segment)
-          manifest_record_paths = manifest_segment.map { |manifest_record| manifest_record["path"] }
-          to_be_removed = cache_file_hash[cookbook_name][segment].keys - manifest_record_paths
-          to_be_removed.each do |path|
-            cache_file = cache_file_hash[cookbook_name][segment][path]
+        manifest_record_paths = @cookbooks_by_name[cookbook_name].manifest["all_files"].to_set { |manifest_record| manifest_record["path"] }
 
-            Chef::Log.info("Removing #{cache_file} from the cache; its is no longer in the cookbook manifest.")
-            cache.delete(cache_file)
-            @events.removed_cookbook_file(cache_file)
-          end
+        to_be_removed = cache_file_hash[cookbook_name].keys.to_set - manifest_record_paths
+        to_be_removed.each do |path|
+          cache_file = cache_file_hash[cookbook_name][path]
+
+          Chef::Log.info("Removing #{cache_file} from the cache; its is no longer in the cookbook manifest.")
+          cache.delete(cache_file)
+          @events.removed_cookbook_file(cache_file)
         end
       end
     end

--- a/spec/unit/cookbook/synchronizer_spec.rb
+++ b/spec/unit/cookbook/synchronizer_spec.rb
@@ -178,8 +178,11 @@ describe Chef::CookbookSynchronizer do
   context "#remove_deleted_files" do
     let(:file_cache) { double("Chef::FileCache with files from unused cookbooks") }
 
+    let(:valid1_cookbook) { double("valid1 cookbook", manifest: { "all_files" => [{ "path" => "recipes/default.rb" }] }) }
+    let(:valid2_cookbook) { double("valid2 cookbook", manifest: { "all_files" => [{ "path" => "recipes/default.rb" }] }) }
+
     let(:cookbook_manifest) do
-      { "valid1" => {}, "valid2" => {} }
+      { "valid1" => valid1_cookbook, "valid2" => valid2_cookbook }
     end
 
     it "removes only deleted files" do
@@ -191,7 +194,6 @@ describe Chef::CookbookSynchronizer do
       # valid2 is a cookbook not in our run_list (we're simulating an override run_list where valid2 needs to be preserved)
       expect(synchronizer).to receive(:have_cookbook?).with("valid2").at_least(:once).and_return(false)
       expect(file_cache).to receive(:delete).with("cookbooks/valid1/recipes/deleted.rb")
-      expect(synchronizer).to receive(:cookbook_segment).with("valid1", "recipes").at_least(:once).and_return([ { "path" => "recipes/default.rb" }])
       allow(synchronizer).to receive(:cache).and_return(file_cache)
       synchronizer.remove_deleted_files
     end


### PR DESCRIPTION
## Description
Simplify remove_deleted_files by flattening the cache hash structure
and using manifest["all_files"] directly instead of iterating per-segment via cookbook_segment(). This reduces regex complexity (3 capture groups to 2) and eliminates a nested loop.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
