### PR TITLE
Disable macos runs with chronoguard comment

### DIFF
--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jaymzh/chronoguard@main
         with:
-          files: .github/workflows/allchecks.yml
+          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -225,35 +225,36 @@ jobs:
 #      - name: Kitchen Test
 #        run: kitchen verify ${{ matrix.os }}
 #
-  mac_arm64:
-    needs: workflow_guard
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-14
-          - macos-15
-          - macos-26
-    runs-on: ${{ matrix.os }}
-    env:
-      CHEF_LICENSE: accept-no-persist
-      KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
-      TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-    steps:
-      - name: Checkout PR code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
-          clean: true
-      - name: Install Chef
-        uses: actionshub/chef-install@main
-        with:
-          version: "25.5.1084"
-      - name: Kitchen Test
-        run: kitchen verify ${{ matrix.os }}
+  # disabled due to no hab support for mac yet - fail-after:2026-05-15
+  # mac_arm64:
+  #   needs: workflow_guard
+  #   permissions:
+  #     contents: read
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os:
+  #         - macos-14
+  #         - macos-15
+  #         - macos-26
+  #   runs-on: ${{ matrix.os }}
+  #   env:
+  #     CHEF_LICENSE: accept-no-persist
+  #     KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
+  #     GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  #   steps:
+  #     - name: Checkout PR code
+  #       uses: actions/checkout@v6
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha }}
+  #         persist-credentials: false
+  #         clean: true
+  #     - name: Install Chef
+  #       uses: actionshub/chef-install@main
+  #       with:
+  #         version: "25.5.1084"
+  #     - name: Kitchen Test
+  #       run: kitchen verify ${{ matrix.os }}
 
   # end-to-end recipe testing using test-kitchen-enterprise and habitat package of Infra Client
   docr_lnx_x86_64:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
macOS runs are still broken, and it might be better to pause while waiting for the rest of the pieces to be there for it.

## Related Issue
CHEF-33444

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
