### PR TITLE
Move debian and rocky-8 over to GHA

### DIFF
--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -7,7 +7,7 @@ echo "  BUILD_TIMESTAMP: $(date +%Y-%m-%d_%H-%M-%S)"
 echo "  CHEF_LICENSE_SERVER: http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/"
 echo "steps:"
 echo ""
-# RHEL-family platforms (RHEL 9): run Unit, Functional, and Integration in Buildkite.
+# RHEL-family platforms (RHEL 9): run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
 # Rocky 8: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
 # Rocky 9: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
 # Debian: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
@@ -30,16 +30,12 @@ for platform in ${rhel_platforms[@]}; do
     queue="default-privileged"
   fi
 
-  echo "- label: \"{{matrix}} $platform :ruby:\""
+  echo "- label: \"Integration $platform :ruby:\""
   echo "  retry:"
   echo "    automatic:"
   echo "      limit: 1"
   echo "  agents:"
   echo "    queue: $queue"
-  echo "  matrix:"
-  echo "    - \"Unit\""
-  echo "    - \"Integration\""
-  echo "    - \"Functional\""
   echo "  plugins:"
   echo "  - docker#v3.5.0:"
   echo "      image: $image"
@@ -49,7 +45,7 @@ for platform in ${rhel_platforms[@]}; do
   echo "      propagate-environment: true"
   echo "  commands:"
   echo "    - .expeditor/scripts/bk_container_prep.sh"
-  echo "    - .expeditor/scripts/prep_and_run_tests.sh {{matrix}}"
+  echo "    - .expeditor/scripts/prep_and_run_tests.sh Integration"
   echo "  timeout_in_minutes: 60"
 done
 

--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -8,9 +8,9 @@ echo "  CHEF_LICENSE_SERVER: http://hosted-license-service-lb-8000-606952349.us-
 echo "steps:"
 echo ""
 # RHEL-family platforms (RHEL 9): run Unit, Functional, and Integration in Buildkite.
-# Rocky 8: run Integration and Functional only here; Unit runs in GitHub Actions (unit-docker).
-# Rocky 9: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-rocky).
-# Debian: run Integration and Functional only here; Unit runs in GitHub Actions (unit-docker).
+# Rocky 8: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
+# Rocky 9: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
+# Debian: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
 # Ubuntu: run Integration only here; Unit/Functional run in GitHub Actions.
 # Windows: run Integration only here; Unit/Functional run in GitHub Actions.
 
@@ -63,15 +63,12 @@ for platform in ${rocky8_platforms[@]}; do
     queue="default-privileged"
   fi
 
-  echo "- label: \"{{matrix}} $platform :ruby:\""
+  echo "- label: \"Integration $platform :ruby:\""
   echo "  retry:"
   echo "    automatic:"
   echo "      limit: 1"
   echo "  agents:"
   echo "    queue: $queue"
-  echo "  matrix:"
-  echo "    - \"Integration\""
-  echo "    - \"Functional\""
   echo "  plugins:"
   echo "  - docker#v3.5.0:"
   echo "      image: $image"
@@ -81,7 +78,7 @@ for platform in ${rocky8_platforms[@]}; do
   echo "      propagate-environment: true"
   echo "  commands:"
   echo "    - .expeditor/scripts/bk_container_prep.sh"
-  echo "    - .expeditor/scripts/prep_and_run_tests.sh {{matrix}}"
+  echo "    - .expeditor/scripts/prep_and_run_tests.sh Integration"
   echo "  timeout_in_minutes: 60"
 done
 
@@ -124,15 +121,12 @@ for platform in ${debian_platforms[@]}; do
     queue="default-privileged"
   fi
 
-  echo "- label: \"{{matrix}} $platform :ruby:\""
+  echo "- label: \"Integration $platform :ruby:\""
   echo "  retry:"
   echo "    automatic:"
   echo "      limit: 1"
   echo "  agents:"
   echo "    queue: $queue"
