### PR TITLE
Fix inconsistent Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt
 gem "knife", git: "https://github.com/chef/knife.git", branch: "main"
 
 if RUBY_PLATFORM.include?("mingw") || RUBY_PLATFORM.include?("darwin")
-  gem "ffi", ">= 1.15.5", "< 1.18.0"
+  gem "ffi", ">= 1.15.5"
 else
   gem "ffi", ">= 1.15.5", force_ruby_platform: true
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    abbrev (0.1.2)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     appbundler (0.13.4)
@@ -221,6 +222,9 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.2)
+    bcrypt_pbkdf (1.1.2-arm64-darwin)
+    bcrypt_pbkdf (1.1.2-x64-mingw-ucrt)
+    bcrypt_pbkdf (1.1.2-x86_64-darwin)
     benchmark (0.5.0)
     bigdecimal (4.1.1)
     binding_of_caller (1.0.1)
@@ -309,9 +313,6 @@ GEM
     fauxhai-ng (9.3.0)
       net-ssh
     ffi (1.17.4)
-    ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x64-mingw-ucrt)
-    ffi (1.17.4-x86_64-darwin)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -613,7 +614,7 @@ DEPENDENCIES
   cheffish!
   crack (~> 1.0.1)
   fauxhai-ng
-  ffi (>= 1.15.5, < 1.18.0)
+  ffi (>= 1.15.5)
   inspec-core-bin (= 7.0.107)
   knife!
   ohai!


### PR DESCRIPTION
The dependabot updates left a slightly inconsistent state for ffi, this
makes both branches consistent.

```
[phil@rider (consistent-ify-gemfile) RBENV(3.3.6) chef]$ bundle install
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Bundle complete! 24 Gemfile dependencies, 171 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

Signed-off-by: Phil Dibowitz <phil@ipom.com>
