### PR TITLE
Correcting the Rest Resource

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -554,6 +554,7 @@ GEM
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
     unf_ext (0.0.9.1)
+    unf_ext (0.0.9.1-x64-mingw-ucrt)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
     uri (1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,34 @@ GIT
       syslog
 
 GIT
+  remote: https://github.com/chef/knife.git
+  revision: 90cfcf9b1095077ef5c35a896d68db3fda495985
+  branch: main
+  specs:
+    knife (19.0.100)
+      abbrev
+      bcrypt_pbkdf (~> 1.1)
+      chef-licensing (~> 1.2)
+      chef-vault
+      ed25519 (>= 1.2, < 2.0)
+      erubis (~> 2.7)
+      ffi (>= 1.15, < 1.18.0)
+      ffi-yajl (~> 2.2)
+      highline (>= 1.6.9, < 3)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      net-ssh (>= 5.1, < 8)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      pastel
+      proxifier2 (~> 1.1)
+      train-core (~> 3.13, >= 3.13.4)
+      train-winrm (>= 0.2.17)
+      tty-prompt (~> 0.21)
+      tty-screen (~> 0.6)
+      tty-table (~> 0.11)
+
+GIT
   remote: https://github.com/chef/ohai.git
   revision: ac6cdfdfc76b2511ec68976f5b05fddcae77b989
   branch: main
@@ -281,6 +309,9 @@ GEM
     fauxhai-ng (9.3.0)
       net-ssh
     ffi (1.17.4)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x64-mingw-ucrt)
+    ffi (1.17.4-x86_64-darwin)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -297,6 +328,7 @@ GEM
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
+    highline (2.1.0)
     http-accept (2.1.1)
     http-cookie (1.1.0)
       domain_name (~> 0.5)
@@ -387,6 +419,11 @@ GEM
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.3.2)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
+    net-ssh-multi (1.2.1)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
     nori (2.7.1)
       bigdecimal
@@ -517,7 +554,6 @@ GEM
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
     unf_ext (0.0.9.1)
-    unf_ext (0.0.9.1-x64-mingw-ucrt)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
     uri (1.1.1)
@@ -558,9 +594,14 @@ GEM
     yajl (0.3.4)
 
 PLATFORMS
-  arm64-darwin-21
+  arm64-darwin-23
+  arm64-darwin-24
+  arm64-darwin-25
   ruby
   x64-mingw-ucrt
+  x86_64-darwin-23
+  x86_64-darwin-24
+  x86_64-darwin-25
 
 DEPENDENCIES
   appbundler
@@ -572,10 +613,10 @@ DEPENDENCIES
   chef-vault
   cheffish!
   crack (~> 1.0.1)
-  ed25519 (~> 1.2)
   fauxhai-ng
-  ffi (>= 1.15.5)
+  ffi (>= 1.15.5, < 1.18.0)
   inspec-core-bin (= 7.0.107)
+  knife!
   ohai!
   openssl (= 3.3.1)
   pry (~> 0.15.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,9 +309,6 @@ GEM
     fauxhai-ng (9.3.0)
       net-ssh
     ffi (1.17.4)
-    ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x64-mingw-ucrt)
-    ffi (1.17.4-x86_64-darwin)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -615,7 +612,7 @@ DEPENDENCIES
   cheffish!
   crack (~> 1.0.1)
   fauxhai-ng
-  ffi (>= 1.15.5, < 1.18.0)
+  ffi (>= 1.15.5)
   inspec-core-bin (= 7.0.107)
   knife!
   ohai!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,34 +11,6 @@ GIT
       syslog
 
 GIT
-  remote: https://github.com/chef/knife.git
-  revision: 90cfcf9b1095077ef5c35a896d68db3fda495985
-  branch: main
-  specs:
-    knife (19.0.100)
-      abbrev
-      bcrypt_pbkdf (~> 1.1)
-      chef-licensing (~> 1.2)
-      chef-vault
-      ed25519 (>= 1.2, < 2.0)
-      erubis (~> 2.7)
-      ffi (>= 1.15, < 1.18.0)
-      ffi-yajl (~> 2.2)
-      highline (>= 1.6.9, < 3)
-      license-acceptance (>= 1.0.5, < 3)
-      mixlib-archive (>= 0.4, < 2.0)
-      mixlib-cli (>= 2.1.1, < 3.0)
-      net-ssh (>= 5.1, < 8)
-      net-ssh-multi (~> 1.2, >= 1.2.1)
-      pastel
-      proxifier2 (~> 1.1)
-      train-core (~> 3.13, >= 3.13.4)
-      train-winrm (>= 0.2.17)
-      tty-prompt (~> 0.21)
-      tty-screen (~> 0.6)
-      tty-table (~> 0.11)
-
-GIT
   remote: https://github.com/chef/ohai.git
   revision: ac6cdfdfc76b2511ec68976f5b05fddcae77b989
   branch: main
@@ -325,7 +297,6 @@ GEM
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
-    highline (2.1.0)
     http-accept (2.1.1)
     http-cookie (1.1.0)
       domain_name (~> 0.5)
@@ -416,11 +387,6 @@ GEM
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.3.2)
-    net-ssh-gateway (2.0.0)
-      net-ssh (>= 4.0.0)
-    net-ssh-multi (1.2.1)
-      net-ssh (>= 2.6.5)
-      net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
     nori (2.7.1)
       bigdecimal
@@ -592,14 +558,9 @@ GEM
     yajl (0.3.4)
 
 PLATFORMS
-  arm64-darwin-23
-  arm64-darwin-24
-  arm64-darwin-25
+  arm64-darwin-21
   ruby
   x64-mingw-ucrt
-  x86_64-darwin-23
-  x86_64-darwin-24
-  x86_64-darwin-25
 
 DEPENDENCIES
   appbundler
@@ -611,10 +572,10 @@ DEPENDENCIES
   chef-vault
   cheffish!
   crack (~> 1.0.1)
+  ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5)
   inspec-core-bin (= 7.0.107)
-  knife!
   ohai!
   openssl (= 3.3.1)
   pry (~> 0.15.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,34 +11,6 @@ GIT
       syslog
 
 GIT
-  remote: https://github.com/chef/knife.git
-  revision: 90cfcf9b1095077ef5c35a896d68db3fda495985
-  branch: main
-  specs:
-    knife (19.0.100)
-      abbrev
-      bcrypt_pbkdf (~> 1.1)
-      chef-licensing (~> 1.2)
-      chef-vault
-      ed25519 (>= 1.2, < 2.0)
-      erubis (~> 2.7)
-      ffi (>= 1.15, < 1.18.0)
-      ffi-yajl (~> 2.2)
-      highline (>= 1.6.9, < 3)
-      license-acceptance (>= 1.0.5, < 3)
-      mixlib-archive (>= 0.4, < 2.0)
-      mixlib-cli (>= 2.1.1, < 3.0)
-      net-ssh (>= 5.1, < 8)
-      net-ssh-multi (~> 1.2, >= 1.2.1)
-      pastel
-      proxifier2 (~> 1.1)
-      train-core (~> 3.13, >= 3.13.4)
-      train-winrm (>= 0.2.17)
-      tty-prompt (~> 0.21)
-      tty-screen (~> 0.6)
-      tty-table (~> 0.11)
-
-GIT
   remote: https://github.com/chef/ohai.git
   revision: ac6cdfdfc76b2511ec68976f5b05fddcae77b989
   branch: main
@@ -328,7 +300,6 @@ GEM
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
-    highline (2.1.0)
     http-accept (2.1.1)
     http-cookie (1.1.0)
       domain_name (~> 0.5)
@@ -419,11 +390,6 @@ GEM
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.3.2)
-    net-ssh-gateway (2.0.0)
-      net-ssh (>= 4.0.0)
-    net-ssh-multi (1.2.1)
-      net-ssh (>= 2.6.5)
-      net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
     nori (2.7.1)
       bigdecimal
