### PR TITLE
set github_sha to the correct ref for macOS kitchen tests

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -240,6 +240,7 @@ jobs:
     env:
       CHEF_LICENSE: accept-no-persist
       KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
+      GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description
This change attempts to fix the mismatch between the checkout sha and `GITHUB_SHA` environment variable that macOS runners use for kitchen tests. 

First observation of macOS runners failing was in this PR yesterday https://github.com/chef/chef/pull/15879. Upon inspection, we can see that appbundler is referring to a different hash [`e353de1`](https://github.com/chef/chef/actions/runs/24391909452/job/71269003230?pr=15879#step:4:135) vs the actual sha of the PR head [`1bc439d`](https://github.com/chef/chef/actions/runs/24391909452/job/71269003230?pr=15879#step:2:85). This is because `appbundle-updater` is called with `GITHUB_SHA` env https://github.com/chef/chef/blob/7109aa61d7816cea9e9afccef07fbc8b54cf5fff/kitchen-tests/kitchen.exec.macos.yml#L22

This means that macOS kitchen tests have probably been running against the code in `main` vs actual PR head since the pull request target change that was introduced in 5bcb9df. 

This fix alone won't actually fix the failures because the error in that PR for chef gem is pointing to a platform mismatch in the lockfile. The bad lock file probably went unnoticed when we did the knife change because macOS runners were pointing to a different source altogether. But that problem needs to be fixed in a separate PR after this is merged. 

**Update: I see there's already a PR #15891 that attempts to address this issue. We can probably get this workflow fix into main and then rebase the gemlock fix from 15891 on top of main to confirm the gemlock fix.** 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
