### PR TITLE
Migrate gem tests to GHA

### DIFF
--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -163,68 +163,8 @@ for platform in ${win_test_platforms[@]}; do
   echo "  timeout_in_minutes: 120"
 done
 
-external_gems=("chef-zero" "cheffish" "chefspec" "knife-windows" "berkshelf")
-for gem in ${external_gems[@]}; do
-  echo "- label: \"$gem gem :ruby:\""
-  echo "  retry:"
-  echo "    automatic:"
-  echo "      limit: 1"
-  echo "  agents:"
-  echo "    queue: default"
-  echo "  plugins:"
-  echo "  - docker#v3.5.0:"
-  echo "      image: chefes/omnibus-toolchain-ubuntu-1804:$OMNIBUS_TOOLCHAIN_VERSION"
-  echo "      environment:"
-  echo "        - CHEF_FOUNDATION_VERSION"
-  echo "        - HAB_AUTH_TOKEN"
-  if [ $gem == "chef-zero" ]
-  then
-    echo "        - PEDANT_OPTS=--skip-oc_id"
-    echo "        - CHEF_FS=true"
-  fi
-  echo "      propagate-environment: true"
-  # echo "  - chef/cache#v1.5.0:"
-  # echo "      s3_bucket: core-buildkite-cache-chef-oss-prod"
-  # echo "      cached_folders:"
-  # echo "      - vendor"
-  echo "  timeout_in_minutes: 60"
-  echo "  commands:"
-  echo "    - .expeditor/scripts/bk_container_prep.sh"
-  if [ $gem == "berkshelf" ]
-  then
-    echo "    - export PATH=\"/root/.rbenv/shims:/opt/chef/bin:/usr/local/sbin:/usr/sbin:/sbin:${PATH}\""
-    echo "    - apt-get update -y"
-    # cspell:disable-next-line
-    echo "    - apt-get install -y graphviz"
-    echo "    - bundle config set --local without packaging"
-  else
-    echo "    - export PATH=\"/root/.rbenv/shims:/opt/chef/bin:${PATH}\""
-    echo "    - bundle config set --local without packaging"
-    echo "    - bundle config set --local path 'vendor/bundle'"
-  fi
-  echo "    - bundle install --jobs=3 --retry=3"
-  case $gem in
-    "chef-zero")
-      echo "    - bundle exec tasks/bin/run_external_test chef/chef-zero main rake pedant"
-      ;;
-    "cheffish")
-      echo "    - bundle exec tasks/bin/run_external_test chef/cheffish main rake spec"
-      ;;
-    "chefspec")
-      echo "    - bundle exec tasks/bin/run_external_test chef/chefspec main rake"
-      ;;
-    "knife-windows")
-      echo "    - bundle exec tasks/bin/run_external_test chef/knife-windows main rake spec"
-      ;;
-    "berkshelf")
-      echo "    - bundle exec tasks/bin/run_external_test chef/berkshelf main rake"
-      ;;
-    *)
-      echo -e "\n Gem $gem is not valid\n" >&2
-      exit 1
-      ;;
-  esac
-done
+# External gem tests (chef-zero, cheffish, chefspec, knife-windows, berkshelf)
+# have been migrated to GitHub Actions: .github/workflows/gem_tests.yml
 habitat_plans=("x86_64-linux" "aarch64-linux" "windows")
 for plan in ${habitat_plans[@]}; do
   echo "- label: \":habicat: $plan plan\""

--- a/.github/workflows/gem_tests.yml
+++ b/.github/workflows/gem_tests.yml
@@ -1,0 +1,137 @@
+---
+name: gem_tests
+
+"on":
+  pull_request:
+    branches: [main, "chef-*"]
+  push:
+    branches: [main, "chef-*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gem-tests-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CHEF_LICENSE: accept-no-persist
+  FORCE_FFI_YAJL: ext
+
+jobs:
+  chef-zero:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      PEDANT_OPTS: "--skip-oc_id"
+      CHEF_FS: "true"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.8"
+          bundler-cache: false
+      - name: Bundle install Chef
+        run: |
+          bundle config set --local without packaging
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs=3 --retry=3
+      - name: Run chef-zero tests
+        run: bundle exec tasks/bin/run_external_test chef/chef-zero main rake pedant
+
+  cheffish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.8"
+          bundler-cache: false
+      - name: Bundle install Chef
+        run: |
+          bundle config set --local without packaging
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs=3 --retry=3
+      - name: Run cheffish tests
+        run: bundle exec tasks/bin/run_external_test chef/cheffish main rake spec
+
+  chefspec:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.8"
+          bundler-cache: false
+      - name: Bundle install Chef
+        run: |
+          bundle config set --local without packaging
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs=3 --retry=3
+      - name: Run chefspec tests
+        run: bundle exec tasks/bin/run_external_test chef/chefspec main rake
+
+  knife-windows:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.8"
+          bundler-cache: false
+      - name: Bundle install Chef
+        run: |
+          bundle config set --local without packaging
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs=3 --retry=3
+      - name: Run knife-windows tests
+        run: bundle exec tasks/bin/run_external_test chef/knife-windows main rake spec
+
+  berkshelf:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev graphviz
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.8"
+          bundler-cache: false
+      - name: Bundle install Chef
+        run: |
+          bundle config set --local without packaging
+          bundle install --jobs=3 --retry=3
+      - name: Run berkshelf tests
+        run: bundle exec tasks/bin/run_external_test chef/berkshelf main rake


### PR DESCRIPTION
## Description

New file: .github/workflows/gem_tests.yml

 - Created a GitHub Actions workflow with 5 separate jobs — one per gem:
  - chef-zero — rake pedant (with PEDANT_OPTS and CHEF_FS env vars)
  - cheffish — rake spec
  - chefspec — rake
  - knife-windows — rake spec
  - berkshelf — rake (with graphviz installed, no vendor/bundle path — matching Buildkite behavior)
 - All jobs run on ubuntu-24.04 with Ruby 3.4.8 via ruby/setup-ruby@v1
 - Triggered on PRs and pushes to main/chef-* branches
 - Uses the existing tasks/bin/run_external_test script

Modified: .buildkite/verify.pipeline.sh

 - Removed the 62-line external_gems loop (previously running on ubuntu-1804 Docker images)
 - Left a comment noting the migration to GitHub Actions

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