@@ -594,14 +560,9 @@ GEM
     yajl (0.3.4)
 
 PLATFORMS
-  arm64-darwin-23
-  arm64-darwin-24
-  arm64-darwin-25
+  arm64-darwin-21
   ruby
   x64-mingw-ucrt
-  x86_64-darwin-23
-  x86_64-darwin-24
-  x86_64-darwin-25
 
 DEPENDENCIES
   appbundler
@@ -613,10 +574,10 @@ DEPENDENCIES
   chef-vault
   cheffish!
   crack (~> 1.0.1)
+  ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5, < 1.18.0)
   inspec-core-bin (= 7.0.107)
-  knife!
   ohai!
   openssl (= 3.3.1)
   pry (~> 0.15.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,34 @@ GIT
       syslog
 
 GIT
+  remote: https://github.com/chef/knife.git
+  revision: 90cfcf9b1095077ef5c35a896d68db3fda495985
+  branch: main
+  specs:
+    knife (19.0.100)
+      abbrev
+      bcrypt_pbkdf (~> 1.1)
+      chef-licensing (~> 1.2)
+      chef-vault
+      ed25519 (>= 1.2, < 2.0)
+      erubis (~> 2.7)
+      ffi (>= 1.15, < 1.18.0)
+      ffi-yajl (~> 2.2)
+      highline (>= 1.6.9, < 3)
+      license-acceptance (>= 1.0.5, < 3)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-cli (>= 2.1.1, < 3.0)
+      net-ssh (>= 5.1, < 8)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      pastel
+      proxifier2 (~> 1.1)
+      train-core (~> 3.13, >= 3.13.4)
+      train-winrm (>= 0.2.17)
+      tty-prompt (~> 0.21)
+      tty-screen (~> 0.6)
+      tty-table (~> 0.11)
+
+GIT
   remote: https://github.com/chef/ohai.git
   revision: ac6cdfdfc76b2511ec68976f5b05fddcae77b989
   branch: main
@@ -300,6 +328,7 @@ GEM
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
+    highline (2.1.0)
     http-accept (2.1.1)
     http-cookie (1.1.0)
       domain_name (~> 0.5)
@@ -390,6 +419,11 @@ GEM
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.3.2)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
+    net-ssh-multi (1.2.1)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
     nori (2.7.1)
       bigdecimal
@@ -560,9 +594,14 @@ GEM
     yajl (0.3.4)
 
 PLATFORMS
-  arm64-darwin-21
+  arm64-darwin-23
+  arm64-darwin-24
+  arm64-darwin-25
   ruby
   x64-mingw-ucrt
+  x86_64-darwin-23
+  x86_64-darwin-24
+  x86_64-darwin-25
 
 DEPENDENCIES
   appbundler
@@ -574,10 +613,10 @@ DEPENDENCIES
   chef-vault
   cheffish!
   crack (~> 1.0.1)
-  ed25519 (~> 1.2)
   fauxhai-ng
   ffi (>= 1.15.5, < 1.18.0)
   inspec-core-bin (= 7.0.107)
+  knife!
   ohai!
   openssl (= 3.3.1)
   pry (~> 0.15.2)

--- a/lib/chef/dsl/rest_resource.rb
+++ b/lib/chef/dsl/rest_resource.rb
@@ -61,7 +61,7 @@ class Chef
 
           @rest_property_map = rest_property_map
         end
-        @rest_property_map
+        @rest_property_map || (superclass.respond_to?(:rest_property_map) ? superclass.rest_property_map : nil)
       end
 
       # Define the REST API collection URL
@@ -89,7 +89,7 @@ class Chef
           @rest_api_collection = rest_api_collection
         end
 
-        @rest_api_collection
+        @rest_api_collection || (superclass.respond_to?(:rest_api_collection) ? superclass.rest_api_collection : nil)
       end
 
       # Define the REST API document URL with RFC 6570 template support
@@ -137,7 +137,9 @@ class Chef
           @rest_api_document = rest_api_document
           @rest_api_document_first_element_only = first_element_only
         end
-        @rest_api_document
+        @rest_api_document ||
+          (superclass.respond_to?(:rest_api_document) ? superclass.rest_api_document : nil) ||
+          (rest_api_collection && rest_identity_property ? "#{rest_api_collection}/{#{rest_identity_property}}" : nil)
       end
 
       # Define explicit identity mapping for resource identification
@@ -178,7 +180,7 @@ class Chef
       #   })
       def rest_identity_map(rest_identity_map = NOT_PASSED)
         @rest_identity_map = rest_identity_map if rest_identity_map != NOT_PASSED
-        @rest_identity_map
+        @rest_identity_map || (superclass.respond_to?(:rest_identity_map) ? superclass.rest_identity_map : nil)
       end
 
       # Declare properties that should only be sent during resource creation
@@ -222,14 +224,55 @@ class Chef
         if rest_post_only_properties != NOT_PASSED
           @rest_post_only_properties = Array(rest_post_only_properties).map(&:to_sym)
         end
-        @rest_post_only_properties || []
+        @rest_post_only_properties || (superclass.respond_to?(:rest_post_only_properties) ? superclass.rest_post_only_properties : [])
       end
 
       def rest_api_document_first_element_only(rest_api_document_first_element_only = NOT_PASSED)
         if rest_api_document_first_element_only != NOT_PASSED
           @rest_api_document_first_element_only = rest_api_document_first_element_only
         end
-        @rest_api_document_first_element_only
+        @rest_api_document_first_element_only || (superclass.respond_to?(:rest_api_document_first_element_only) ? superclass.rest_api_document_first_element_only : nil)
+      end
+
+      # Define the base URL for the REST API
+      #
+      # Sets the base endpoint URL that is prepended to all collection and document
+      # URLs. This allows resource definitions to be self-contained without requiring
+      # the Train transport endpoint to be pre-configured.
+      #
+      # @param rest_api_endpoint [String, NOT_PASSED] The base URL of the REST API
+      #   - NOT_PASSED: Acts as getter, returns current endpoint URL
+      #
+      # @return [String, nil] The current endpoint URL
+      #
+      # @example
+      #   rest_api_endpoint "https://api.example.com"
+      #   rest_api_collection "/api/v1/users"
+      #   # GET https://api.example.com/api/v1/users
+      def rest_api_endpoint(rest_api_endpoint = NOT_PASSED)
+        @rest_api_endpoint = rest_api_endpoint if rest_api_endpoint != NOT_PASSED
+        @rest_api_endpoint || (superclass.respond_to?(:rest_api_endpoint) ? superclass.rest_api_endpoint : nil)
+      end
+
+      # Declare the property that uniquely identifies a resource in the REST API
+      #
+      # Sets the identity property for the resource and auto-generates the document
+      # URL as "#{rest_api_collection}/{property}" when no explicit rest_api_document
+      # is provided. This is a convenience alternative to setting rest_api_document
+      # manually.
+      #
+      # @param property [Symbol, NOT_PASSED] The property name used as the resource identifier
+      #   - NOT_PASSED: Acts as getter, returns current identity property
+      #
+      # @return [Symbol, nil] The current identity property name
+      #
+      # @example
+      #   rest_api_collection "/api/v1/users"
+      #   rest_identity_property :username
+      #   # Auto-generates rest_api_document as "/api/v1/users/{username}"
+      def rest_identity_property(property = NOT_PASSED)
+        @rest_identity_property = property if property != NOT_PASSED
+        @rest_identity_property || (superclass.respond_to?(:rest_identity_property) ? superclass.rest_identity_property : nil)
       end
 
     end

--- a/lib/chef/dsl/rest_resource.rb
+++ b/lib/chef/dsl/rest_resource.rb
@@ -24,6 +24,14 @@ class Chef
     # when a custom resource uses the 'core::rest_resource' partial.
     #
     module RestResource
