### PR TITLE
fix docker build aarch64

### DIFF
--- a/.expeditor/docker-build.pipeline.yml
+++ b/.expeditor/docker-build.pipeline.yml
@@ -29,12 +29,6 @@ steps:
       HAB_AUTH_TOKEN:
         path: account/static/habitat/chef-ci
         field: auth_token
-    executor:
-      linux:
-        privileged: true
-        propagate-environment: true
-        environment:
-          - HAB_AUTH_TOKEN
   command: .expeditor/build-docker-images.sh arm64
 
 - wait

--- a/.expeditor/docker-build.pipeline.yml
+++ b/.expeditor/docker-build.pipeline.yml
@@ -15,7 +15,6 @@ steps:
         field: auth_token
     executor:
       linux:
-        privileged: true
         propagate-environment: true
         environment:
           - HAB_AUTH_TOKEN

--- a/.expeditor/docker-build.pipeline.yml
+++ b/.expeditor/docker-build.pipeline.yml
@@ -15,6 +15,7 @@ steps:
         field: auth_token
     executor:
       linux:
+        privileged: true
         propagate-environment: true
         environment:
           - HAB_AUTH_TOKEN


### PR DESCRIPTION
This pull request makes a small change to the `.expeditor/docker-build.pipeline.yml` file by removing the custom `executor` block from one of the build steps. This simplifies the pipeline configuration and relies on the default executor settings.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
