### PR TITLE
use local server and cert instead of external in trusted cert recipe

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
@@ -25,13 +25,12 @@ cert.sign(key, OpenSSL::Digest.new("SHA256"))
 
 cert_pem = cert.to_pem
 
-# Start a local HTTPS server in the background serving a test page
 server = WEBrick::HTTPServer.new(
   Port: 9443,
   SSLEnable: true,
   SSLCertificate: cert,
   SSLPrivateKey: key,
-  Logger: WEBrick::Log.new("/dev/null"),
+  Logger: WEBrick::Log.new(File::NULL),
   AccessLog: []
 )
 server.mount_proc("/index.html") { |_req, res| res.body = "trusted cert test OK" }

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
@@ -1,21 +1,55 @@
-# First grab the cert. While this wouldn't ordinarily be secure, this isn't
-# trying to secure something, we simply want to make sure that if we
-# have said a certificate is trusted, it will be trusted. So lets grab it, trust
-# it, and then try to use it.
+# This test verifies that the chef_client_trusted_certificate resource correctly
+# installs a certificate into Chef's trusted_certs_dir and that the SSL trust
+# chain works end-to-end (set_custom_certs -> OpenSSL::X509::Store -> TLS handshake).
 
-# First, grab it
-out = Mixlib::ShellOut.new(
-  %w{openssl s_client -servername self-signed.badssl.com -showcerts -connect self-signed.badssl.com:443}
-).run_command.stdout
+require "openssl"
+require "webrick"
+require "webrick/https"
 
-cert = Mixlib::ShellOut.new(%w{openssl x509}, input: out).run_command.stdout
+# Generate a self-signed certificate for localhost
+key = OpenSSL::PKey::RSA.new(2048)
+cert = OpenSSL::X509::Certificate.new
+cert.version = 2
+cert.serial = 1
+cert.subject = OpenSSL::X509::Name.parse("/CN=localhost")
+cert.issuer = cert.subject
+cert.public_key = key.public_key
+cert.not_before = Time.now
+cert.not_after = Time.now + 3600
 
-# Second trust it
-chef_client_trusted_certificate "self-signed.badssl.com" do
-  certificate cert
+ef = OpenSSL::X509::ExtensionFactory.new
+ef.subject_certificate = cert
+ef.issuer_certificate = cert
+cert.add_extension(ef.create_extension("subjectAltName", "DNS:localhost,IP:127.0.0.1", false))
+cert.sign(key, OpenSSL::Digest.new("SHA256"))
+
+cert_pem = cert.to_pem
+
+# Start a local HTTPS server in the background serving a test page
+server = WEBrick::HTTPServer.new(
+  Port: 9443,
+  SSLEnable: true,
+  SSLCertificate: cert,
+  SSLPrivateKey: key,
+  Logger: WEBrick::Log.new("/dev/null"),
+  AccessLog: []
+)
+server.mount_proc("/index.html") { |_req, res| res.body = "trusted cert test OK" }
+Thread.new { server.start }
+
+# Trust our self-signed cert via the Chef resource (exercises chef_client_trusted_certificate -> file write)
+chef_client_trusted_certificate "localhost" do
+  certificate cert_pem
 end
 
-# see if we can fetch from our new trusted domain
+# Fetch from the local HTTPS server — this exercises the full SSL trust chain:
+# trusted_certs_dir -> set_custom_certs -> OpenSSL::X509::Store -> TLS peer verification
 remote_file ::File.join(Chef::Config[:file_cache_path], "index.html") do
-  source "https://self-signed.badssl.com/index.html"
+  source "https://localhost:9443/index.html"
+  notifies :run, "ruby_block[stop local https server]", :immediately
+end
+
+ruby_block "stop local https server" do
+  block { server.shutdown }
+  action :nothing
 end


### PR DESCRIPTION
## Description
Use a locally-generated self-signed cert and a local HTTPS server to avoid depending on whatever url it was trying to access before because that was intermittently failing the kitchen tests.