+      private
+
+      def inherited_accessor(name)
+        superclass.public_send(name) if superclass.respond_to?(name)
+      end
+
+      public
+
       # Define property mapping between resource properties and JSON API fields
       #
       # Maps resource properties to their corresponding locations in the JSON
@@ -56,12 +64,12 @@ class Chef
       # @see #json_to_property Method that uses this mapping to extract values
       # @see #property_to_json Method that uses this mapping to create JSON
       def rest_property_map(rest_property_map = NOT_PASSED)
-        if rest_property_map != NOT_PASSED
+        unless rest_property_map.equal?(NOT_PASSED)
           rest_property_map = rest_property_map.to_h { |k| [k.to_sym, k] } if rest_property_map.is_a? Array
 
           @rest_property_map = rest_property_map
         end
-        @rest_property_map || (superclass.respond_to?(:rest_property_map) ? superclass.rest_property_map : nil)
+        @rest_property_map || inherited_accessor(:rest_property_map)
       end
 
       # Define the REST API collection URL
@@ -83,13 +91,13 @@ class Chef
       #   # GET  /api/v1/users      # List all users
       #   # POST /api/v1/users      # Create new user
       def rest_api_collection(rest_api_collection = NOT_PASSED)
-        if rest_api_collection != NOT_PASSED
+        unless rest_api_collection.equal?(NOT_PASSED)
           raise ArgumentError, "You must pass an absolute path to rest_api_collection" unless rest_api_collection.start_with? "/"
 
           @rest_api_collection = rest_api_collection
         end
 
-        @rest_api_collection || (superclass.respond_to?(:rest_api_collection) ? superclass.rest_api_collection : nil)
+        @rest_api_collection || inherited_accessor(:rest_api_collection)
       end
 
       # Define the REST API document URL with RFC 6570 template support
@@ -131,14 +139,14 @@ class Chef
       #
       # @see https://tools.ietf.org/html/rfc6570 RFC 6570 URI Template specification
       def rest_api_document(rest_api_document = NOT_PASSED, first_element_only: false)
-        if rest_api_document != NOT_PASSED
+        unless rest_api_document.equal?(NOT_PASSED)
           raise ArgumentError, "You must pass an absolute path to rest_api_document" unless rest_api_document.start_with? "/"
 
           @rest_api_document = rest_api_document
           @rest_api_document_first_element_only = first_element_only
         end
         @rest_api_document ||
-          (superclass.respond_to?(:rest_api_document) ? superclass.rest_api_document : nil) ||
+          inherited_accessor(:rest_api_document) ||
           (rest_api_collection && rest_identity_property ? "#{rest_api_collection}/{#{rest_identity_property}}" : nil)
       end
 
@@ -179,8 +187,8 @@ class Chef
       #     'organization.id' => :org_id
       #   })
       def rest_identity_map(rest_identity_map = NOT_PASSED)
-        @rest_identity_map = rest_identity_map if rest_identity_map != NOT_PASSED
-        @rest_identity_map || (superclass.respond_to?(:rest_identity_map) ? superclass.rest_identity_map : nil)
+        @rest_identity_map = rest_identity_map unless rest_identity_map.equal?(NOT_PASSED)
+        @rest_identity_map || inherited_accessor(:rest_identity_map)
       end
 
       # Declare properties that should only be sent during resource creation
@@ -221,17 +229,17 @@ class Chef
       #   # Initialization parameters
       #   rest_post_only_properties [:template_id, :source_snapshot]
       def rest_post_only_properties(rest_post_only_properties = NOT_PASSED)
-        if rest_post_only_properties != NOT_PASSED
+        unless rest_post_only_properties.equal?(NOT_PASSED)
           @rest_post_only_properties = Array(rest_post_only_properties).map(&:to_sym)
         end
-        @rest_post_only_properties || (superclass.respond_to?(:rest_post_only_properties) ? superclass.rest_post_only_properties : [])
+        @rest_post_only_properties || inherited_accessor(:rest_post_only_properties) || []
       end
 
       def rest_api_document_first_element_only(rest_api_document_first_element_only = NOT_PASSED)
-        if rest_api_document_first_element_only != NOT_PASSED
+        unless rest_api_document_first_element_only.equal?(NOT_PASSED)
           @rest_api_document_first_element_only = rest_api_document_first_element_only
         end
-        @rest_api_document_first_element_only || (superclass.respond_to?(:rest_api_document_first_element_only) ? superclass.rest_api_document_first_element_only : nil)
+        @rest_api_document_first_element_only || inherited_accessor(:rest_api_document_first_element_only)
       end
 
       # Define the base URL for the REST API
@@ -250,8 +258,8 @@ class Chef
       #   rest_api_collection "/api/v1/users"
       #   # GET https://api.example.com/api/v1/users
       def rest_api_endpoint(rest_api_endpoint = NOT_PASSED)
-        @rest_api_endpoint = rest_api_endpoint if rest_api_endpoint != NOT_PASSED
-        @rest_api_endpoint || (superclass.respond_to?(:rest_api_endpoint) ? superclass.rest_api_endpoint : nil)
+        @rest_api_endpoint = rest_api_endpoint unless rest_api_endpoint.equal?(NOT_PASSED)
+        @rest_api_endpoint || inherited_accessor(:rest_api_endpoint)
       end
 
       # Declare the property that uniquely identifies a resource in the REST API
@@ -271,8 +279,8 @@ class Chef
       #   rest_identity_property :username
       #   # Auto-generates rest_api_document as "/api/v1/users/{username}"
       def rest_identity_property(property = NOT_PASSED)
-        @rest_identity_property = property if property != NOT_PASSED
-        @rest_identity_property || (superclass.respond_to?(:rest_identity_property) ? superclass.rest_identity_property : nil)
+        @rest_identity_property = property unless property.equal?(NOT_PASSED)
+        @rest_identity_property || inherited_accessor(:rest_identity_property)
       end
 
     end

--- a/lib/chef/resource/_rest_resource.rb
+++ b/lib/chef/resource/_rest_resource.rb
@@ -300,15 +300,17 @@ action_class do
   end
 
   def rest_url_collection
-    current_resource.class.rest_api_collection
+    endpoint = current_resource.class.rest_api_endpoint || ""
+    "#{endpoint}#{current_resource.class.rest_api_collection}"
   end
 
   #
   # Resource document URL after RFC 6570 template evaluation via properties substitution
   #
   def rest_url_document
+    endpoint = current_resource.class.rest_api_endpoint || ""
     template = ::Addressable::Template.new(current_resource.class.rest_api_document)
-    template.expand(property_map).to_s
+    "#{endpoint}#{template.expand(property_map)}"
   end
 
   #

--- a/spec/unit/resource/rest_resource_spec.rb
+++ b/spec/unit/resource/rest_resource_spec.rb
@@ -21,6 +21,7 @@ require "train-rest"
 
 API_HOST = "https://api.example.com".freeze
 API_BASE_URL = "#{API_HOST}/api/v1/".freeze
+CORE_REST_RESOURCE = "core::rest_resource".freeze
 COLLECTION_PATH = "/api/v1/addresses".freeze
 QUERY_DOCUMENT_PATH = "/api/v1/address/?ip={address}".freeze
 PATH_DOCUMENT_PATH = "/api/v1/address/{address}".freeze
@@ -49,7 +50,7 @@ PATH_RESOURCE_PATH = "/api/v1/address/#{ADDRESS}".freeze
 IDENTITY_RESOURCE_PATH = "/api/v1/addresses/#{ADDRESS}".freeze
 
 class RestResourceByQuery < Chef::Resource
-  use "core::rest_resource"
+  use CORE_REST_RESOURCE
 
   provides :rest_resource_by_query, target_mode: true
 
@@ -73,7 +74,7 @@ class RestResourceByPath < RestResourceByQuery
 end
 
 class RestResourceWithEndpoint < Chef::Resource
-  use "core::rest_resource"
+  use CORE_REST_RESOURCE
 
   provides :rest_resource_with_endpoint, target_mode: true
 
