### PR TITLE
Enable manual kitchen tests, fix push kitchen tests

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -9,6 +9,9 @@ name: kitchen
     branches:
       - main
 
+  # allow manual runs
+  workflow_dispatch:
+
 concurrency:
   group: kitchen-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
@@ -21,7 +24,6 @@ defaults:
 
 jobs:
   workflow_guard:
-    if: github.event_name == 'pull_request_target'
     uses: chef/chef/.github/workflows/workflow-change-guard.yml@main
     permissions:
       contents: read

--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -49,7 +49,7 @@ jobs:
 
   approve:
     needs: detect
-    if: needs.detect.outputs.workflow_changed == 'true'
+    if: (github.event_name == 'pull_request_target' && needs.detect.outputs.workflow_changed == 'true')
     runs-on: ubuntu-latest
 
     # Approval happens ONLY here


### PR DESCRIPTION
* The guard never ran on pushes, so pushes never ran kitchen
* Enable workflow dispatch

Signed-off-by: Phil Dibowitz <phil@ipom.com>