-  echo "  matrix:"
-  echo "    - \"Integration\""
-  echo "    - \"Functional\""
   echo "  plugins:"
   echo "  - docker#v3.5.0:"
   echo "      image: $image"
@@ -142,7 +136,7 @@ for platform in ${debian_platforms[@]}; do
   echo "      propagate-environment: true"
   echo "  commands:"
   echo "    - .expeditor/scripts/bk_container_prep.sh"
-  echo "    - .expeditor/scripts/prep_and_run_tests.sh {{matrix}}"
+  echo "    - .expeditor/scripts/prep_and_run_tests.sh Integration"
   echo "  timeout_in_minutes: 60"
 done
 

--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -7,7 +7,7 @@ echo "  BUILD_TIMESTAMP: $(date +%Y-%m-%d_%H-%M-%S)"
 echo "  CHEF_LICENSE_SERVER: http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/"
 echo "steps:"
 echo ""
-# RHEL-family platforms (RHEL 9): run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
+# RHEL-family platforms (RHEL 9): run Unit, Functional, and Integration in Buildkite (requires subscription).
 # Rocky 8: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
 # Rocky 9: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
 # Debian: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
@@ -30,12 +30,16 @@ for platform in ${rhel_platforms[@]}; do
     queue="default-privileged"
   fi
 
-  echo "- label: \"Integration $platform :ruby:\""
+  echo "- label: \"{{matrix}} $platform :ruby:\""
   echo "  retry:"
   echo "    automatic:"
   echo "      limit: 1"
   echo "  agents:"
   echo "    queue: $queue"
+  echo "  matrix:"
+  echo "    - \"Unit\""
+  echo "    - \"Integration\""
+  echo "    - \"Functional\""
   echo "  plugins:"
   echo "  - docker#v3.5.0:"
   echo "      image: $image"
@@ -45,7 +49,7 @@ for platform in ${rhel_platforms[@]}; do
   echo "      propagate-environment: true"
   echo "  commands:"
   echo "    - .expeditor/scripts/bk_container_prep.sh"
-  echo "    - .expeditor/scripts/prep_and_run_tests.sh Integration"
+  echo "    - .expeditor/scripts/prep_and_run_tests.sh {{matrix}}"
   echo "  timeout_in_minutes: 60"
 done
 

--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -8,15 +8,13 @@ echo "  CHEF_LICENSE_SERVER: http://hosted-license-service-lb-8000-606952349.us-
 echo "steps:"
 echo ""
 # RHEL-family platforms (RHEL 9): run Unit, Functional, and Integration in Buildkite (requires subscription).
-# Rocky 8: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
-# Rocky 9: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
+# Rocky: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
 # Debian: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-docker).
 # Ubuntu: run Integration only here; Unit/Functional run in GitHub Actions.
 # Windows: run Integration only here; Unit/Functional run in GitHub Actions.
 
 rhel_platforms=("rhel-9" "rhel-9-aarch64")
-rocky8_platforms=("rocky-8" "rocky-8-aarch64")
-rocky9_platforms=("rocky-9" "rocky-9-aarch64")
+rocky_platforms=("rocky-8" "rocky-8-aarch64" "rocky-9" "rocky-9-aarch64")
 debian_platforms=("debian-11" "debian-11-aarch64")
 ubuntu_platforms=("ubuntu-2204" "ubuntu-2204-aarch64")
 
@@ -53,36 +51,7 @@ for platform in ${rhel_platforms[@]}; do
   echo "  timeout_in_minutes: 60"
 done
 