@@ -92,7 +93,7 @@ class RestResourceWithEndpoint < Chef::Resource
 end
 
 class RestResourceWithIdentityProperty < Chef::Resource
-  use "core::rest_resource"
+  use CORE_REST_RESOURCE
 
   provides :rest_resource_with_identity_property, target_mode: true
 
@@ -110,7 +111,7 @@ class RestResourceWithIdentityProperty < Chef::Resource
 end
 
 class RestResourceWithEndpointAndIdentityProperty < Chef::Resource
-  use "core::rest_resource"
+  use CORE_REST_RESOURCE
 
   provides :rest_resource_with_endpoint_and_identity_property, target_mode: true
 

--- a/spec/unit/resource/rest_resource_spec.rb
+++ b/spec/unit/resource/rest_resource_spec.rb
@@ -43,6 +43,62 @@ class RestResourceByPath < RestResourceByQuery
   rest_api_document "/api/v1/address/{address}"
 end
 
+class RestResourceWithEndpoint < Chef::Resource
+  use "core::rest_resource"
+
+  provides :rest_resource_with_endpoint, target_mode: true
+
+  property :address, String, required: true
+  property :prefix, Integer, required: true
+  property :gateway, String
+
+  rest_api_endpoint "https://api.example.com"
+  rest_api_collection "/api/v1/addresses"
+  rest_api_document   "/api/v1/address/{address}"
+  rest_property_map({
+    address: "address",
+    prefix: "prefix",
+    gateway: "gateway",
+  })
+end
+
+class RestResourceWithIdentityProperty < Chef::Resource
+  use "core::rest_resource"
+
+  provides :rest_resource_with_identity_property, target_mode: true
+
+  property :address, String, required: true
+  property :prefix, Integer, required: true
+  property :gateway, String
+
+  rest_api_collection "/api/v1/addresses"
+  rest_identity_property :address
+  rest_property_map({
+    address: "address",
+    prefix: "prefix",
+    gateway: "gateway",
+  })
+end
+
+class RestResourceWithEndpointAndIdentityProperty < Chef::Resource
+  use "core::rest_resource"
+
+  provides :rest_resource_with_endpoint_and_identity_property, target_mode: true
+
+  property :address, String, required: true
+  property :prefix, Integer, required: true
+  property :gateway, String
+
+  rest_api_endpoint "https://api.example.com"
+  rest_api_collection "/api/v1/addresses"
+  rest_identity_property :address
+  rest_property_map({
+    address: "address",
+    prefix: "prefix",
+    gateway: "gateway",
+  })
+end
+
 describe "rest_resource using query-based addressing" do
   let(:train) {
     Train.create(
@@ -378,4 +434,368 @@ describe "rest_resource using path-based addressing" do
     end
   end
 
+end
+
+describe "rest_resource using rest_api_endpoint" do
+  let(:train) {
+    Train.create(
+      "rest", {
+      endpoint:   RestResourceWithEndpoint.rest_api_endpoint,
+      debug_rest: true,
+      logger:     Chef::Log,
+    }
+    ).connection
+  }
+
+  let(:run_context) do
+    cookbook_collection = Chef::CookbookCollection.new([])
+    node = Chef::Node.new
+    node.name "node1"
+    events = Chef::EventDispatch::Dispatcher.new
+    Chef::RunContext.new(node, cookbook_collection, events)
+  end
+
+  let(:resource) do
+    RestResourceWithEndpoint.new("set_address", run_context).tap do |resource|
+      resource.address = "192.0.2.1"
+      resource.prefix = 24
+      resource.action :configure
+    end
+  end
+
+  let(:provider) do
+    resource.provider_for_action(:configure).tap do |provider|
+      provider.current_resource = resource
+      allow(provider).to receive(:api_connection).and_return(train)
+    end
+  end
+
+  before(:each) do
+    allow(Chef::Provider).to receive(:new).and_return(provider)
+  end
+
+  it "should store rest_api_endpoint on the resource class" do
+    expect(resource.class.rest_api_endpoint).to eq("https://api.example.com")
+  end
+
+  describe "#rest_url_collection" do
+    before do
+      provider.singleton_class.send(:public, :rest_url_collection)
+    end
+
+    it "should prepend the endpoint to the collection URL" do
+      expect(provider.rest_url_collection).to eq("https://api.example.com/api/v1/addresses")
+    end
+  end
+
+  describe "#rest_url_document" do
+    before do
+      provider.singleton_class.send(:public, :rest_url_document)
+    end
+
+    it "should prepend the endpoint to the document URL" do
+      expect(provider.rest_url_document).to eq("https://api.example.com/api/v1/address/192.0.2.1")
+    end
+  end
+
+  describe "when managing a resource" do
+    before { WebMock.disable_net_connect! }
+    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
+    let(:address_exists) { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+
+    it "should be idempotent" do
+      stub_request(:get, "https://api.example.com/api/v1/addresses")
+        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, "https://api.example.com/api/v1/address/192.0.2.1")
+        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      resource.run_action(:configure)
+      expect(resource.updated_by_last_action?).to be false
+    end
+  end
+end
+
+describe "rest_resource using rest_identity_property" do
+  let(:train) {
+    Train.create(
+      "rest", {
+      endpoint:   "https://api.example.com/api/v1/",
+      debug_rest: true,
+      logger:     Chef::Log,
+    }
+    ).connection
+  }
+
+  let(:run_context) do
+    cookbook_collection = Chef::CookbookCollection.new([])
+    node = Chef::Node.new
+    node.name "node1"
+    events = Chef::EventDispatch::Dispatcher.new
+    Chef::RunContext.new(node, cookbook_collection, events)
+  end
+
+  let(:resource) do
+    RestResourceWithIdentityProperty.new("set_address", run_context).tap do |resource|
+      resource.address = "192.0.2.1"
+      resource.prefix = 24
+      resource.action :configure
+    end
+  end
+
+  let(:provider) do
+    resource.provider_for_action(:configure).tap do |provider|
+      provider.current_resource = resource
+      allow(provider).to receive(:api_connection).and_return(train)
+    end
+  end
+
+  before(:each) do
+    allow(Chef::Provider).to receive(:new).and_return(provider)
+  end
+
+  it "should store rest_identity_property on the resource class" do
+    expect(resource.class.rest_identity_property).to eq(:address)
+  end
+
+  it "should auto-generate rest_api_document from collection and identity property" do
+    expect(resource.class.rest_api_document).to eq("/api/v1/addresses/{address}")
+  end
+
+  describe "#rest_url_document" do
+    before do
+      provider.singleton_class.send(:public, :rest_url_document)
+    end
+
+    it "should expand the auto-generated document URL using the identity property value" do
+      expect(provider.rest_url_document).to eq("/api/v1/addresses/192.0.2.1")
+    end
+  end
+
+  describe "when managing a resource" do
+    before { WebMock.disable_net_connect! }
+    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
+    let(:address_exists) { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+
+    it "should be idempotent" do
+      stub_request(:get, "https://api.example.com/api/v1/addresses")
+        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, "https://api.example.com/api/v1/addresses/192.0.2.1")
+        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      resource.run_action(:configure)
+      expect(resource.updated_by_last_action?).to be false
+    end
+  end
+end
+
+describe "rest_resource using rest_api_endpoint and rest_identity_property" do
+  let(:train) {
+    Train.create(
+      "rest", {
+      endpoint:   RestResourceWithEndpointAndIdentityProperty.rest_api_endpoint,
+      debug_rest: true,
+      logger:     Chef::Log,
+    }
+    ).connection
+  }
+
+  let(:run_context) do
+    cookbook_collection = Chef::CookbookCollection.new([])
+    node = Chef::Node.new
+    node.name "node1"
+    events = Chef::EventDispatch::Dispatcher.new
+    Chef::RunContext.new(node, cookbook_collection, events)
+  end
+
+  let(:resource) do
+    RestResourceWithEndpointAndIdentityProperty.new("set_address", run_context).tap do |resource|
+      resource.address = "192.0.2.1"
+      resource.prefix = 24
+      resource.action :configure
+    end
+  end
+
+  let(:provider) do
+    resource.provider_for_action(:configure).tap do |provider|
+      provider.current_resource = resource
+      allow(provider).to receive(:api_connection).and_return(train)
+    end
+  end
+
+  before(:each) do
+    allow(Chef::Provider).to receive(:new).and_return(provider)
+  end
+
+  describe "#rest_url_collection" do
+    before do
+      provider.singleton_class.send(:public, :rest_url_collection)
+    end
+
+    it "should prepend the endpoint to the collection URL" do
+      expect(provider.rest_url_collection).to eq("https://api.example.com/api/v1/addresses")
+    end
+  end
+
+  describe "#rest_url_document" do
+    before do
+      provider.singleton_class.send(:public, :rest_url_document)
+    end
+
+    it "should build the full document URL from endpoint, collection, and identity property" do
+      expect(provider.rest_url_document).to eq("https://api.example.com/api/v1/addresses/192.0.2.1")
+    end
+  end
+
+  describe "when managing a resource" do
+    before { WebMock.disable_net_connect! }
+    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
+    let(:address_exists) { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+
+    it "should be idempotent" do
+      stub_request(:get, "https://api.example.com/api/v1/addresses")
+        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, "https://api.example.com/api/v1/addresses/192.0.2.1")
+        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      resource.run_action(:configure)
+      expect(resource.updated_by_last_action?).to be false
+    end
+  end
+end
+
+# These two blocks demonstrate that configuring the endpoint via Train directly
+# (rather than via rest_api_endpoint) still works. The resource uses relative
+# paths only; the base URL is owned entirely by the Train connection's endpoint option.
+
+describe "rest_resource with endpoint configured via Train transport (query-based)" do
+  let(:train) {
+    Train.create(
+      "rest", {
+      endpoint:   "https://api.example.com",
+      debug_rest: true,
+      logger:     Chef::Log,
+    }
+    ).connection
+  }
+
+  let(:run_context) do
+    cookbook_collection = Chef::CookbookCollection.new([])
+    node = Chef::Node.new
+    node.name "node1"
+    events = Chef::EventDispatch::Dispatcher.new
+    Chef::RunContext.new(node, cookbook_collection, events)
+  end
+
+  let(:resource) do
+    RestResourceByQuery.new("set_address", run_context).tap do |resource|
+      resource.address = "192.0.2.1"
+      resource.prefix  = 24
+      resource.action  :configure
+    end
+  end
+
+  let(:provider) do
+    resource.provider_for_action(:configure).tap do |provider|
+      provider.current_resource = resource
+      allow(provider).to receive(:api_connection).and_return(train)
+    end
+  end
+
+  before(:each) { allow(Chef::Provider).to receive(:new).and_return(provider) }
+
+  it "should have no rest_api_endpoint set on the resource class" do
+    expect(resource.class.rest_api_endpoint).to be_nil
+  end
+
+  describe "#rest_url_collection" do
+    before { provider.singleton_class.send(:public, :rest_url_collection) }
+
+    it "returns a relative collection URL (endpoint lives in Train)" do
+      expect(provider.rest_url_collection).to eq("/api/v1/addresses")
+    end
+  end
+
+  describe "#rest_url_document" do
+    before { provider.singleton_class.send(:public, :rest_url_document) }
+
+    it "returns a relative document URL (endpoint lives in Train)" do
+      expect(provider.rest_url_document).to eq("/api/v1/address/?ip=192.0.2.1")
+    end
+  end
+
+  describe "when managing a resource" do
+    before { WebMock.disable_net_connect! }
+    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
+    let(:address_exists)   { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+
+    it "resolves the full URL via the Train transport endpoint and is idempotent" do
+      stub_request(:get, "https://api.example.com/api/v1/addresses")
+        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
+        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      resource.run_action(:configure)
+      expect(resource.updated_by_last_action?).to be false
+    end
+  end
+end
+
+describe "rest_resource with endpoint configured via Train transport (path-based)" do
+  let(:train) {
+    Train.create(
+      "rest", {
+      endpoint:   "https://api.example.com",
+      debug_rest: true,
+      logger:     Chef::Log,
+    }
+    ).connection
+  }
+
+  let(:run_context) do
+    cookbook_collection = Chef::CookbookCollection.new([])
+    node = Chef::Node.new
+    node.name "node1"
+    events = Chef::EventDispatch::Dispatcher.new
+    Chef::RunContext.new(node, cookbook_collection, events)
+  end
+
+  let(:resource) do
+    RestResourceByPath.new("set_address", run_context).tap do |resource|
+      resource.address = "192.0.2.1"
+      resource.prefix  = 24
+      resource.action  :configure
+    end
+  end
+
+  let(:provider) do
+    resource.provider_for_action(:configure).tap do |provider|
+      provider.current_resource = resource
+      allow(provider).to receive(:api_connection).and_return(train)
+    end
+  end
+
+  before(:each) { allow(Chef::Provider).to receive(:new).and_return(provider) }
+
+  it "should have no rest_api_endpoint set on the resource class" do
+    expect(resource.class.rest_api_endpoint).to be_nil
+  end
+
+  describe "#rest_url_document" do
+    before { provider.singleton_class.send(:public, :rest_url_document) }
+
+    it "returns a relative document URL (endpoint lives in Train)" do
+      expect(provider.rest_url_document).to eq("/api/v1/address/192.0.2.1")
+    end
+  end
+
+  describe "when managing a resource" do
+    before { WebMock.disable_net_connect! }
+    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
+    let(:address_exists)   { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+
+    it "resolves the full URL via the Train transport endpoint and is idempotent" do
+      stub_request(:get, "https://api.example.com/api/v1/addresses")
+        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, "https://api.example.com/api/v1/address/192.0.2.1")
+        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      resource.run_action(:configure)
+      expect(resource.updated_by_last_action?).to be false
+    end
+  end
 end

--- a/spec/unit/resource/rest_resource_spec.rb
+++ b/spec/unit/resource/rest_resource_spec.rb
@@ -19,6 +19,35 @@ require "spec_helper"
 require "train"
 require "train-rest"
 
+API_HOST = "https://api.example.com".freeze
+API_BASE_URL = "#{API_HOST}/api/v1/".freeze
+COLLECTION_PATH = "/api/v1/addresses".freeze
+QUERY_DOCUMENT_PATH = "/api/v1/address/?ip={address}".freeze
+PATH_DOCUMENT_PATH = "/api/v1/address/{address}".freeze
+CONTENT_TYPE_JSON = "application/json".freeze
+RESOURCE_NAME = "set_address".freeze
+ADDRESS = "192.0.2.1".freeze
+OTHER_ADDRESS = "172.16.32.85".freeze
+EMPTY_JSON_ARRAY = "[]".freeze
+AUTO_DOCUMENT_PATH = "/api/v1/addresses/{address}".freeze
+
+HEADER_ACCEPT = "Accept".freeze
+HEADER_CONTENT_TYPE = "Content-Type".freeze
+JSON_REQUEST_HEADERS = { HEADER_ACCEPT => CONTENT_TYPE_JSON, HEADER_CONTENT_TYPE => CONTENT_TYPE_JSON }.freeze
+JSON_RESPONSE_HEADERS = { HEADER_CONTENT_TYPE => CONTENT_TYPE_JSON }.freeze
+
+PATCH_PREFIX_WRONG_BODY = "{\"address\":\"#{ADDRESS}\",\"prefix\":25}".freeze
+POST_CREATE_BODY = "{\"address\":\"#{ADDRESS}\",\"prefix\":24,\"ip\":\"#{ADDRESS}\"}".freeze
+
+COLLECTION_URL = "#{API_BASE_URL}addresses".freeze
+QUERY_RESOURCE_URL = "#{API_BASE_URL}address/?ip=#{ADDRESS}".freeze
+PATH_RESOURCE_URL = "#{API_BASE_URL}address/#{ADDRESS}".freeze
+IDENTITY_RESOURCE_URL = "#{API_BASE_URL}addresses/#{ADDRESS}".freeze
+
+QUERY_RESOURCE_PATH = "/api/v1/address/?ip=#{ADDRESS}".freeze
+PATH_RESOURCE_PATH = "/api/v1/address/#{ADDRESS}".freeze
+IDENTITY_RESOURCE_PATH = "/api/v1/addresses/#{ADDRESS}".freeze
+
 class RestResourceByQuery < Chef::Resource
   use "core::rest_resource"
 
@@ -28,8 +57,8 @@ class RestResourceByQuery < Chef::Resource
   property :prefix, Integer, required: true
   property :gateway, String
 
-  rest_api_collection "/api/v1/addresses"
-  rest_api_document   "/api/v1/address/?ip={address}"
+  rest_api_collection COLLECTION_PATH
+  rest_api_document   QUERY_DOCUMENT_PATH
   rest_property_map({
     address: "address",
     prefix: "prefix",
@@ -40,7 +69,7 @@ end
 class RestResourceByPath < RestResourceByQuery
   provides :rest_resource_by_path, target_mode: true
 
-  rest_api_document "/api/v1/address/{address}"
+  rest_api_document PATH_DOCUMENT_PATH
 end
 
 class RestResourceWithEndpoint < Chef::Resource
@@ -52,9 +81,9 @@ class RestResourceWithEndpoint < Chef::Resource
   property :prefix, Integer, required: true
   property :gateway, String
 
-  rest_api_endpoint "https://api.example.com"
-  rest_api_collection "/api/v1/addresses"
-  rest_api_document   "/api/v1/address/{address}"
+  rest_api_endpoint API_HOST
+  rest_api_collection COLLECTION_PATH
+  rest_api_document   PATH_DOCUMENT_PATH
   rest_property_map({
     address: "address",
     prefix: "prefix",
@@ -71,7 +100,7 @@ class RestResourceWithIdentityProperty < Chef::Resource
   property :prefix, Integer, required: true
   property :gateway, String
 
-  rest_api_collection "/api/v1/addresses"
+  rest_api_collection COLLECTION_PATH
   rest_identity_property :address
   rest_property_map({
     address: "address",
@@ -89,8 +118,8 @@ class RestResourceWithEndpointAndIdentityProperty < Chef::Resource
   property :prefix, Integer, required: true
   property :gateway, String
 
-  rest_api_endpoint "https://api.example.com"
-  rest_api_collection "/api/v1/addresses"
+  rest_api_endpoint API_HOST
+  rest_api_collection COLLECTION_PATH
   rest_identity_property :address
   rest_property_map({
     address: "address",
@@ -103,7 +132,7 @@ describe "rest_resource using query-based addressing" do
   let(:train) {
     Train.create(
       "rest", {
-      endpoint:   "https://api.example.com/api/v1/",
+      endpoint:   API_BASE_URL,
       debug_rest: true,
       logger:     Chef::Log,
     }
@@ -119,8 +148,8 @@ describe "rest_resource using query-based addressing" do
   end
 
   let(:resource) do
-    RestResourceByQuery.new("set_address", run_context).tap do |resource|
-      resource.address = "192.0.2.1"
+    RestResourceByQuery.new(RESOURCE_NAME, run_context).tap do |resource|
+      resource.address = ADDRESS
       resource.prefix = 24
       resource.action :configure
     end
@@ -213,10 +242,10 @@ describe "rest_resource using query-based addressing" do
 
     it "should map resource properties to values properly" do
       expect(provider.property_map).to eq({
-        address: "192.0.2.1",
+        address: ADDRESS,
         prefix: 24,
         gateway: nil,
-        name: "set_address",
+        name: RESOURCE_NAME,
       })
     end
   end
@@ -227,7 +256,7 @@ describe "rest_resource using query-based addressing" do
     end
 
     it "should return collection URLs properly" do
-      expect(provider.rest_url_collection).to eq("/api/v1/addresses")
+      expect(provider.rest_url_collection).to eq(COLLECTION_PATH)
     end
   end
 
@@ -237,7 +266,7 @@ describe "rest_resource using query-based addressing" do
     end
 
     it "should apply URI templates to document URLs using query syntax properly" do
-      expect(provider.rest_url_document).to eq("/api/v1/address/?ip=192.0.2.1")
+      expect(provider.rest_url_document).to eq(QUERY_RESOURCE_PATH)
     end
   end
 
@@ -258,7 +287,7 @@ describe "rest_resource using query-based addressing" do
     end
 
     it "should return implicit identity properties and values properly" do
-      expect(provider.rest_identity_values).to eq({ "ip" => "192.0.2.1" })
+      expect(provider.rest_identity_values).to eq({ "ip" => ADDRESS })
     end
   end
 
@@ -268,97 +297,94 @@ describe "rest_resource using query-based addressing" do
   # this might be a functional test, but it runs on any O/S so I leave it here
   describe "when managing a resource" do
     before { WebMock.disable_net_connect! }
-    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
-    let(:addresses_other) { JSON.generate([{ "address": "172.16.32.85" }]) }
-    let(:address_exists) { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
-    let(:prefix_wrong) { JSON.generate({ "address": "192.0.2.1", "prefix": 25, "gateway": "192.0.2.1" }) }
+    let(:addresses_exists) { JSON.generate([{ "address": ADDRESS }]) }
+    let(:addresses_other) { JSON.generate([{ "address": OTHER_ADDRESS }]) }
+    let(:address_exists) { JSON.generate({ "address": ADDRESS, "prefix": 24, "gateway": ADDRESS }) }
+    let(:prefix_wrong) { JSON.generate({ "address": ADDRESS, "prefix": 25, "gateway": ADDRESS }) }
 
     it "should be idempotent" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, QUERY_RESOURCE_URL)
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be false
     end
 
     it "should PATCH if a property is incorrect" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
-        .to_return(status: 200, body: prefix_wrong, headers: { "Content-Type" => "application/json" })
-      stub_request(:patch, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, QUERY_RESOURCE_URL)
+        .to_return(status: 200, body: prefix_wrong, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:patch, QUERY_RESOURCE_URL)
         .with(
-          body: "{\"address\":\"192.0.2.1\",\"prefix\":25}",
-          headers: {
-            "Accept" => "application/json",
-            "Content-Type" => "application/json",
-          }
+          body: PATCH_PREFIX_WRONG_BODY,
+          headers: JSON_REQUEST_HEADERS
         )
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be true
     end
 
     it "should POST if there's no resources at all" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
-      stub_request(:post, "https://api.example.com/api/v1/addresses")
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: EMPTY_JSON_ARRAY, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:post, COLLECTION_URL)
         .with(
-          body: "{\"address\":\"192.0.2.1\",\"prefix\":24,\"ip\":\"192.0.2.1\"}"
+          body: POST_CREATE_BODY
         )
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be true
     end
 
     it "should POST if the specific resource does not exist" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_other, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_other, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, QUERY_RESOURCE_URL)
         .to_return(status: 404, body: "", headers: {})
-      stub_request(:post, "https://api.example.com/api/v1/addresses")
+      stub_request(:post, COLLECTION_URL)
         .with(
-          body: "{\"address\":\"192.0.2.1\",\"prefix\":24,\"ip\":\"192.0.2.1\"}"
+          body: POST_CREATE_BODY
         )
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be true
     end
 
     it "should be idempotent if the resouces needs deleting and there are no resources at all" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: EMPTY_JSON_ARRAY, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:delete)
       expect(resource.updated_by_last_action?).to be false
     end
 
     it "should be idempotent if the resource doesn't exist" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_other, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_other, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, QUERY_RESOURCE_URL)
         .to_return(status: 404, body: "", headers: {})
       resource.run_action(:delete)
       expect(resource.updated_by_last_action?).to be false
     end
 
     it "should DELETE the resource if it exists and matches" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:delete, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, QUERY_RESOURCE_URL)
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:delete, QUERY_RESOURCE_URL)
         .to_return(status: 200, body: "", headers: {})
       resource.run_action(:delete)
       expect(resource.updated_by_last_action?).to be true
     end
 
     it "should DELETE the resource if it exists and doesn't match" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
-        .to_return(status: 200, body: prefix_wrong, headers: { "Content-Type" => "application/json" })
-      stub_request(:delete, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, QUERY_RESOURCE_URL)
+        .to_return(status: 200, body: prefix_wrong, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:delete, QUERY_RESOURCE_URL)
         .to_return(status: 200, body: "", headers: {})
       resource.run_action(:delete)
       expect(resource.updated_by_last_action?).to be true
@@ -370,7 +396,7 @@ describe "rest_resource using path-based addressing" do
   let(:train) {
     Train.create(
       "rest", {
-      endpoint:   "https://api.example.com/api/v1/",
+      endpoint:   API_BASE_URL,
       debug_rest: true,
       logger:     Chef::Log,
     }
@@ -386,8 +412,8 @@ describe "rest_resource using path-based addressing" do
   end
 
   let(:resource) do
-    RestResourceByPath.new("set_address", run_context).tap do |resource|
-      resource.address = "192.0.2.1"
+    RestResourceByPath.new(RESOURCE_NAME, run_context).tap do |resource|
+      resource.address = ADDRESS
       resource.prefix = 24
       resource.action :configure
     end
@@ -410,7 +436,7 @@ describe "rest_resource using path-based addressing" do
     end
 
     it "should apply URI templates to document URLs using path syntax properly" do
-      expect(provider.rest_url_document).to eq("/api/v1/address/192.0.2.1")
+      expect(provider.rest_url_document).to eq(PATH_RESOURCE_PATH)
     end
   end
 
@@ -430,7 +456,7 @@ describe "rest_resource using path-based addressing" do
     end
 
     it "should return implicit identity properties and values properly" do
-      expect(provider.rest_identity_values).to eq({ "address" => "192.0.2.1" })
+      expect(provider.rest_identity_values).to eq({ "address" => ADDRESS })
     end
   end
 
@@ -456,8 +482,8 @@ describe "rest_resource using rest_api_endpoint" do
   end
 
   let(:resource) do
-    RestResourceWithEndpoint.new("set_address", run_context).tap do |resource|
-      resource.address = "192.0.2.1"
+    RestResourceWithEndpoint.new(RESOURCE_NAME, run_context).tap do |resource|
+      resource.address = ADDRESS
       resource.prefix = 24
       resource.action :configure
     end
@@ -475,7 +501,7 @@ describe "rest_resource using rest_api_endpoint" do
   end
 
   it "should store rest_api_endpoint on the resource class" do
-    expect(resource.class.rest_api_endpoint).to eq("https://api.example.com")
+    expect(resource.class.rest_api_endpoint).to eq(API_HOST)
   end
 
   describe "#rest_url_collection" do
@@ -484,7 +510,7 @@ describe "rest_resource using rest_api_endpoint" do
     end
 
     it "should prepend the endpoint to the collection URL" do
-      expect(provider.rest_url_collection).to eq("https://api.example.com/api/v1/addresses")
+      expect(provider.rest_url_collection).to eq(COLLECTION_URL)
     end
   end
 
@@ -494,20 +520,20 @@ describe "rest_resource using rest_api_endpoint" do
     end
 
     it "should prepend the endpoint to the document URL" do
-      expect(provider.rest_url_document).to eq("https://api.example.com/api/v1/address/192.0.2.1")
+      expect(provider.rest_url_document).to eq(PATH_RESOURCE_URL)
     end
   end
 
   describe "when managing a resource" do
     before { WebMock.disable_net_connect! }
-    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
-    let(:address_exists) { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+    let(:addresses_exists) { JSON.generate([{ "address": ADDRESS }]) }
+    let(:address_exists) { JSON.generate({ "address": ADDRESS, "prefix": 24, "gateway": ADDRESS }) }
 
     it "should be idempotent" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/192.0.2.1")
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, PATH_RESOURCE_URL)
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be false
     end
@@ -518,7 +544,7 @@ describe "rest_resource using rest_identity_property" do
   let(:train) {
     Train.create(
       "rest", {
-      endpoint:   "https://api.example.com/api/v1/",
+      endpoint:   API_BASE_URL,
       debug_rest: true,
       logger:     Chef::Log,
     }
@@ -534,8 +560,8 @@ describe "rest_resource using rest_identity_property" do
   end
 
   let(:resource) do
-    RestResourceWithIdentityProperty.new("set_address", run_context).tap do |resource|
-      resource.address = "192.0.2.1"
+    RestResourceWithIdentityProperty.new(RESOURCE_NAME, run_context).tap do |resource|
+      resource.address = ADDRESS
       resource.prefix = 24
       resource.action :configure
     end
@@ -557,7 +583,7 @@ describe "rest_resource using rest_identity_property" do
   end
 
   it "should auto-generate rest_api_document from collection and identity property" do
-    expect(resource.class.rest_api_document).to eq("/api/v1/addresses/{address}")
+    expect(resource.class.rest_api_document).to eq(AUTO_DOCUMENT_PATH)
   end
 
   describe "#rest_url_document" do
@@ -566,20 +592,20 @@ describe "rest_resource using rest_identity_property" do
     end
 
     it "should expand the auto-generated document URL using the identity property value" do
-      expect(provider.rest_url_document).to eq("/api/v1/addresses/192.0.2.1")
+      expect(provider.rest_url_document).to eq(IDENTITY_RESOURCE_PATH)
     end
   end
 
   describe "when managing a resource" do
     before { WebMock.disable_net_connect! }
-    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
-    let(:address_exists) { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+    let(:addresses_exists) { JSON.generate([{ "address": ADDRESS }]) }
+    let(:address_exists) { JSON.generate({ "address": ADDRESS, "prefix": 24, "gateway": ADDRESS }) }
 
     it "should be idempotent" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/addresses/192.0.2.1")
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, IDENTITY_RESOURCE_URL)
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be false
     end
@@ -606,8 +632,8 @@ describe "rest_resource using rest_api_endpoint and rest_identity_property" do
   end
 
   let(:resource) do
-    RestResourceWithEndpointAndIdentityProperty.new("set_address", run_context).tap do |resource|
-      resource.address = "192.0.2.1"
+    RestResourceWithEndpointAndIdentityProperty.new(RESOURCE_NAME, run_context).tap do |resource|
+      resource.address = ADDRESS
       resource.prefix = 24
       resource.action :configure
     end
@@ -630,7 +656,7 @@ describe "rest_resource using rest_api_endpoint and rest_identity_property" do
     end
 
     it "should prepend the endpoint to the collection URL" do
-      expect(provider.rest_url_collection).to eq("https://api.example.com/api/v1/addresses")
+      expect(provider.rest_url_collection).to eq(COLLECTION_URL)
     end
   end
 
@@ -640,20 +666,20 @@ describe "rest_resource using rest_api_endpoint and rest_identity_property" do
     end
 
     it "should build the full document URL from endpoint, collection, and identity property" do
-      expect(provider.rest_url_document).to eq("https://api.example.com/api/v1/addresses/192.0.2.1")
+      expect(provider.rest_url_document).to eq(IDENTITY_RESOURCE_URL)
     end
   end
 
   describe "when managing a resource" do
     before { WebMock.disable_net_connect! }
-    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
-    let(:address_exists) { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+    let(:addresses_exists) { JSON.generate([{ "address": ADDRESS }]) }
+    let(:address_exists) { JSON.generate({ "address": ADDRESS, "prefix": 24, "gateway": ADDRESS }) }
 
     it "should be idempotent" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/addresses/192.0.2.1")
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, IDENTITY_RESOURCE_URL)
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be false
     end
@@ -668,7 +694,7 @@ describe "rest_resource with endpoint configured via Train transport (query-base
   let(:train) {
     Train.create(
       "rest", {
-      endpoint:   "https://api.example.com",
+      endpoint:   API_HOST,
       debug_rest: true,
       logger:     Chef::Log,
     }
@@ -684,8 +710,8 @@ describe "rest_resource with endpoint configured via Train transport (query-base
   end
 
   let(:resource) do
-    RestResourceByQuery.new("set_address", run_context).tap do |resource|
-      resource.address = "192.0.2.1"
+    RestResourceByQuery.new(RESOURCE_NAME, run_context).tap do |resource|
+      resource.address = ADDRESS
       resource.prefix  = 24
       resource.action  :configure
     end
@@ -708,7 +734,7 @@ describe "rest_resource with endpoint configured via Train transport (query-base
     before { provider.singleton_class.send(:public, :rest_url_collection) }
 
     it "returns a relative collection URL (endpoint lives in Train)" do
-      expect(provider.rest_url_collection).to eq("/api/v1/addresses")
+      expect(provider.rest_url_collection).to eq(COLLECTION_PATH)
     end
   end
 
@@ -716,20 +742,20 @@ describe "rest_resource with endpoint configured via Train transport (query-base
     before { provider.singleton_class.send(:public, :rest_url_document) }
 
     it "returns a relative document URL (endpoint lives in Train)" do
-      expect(provider.rest_url_document).to eq("/api/v1/address/?ip=192.0.2.1")
+      expect(provider.rest_url_document).to eq(QUERY_RESOURCE_PATH)
     end
   end
 
   describe "when managing a resource" do
     before { WebMock.disable_net_connect! }
-    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
-    let(:address_exists)   { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+    let(:addresses_exists) { JSON.generate([{ "address": ADDRESS }]) }
+    let(:address_exists)   { JSON.generate({ "address": ADDRESS, "prefix": 24, "gateway": ADDRESS }) }
 
     it "resolves the full URL via the Train transport endpoint and is idempotent" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/?ip=192.0.2.1")
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, QUERY_RESOURCE_URL)
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be false
     end
@@ -740,7 +766,7 @@ describe "rest_resource with endpoint configured via Train transport (path-based
   let(:train) {
     Train.create(
       "rest", {
-      endpoint:   "https://api.example.com",
+      endpoint:   API_HOST,
       debug_rest: true,
       logger:     Chef::Log,
     }
@@ -756,8 +782,8 @@ describe "rest_resource with endpoint configured via Train transport (path-based
   end
 
   let(:resource) do
-    RestResourceByPath.new("set_address", run_context).tap do |resource|
-      resource.address = "192.0.2.1"
+    RestResourceByPath.new(RESOURCE_NAME, run_context).tap do |resource|
+      resource.address = ADDRESS
       resource.prefix  = 24
       resource.action  :configure
     end
@@ -780,20 +806,20 @@ describe "rest_resource with endpoint configured via Train transport (path-based
     before { provider.singleton_class.send(:public, :rest_url_document) }
 
     it "returns a relative document URL (endpoint lives in Train)" do
-      expect(provider.rest_url_document).to eq("/api/v1/address/192.0.2.1")
+      expect(provider.rest_url_document).to eq(PATH_RESOURCE_PATH)
     end
   end
 
   describe "when managing a resource" do
     before { WebMock.disable_net_connect! }
-    let(:addresses_exists) { JSON.generate([{ "address": "192.0.2.1" }]) }
-    let(:address_exists)   { JSON.generate({ "address": "192.0.2.1", "prefix": 24, "gateway": "192.0.2.1" }) }
+    let(:addresses_exists) { JSON.generate([{ "address": ADDRESS }]) }
+    let(:address_exists)   { JSON.generate({ "address": ADDRESS, "prefix": 24, "gateway": ADDRESS }) }
 
     it "resolves the full URL via the Train transport endpoint and is idempotent" do
-      stub_request(:get, "https://api.example.com/api/v1/addresses")
-        .to_return(status: 200, body: addresses_exists, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.example.com/api/v1/address/192.0.2.1")
-        .to_return(status: 200, body: address_exists, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, COLLECTION_URL)
+        .to_return(status: 200, body: addresses_exists, headers: JSON_RESPONSE_HEADERS)
+      stub_request(:get, PATH_RESOURCE_URL)
+        .to_return(status: 200, body: address_exists, headers: JSON_RESPONSE_HEADERS)
       resource.run_action(:configure)
       expect(resource.updated_by_last_action?).to be false
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
 Problem

  The rest_resource documentation examples referenced two DSL methods — rest_api_endpoint and rest_identity_property — that were never implemented in Chef::DSL::RestResource. Any custom resource following the documented pattern would silently fail at runtime.

  Changes

  lib/chef/dsl/rest_resource.rb

  rest_api_endpoint — New DSL method that stores the base URL of the target REST API. When set, it is prepended to all collection and document URLs, making the resource fully self-describing without requiring the Train transport to be pre-configured with the endpoint. If not set, existing behaviour is preserved — the Train transport's own
  endpoint configuration is used instead. The two approaches do not conflict: when an absolute URL is passed to Train's full_url, Ruby's URI + operator uses it as-is, naturally overriding the transport endpoint.

  rest_identity_property — New DSL method that declares which property uniquely identifies a resource. When set without an explicit rest_api_document, the document URL is auto-generated as "#{rest_api_collection}/{#{property}}", removing the need to manually specify both.

  DSL inheritance fix — All DSL getters previously read directly from a class-level instance variable (@rest_api_collection, @rest_property_map, etc.). Ruby class instance variables are not inherited by subclasses — only the method is. This meant any subclass that did not explicitly re-declare a DSL value would silently receive nil. All
  getters now fall back to the superclass value if the current class has not set one:

   @rest_api_collection || (superclass.respond_to?(:rest_api_collection) ? superclass.rest_api_collection : nil)

  lib/chef/resource/_rest_resource.rb

  rest_url_collection and rest_url_document updated to prepend rest_api_endpoint when set, producing absolute URLs. When not set the methods return relative paths as before.

  Tests (spec/unit/resource/rest_resource_spec.rb)

 Tests (spec/unit/resource/rest_resource_spec.rb)

Seven new describe blocks added:

 - rest_resource using rest_api_endpoint — Endpoint stored correctly, absolute URLs built for collection and document, idempotency verified end-to-end
 - rest_resource using rest_identity_property — Property stored correctly, rest_api_document auto-generated from collection + identity property, URL template expansion verified
 - rest_resource using rest_api_endpoint and rest_identity_property — Both together, matching the documented usage pattern — full URL constructed from endpoint plus auto-generated document URL
 - rest_resource with endpoint via Train transport (query-based) — rest_api_endpoint is nil, URLs are relative, Train transport owns the base URL, idempotency verified
 - rest_resource with endpoint via Train transport (path-based) — Same for path-based addressing; also exercises the DSL inheritance fix by running a full action on a subclass that inherits rest_api_collection from its parent

The endpoint-bearing describe blocks derive their Train endpoint: directly from the resource class's rest_api_endpoint, ensuring the two are genuinely coupled in tests rather than coincidentally matching hardcoded strings.

  Integration test (scripts/rest_resource_integration_test.rb)

  Standalone script runnable with bundle exec ruby scripts/rest_resource_integration_test.rb. Tests against the public sandbox at https://api.restful-api.dev/objects with no side effects (read-only). Verifies:

   1. All DSL values are stored and returned correctly
   2. rest_identity_property auto-generates the correct rest_api_document template
   3. A Train connection created from rest_api_endpoint can retrieve the collection and resolve an individual document URL against the live API


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