original error:
```
2026-04-20T10:17:11.5027628Z        Recipe: end_to_end::_chef_client_trusted_certificate
2026-04-20T10:17:11.5031727Z          * chef_client_trusted_certificate[self-signed.badssl.com] action add
2026-04-20T10:17:11.5041784Z            * directory[/opt/kitchen/trusted_certs] action create
2026-04-20T10:17:11.5045099Z              - create new directory /opt/kitchen/trusted_certs
2026-04-20T10:17:11.5049277Z              - change mode from '' to '0640'
2026-04-20T10:17:11.5066626Z            * file[/opt/kitchen/trusted_certs/self-signed.badssl.com.pem] action create
2026-04-20T10:17:11.5072211Z              - create new file /opt/kitchen/trusted_certs/self-signed.badssl.com.pem
2026-04-20T10:17:11.5073464Z              - update content in file /opt/kitchen/trusted_certs/self-signed.badssl.com.pem from none to e3b0c4
2026-04-20T10:17:11.5075905Z              (diff output suppressed by config)
2026-04-20T10:17:11.5079625Z              - change mode from '' to '0640'
2026-04-20T10:17:11.5082123Z
2026-04-20T10:17:11.5290353Z          * remote_file[/opt/kitchen/cache/index.html] action create
2026-04-20T10:17:11.5290969Z
2026-04-20T10:17:11.5291749Z            ================================================================================
2026-04-20T10:17:11.5293388Z            Error executing action `create` on resource 'remote_file[/opt/kitchen/cache/index.html]'
2026-04-20T10:17:11.5294790Z            ================================================================================
2026-04-20T10:17:11.5295945Z
2026-04-20T10:17:11.5296539Z            ChefConfig::ConfigurationError
2026-04-20T10:17:11.5297071Z            ------------------------------
2026-04-20T10:17:11.5298782Z            Error reading cert file '/opt/kitchen/trusted_certs/self-signed.badssl.com.pem', original error 'OpenSSL::X509::CertificateError: PEM_read_bio_X509: no start line (Expecting: CERTIFICATE)'
2026-04-20T10:17:11.5300486Z
2026-04-20T10:17:11.5300855Z            Resource Declaration:
2026-04-20T10:17:11.5301351Z            ---------------------
2026-04-20T10:17:11.5302263Z            # In /opt/kitchen/cache/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
2026-04-20T10:17:11.5303501Z
2026-04-20T10:17:11.5304117Z             19: remote_file ::File.join(Chef::Config[:file_cache_path], "index.html") do
2026-04-20T10:17:11.5305141Z             20:   source "https://self-signed.badssl.com/index.html"
2026-04-20T10:17:11.5305690Z             21: end
2026-04-20T10:17:11.5305999Z
2026-04-20T10:17:11.5306274Z            Compiled Resource:
2026-04-20T10:17:11.5306620Z            ------------------
2026-04-20T10:17:11.5307624Z            # Declared in /opt/kitchen/cache/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb:19:in 'Chef::Mixin::FromFile#from_file'
2026-04-20T10:17:11.5308603Z
2026-04-20T10:17:11.5308957Z            remote_file("/opt/kitchen/cache/index.html") do
2026-04-20T10:17:11.5309434Z              action [:create]
2026-04-20T10:17:11.5309819Z              default_guard_interpreter :default
2026-04-20T10:17:11.5310363Z              source ["https://self-signed.badssl.com/index.html"]
2026-04-20T10:17:11.5310897Z              declared_type :remote_file
2026-04-20T10:17:11.5311296Z              cookbook_name "end_to_end"
2026-04-20T10:17:11.5311757Z              recipe_name "_chef_client_trusted_certificate"
2026-04-20T10:17:11.5312163Z              path "/opt/kitchen/cache/index.html"
2026-04-20T10:17:11.5312434Z            end
2026-04-20T10:17:11.5312921Z
2026-04-20T10:17:11.5313111Z            System Info:
2026-04-20T10:17:11.5313309Z            ------------
2026-04-20T10:17:11.5313501Z            chef_version=19.2.106
2026-04-20T10:17:11.5313728Z            platform=oracle
2026-04-20T10:17:11.5313935Z            platform_version=9.7
2026-04-20T10:17:11.5314236Z            ruby=ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [x86_64-linux]
2026-04-20T10:17:11.5314735Z            program_name=/hab/pkgs/chef/chef-infra-client/19.2.106/20260419201139/bin/chef-client
2026-04-20T10:17:11.5315278Z            executable=/hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/bin/chef-client
2026-04-20T10:17:11.5315656Z
2026-04-20T10:17:11.5324635Z          * template[update ssh known hosts file /etc/ssh/ssh_known_hosts] action create
2026-04-20T10:17:11.5332559Z            - create new file /etc/ssh/ssh_known_hosts
2026-04-20T10:17:11.5333701Z            - update content in file /etc/ssh/ssh_known_hosts from none to 80be70
2026-04-20T10:17:11.5344674Z            (diff output suppressed by config)
2026-04-20T10:17:11.5345335Z            - change mode from '' to '0644'
2026-04-20T10:17:11.5345934Z            - change owner from '' to 'root'
2026-04-20T10:17:11.5348616Z            - change group from '' to 'root'
2026-04-20T10:17:11.5351607Z        Recipe: openssh::default
2026-04-20T10:17:11.5845460Z          * service[ssh] action restart
2026-04-20T10:17:11.5845971Z            - restart service service[ssh]
2026-04-20T10:17:11.5853560Z
2026-04-20T10:17:11.5853916Z        Running handlers:
2026-04-20T10:17:11.5857662Z        [2026-04-20T10:17:11+00:00] ERROR: Running exception handlers
2026-04-20T10:17:11.5858298Z        Running handlers complete
2026-04-20T10:17:11.5858974Z        [2026-04-20T10:17:11+00:00] ERROR: Exception handlers complete
2026-04-20T10:17:11.5859930Z        Infra Phase failed. 93 resources updated in 03 minutes 25 seconds
2026-04-20T10:17:11.5873665Z        [2026-04-20T10:17:11+00:00] FATAL: Stacktrace dumped to /opt/kitchen/cache/chef-stacktrace.out
2026-04-20T10:17:11.5874921Z        [2026-04-20T10:17:11+00:00] FATAL: ---------------------------------------------------------------------------------------
2026-04-20T10:17:11.5876275Z        [2026-04-20T10:17:11+00:00] FATAL: PLEASE PROVIDE THE CONTENTS OF THE stacktrace.out FILE (above) IF YOU FILE A BUG REPORT
2026-04-20T10:17:11.5877619Z        [2026-04-20T10:17:11+00:00] FATAL: ---------------------------------------------------------------------------------------
2026-04-20T10:17:11.5889067Z        [2026-04-20T10:17:11+00:00] FATAL: ChefConfig::ConfigurationError: remote_file[/opt/kitchen/cache/index.html] (end_to_end::_chef_client_trusted_certificate line 19) had an error: ChefConfig::ConfigurationError: Error reading cert file '/opt/kitchen/trusted_certs/self-signed.badssl.com.pem', original error 'OpenSSL::X509::CertificateError: PEM_read_bio_X509: no start line (Expecting: CERTIFICATE)'
2026-04-20T10:17:11.5893197Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:93:in 'block in Chef::HTTP::DefaultSSLPolicy#set_custom_certs'
2026-04-20T10:17:11.5894979Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:89:in 'Array#each'
2026-04-20T10:17:11.5896704Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:89:in 'Chef::HTTP::DefaultSSLPolicy#set_custom_certs'
2026-04-20T10:17:11.5898604Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:48:in 'Chef::HTTP::DefaultSSLPolicy#apply'
2026-04-20T10:17:11.5900460Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:35:in 'Chef::HTTP::DefaultSSLPolicy.apply_to'
2026-04-20T10:17:11.5903805Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:162:in 'Chef::HTTP::BasicClient#configure_ssl'
2026-04-20T10:17:11.5905650Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:120:in 'Chef::HTTP::BasicClient#build_http_client'
2026-04-20T10:17:11.5907479Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:54:in 'Chef::HTTP::BasicClient#http_client'
2026-04-20T10:17:11.5909053Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:73:in 'Chef::HTTP::BasicClient#request'
2026-04-20T10:17:11.5910655Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:384:in 'block in Chef::HTTP#send_http_request'
2026-04-20T10:17:11.5912245Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:425:in 'block in Chef::HTTP#retrying_http_errors'
2026-04-20T10:17:11.5913981Z        <internal:kernel>:168:in 'Kernel#loop'
2026-04-20T10:17:11.5914966Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:423:in 'Chef::HTTP#retrying_http_errors'
2026-04-20T10:17:11.5916389Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:379:in 'Chef::HTTP#send_http_request'
2026-04-20T10:17:11.5917667Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:228:in 'Chef::HTTP#streaming_request'
2026-04-20T10:17:11.5918860Z        /hab/pkgs/core/ruby3_4/3.4.8/20260306111612/lib/ruby/3.4.0/forwardable.rb:240:in 'TargetIO::HTTP#streaming_request'
2026-04-20T10:17:11.5920472Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/http.rb:71:in 'Chef::Provider::RemoteFile::HTTP#fetch'
2026-04-20T10:17:11.5922259Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:74:in 'Chef::Provider::RemoteFile::Content#grab_file_from_uri'
2026-04-20T10:17:11.5924384Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:59:in 'Chef::Provider::RemoteFile::Content#try_multiple_sources'
2026-04-20T10:17:11.5926288Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:44:in 'Chef::Provider::RemoteFile::Content#file_for_provider'
2026-04-20T10:17:11.5928198Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/file_content_management/content_base.rb:42:in 'Chef::FileContentManagement::ContentBase#tempfile'
2026-04-20T10:17:11.5930125Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:471:in 'Chef::Provider::File#tempfile'
2026-04-20T10:17:11.5931774Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:337:in 'Chef::Provider::File#do_generate_content'
2026-04-20T10:17:11.5933586Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:149:in 'block in <class:File>'
2026-04-20T10:17:11.5935301Z        (eval at /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:67):2:in 'block in Chef::Provider::File#action_create'
2026-04-20T10:17:11.5936808Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:304:in 'BasicObject#instance_eval'
2026-04-20T10:17:11.5938404Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:304:in 'Chef::Provider#compile_and_converge_action'
2026-04-20T10:17:11.5940287Z        (eval at /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:67):2:in 'Chef::Provider::File#action_create'
2026-04-20T10:17:11.5942040Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:245:in 'Chef::Provider#run_action'
2026-04-20T10:17:11.5944017Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:601:in 'block in Chef::Resource#run_action'
2026-04-20T10:17:11.5945728Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:629:in 'Chef::Resource#with_umask'
2026-04-20T10:17:11.5947373Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:600:in 'Chef::Resource#run_action'
2026-04-20T10:17:11.5949015Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:74:in 'Chef::Runner#run_action'
2026-04-20T10:17:11.5950680Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'block in Chef::Runner#run_all_actions'
2026-04-20T10:17:11.5952211Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'Array#each'
2026-04-20T10:17:11.5953910Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'Chef::Runner#run_all_actions'
2026-04-20T10:17:11.5955484Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:132:in 'block in Chef::Runner#converge'
2026-04-20T10:17:11.5957465Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/resource_list.rb:96:in 'block in Chef::ResourceCollection::ResourceList#execute_each_resource'
2026-04-20T10:17:11.5959273Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:114:in 'Chef::ResourceCollection::StepableIterator#call_iterator_block'
2026-04-20T10:17:11.5960561Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:85:in 'Chef::ResourceCollection::StepableIterator#step'
2026-04-20T10:17:11.5961806Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:103:in 'Chef::ResourceCollection::StepableIterator#iterate'
2026-04-20T10:17:11.5963435Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:54:in 'Chef::ResourceCollection::StepableIterator#each_with_index'
2026-04-20T10:17:11.5964723Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/resource_list.rb:94:in 'Chef::ResourceCollection::ResourceList#execute_each_resource'
2026-04-20T10:17:11.5965920Z        /hab/pkgs/core/ruby3_4/3.4.8/20260306111612/lib/ruby/3.4.0/forwardable.rb:240:in 'Chef::ResourceCollection#execute_each_resource'
2026-04-20T10:17:11.5966739Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:130:in 'Chef::Runner#converge'
2026-04-20T10:17:11.5967657Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:882:in 'block in Chef::Client#converge'
2026-04-20T10:17:11.5968487Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:877:in 'Kernel#catch'
2026-04-20T10:17:11.5969284Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:877:in 'Chef::Client#converge'
2026-04-20T10:17:11.5970146Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:901:in 'Chef::Client#converge_and_save'
2026-04-20T10:17:11.5970981Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:299:in 'Chef::Client#run'
2026-04-20T10:17:11.5971898Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:310:in 'Chef::Application#run_with_graceful_exit_option'
2026-04-20T10:17:11.5973248Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:286:in 'block in Chef::Application#run_chef_client'
2026-04-20T10:17:11.5974255Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/local_mode.rb:42:in 'Chef::LocalMode.with_server_connectivity'
2026-04-20T10:17:11.5975240Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:269:in 'Chef::Application#run_chef_client'
2026-04-20T10:17:11.5976253Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application/base.rb:385:in 'Chef::Application::Base#run_application'
2026-04-20T10:17:11.5977223Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:72:in 'Chef::Application#run'
2026-04-20T10:17:11.5978065Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-bin-19.2.106/bin/chef-client:25:in '<top (required)>'
2026-04-20T10:17:11.5978757Z        /hab/pkgs/chef/chef-infra-client/19.2.106/20260419201139/bin/chef-client:218:in 'Kernel.load'
2026-04-20T10:17:11.5979320Z        /hab/pkgs/chef/chef-infra-client/19.2.106/20260419201139/bin/chef-client:218:in '<main>'
2026-04-20T10:17:11.5979706Z
2026-04-20T10:17:11.5980080Z        >>>> Caused by OpenSSL::X509::CertificateError: PEM_read_bio_X509: no start line (Expecting: CERTIFICATE)
2026-04-20T10:17:11.5981084Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:91:in 'OpenSSL::X509::Certificate#initialize'
2026-04-20T10:17:11.5982050Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:91:in 'Class#new'
2026-04-20T10:17:11.5983773Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:91:in 'block in Chef::HTTP::DefaultSSLPolicy#set_custom_certs'
2026-04-20T10:17:11.5984780Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:89:in 'Array#each'
2026-04-20T10:17:11.5985730Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:89:in 'Chef::HTTP::DefaultSSLPolicy#set_custom_certs'
2026-04-20T10:17:11.5986760Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:48:in 'Chef::HTTP::DefaultSSLPolicy#apply'
2026-04-20T10:17:11.5987993Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:35:in 'Chef::HTTP::DefaultSSLPolicy.apply_to'
2026-04-20T10:17:11.5989002Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:162:in 'Chef::HTTP::BasicClient#configure_ssl'
2026-04-20T10:17:11.5990052Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:120:in 'Chef::HTTP::BasicClient#build_http_client'
2026-04-20T10:17:11.5991069Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:54:in 'Chef::HTTP::BasicClient#http_client'
2026-04-20T10:17:11.5992047Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:73:in 'Chef::HTTP::BasicClient#request'
2026-04-20T10:17:11.5993330Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:384:in 'block in Chef::HTTP#send_http_request'
2026-04-20T10:17:11.5994267Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:425:in 'block in Chef::HTTP#retrying_http_errors'
2026-04-20T10:17:11.5994873Z        <internal:kernel>:168:in 'Kernel#loop'
2026-04-20T10:17:11.5995444Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:423:in 'Chef::HTTP#retrying_http_errors'
2026-04-20T10:17:11.5996309Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:379:in 'Chef::HTTP#send_http_request'
2026-04-20T10:17:11.5997185Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:228:in 'Chef::HTTP#streaming_request'
2026-04-20T10:17:11.5997997Z        /hab/pkgs/core/ruby3_4/3.4.8/20260306111612/lib/ruby/3.4.0/forwardable.rb:240:in 'TargetIO::HTTP#streaming_request'
2026-04-20T10:17:11.5998895Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/http.rb:71:in 'Chef::Provider::RemoteFile::HTTP#fetch'
2026-04-20T10:17:11.6000034Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:74:in 'Chef::Provider::RemoteFile::Content#grab_file_from_uri'
2026-04-20T10:17:11.6001225Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:59:in 'Chef::Provider::RemoteFile::Content#try_multiple_sources'
2026-04-20T10:17:11.6002449Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:44:in 'Chef::Provider::RemoteFile::Content#file_for_provider'
2026-04-20T10:17:11.6004248Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/file_content_management/content_base.rb:42:in 'Chef::FileContentManagement::ContentBase#tempfile'
2026-04-20T10:17:11.6005378Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:471:in 'Chef::Provider::File#tempfile'
2026-04-20T10:17:11.6006371Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:337:in 'Chef::Provider::File#do_generate_content'
2026-04-20T10:17:11.6007324Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:149:in 'block in <class:File>'
2026-04-20T10:17:11.6008298Z        (eval at /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:67):2:in 'block in Chef::Provider::File#action_create'
2026-04-20T10:17:11.6009262Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:304:in 'BasicObject#instance_eval'
2026-04-20T10:17:11.6010325Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:304:in 'Chef::Provider#compile_and_converge_action'
2026-04-20T10:17:11.6011324Z        (eval at /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:67):2:in 'Chef::Provider::File#action_create'
2026-04-20T10:17:11.6012258Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:245:in 'Chef::Provider#run_action'
2026-04-20T10:17:11.6013308Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:601:in 'block in Chef::Resource#run_action'
2026-04-20T10:17:11.6014216Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:629:in 'Chef::Resource#with_umask'
2026-04-20T10:17:11.6015123Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:600:in 'Chef::Resource#run_action'
2026-04-20T10:17:11.6015977Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:74:in 'Chef::Runner#run_action'
2026-04-20T10:17:11.6016862Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'block in Chef::Runner#run_all_actions'
2026-04-20T10:17:11.6017717Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'Array#each'
2026-04-20T10:17:11.6018540Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'Chef::Runner#run_all_actions'
2026-04-20T10:17:11.6019422Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:132:in 'block in Chef::Runner#converge'
2026-04-20T10:17:11.6020550Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/resource_list.rb:96:in 'block in Chef::ResourceCollection::ResourceList#execute_each_resource'
2026-04-20T10:17:11.6021881Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:114:in 'Chef::ResourceCollection::StepableIterator#call_iterator_block'
2026-04-20T10:17:11.6023374Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:85:in 'Chef::ResourceCollection::StepableIterator#step'
2026-04-20T10:17:11.6024759Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:103:in 'Chef::ResourceCollection::StepableIterator#iterate'
2026-04-20T10:17:11.6026179Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:54:in 'Chef::ResourceCollection::StepableIterator#each_with_index'
2026-04-20T10:17:11.6027463Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/resource_list.rb:94:in 'Chef::ResourceCollection::ResourceList#execute_each_resource'
2026-04-20T10:17:11.6028504Z        /hab/pkgs/core/ruby3_4/3.4.8/20260306111612/lib/ruby/3.4.0/forwardable.rb:240:in 'Chef::ResourceCollection#execute_each_resource'
2026-04-20T10:17:11.6029327Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:130:in 'Chef::Runner#converge'
2026-04-20T10:17:11.6030190Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:882:in 'block in Chef::Client#converge'
2026-04-20T10:17:11.6031023Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:877:in 'Kernel#catch'
2026-04-20T10:17:11.6031940Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:877:in 'Chef::Client#converge'
2026-04-20T10:17:11.6033076Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:901:in 'Chef::Client#converge_and_save'
2026-04-20T10:17:11.6033930Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:299:in 'Chef::Client#run'
2026-04-20T10:17:11.6034855Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:310:in 'Chef::Application#run_with_graceful_exit_option'
2026-04-20T10:17:11.6035920Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:286:in 'block in Chef::Application#run_chef_client'
2026-04-20T10:17:11.6036922Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/local_mode.rb:42:in 'Chef::LocalMode.with_server_connectivity'
2026-04-20T10:17:11.6037895Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:269:in 'Chef::Application#run_chef_client'
2026-04-20T10:17:11.6038885Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application/base.rb:385:in 'Chef::Application::Base#run_application'
2026-04-20T10:17:11.6039843Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:72:in 'Chef::Application#run'
2026-04-20T10:17:11.6040680Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-bin-19.2.106/bin/chef-client:25:in '<top (required)>'
2026-04-20T10:17:11.6041368Z        /hab/pkgs/chef/chef-infra-client/19.2.106/20260419201139/bin/chef-client:218:in 'Kernel.load'
2026-04-20T10:17:11.6041935Z        /hab/pkgs/chef/chef-infra-client/19.2.106/20260419201139/bin/chef-client:218:in '<main>'
2026-04-20T10:17:11.6043864Z        [2026-04-20T10:17:11+00:00] FATAL: ChefConfig::ConfigurationError: remote_file[/opt/kitchen/cache/index.html] (end_to_end::_chef_client_trusted_certificate line 19) had an error: ChefConfig::ConfigurationError: Error reading cert file '/opt/kitchen/trusted_certs/self-signed.badssl.com.pem', original error 'OpenSSL::X509::CertificateError: PEM_read_bio_X509: no start line (Expecting: CERTIFICATE)'
2026-04-20T10:17:11.6045766Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:93:in 'block in Chef::HTTP::DefaultSSLPolicy#set_custom_certs'
2026-04-20T10:17:11.6046740Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:89:in 'Array#each'
2026-04-20T10:17:11.6047678Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:89:in 'Chef::HTTP::DefaultSSLPolicy#set_custom_certs'
2026-04-20T10:17:11.6048852Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:48:in 'Chef::HTTP::DefaultSSLPolicy#apply'
2026-04-20T10:17:11.6049868Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/ssl_policies.rb:35:in 'Chef::HTTP::DefaultSSLPolicy.apply_to'
2026-04-20T10:17:11.6050880Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:162:in 'Chef::HTTP::BasicClient#configure_ssl'
2026-04-20T10:17:11.6051903Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:120:in 'Chef::HTTP::BasicClient#build_http_client'
2026-04-20T10:17:11.6053194Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:54:in 'Chef::HTTP::BasicClient#http_client'
2026-04-20T10:17:11.6054332Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http/basic_client.rb:73:in 'Chef::HTTP::BasicClient#request'
2026-04-20T10:17:11.6055273Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:384:in 'block in Chef::HTTP#send_http_request'
2026-04-20T10:17:11.6056324Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:425:in 'block in Chef::HTTP#retrying_http_errors'
2026-04-20T10:17:11.6056945Z        <internal:kernel>:168:in 'Kernel#loop'
2026-04-20T10:17:11.6057523Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:423:in 'Chef::HTTP#retrying_http_errors'
2026-04-20T10:17:11.6058399Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:379:in 'Chef::HTTP#send_http_request'
2026-04-20T10:17:11.6059272Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/http.rb:228:in 'Chef::HTTP#streaming_request'
2026-04-20T10:17:11.6060062Z        /hab/pkgs/core/ruby3_4/3.4.8/20260306111612/lib/ruby/3.4.0/forwardable.rb:240:in 'TargetIO::HTTP#streaming_request'
2026-04-20T10:17:11.6060962Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/http.rb:71:in 'Chef::Provider::RemoteFile::HTTP#fetch'
2026-04-20T10:17:11.6062096Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:74:in 'Chef::Provider::RemoteFile::Content#grab_file_from_uri'
2026-04-20T10:17:11.6063455Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:59:in 'Chef::Provider::RemoteFile::Content#try_multiple_sources'
2026-04-20T10:17:11.6064656Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/remote_file/content.rb:44:in 'Chef::Provider::RemoteFile::Content#file_for_provider'
2026-04-20T10:17:11.6065860Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/file_content_management/content_base.rb:42:in 'Chef::FileContentManagement::ContentBase#tempfile'
2026-04-20T10:17:11.6066943Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:471:in 'Chef::Provider::File#tempfile'
2026-04-20T10:17:11.6067922Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:337:in 'Chef::Provider::File#do_generate_content'
2026-04-20T10:17:11.6068863Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider/file.rb:149:in 'block in <class:File>'
2026-04-20T10:17:11.6079296Z        (eval at /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:67):2:in 'block in Chef::Provider::File#action_create'
2026-04-20T10:17:11.6080644Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:304:in 'BasicObject#instance_eval'
2026-04-20T10:17:11.6081643Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:304:in 'Chef::Provider#compile_and_converge_action'
2026-04-20T10:17:11.6083241Z        (eval at /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:67):2:in 'Chef::Provider::File#action_create'
2026-04-20T10:17:11.6084391Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/provider.rb:245:in 'Chef::Provider#run_action'
2026-04-20T10:17:11.6085476Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:601:in 'block in Chef::Resource#run_action'
2026-04-20T10:17:11.6086762Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:629:in 'Chef::Resource#with_umask'
2026-04-20T10:17:11.6087776Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource.rb:600:in 'Chef::Resource#run_action'
2026-04-20T10:17:11.6088777Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:74:in 'Chef::Runner#run_action'
2026-04-20T10:17:11.6089842Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'block in Chef::Runner#run_all_actions'
2026-04-20T10:17:11.6090843Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'Array#each'
2026-04-20T10:17:11.6091812Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:108:in 'Chef::Runner#run_all_actions'
2026-04-20T10:17:11.6093410Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:132:in 'block in Chef::Runner#converge'
2026-04-20T10:17:11.6094746Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/resource_list.rb:96:in 'block in Chef::ResourceCollection::ResourceList#execute_each_resource'
2026-04-20T10:17:11.6096300Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:114:in 'Chef::ResourceCollection::StepableIterator#call_iterator_block'
2026-04-20T10:17:11.6097802Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:85:in 'Chef::ResourceCollection::StepableIterator#step'
2026-04-20T10:17:11.6099295Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:103:in 'Chef::ResourceCollection::StepableIterator#iterate'
2026-04-20T10:17:11.6100802Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/stepable_iterator.rb:54:in 'Chef::ResourceCollection::StepableIterator#each_with_index'
2026-04-20T10:17:11.6102329Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/resource_collection/resource_list.rb:94:in 'Chef::ResourceCollection::ResourceList#execute_each_resource'
2026-04-20T10:17:11.6103804Z        /hab/pkgs/core/ruby3_4/3.4.8/20260306111612/lib/ruby/3.4.0/forwardable.rb:240:in 'Chef::ResourceCollection#execute_each_resource'
2026-04-20T10:17:11.6104778Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/runner.rb:130:in 'Chef::Runner#converge'
2026-04-20T10:17:11.6105816Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:882:in 'block in Chef::Client#converge'
2026-04-20T10:17:11.6107042Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:877:in 'Kernel#catch'
2026-04-20T10:17:11.6108068Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:877:in 'Chef::Client#converge'
2026-04-20T10:17:11.6109102Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:901:in 'Chef::Client#converge_and_save'
2026-04-20T10:17:11.6110114Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/client.rb:299:in 'Chef::Client#run'
2026-04-20T10:17:11.6111220Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:310:in 'Chef::Application#run_with_graceful_exit_option'
2026-04-20T10:17:11.6112414Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:286:in 'block in Chef::Application#run_chef_client'
2026-04-20T10:17:11.6114200Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/local_mode.rb:42:in 'Chef::LocalMode.with_server_connectivity'
2026-04-20T10:17:11.6115356Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:269:in 'Chef::Application#run_chef_client'
2026-04-20T10:17:11.6116532Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application/base.rb:385:in 'Chef::Application::Base#run_application'
2026-04-20T10:17:11.6117672Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-19.2.106/lib/chef/application.rb:72:in 'Chef::Application#run'
2026-04-20T10:17:11.6118689Z        /hab/pkgs/gha/chef-infra-client/19.2.106/20260420100702/vendor/gems/chef-bin-19.2.106/bin/chef-client:25:in '<top (required)>'
2026-04-20T10:17:11.6119518Z        /hab/pkgs/chef/chef-infra-client/19.2.106/20260419201139/bin/chef-client:218:in 'Kernel.load'
2026-04-20T10:17:11.6120191Z        /hab/pkgs/chef/chef-infra-client/19.2.106/20260419201139/bin/chef-client:218:in '<main>'
2026-04-20T10:17:11.6388012Z >>>>>> ------Exception-------
2026-04-20T10:17:11.6388511Z >>>>>> Class: Kitchen::ActionFailed
2026-04-20T10:17:11.6388906Z >>>>>> Message: 1 actions failed.
2026-04-20T10:17:11.6389877Z >>>>>>     Converge failed on instance <end-to-end-oraclelinux-9>.  Please see .kitchen/logs/end-to-end-oraclelinux-9.log for more details
2026-04-20T10:17:11.6390903Z >>>>>> ----------------------
2026-04-20T10:17:11.6391369Z >>>>>> Please see .kitchen/logs/kitchen.log for more details
2026-04-20T10:17:11.6392024Z >>>>>> Also try running `kitchen diagnose --all` for configuration
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