-for platform in ${rocky8_platforms[@]}; do
-
-  if [[ $platform == *"-aarch64" ]]; then
-    image="chefes/omnibus-toolchain-${platform%-aarch64}:aarch64"
-    queue="default-privileged-aarch64"
-  else
-    image="chefes/omnibus-toolchain-${platform}:$OMNIBUS_TOOLCHAIN_VERSION"
-    queue="default-privileged"
-  fi
-
-  echo "- label: \"Integration $platform :ruby:\""
-  echo "  retry:"
-  echo "    automatic:"
-  echo "      limit: 1"
-  echo "  agents:"
-  echo "    queue: $queue"
-  echo "  plugins:"
-  echo "  - docker#v3.5.0:"
-  echo "      image: $image"
-  echo "      privileged: true"
-  echo "      environment:"
-  echo "        - HAB_AUTH_TOKEN"
-  echo "      propagate-environment: true"
-  echo "  commands:"
-  echo "    - .expeditor/scripts/bk_container_prep.sh"
-  echo "    - .expeditor/scripts/prep_and_run_tests.sh Integration"
-  echo "  timeout_in_minutes: 60"
-done
-
-for platform in ${rocky9_platforms[@]}; do
+for platform in ${rocky_platforms[@]}; do
 
   if [[ $platform == *"-aarch64" ]]; then
     image="chefes/omnibus-toolchain-${platform%-aarch64}:aarch64"

--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -7,13 +7,15 @@ echo "  BUILD_TIMESTAMP: $(date +%Y-%m-%d_%H-%M-%S)"
 echo "  CHEF_LICENSE_SERVER: http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/"
 echo "steps:"
 echo ""
-# RHEL-family platforms (Rocky 8, RHEL): run Unit, Functional, and Integration in Buildkite.
-# Rocky 9: run Integration only here; Unit/Functional run in GitHub Actions (unit-rocky, functional-rocky).
-# Debian: run Unit, Functional, and Integration in Buildkite (not available on GitHub Actions).
+# RHEL-family platforms (RHEL 9): run Unit, Functional, and Integration in Buildkite.
+# Rocky 8: run Integration and Functional only here; Unit runs in GitHub Actions (unit-docker).
+# Rocky 9: run Integration only here; Unit/Functional run in GitHub Actions (unit-docker, functional-rocky).
+# Debian: run Integration and Functional only here; Unit runs in GitHub Actions (unit-docker).
 # Ubuntu: run Integration only here; Unit/Functional run in GitHub Actions.
 # Windows: run Integration only here; Unit/Functional run in GitHub Actions.
 
-rhel_platforms=("rocky-8" "rocky-8-aarch64" "rhel-9" "rhel-9-aarch64")
+rhel_platforms=("rhel-9" "rhel-9-aarch64")
+rocky8_platforms=("rocky-8" "rocky-8-aarch64")
 rocky9_platforms=("rocky-9" "rocky-9-aarch64")
 debian_platforms=("debian-11" "debian-11-aarch64")
 ubuntu_platforms=("ubuntu-2204" "ubuntu-2204-aarch64")
@@ -36,6 +38,38 @@ for platform in ${rhel_platforms[@]}; do
   echo "    queue: $queue"
   echo "  matrix:"
   echo "    - \"Unit\""
+  echo "    - \"Integration\""
+  echo "    - \"Functional\""
+  echo "  plugins:"
+  echo "  - docker#v3.5.0:"
+  echo "      image: $image"
+  echo "      privileged: true"
+  echo "      environment:"
+  echo "        - HAB_AUTH_TOKEN"
+  echo "      propagate-environment: true"
+  echo "  commands:"
+  echo "    - .expeditor/scripts/bk_container_prep.sh"
+  echo "    - .expeditor/scripts/prep_and_run_tests.sh {{matrix}}"
+  echo "  timeout_in_minutes: 60"
+done
+
+for platform in ${rocky8_platforms[@]}; do
+
+  if [[ $platform == *"-aarch64" ]]; then
+    image="chefes/omnibus-toolchain-${platform%-aarch64}:aarch64"
+    queue="default-privileged-aarch64"
+  else
+    image="chefes/omnibus-toolchain-${platform}:$OMNIBUS_TOOLCHAIN_VERSION"
+    queue="default-privileged"
+  fi
+
+  echo "- label: \"{{matrix}} $platform :ruby:\""
+  echo "  retry:"
+  echo "    automatic:"
+  echo "      limit: 1"
+  echo "  agents:"
+  echo "    queue: $queue"
+  echo "  matrix:"
   echo "    - \"Integration\""
   echo "    - \"Functional\""
   echo "  plugins:"
