### PR TITLE
Don't waste buildkite time on github-only changes

### DIFF
--- a/.buildkite/verify.pipeline.sh
+++ b/.buildkite/verify.pipeline.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 # exit immediately on failure, or if an undefined variable is used
 set -eu
+
+# If the only changed files are under .github/, skip all tests
+BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
+changed_files=$(git diff --name-only "origin/${BASE_BRANCH}...HEAD" 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || true)
+
+if [[ -n "$changed_files" ]] && ! echo "$changed_files" | grep -qv '^\.github/'; then
+  echo "steps: []"
+  exit 0
+fi
+
 echo "---"
 echo "env:"
 echo "  BUILD_TIMESTAMP: $(date +%Y-%m-%d_%H-%M-%S)"


### PR DESCRIPTION
If we're only changing the configuration for github specific things,
none of the buildkite tests are applicable, so don't waste time on them.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
