### PR TITLE
CHEF-14144: Limit excessive output from template errors

### DIFF
--- a/lib/chef/formatters/error_description.rb
+++ b/lib/chef/formatters/error_description.rb
@@ -59,10 +59,20 @@ class Chef
 
       private
 
+      # Maximum size for section text displayed on STDOUT (CHEF-14144).
+      # Error messages (especially from template errors) can be megabytes in size
+      # when they include a full node object dump. Truncate to a sane size.
+      MAX_DISPLAY_TEXT_LENGTH = 10_000
+
       def display_section(heading, text, out)
         out.puts heading
         out.puts "-" * heading.size
-        out.puts text
+        if text.is_a?(String) && text.length > MAX_DISPLAY_TEXT_LENGTH
+          out.puts text[0, MAX_DISPLAY_TEXT_LENGTH]
+          out.puts "\n... [truncated #{text.length - MAX_DISPLAY_TEXT_LENGTH} characters of output]"
+        else
+          out.puts text
+        end
         out.puts "\n"
       end
 

--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -93,6 +93,15 @@ class Chef
           @_extension_modules = []
         end
 
+        # Provide a compact inspect to prevent massive output in error messages.
+        # Ruby's NoMethodError includes #inspect of the receiver, which by default
+        # dumps all instance variables. Since TemplateContext holds the full node
+        # object (with all attributes and secrets), this can produce 60MB+ of
+        # output, causing segfaults and exposing sensitive data. (CHEF-14144)
+        def inspect
+          "#<#{self.class} template_name=#{@template_name.inspect} cookbook_name=#{@cookbook_name.inspect}>"
+        end
+
         ###
         # USER FACING API
         ###
@@ -220,8 +229,19 @@ class Chef
           @original_exception, @template, @context, @options = original_exception, template, context, options
         end
 
+        # Maximum size for error messages to prevent excessive output (CHEF-14144).
+        # Template errors (e.g. NoMethodError) can include the full #inspect of
+        # the TemplateContext, which holds the entire node object. Cap the message
+        # to a sane size to avoid multi-megabyte log output and segfaults.
+        MAX_MESSAGE_LENGTH = 10_000
+
         def message
-          @original_exception.message
+          msg = @original_exception.message
+          if msg.length > MAX_MESSAGE_LENGTH
+            msg[0, MAX_MESSAGE_LENGTH] + "\n... [truncated #{msg.length - MAX_MESSAGE_LENGTH} characters]"
+          else
+            msg
+          end
         end
 
         def line_number

--- a/spec/unit/formatters/error_description_spec.rb
+++ b/spec/unit/formatters/error_description_spec.rb
@@ -137,5 +137,23 @@ describe Chef::Formatters::ErrorDescription do
       end
 
     end
+
+    # CHEF-14144: Excessive output from template errors
+    context "when a section has excessively long text" do
+      let(:huge_text) { "x" * 50_000 }
+
+      before do
+        subject.section("Huge Section", huge_text)
+      end
+
+      it "should truncate the section text to MAX_DISPLAY_TEXT_LENGTH" do
+        subject.display(out)
+        output = out.out.string
+        expect(output).to include("Huge Section")
+        expect(output).to include("[truncated")
+        # Output should be much smaller than the original 50KB
+        expect(output.length).to be < (Chef::Formatters::ErrorDescription::MAX_DISPLAY_TEXT_LENGTH + 1000)
+      end
+    end
   end
 end

--- a/spec/unit/mixin/template_spec.rb
+++ b/spec/unit/mixin/template_spec.rb
@@ -314,4 +314,51 @@ describe Chef::Mixin::Template, "render_template" do
       end
     end
   end
+
+  # CHEF-14144: Excessive output from template errors
+  describe "TemplateContext#inspect" do
+    it "should return a compact string instead of dumping all instance variables" do
+      context = Chef::Mixin::Template::TemplateContext.new({})
+      context[:node] = { "platform" => "centos", "large_data" => "x" * 100_000 }
+      context[:template_name] = "test.erb"
+      context[:cookbook_name] = "my_cookbook"
+
+      result = context.inspect
+      expect(result).to include("Chef::Mixin::Template::TemplateContext")
+      expect(result).to include("my_cookbook")
+      expect(result).to include("test.erb")
+      expect(result.length).to be < 200
+      expect(result).not_to include("large_data")
+    end
+  end
+
+  describe "TemplateError message truncation (CHEF-14144)" do
+    it "should truncate excessively long error messages" do
+      huge_message = "undefined method `platform?' for " + ("x" * 20_000)
+      original_exception = double("exception",
+        message: huge_message,
+        backtrace: ["(erubis):1"]
+      )
+      template_error = Chef::Mixin::Template::TemplateError.new(
+        original_exception, "<%= platform? %>", {}, {}
+      )
+
+      msg = template_error.message
+      expect(msg.length).to be < (Chef::Mixin::Template::TemplateError::MAX_MESSAGE_LENGTH + 200)
+      expect(msg).to include("[truncated")
+      expect(msg).to include("undefined method `platform?'")
+    end
+
+    it "should not truncate short error messages" do
+      original_exception = double("exception",
+        message: "undefined method `platform?'",
+        backtrace: ["(erubis):1"]
+      )
+      template_error = Chef::Mixin::Template::TemplateError.new(
+        original_exception, "<%= platform? %>", {}, {}
+      )
+
+      expect(template_error.message).to eq("undefined method `platform?'")
+    end
+  end
 end


### PR DESCRIPTION
When a template error occurs (e.g., calling an undefined method like platform? in ERB context), Ruby's NoMethodError includes #inspect of the TemplateContext receiver. Since TemplateContext holds the full node object with all attributes and secrets, this produces 60MB+ of output, causing segfaults, extreme slowness, and sensitive data exposure in logs.

Three-layer fix:
1. Override TemplateContext#inspect to return a compact string, preventing the massive string from being generated in the first place.
2. Truncate TemplateError#message to MAX_MESSAGE_LENGTH (10KB) as a safety net for any exceptions with oversized messages.
3. Truncate display_section output in ErrorDescription to cap STDOUT output at MAX_DISPLAY_TEXT_LENGTH (10KB).

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