@@ -97,7 +131,6 @@ for platform in ${debian_platforms[@]}; do
   echo "  agents:"
   echo "    queue: $queue"
   echo "  matrix:"
-  echo "    - \"Unit\""
   echo "    - \"Integration\""
   echo "    - \"Functional\""
   echo "  plugins:"

--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: wechuli/allcheckspassed@v2
         with:
           # SonarCloud - never works for forks
-          checks_exclude: ".*(SonarCloud Code Analysis).*"
+          checks_exclude: ".*(SonarCloud Code Analysis|Expeditor Config Validation).*"
           # Retry every minute for 30 minutes...
           retries: 90
           verbose: true

--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: wechuli/allcheckspassed@v2
         with:
           # SonarCloud - never works for forks
-          checks_exclude: ".*(SonarCloud Code Analysis|Expeditor Config Validation).*"
+          checks_exclude: ".*(SonarCloud Code Analysis).*"
           # Retry every minute for 30 minutes...
           retries: 90
           verbose: true

--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -76,15 +76,29 @@ jobs:
           Install-PackageProvider -Name NuGet -Force -ErrorAction SilentlyContinue
       - run: bundle exec rake spec:functional
 
-  functional-rocky:
+  functional-docker:
     strategy:
       fail-fast: false
       matrix:
         include:
           - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-rocky-9:3.0.39
+            pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
             container: chefes/omnibus-toolchain-rocky-9:aarch64
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04
+            container: chefes/omnibus-toolchain-rocky-8:3.0.39
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04-arm
+            container: chefes/omnibus-toolchain-rocky-8:aarch64
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04
+            container: chefes/omnibus-toolchain-debian-11:3.0.39
+            pkg_mgr: apt
+          - runs-on: ubuntu-24.04-arm
+            container: chefes/omnibus-toolchain-debian-11:aarch64
+            pkg_mgr: apt
     runs-on: ${{ matrix.runs-on }}
     container:
       image: ${{ matrix.container }}
@@ -92,9 +106,16 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
-      - name: Install dependencies and Ruby via rbenv
+      - name: Install native deps (dnf)
+        if: matrix.pkg_mgr == 'dnf'
+        run: dnf install -y --enablerepo=devel openssl-devel libarchive-devel libffi-devel libyaml-devel readline-devel zlib-devel
+      - name: Install native deps (apt)
+        if: matrix.pkg_mgr == 'apt'
         run: |
-          dnf install -y --enablerepo=devel openssl-devel libarchive-devel libffi-devel libyaml-devel readline-devel zlib-devel
+          apt-get update
+          apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev libreadline-dev zlib1g-dev curl
+      - name: Install Ruby via rbenv
+        run: |
           curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
           export PATH="$HOME/.rbenv/bin:$PATH"
           eval "$(rbenv init -)"

--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -17,10 +17,19 @@ concurrency:
 env:
   CHEF_LICENSE: accept-no-persist
   FORCE_FFI_YAJL: ext
-  OMNIBUS_TOOLCHAIN_X86_TAG: "3.0.39"
-  OMNIBUS_TOOLCHAIN_ARM_TAG: "aarch64"
 
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      x86_tag: ${{ steps.tags.outputs.x86_tag }}
+      arm_tag: ${{ steps.tags.outputs.arm_tag }}
+    steps:
+      - id: tags
+        run: |
+          echo "x86_tag=3.0.39" >> $GITHUB_OUTPUT
+          echo "arm_tag=aarch64" >> $GITHUB_OUTPUT
+
   functional:
     strategy:
       fail-fast: false
@@ -79,33 +88,34 @@ jobs:
       - run: bundle exec rake spec:functional
 
   functional-docker:
