### PR TITLE
Fix up platforms list in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,11 +597,10 @@ PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
   arm64-darwin-25
+  arm64-darwin-26
   ruby
   x64-mingw-ucrt
   x86_64-darwin-23
-  x86_64-darwin-24
-  x86_64-darwin-25
 
 DEPENDENCIES
   appbundler


### PR DESCRIPTION
Anything after Darwin23 doesn't support intel.

And add 26.

#gemlock_major_upgrade

not really, but to make the checks happy.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
