### PR TITLE
update docker/build queues

### DIFF
--- a/.expeditor/docker-build.pipeline.yml
+++ b/.expeditor/docker-build.pipeline.yml
@@ -7,7 +7,7 @@ expeditor:
 steps:
 - label: ":docker: build chef-hab amd64"
   agents:
-    queue: docker-linux
+    queue: default-privileged
   expeditor:
     secrets:
       HAB_AUTH_TOKEN:
@@ -23,7 +23,7 @@ steps:
 
 - label: ":docker: build chef-hab arm64"
   agents:
-    queue: docker-linux-arm64
+    queue: default-privileged-aarch64
   expeditor:
     secrets:
       HAB_AUTH_TOKEN:
@@ -32,7 +32,6 @@ steps:
     executor:
       linux:
         privileged: true
-        single-use: true
         propagate-environment: true
         environment:
           - HAB_AUTH_TOKEN


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
updating docker build queues. they were resolving to default-privileged and single use amd queue. made the 86_64 queue explicit and removed single-use:true.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