+    needs: config
     strategy:
       fail-fast: false
       matrix:
         include:
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rocky-9:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            container: chefes/omnibus-toolchain-rocky-9:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rocky-9:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            container: chefes/omnibus-toolchain-rocky-9:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rocky-8:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rocky-8:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rhel-9:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            container: chefes/omnibus-toolchain-rhel-9:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rhel-9:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            container: chefes/omnibus-toolchain-rhel-9:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-debian-11:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: apt
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-debian-11:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: apt
     runs-on: ${{ matrix.runs-on }}
     container:

--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -106,12 +106,6 @@ jobs:
             container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rhel-9:${{ needs.config.outputs.x86_tag }}
-            pkg_mgr: dnf
-          - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rhel-9:${{ needs.config.outputs.arm_tag }}
-            pkg_mgr: dnf
-          - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: apt
           - runs-on: ubuntu-24.04-arm

--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -17,6 +17,8 @@ concurrency:
 env:
   CHEF_LICENSE: accept-no-persist
   FORCE_FFI_YAJL: ext
+  OMNIBUS_TOOLCHAIN_X86_TAG: "3.0.39"
+  OMNIBUS_TOOLCHAIN_ARM_TAG: "aarch64"
 
 jobs:
   functional:
@@ -82,22 +84,28 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rocky-9:3.0.39
+            container: chefes/omnibus-toolchain-rocky-9:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rocky-9:aarch64
+            container: chefes/omnibus-toolchain-rocky-9:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rocky-8:3.0.39
+            container: chefes/omnibus-toolchain-rocky-8:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rocky-8:aarch64
+            container: chefes/omnibus-toolchain-rocky-8:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-debian-11:3.0.39
+            container: chefes/omnibus-toolchain-rhel-9:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04-arm
+            container: chefes/omnibus-toolchain-rhel-9:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04
+            container: chefes/omnibus-toolchain-debian-11:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
             pkg_mgr: apt
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-debian-11:aarch64
+            container: chefes/omnibus-toolchain-debian-11:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
             pkg_mgr: apt
     runs-on: ${{ matrix.runs-on }}
     container:

--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -89,6 +89,7 @@ jobs:
 
   functional-docker:
     needs: config
+    name: ${{ matrix.label }}
     strategy:
       fail-fast: false
       matrix:
@@ -96,21 +97,27 @@ jobs:
           - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-rocky-9:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
+            label: rocky-9-x86
           - runs-on: ubuntu-24.04-arm
             container: chefes/omnibus-toolchain-rocky-9:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
+            label: rocky-9-arm
           - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
+            label: rocky-8-x86
           - runs-on: ubuntu-24.04-arm
             container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
+            label: rocky-8-arm
           - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: apt
+            label: debian-11-x86
           - runs-on: ubuntu-24.04-arm
             container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: apt
+            label: debian-11-arm
     runs-on: ${{ matrix.runs-on }}
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -66,15 +66,29 @@ jobs:
       - run: bundle exec rake spec:unit
       - run: bundle exec rake component_specs
 
-  unit-rocky:
+  unit-docker:
     strategy:
       fail-fast: false
       matrix:
         include:
           - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-rocky-9:3.0.39
+            pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
             container: chefes/omnibus-toolchain-rocky-9:aarch64
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04
+            container: chefes/omnibus-toolchain-rocky-8:3.0.39
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04-arm
+            container: chefes/omnibus-toolchain-rocky-8:aarch64
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04
+            container: chefes/omnibus-toolchain-debian-11:3.0.39
+            pkg_mgr: apt
+          - runs-on: ubuntu-24.04-arm
+            container: chefes/omnibus-toolchain-debian-11:aarch64
+            pkg_mgr: apt
     runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.container }}
     timeout-minutes: 60
