### PR TITLE
Dependabot: Don't auto rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
       # Due to FIPS builds and having to couple the openssl
       # build itself, we don't let dependabot bump openssl
       - dependency-name: "openssl"
+    # don't automatically rebase on every single time we're out of date with
+    # base (whith is always) because it kills CI capacity
+    rebase-strategy: disabled
 
   - package-ecosystem: bundler
     directory: "/"
@@ -31,6 +34,9 @@ updates:
       # chef-18 needs to stay on toml 1 which is less strict
       - dependency-name: "tomlrb"
         versions: [">= 2"]
+    # don't automatically rebase on every single time we're out of date with
+    # base (whith is always) because it kills CI capacity
+    rebase-strategy: disabled
 
   - package-ecosystem: bundler
     directory: "/omnibus"
@@ -40,6 +46,9 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "Type: Chore"
+    # don't automatically rebase on every single time we're out of date with
+    # base (whith is always) because it kills CI capacity
+    rebase-strategy: disabled
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -48,3 +57,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "Type: Chore"
+    # don't automatically rebase on every single time we're out of date with
+    # base (whith is always) because it kills CI capacity
+    rebase-strategy: disabled


### PR DESCRIPTION
Turn off autorebasing, which causes Dependabot to automatically
rebase all PRs everytime there's a commit, which ends up creating
CI storms.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
