### PR TITLE
Fix 'occured' -> 'occurred' typo in client_spec unit test strings

### DIFF
--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -225,9 +225,9 @@ describe Chef::Application::Client, "reconfigure" do
 
       context "local mode not set" do
         it "fails with a message stating local mode required" do
-          expect(Chef::Application).to receive(:fatal!).with("recipe-url can be used only in local-mode").and_raise("error occured")
+          expect(Chef::Application).to receive(:fatal!).with("recipe-url can be used only in local-mode").and_raise("error occurred")
           ARGV.replace(["--recipe-url=test_url"])
-          expect { app.reconfigure }.to raise_error "error occured"
+          expect { app.reconfigure }.to raise_error "error occurred"
         end
       end
 


### PR DESCRIPTION
Two test fixtures in `spec/unit/application/client_spec.rb` (lines 228 and 230) around the `recipe-url` local-mode expectation used `error occured`:

```ruby
expect(Chef::Application).to receive(:fatal!).with("recipe-url can be used only in local-mode").and_raise("error occured")
...
expect { app.reconfigure }.to raise_error "error occured"
```

String-literal-only change; `ruby -c` stays clean.