@@ -82,9 +96,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           clean: true
-      - name: Install dependencies and Ruby via rbenv
+      - name: Install native deps (dnf)
+        if: matrix.pkg_mgr == 'dnf'
+        run: dnf install -y --enablerepo=devel openssl-devel libarchive-devel libffi-devel libyaml-devel readline-devel zlib-devel curl
+      - name: Install native deps (apt)
+        if: matrix.pkg_mgr == 'apt'
         run: |
-          dnf install -y --enablerepo=devel openssl-devel libarchive-devel libffi-devel libyaml-devel readline-devel zlib-devel
+          apt-get update
+          apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev libreadline-dev zlib1g-dev curl
+      - name: Install Ruby via rbenv
+        run: |
           curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
           export PATH="$HOME/.rbenv/bin:$PATH"
           eval "$(rbenv init -)"

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -17,6 +17,8 @@ concurrency:
 env:
   CHEF_LICENSE: accept-no-persist
   FORCE_FFI_YAJL: ext
+  OMNIBUS_TOOLCHAIN_X86_TAG: "3.0.39"
+  OMNIBUS_TOOLCHAIN_ARM_TAG: "aarch64"
 
 jobs:
   unit:
@@ -72,22 +74,28 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rocky-9:3.0.39
+            container: chefes/omnibus-toolchain-rocky-9:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rocky-9:aarch64
+            container: chefes/omnibus-toolchain-rocky-9:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rocky-8:3.0.39
+            container: chefes/omnibus-toolchain-rocky-8:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rocky-8:aarch64
+            container: chefes/omnibus-toolchain-rocky-8:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-debian-11:3.0.39
+            container: chefes/omnibus-toolchain-rhel-9:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04-arm
+            container: chefes/omnibus-toolchain-rhel-9:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            pkg_mgr: dnf
+          - runs-on: ubuntu-24.04
+            container: chefes/omnibus-toolchain-debian-11:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
             pkg_mgr: apt
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-debian-11:aarch64
+            container: chefes/omnibus-toolchain-debian-11:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
             pkg_mgr: apt
     runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.container }}

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -98,7 +98,7 @@ jobs:
           clean: true
       - name: Install native deps (dnf)
         if: matrix.pkg_mgr == 'dnf'
-        run: dnf install -y --enablerepo=devel openssl-devel libarchive-devel libffi-devel libyaml-devel readline-devel zlib-devel curl
+        run: dnf install -y --enablerepo=devel openssl-devel libarchive-devel libffi-devel libyaml-devel readline-devel zlib-devel
       - name: Install native deps (apt)
         if: matrix.pkg_mgr == 'apt'
         run: |

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -96,12 +96,6 @@ jobs:
             container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rhel-9:${{ needs.config.outputs.x86_tag }}
-            pkg_mgr: dnf
-          - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rhel-9:${{ needs.config.outputs.arm_tag }}
-            pkg_mgr: dnf
-          - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: apt
           - runs-on: ubuntu-24.04-arm

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -79,6 +79,7 @@ jobs:
 
   unit-docker:
     needs: config
+    name: ${{ matrix.label }}
     strategy:
       fail-fast: false
       matrix:
@@ -86,21 +87,27 @@ jobs:
           - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-rocky-9:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
+            label: rocky-9-x86
           - runs-on: ubuntu-24.04-arm
             container: chefes/omnibus-toolchain-rocky-9:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
+            label: rocky-9-arm
           - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
+            label: rocky-8-x86
           - runs-on: ubuntu-24.04-arm
             container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
+            label: rocky-8-arm
           - runs-on: ubuntu-24.04
             container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: apt
+            label: debian-11-x86
           - runs-on: ubuntu-24.04-arm
             container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: apt
+            label: debian-11-arm
     runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.container }}
     timeout-minutes: 60

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -17,10 +17,19 @@ concurrency:
 env:
   CHEF_LICENSE: accept-no-persist
   FORCE_FFI_YAJL: ext
-  OMNIBUS_TOOLCHAIN_X86_TAG: "3.0.39"
-  OMNIBUS_TOOLCHAIN_ARM_TAG: "aarch64"
 
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      x86_tag: ${{ steps.tags.outputs.x86_tag }}
+      arm_tag: ${{ steps.tags.outputs.arm_tag }}
+    steps:
+      - id: tags
+        run: |
+          echo "x86_tag=3.0.39" >> $GITHUB_OUTPUT
+          echo "arm_tag=aarch64" >> $GITHUB_OUTPUT
+
   unit:
     strategy:
       fail-fast: false
@@ -69,33 +78,34 @@ jobs:
       - run: bundle exec rake component_specs
 
   unit-docker:
+    needs: config
     strategy:
       fail-fast: false
       matrix:
         include:
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rocky-9:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            container: chefes/omnibus-toolchain-rocky-9:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rocky-9:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            container: chefes/omnibus-toolchain-rocky-9:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rocky-8:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rocky-8:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            container: chefes/omnibus-toolchain-rocky-8:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-rhel-9:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            container: chefes/omnibus-toolchain-rhel-9:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-rhel-9:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            container: chefes/omnibus-toolchain-rhel-9:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: dnf
           - runs-on: ubuntu-24.04
-            container: chefes/omnibus-toolchain-debian-11:${{ env.OMNIBUS_TOOLCHAIN_X86_TAG }}
+            container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.x86_tag }}
             pkg_mgr: apt
           - runs-on: ubuntu-24.04-arm
-            container: chefes/omnibus-toolchain-debian-11:${{ env.OMNIBUS_TOOLCHAIN_ARM_TAG }}
+            container: chefes/omnibus-toolchain-debian-11:${{ needs.config.outputs.arm_tag }}
             pkg_mgr: apt
     runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.container }}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Before these migrations started, there were a minimum of 16 aarch64 jobs per build (assuming no terminations). This reduces that number to 6, allowing for multiple PRs to be built per hour. Total job count per build on the verify pipeline has been reduced from 41 as of 19.2.41 to 18 after this PR.

  .github/workflows/unit_specs.yml

   - Renamed unit-rocky → unit-docker
   - Expanded matrix from 2 → 6 entries:
    - rocky-9 x86_64 (chefes/omnibus-toolchain-rocky-9:3.0.39) — existing
    - rocky-9 aarch64 (chefes/omnibus-toolchain-rocky-9:aarch64) — existing
    - rocky-8 x86_64 (chefes/omnibus-toolchain-rocky-8:3.0.39) — new
    - rocky-8 aarch64 (chefes/omnibus-toolchain-rocky-8:aarch64) — new
    - debian-11 x86_64 (chefes/omnibus-toolchain-debian-11:3.0.39) — new
    - debian-11 aarch64 (chefes/omnibus-toolchain-debian-11:aarch64) — new
   - Each entry carries a pkg_mgr: dnf|apt field
   - Split install steps: Install native deps (dnf) and Install native deps (apt) with if: conditions, followed by a shared Install Ruby via rbenv step
   - Fix: curl omitted from the dnf install list to avoid conflict with curl-minimal present in Rocky 9 containers

  .github/workflows/func_spec.yml

   - Same changes as unit_specs.yml above, applied to functional-rocky → functional-docker
   - Matrix expanded identically (6 entries, same images, same pkg_mgr pattern)
   - Container runs with --privileged (preserved from original)

  .buildkite/verify.pipeline.sh

   - Updated comments to reflect GHA ownership
   - rhel_platforms: trimmed to rhel-9 + rhel-9-aarch64 only — still runs Unit + Functional + Integration in Buildkite
   - rocky8_platforms (new array): rocky-8 + rocky-8-aarch64 — runs Integration only (Unit → unit-docker, Functional → functional-docker)
   - rocky9_platforms: unchanged loop — runs Integration only (was already the case)
   - debian_platforms loop: reduced from Unit + Functional + Integration → Integration only (Unit → unit-docker, Functional → functional-docker)


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
