### PR TITLE
Fixing download bug

### DIFF
--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -1,13 +1,13 @@
-require 'cgi'
-require 'uri'
+require "cgi" unless defined?(CGI)
+require "uri" unless defined?(URI)
 
 class Chef
   class Resource
     class ChocolateyInstaller < Chef::Resource
       provides :chocolatey_installer
 
-      description 'Use the chocolatey_installer resource to ensure that Chocolatey itself is installed to your specification. Use the Chocolatey Feature resource to customize your install. Then use the Chocolatey Package resource to install packages on Windows via Chocolatey.'
-      introduced '18.3'
+      description "Use the chocolatey_installer resource to ensure that Chocolatey itself is installed to your specification. Use the Chocolatey Feature resource to customize your install. Then use the Chocolatey Package resource to install packages on Windows via Chocolatey."
+      introduced "18.3"
       examples <<~DOC
         **Install Chocolatey**
 
@@ -56,25 +56,25 @@ class Chef
       allowed_actions :install, :uninstall, :upgrade
 
       property :download_url, String,
-        description: 'The URL to download Chocolatey from. This sets the value of $env:ChocolateyDownloadUrl and causes the installer to choose an alternate download location. If this is not set, Chocolatey installs fall back to the official Chocolatey community repository to download Chocolatey from. It can also be used for offline installation by providing a path to a Chocolatey.nupkg. If the provided URL is a PowerShell script (ending in .ps1), that script will be downloaded and executed directly. If it is any other file type, it will be downloaded to the Chef client directory. ChefConfig::Config.etc_chef_dir(windows: true) is used to find that location.'
+        description: "The URL to download Chocolatey from. This sets the value of $env:ChocolateyDownloadUrl and causes the installer to choose an alternate download location. If this is not set, Chocolatey installs fall back to the official Chocolatey community repository to download Chocolatey from. It can also be used for offline installation by providing a path to a Chocolatey.nupkg. If the provided URL is a PowerShell script (ending in .ps1), that script will be downloaded and executed directly. If it is any other file type, it will be downloaded to the Chef client directory. ChefConfig::Config.etc_chef_dir(windows: true) is used to find that location."
 
       property :chocolatey_version, String,
-        description: 'Specifies a target version of Chocolatey to install. By default, the latest stable version is installed. This will use the value in $env:ChocolateyVersion by default, if that environment variable is present. This parameter is ignored if download_url is set.'
+        description: "Specifies a target version of Chocolatey to install. By default, the latest stable version is installed. This will use the value in $env:ChocolateyVersion by default, if that environment variable is present. This parameter is ignored if download_url is set."
 
       property :use_native_unzip, [TrueClass, FalseClass], default: false,
-                                                           description: "If set, uses built-in Windows decompression tools instead of 7zip when unpacking the downloaded nupkg. This will be set by default if use_native_unzip is set to a value other than 'false' or '0'. This parameter will be ignored in PS 5+ in favour of using the Expand-Archive built in PowerShell cmdlet directly."
+        description: "If set, uses built-in Windows decompression tools instead of 7zip when unpacking the downloaded nupkg. This will be set by default if use_native_unzip is set to a value other than 'false' or '0'. This parameter will be ignored in PS 5+ in favour of using the Expand-Archive built in PowerShell cmdlet directly."
 
       property :ignore_proxy, [TrueClass, FalseClass], default: false,
-                                                       description: "If set, ignores any configured proxy. This will override any proxy environment variables or parameters. This will be set by default if ignore_proxy is set to a value other than 'false' or '0'."
+        description: "If set, ignores any configured proxy. This will override any proxy environment variables or parameters. This will be set by default if ignore_proxy is set to a value other than 'false' or '0'."
 
       property :proxy_url, String,
-        description: 'Specifies the proxy URL to use during the download.'
+        description: "Specifies the proxy URL to use during the download."
 
       property :proxy_user, String,
-        description: 'The username to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_password are set'
+        description: "The username to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_password are set"
 
       property :proxy_password, String,
-        description: 'The password to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_user are set'
+        description: "The password to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_user are set"
 
       load_current_value do
         current_state = is_choco_installed?
@@ -83,11 +83,11 @@ class Chef
       end
 
       def is_choco_installed?
-        ::File.exist?("#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin\\choco.exe")
+        ::File.exist?("#{ENV["ALLUSERSPROFILE"]}\\chocolatey\\bin\\choco.exe")
       end
 
       def get_choco_version
-        powershell_exec('choco --version').result
+        powershell_exec("choco --version").result
       end
 
       def existing_version
@@ -95,7 +95,7 @@ class Chef
       end
 
       def download_url_path
-        return download_url if download_url.match?(%r{^[a-zA-Z]:[\\/]}) || download_url.start_with?('\\\\')
+        return download_url if download_url.match?(%r{^[a-zA-Z]:[\\/]}) || download_url.start_with?("\\\\")
 
         ::URI.parse(download_url).path
       rescue URI::InvalidURIError
@@ -103,12 +103,12 @@ class Chef
       end
 
       def download_url_script?
-        ::File.extname(download_url_path).casecmp('.ps1') == 0
+        ::File.extname(download_url_path).casecmp(".ps1") == 0
       end
 
       def download_destination
         filename = ::File.basename(::CGI.unescape(download_url_path.to_s))
-        filename = 'chocolatey.nupkg' if filename.empty? || ['/', '\\', '.'].include?(filename)
+        filename = "chocolatey.nupkg" if filename.empty? || ["/", "\\", "."].include?(filename)
 
         Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), filename)
       end
@@ -120,12 +120,12 @@ class Chef
             # parameters are empty.
             new_resource.proxy_user.nil? != new_resource.proxy_password.nil?
           end
-          a.failure_message(Chef::Exceptions::ValidationFailed, 'You must specify both a proxy_user and a proxy_password')
+          a.failure_message(Chef::Exceptions::ValidationFailed, "You must specify both a proxy_user and a proxy_password")
           a.whyrun("Assuming that if you have configured a 'proxy_user' you must also supply a 'proxy_password'")
         end
       end
 
-      action :install, description: 'Installs Chocolatey package manager' do
+      action :install, description: "Installs Chocolatey package manager" do
         if new_resource.download_url
           powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value #{new_resource.download_url}")
         end
@@ -135,11 +135,11 @@ class Chef
         end
 
         if new_resource.use_native_unzip
-          powershell_exec('Set-Item -path env:ChocolateyUseWindowsCompression -Value true')
+          powershell_exec("Set-Item -path env:ChocolateyUseWindowsCompression -Value true")
         end
 
         if new_resource.ignore_proxy
-          powershell_exec('Set-Item -path env:ChocolateyIgnoreProxy -Value true')
+          powershell_exec("Set-Item -path env:ChocolateyIgnoreProxy -Value true")
         end
 
         if new_resource.proxy_url
@@ -170,7 +170,7 @@ class Chef
         end
       end
 
-      action :upgrade, description: 'Upgrades the Chocolatey package manager' do
+      action :upgrade, description: "Upgrades the Chocolatey package manager" do
         proposed_version = if new_resource.chocolatey_version
                              Gem::Version.new(new_resource.chocolatey_version)
                            end
@@ -184,11 +184,11 @@ class Chef
         end
 
         if new_resource.use_native_unzip
-          powershell_exec('Set-Item -path env:ChocolateyUseWindowsCompression -Value true')
+          powershell_exec("Set-Item -path env:ChocolateyUseWindowsCompression -Value true")
         end
 
         if new_resource.ignore_proxy
-          powershell_exec('Set-Item -path env:ChocolateyIgnoreProxy -Value true')
+          powershell_exec("Set-Item -path env:ChocolateyIgnoreProxy -Value true")
         end
 
         if new_resource.proxy_url
@@ -202,18 +202,18 @@ class Chef
         if proposed_version && existing_version < proposed_version
           powershell_exec("Set-Item -path env:ChocolateyVersion -Value #{proposed_version}")
         else
-          powershell_exec('Remove-Item -path env:ChocolateyVersion')
+          powershell_exec("Remove-Item -path env:ChocolateyVersion")
         end
 
-        converge_by('upgrade choco version') do
-          powershell_exec('choco upgrade Chocolatey -y').result
+        converge_by("upgrade choco version") do
+          powershell_exec("choco upgrade Chocolatey -y").result
         end
       end
 
-      action :uninstall, description: 'Uninstall Chocolatey package manager' do
+      action :uninstall, description: "Uninstall Chocolatey package manager" do
         path = 'c:\\programdata\\chocolatey\\bin'
         if File.exists?(path)
-          converge_by('Uninstall Choco') do
+          converge_by("Uninstall Choco") do
             powershell_code = <<~CODE
               Remove-Item $env:ALLUSERSPROFILE\\chocolatey -Recurse -Force
               [Environment]::SetEnvironmentVariable("ChocolateyLastPathUpdate", $null ,"User")
@@ -233,7 +233,7 @@ class Chef
             powershell_exec(powershell_code).error!
           end
         end
-        Chef::Log.warn('Chocolatey is already uninstalled.')
+        Chef::Log.warn("Chocolatey is already uninstalled.")
       end
     end
   end

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -1,10 +1,13 @@
+require 'cgi'
+require 'uri'
+
 class Chef
   class Resource
     class ChocolateyInstaller < Chef::Resource
       provides :chocolatey_installer
 
-      description "Use the chocolatey_installer resource to ensure that Chocolatey itself is installed to your specification. Use the Chocolatey Feature resource to customize your install. Then use the Chocolatey Package resource to install packages on Windows via Chocolatey."
-      introduced "18.3"
+      description 'Use the chocolatey_installer resource to ensure that Chocolatey itself is installed to your specification. Use the Chocolatey Feature resource to customize your install. Then use the Chocolatey Package resource to install packages on Windows via Chocolatey.'
+      introduced '18.3'
       examples <<~DOC
         **Install Chocolatey**
 
@@ -53,25 +56,25 @@ class Chef
       allowed_actions :install, :uninstall, :upgrade
 
       property :download_url, String,
-        description: "The URL to download Chocolatey from. This sets the value of $env:ChocolateyDownloadUrl and causes the installer to choose an alternate download location. If this is not set, Chocolatey installs fall back to the official Chocolatey community repository to download Chocolatey from. It can also be used for offline installation by providing a path to a Chocolatey.nupkg. If the provided URL is a PowerShell script (ending in .ps1), that script will be downloaded and executed directly. If it is any other file type, it will be downloaded to the Chef client directory. ChefConfig::Config.etc_chef_dir(windows: true) is used to find that location."
+        description: 'The URL to download Chocolatey from. This sets the value of $env:ChocolateyDownloadUrl and causes the installer to choose an alternate download location. If this is not set, Chocolatey installs fall back to the official Chocolatey community repository to download Chocolatey from. It can also be used for offline installation by providing a path to a Chocolatey.nupkg. If the provided URL is a PowerShell script (ending in .ps1), that script will be downloaded and executed directly. If it is any other file type, it will be downloaded to the Chef client directory. ChefConfig::Config.etc_chef_dir(windows: true) is used to find that location.'
 
       property :chocolatey_version, String,
-        description: "Specifies a target version of Chocolatey to install. By default, the latest stable version is installed. This will use the value in $env:ChocolateyVersion by default, if that environment variable is present. This parameter is ignored if download_url is set."
+        description: 'Specifies a target version of Chocolatey to install. By default, the latest stable version is installed. This will use the value in $env:ChocolateyVersion by default, if that environment variable is present. This parameter is ignored if download_url is set.'
 
       property :use_native_unzip, [TrueClass, FalseClass], default: false,
-        description: "If set, uses built-in Windows decompression tools instead of 7zip when unpacking the downloaded nupkg. This will be set by default if use_native_unzip is set to a value other than 'false' or '0'. This parameter will be ignored in PS 5+ in favour of using the Expand-Archive built in PowerShell cmdlet directly."
+                                                           description: "If set, uses built-in Windows decompression tools instead of 7zip when unpacking the downloaded nupkg. This will be set by default if use_native_unzip is set to a value other than 'false' or '0'. This parameter will be ignored in PS 5+ in favour of using the Expand-Archive built in PowerShell cmdlet directly."
 
       property :ignore_proxy, [TrueClass, FalseClass], default: false,
-        description: "If set, ignores any configured proxy. This will override any proxy environment variables or parameters. This will be set by default if ignore_proxy is set to a value other than 'false' or '0'."
+                                                       description: "If set, ignores any configured proxy. This will override any proxy environment variables or parameters. This will be set by default if ignore_proxy is set to a value other than 'false' or '0'."
 
       property :proxy_url, String,
-        description: "Specifies the proxy URL to use during the download."
+        description: 'Specifies the proxy URL to use during the download.'
 
       property :proxy_user, String,
-        description: "The username to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_password are set"
+        description: 'The username to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_password are set'
 
       property :proxy_password, String,
-        description: "The password to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_user are set"
+        description: 'The password to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_user are set'
 
       load_current_value do
         current_state = is_choco_installed?
@@ -80,15 +83,34 @@ class Chef
       end
 
       def is_choco_installed?
-        ::File.exist?("#{ENV["ALLUSERSPROFILE"]}\\chocolatey\\bin\\choco.exe")
+        ::File.exist?("#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin\\choco.exe")
       end
 
       def get_choco_version
-        powershell_exec("choco --version").result
+        powershell_exec('choco --version').result
       end
 
       def existing_version
         Gem::Version.new(get_choco_version)
+      end
+
+      def download_url_path
+        return download_url if download_url.match?(%r{^[a-zA-Z]:[\\/]}) || download_url.start_with?('\\\\')
+
+        ::URI.parse(download_url).path
+      rescue URI::InvalidURIError
+        download_url
+      end
+
+      def download_url_script?
+        ::File.extname(download_url_path).casecmp('.ps1') == 0
+      end
+
+      def download_destination
+        filename = ::File.basename(::CGI.unescape(download_url_path.to_s))
+        filename = 'chocolatey.nupkg' if filename.empty? || ['/', '\\', '.'].include?(filename)
+
+        Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), filename)
       end
 
       def define_resource_requirements
@@ -98,12 +120,12 @@ class Chef
             # parameters are empty.
             new_resource.proxy_user.nil? != new_resource.proxy_password.nil?
           end
-          a.failure_message(Chef::Exceptions::ValidationFailed, "You must specify both a proxy_user and a proxy_password")
+          a.failure_message(Chef::Exceptions::ValidationFailed, 'You must specify both a proxy_user and a proxy_password')
           a.whyrun("Assuming that if you have configured a 'proxy_user' you must also supply a 'proxy_password'")
         end
       end
 
-      action :install, description: "Installs Chocolatey package manager" do
+      action :install, description: 'Installs Chocolatey package manager' do
         if new_resource.download_url
           powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value #{new_resource.download_url}")
         end
@@ -113,11 +135,11 @@ class Chef
         end
 
         if new_resource.use_native_unzip
-          powershell_exec("Set-Item -path env:ChocolateyUseWindowsCompression -Value true")
+          powershell_exec('Set-Item -path env:ChocolateyUseWindowsCompression -Value true')
         end
 
         if new_resource.ignore_proxy
-          powershell_exec("Set-Item -path env:ChocolateyIgnoreProxy -Value true")
+          powershell_exec('Set-Item -path env:ChocolateyIgnoreProxy -Value true')
         end
 
         if new_resource.proxy_url
@@ -133,16 +155,14 @@ class Chef
           if new_resource.download_url
             Chef::Log.info("Using custom download URL for Chocolatey installation: #{new_resource.download_url}")
             # If it's a PowerShell script, execute it directly (original behavior)
-            if new_resource.download_url.downcase.end_with?(".ps1")
+            if download_url_script?
               powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{new_resource.download_url}'))").error!
             else
               # Assume it's a direct link to a nupkg or other file and handle accordingly
-              chef_dir = ChefConfig::Config.etc_chef_dir(windows: true)
+              destination = download_destination
 
-              # Let PowerShell handle the filename - it will use the server's suggested filename
-              # from Content-Disposition header, or fall back to the URL path
-              powershell_exec("Invoke-WebRequest '#{new_resource.download_url}' -OutFile '#{chef_dir}'").error!
-              Chef::Log.info("Downloaded file from #{new_resource.download_url} to #{chef_dir}")
+              powershell_exec("Invoke-WebRequest '#{new_resource.download_url}' -OutFile '#{destination}'").error!
+              Chef::Log.info("Downloaded file from #{new_resource.download_url} to #{destination}")
             end
           else
             powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))").error!
@@ -150,12 +170,10 @@ class Chef
         end
       end
 
-      action :upgrade, description: "Upgrades the Chocolatey package manager" do
-        if new_resource.chocolatey_version
-          proposed_version = Gem::Version.new(new_resource.chocolatey_version)
-        else
-          proposed_version = nil
-        end
+      action :upgrade, description: 'Upgrades the Chocolatey package manager' do
+        proposed_version = if new_resource.chocolatey_version
+                             Gem::Version.new(new_resource.chocolatey_version)
+                           end
 
         if new_resource.download_url
           powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value #{new_resource.download_url}")
@@ -166,11 +184,11 @@ class Chef
         end
 
         if new_resource.use_native_unzip
-          powershell_exec("Set-Item -path env:ChocolateyUseWindowsCompression -Value true")
+          powershell_exec('Set-Item -path env:ChocolateyUseWindowsCompression -Value true')
         end
 
         if new_resource.ignore_proxy
-          powershell_exec("Set-Item -path env:ChocolateyIgnoreProxy -Value true")
+          powershell_exec('Set-Item -path env:ChocolateyIgnoreProxy -Value true')
         end
 
         if new_resource.proxy_url
@@ -184,18 +202,18 @@ class Chef
         if proposed_version && existing_version < proposed_version
           powershell_exec("Set-Item -path env:ChocolateyVersion -Value #{proposed_version}")
         else
-          powershell_exec("Remove-Item -path env:ChocolateyVersion")
+          powershell_exec('Remove-Item -path env:ChocolateyVersion')
         end
 
-        converge_by("upgrade choco version") do
-          powershell_exec("choco upgrade Chocolatey -y").result
+        converge_by('upgrade choco version') do
+          powershell_exec('choco upgrade Chocolatey -y').result
         end
       end
 
-      action :uninstall, description: "Uninstall Chocolatey package manager" do
-        path = "c:\\programdata\\chocolatey\\bin"
+      action :uninstall, description: 'Uninstall Chocolatey package manager' do
+        path = 'c:\\programdata\\chocolatey\\bin'
         if File.exists?(path)
-          converge_by("Uninstall Choco") do
+          converge_by('Uninstall Choco') do
             powershell_code = <<~CODE
               Remove-Item $env:ALLUSERSPROFILE\\chocolatey -Recurse -Force
               [Environment]::SetEnvironmentVariable("ChocolateyLastPathUpdate", $null ,"User")
@@ -215,7 +233,7 @@ class Chef
             powershell_exec(powershell_code).error!
           end
         end
-        Chef::Log.warn("Chocolatey is already uninstalled.")
+        Chef::Log.warn('Chocolatey is already uninstalled.')
       end
     end
   end

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -15,13 +15,17 @@
 # limitations under the License.
 #
 
-require "spec_helper"
+require 'spec_helper'
 
 describe Chef::Resource::ChocolateyInstaller do
-  describe "When installing from Chocolatey" do
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+
+  describe 'When installing from Chocolatey' do
     include RecipeDSLHelper
 
-    let(:resource) { Chef::Resource::ChocolateyInstaller.new("fakey_fakerton") }
+    let(:resource) { Chef::Resource::ChocolateyInstaller.new('fakey_fakerton') }
     let(:config) do
       <<-CONFIG
         <?xml version="1.0" encoding="utf-8"?>
@@ -43,7 +47,7 @@ describe Chef::Resource::ChocolateyInstaller do
     # we save off the ENV and set ALLUSERSPROFILE so these specs will work on *nix and non-C drive Windows installs
     before(:each) do
       @original_env = ENV.to_hash
-      ENV["ALLUSERSPROFILE"] = "C:\\ProgramData"
+      ENV['ALLUSERSPROFILE'] = 'C:\\ProgramData'
     end
 
     after(:each) do
@@ -51,9 +55,9 @@ describe Chef::Resource::ChocolateyInstaller do
       ENV.update(@original_env)
     end
 
-    describe "Basic Resource Settings" do
-      context "on windows", :windows_only do
-        it "supports :install, :uninstall, :upgrade actions" do
+    describe 'Basic Resource Settings' do
+      context 'on windows', :windows_only do
+        it 'supports :install, :uninstall, :upgrade actions' do
           expect { resource.action :install }.not_to raise_error
           expect { resource.action :uninstall }.not_to raise_error
           expect { resource.action :upgrade }.not_to raise_error
@@ -61,68 +65,67 @@ describe Chef::Resource::ChocolateyInstaller do
       end
     end
 
-    describe "Basic chocolatey settings" do
-      context "on windows", :windows_only do
-        it "has a resource name of :chocolatey_installer" do
+    describe 'Basic chocolatey settings' do
+      context 'on windows', :windows_only do
+        it 'has a resource name of :chocolatey_installer' do
           expect(resource.resource_name).to eql(:chocolatey_installer)
         end
 
-        it "sets the default action as :install" do
+        it 'sets the default action as :install' do
           expect(resource.action).to eql([:install])
         end
 
-        it "supports :install and :uninstall actions" do
+        it 'supports :install and :uninstall actions' do
           expect { resource.action :install }.not_to raise_error
           expect { resource.action :uninstall }.not_to raise_error
         end
 
-        it "does not support bologna install options" do
+        it 'does not support bologna install options' do
           expect { resource.action :foo }.to raise_error(Chef::Exceptions::ValidationFailed)
         end
       end
     end
 
-    describe "Installing chocolatey" do
-      context "on windows", :windows_only do
-        it "can install Chocolatey with parameters" do
-          resource.chocolatey_version = "1.4.0"
+    describe 'Installing chocolatey' do
+      context 'on windows', :windows_only do
+        it 'can install Chocolatey with parameters' do
+          resource.chocolatey_version = '1.4.0'
           expect { resource.action :install }.not_to raise_error
         end
 
-        it "logs a warning if a chocolatey install cannot be found" do
+        it 'logs a warning if a chocolatey install cannot be found' do
           allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
-          expect { Chef::Log.warn("Chocolatey is already uninstalled.") }.not_to output.to_stderr
+          expect { Chef::Log.warn('Chocolatey is already uninstalled.') }.not_to output.to_stderr
         end
       end
     end
 
-    describe "Chocolatey is idempotent because" do
-      context "on windows", :windows_only do
-        it "it does not install choco again if it is already installed" do
+    describe 'Chocolatey is idempotent because' do
+      context 'on windows', :windows_only do
+        it 'it does not install choco again if it is already installed' do
           install_choco
-          chocolatey_installer "install" do
+          chocolatey_installer 'install' do
             action :install
           end.should_not_be_updated
         end
       end
     end
 
-    describe "upgrading choco versions" do
-
-      context "on windows", :windows_only do
-        describe "when the versions do not match" do
-          it "upgrades if the proposed version is newer" do
-            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("1.2.2"))
-            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new("4.2.2"))
+    describe 'upgrading choco versions' do
+      context 'on windows', :windows_only do
+        describe 'when the versions do not match' do
+          it 'upgrades if the proposed version is newer' do
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new('1.2.2'))
+            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new('4.2.2'))
             expect { resource.action :upgrade }.not_to raise_error
-            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("4.2.2"))
-            expect(resource.get_choco_version).to eql(Gem::Version.new("4.2.2"))
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new('4.2.2'))
+            expect(resource.get_choco_version).to eql(Gem::Version.new('4.2.2'))
           end
         end
-        describe "when the versions match" do
-          it "does not upgrade if the old version is identical" do
-            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("2.2.2"))
-            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new("2.2.2"))
+        describe 'when the versions match' do
+          it 'does not upgrade if the old version is identical' do
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new('2.2.2'))
+            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new('2.2.2'))
             expect { resource.action :upgrade }.not_to raise_error
             expect(resource).not_to be_updated
           end
@@ -130,8 +133,8 @@ describe Chef::Resource::ChocolateyInstaller do
       end
     end
 
-    describe "Uninstalling chocolatey" do
-      context "on windows", :windows_only do
+    describe 'Uninstalling chocolatey' do
+      context 'on windows', :windows_only do
         it "doesn't error out uninstalling chocolatey if chocolatey is not installed" do
           allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
           expect { resource.action :uninstall }.not_to raise_error
@@ -140,7 +143,7 @@ describe Chef::Resource::ChocolateyInstaller do
     end
 
     def install_choco
-      require "chef-powershell"
+      require 'chef-powershell'
       include ChefPowerShell::ChefPowerShellModule::PowerShellExec
       powershell_code = <<-CODE
         Set-ExecutionPolicy Bypass -Scope Process -Force;
@@ -151,15 +154,15 @@ describe Chef::Resource::ChocolateyInstaller do
     end
   end
 
-  describe "When installing from a custom URL" do
+  describe 'When installing from a custom URL' do
     include RecipeDSLHelper
 
-    let(:resource) { Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom") }
+    let(:resource) { Chef::Resource::ChocolateyInstaller.new('fakey_fakerton_custom') }
 
     # we save off the ENV and set ALLUSERSPROFILE so these specs will work on *nix and non-C drive Windows installs
     before(:each) do
       @original_env = ENV.to_hash
-      ENV["ALLUSERSPROFILE"] = "C:\\ProgramData"
+      ENV['ALLUSERSPROFILE'] = 'C:\\ProgramData'
     end
 
     after(:each) do
@@ -167,12 +170,51 @@ describe Chef::Resource::ChocolateyInstaller do
       ENV.update(@original_env)
     end
 
-    describe "Installing chocolatey" do
-      context "on windows", :windows_only do
-        it "can install Chocolatey with a custom download URL" do
-          resource.download_url = "https://some.custom.url/install.ps1"
+    describe 'Installing chocolatey' do
+      context 'on windows', :windows_only do
+        it 'can install Chocolatey with a custom download URL' do
+          resource.download_url = 'https://some.custom.url/install.ps1'
           expect { resource.action :install }.not_to raise_error
         end
+
+        it 'downloads non-script URLs to a full path in the chef directory' do
+          resource = Chef::Resource::ChocolateyInstaller.new('fakey_fakerton_custom_download', run_context)
+          resource.download_url = 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg'
+          expected_destination = Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), 'chocolatey.2.0.0.nupkg')
+          install_provider = resource.provider_for_action(:install)
+
+          commands = []
+          shell_out = instance_double('Mixlib::ShellOut', error!: nil)
+
+          allow(resource).to receive(:provider_for_action).with(:install).and_return(install_provider)
+          allow(resource).to receive(:is_choco_installed?).and_return(false)
+          allow(install_provider).to receive(:powershell_exec) do |command|
+            commands << command
+            shell_out
+          end
+          allow(Chef::Log).to receive(:info)
+
+          resource.run_action(:install)
+
+          expect(commands).to include('Set-Item -path env:ChocolateyDownloadUrl -Value https://some.custom.url/packages/chocolatey.2.0.0.nupkg')
+          expect(commands).to include("Invoke-WebRequest 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg' -OutFile '#{expected_destination}'")
+        end
+      end
+    end
+
+    describe 'custom download path helpers' do
+      it 'detects PowerShell scripts from the URL path' do
+        resource = Chef::Resource::ChocolateyInstaller.new('fakey_fakerton_custom_script', run_context)
+        resource.download_url = 'https://some.custom.url/install.ps1?token=abc123'
+
+        expect(resource.download_url_script?).to be true
+      end
+
+      it 'falls back to a package filename when the URL path has no basename' do
+        resource = Chef::Resource::ChocolateyInstaller.new('fakey_fakerton_custom_path', run_context)
+        resource.download_url = 'https://some.custom.url/'
+
+        expect(resource.download_destination).to eq(Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), 'chocolatey.nupkg'))
       end
     end
   end

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -15,17 +15,17 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Chef::Resource::ChocolateyInstaller do
   let(:node) { Chef::Node.new }
   let(:events) { Chef::EventDispatch::Dispatcher.new }
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
 
-  describe 'When installing from Chocolatey' do
+  describe "When installing from Chocolatey" do
     include RecipeDSLHelper
 
-    let(:resource) { Chef::Resource::ChocolateyInstaller.new('fakey_fakerton') }
+    let(:resource) { Chef::Resource::ChocolateyInstaller.new("fakey_fakerton") }
     let(:config) do
       <<-CONFIG
         <?xml version="1.0" encoding="utf-8"?>
@@ -47,7 +47,7 @@ describe Chef::Resource::ChocolateyInstaller do
     # we save off the ENV and set ALLUSERSPROFILE so these specs will work on *nix and non-C drive Windows installs
     before(:each) do
       @original_env = ENV.to_hash
-      ENV['ALLUSERSPROFILE'] = 'C:\\ProgramData'
+      ENV["ALLUSERSPROFILE"] = 'C:\\ProgramData'
     end
 
     after(:each) do
@@ -55,9 +55,9 @@ describe Chef::Resource::ChocolateyInstaller do
       ENV.update(@original_env)
     end
 
-    describe 'Basic Resource Settings' do
-      context 'on windows', :windows_only do
-        it 'supports :install, :uninstall, :upgrade actions' do
+    describe "Basic Resource Settings" do
+      context "on windows", :windows_only do
+        it "supports :install, :uninstall, :upgrade actions" do
           expect { resource.action :install }.not_to raise_error
           expect { resource.action :uninstall }.not_to raise_error
           expect { resource.action :upgrade }.not_to raise_error
@@ -65,67 +65,67 @@ describe Chef::Resource::ChocolateyInstaller do
       end
     end
 
-    describe 'Basic chocolatey settings' do
-      context 'on windows', :windows_only do
-        it 'has a resource name of :chocolatey_installer' do
+    describe "Basic chocolatey settings" do
+      context "on windows", :windows_only do
+        it "has a resource name of :chocolatey_installer" do
           expect(resource.resource_name).to eql(:chocolatey_installer)
         end
 
-        it 'sets the default action as :install' do
+        it "sets the default action as :install" do
           expect(resource.action).to eql([:install])
         end
 
-        it 'supports :install and :uninstall actions' do
+        it "supports :install and :uninstall actions" do
           expect { resource.action :install }.not_to raise_error
           expect { resource.action :uninstall }.not_to raise_error
         end
 
-        it 'does not support bologna install options' do
+        it "does not support bologna install options" do
           expect { resource.action :foo }.to raise_error(Chef::Exceptions::ValidationFailed)
         end
       end
     end
 
-    describe 'Installing chocolatey' do
-      context 'on windows', :windows_only do
-        it 'can install Chocolatey with parameters' do
-          resource.chocolatey_version = '1.4.0'
+    describe "Installing chocolatey" do
+      context "on windows", :windows_only do
+        it "can install Chocolatey with parameters" do
+          resource.chocolatey_version = "1.4.0"
           expect { resource.action :install }.not_to raise_error
         end
 
-        it 'logs a warning if a chocolatey install cannot be found' do
+        it "logs a warning if a chocolatey install cannot be found" do
           allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
-          expect { Chef::Log.warn('Chocolatey is already uninstalled.') }.not_to output.to_stderr
+          expect { Chef::Log.warn("Chocolatey is already uninstalled.") }.not_to output.to_stderr
         end
       end
     end
 
-    describe 'Chocolatey is idempotent because' do
-      context 'on windows', :windows_only do
-        it 'it does not install choco again if it is already installed' do
+    describe "Chocolatey is idempotent because" do
+      context "on windows", :windows_only do
+        it "it does not install choco again if it is already installed" do
           install_choco
-          chocolatey_installer 'install' do
+          chocolatey_installer "install" do
             action :install
           end.should_not_be_updated
         end
       end
     end
 
-    describe 'upgrading choco versions' do
-      context 'on windows', :windows_only do
-        describe 'when the versions do not match' do
-          it 'upgrades if the proposed version is newer' do
-            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new('1.2.2'))
-            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new('4.2.2'))
+    describe "upgrading choco versions" do
+      context "on windows", :windows_only do
+        describe "when the versions do not match" do
+          it "upgrades if the proposed version is newer" do
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("1.2.2"))
+            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new("4.2.2"))
             expect { resource.action :upgrade }.not_to raise_error
-            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new('4.2.2'))
-            expect(resource.get_choco_version).to eql(Gem::Version.new('4.2.2'))
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("4.2.2"))
+            expect(resource.get_choco_version).to eql(Gem::Version.new("4.2.2"))
           end
         end
-        describe 'when the versions match' do
-          it 'does not upgrade if the old version is identical' do
-            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new('2.2.2'))
-            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new('2.2.2'))
+        describe "when the versions match" do
+          it "does not upgrade if the old version is identical" do
+            allow(resource).to receive(:get_choco_version).and_return(Gem::Version.new("2.2.2"))
+            allow(resource).to receive(:chocolatey_version).and_return(Gem::Version.new("2.2.2"))
             expect { resource.action :upgrade }.not_to raise_error
             expect(resource).not_to be_updated
           end
@@ -133,8 +133,8 @@ describe Chef::Resource::ChocolateyInstaller do
       end
     end
 
-    describe 'Uninstalling chocolatey' do
-      context 'on windows', :windows_only do
+    describe "Uninstalling chocolatey" do
+      context "on windows", :windows_only do
         it "doesn't error out uninstalling chocolatey if chocolatey is not installed" do
           allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
           expect { resource.action :uninstall }.not_to raise_error
@@ -143,7 +143,7 @@ describe Chef::Resource::ChocolateyInstaller do
     end
 
     def install_choco
-      require 'chef-powershell'
+      require "chef-powershell"
       include ChefPowerShell::ChefPowerShellModule::PowerShellExec
       powershell_code = <<-CODE
         Set-ExecutionPolicy Bypass -Scope Process -Force;
@@ -154,15 +154,15 @@ describe Chef::Resource::ChocolateyInstaller do
     end
   end
 
-  describe 'When installing from a custom URL' do
+  describe "When installing from a custom URL" do
     include RecipeDSLHelper
 
-    let(:resource) { Chef::Resource::ChocolateyInstaller.new('fakey_fakerton_custom') }
+    let(:resource) { Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom") }
 
     # we save off the ENV and set ALLUSERSPROFILE so these specs will work on *nix and non-C drive Windows installs
     before(:each) do
       @original_env = ENV.to_hash
-      ENV['ALLUSERSPROFILE'] = 'C:\\ProgramData'
+      ENV["ALLUSERSPROFILE"] = 'C:\\ProgramData'
     end
 
     after(:each) do
@@ -170,21 +170,21 @@ describe Chef::Resource::ChocolateyInstaller do
       ENV.update(@original_env)
     end
 
-    describe 'Installing chocolatey' do
-      context 'on windows', :windows_only do
-        it 'can install Chocolatey with a custom download URL' do
-          resource.download_url = 'https://some.custom.url/install.ps1'
+    describe "Installing chocolatey" do
+      context "on windows", :windows_only do
+        it "can install Chocolatey with a custom download URL" do
+          resource.download_url = "https://some.custom.url/install.ps1"
           expect { resource.action :install }.not_to raise_error
         end
 
-        it 'downloads non-script URLs to a full path in the chef directory' do
-          resource = Chef::Resource::ChocolateyInstaller.new('fakey_fakerton_custom_download', run_context)
-          resource.download_url = 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg'
-          expected_destination = Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), 'chocolatey.2.0.0.nupkg')
+        it "downloads non-script URLs to a full path in the chef directory" do
+          resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom_download", run_context)
+          resource.download_url = "https://some.custom.url/packages/chocolatey.2.0.0.nupkg"
+          expected_destination = Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), "chocolatey.2.0.0.nupkg")
           install_provider = resource.provider_for_action(:install)
 
           commands = []
-          shell_out = instance_double('Mixlib::ShellOut', error!: nil)
+          shell_out = instance_double("Mixlib::ShellOut", error!: nil)
 
           allow(resource).to receive(:provider_for_action).with(:install).and_return(install_provider)
           allow(resource).to receive(:is_choco_installed?).and_return(false)
@@ -196,25 +196,25 @@ describe Chef::Resource::ChocolateyInstaller do
 
           resource.run_action(:install)
 
-          expect(commands).to include('Set-Item -path env:ChocolateyDownloadUrl -Value https://some.custom.url/packages/chocolatey.2.0.0.nupkg')
+          expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value https://some.custom.url/packages/chocolatey.2.0.0.nupkg")
           expect(commands).to include("Invoke-WebRequest 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg' -OutFile '#{expected_destination}'")
         end
       end
     end
 
-    describe 'custom download path helpers' do
-      it 'detects PowerShell scripts from the URL path' do
-        resource = Chef::Resource::ChocolateyInstaller.new('fakey_fakerton_custom_script', run_context)
-        resource.download_url = 'https://some.custom.url/install.ps1?token=abc123'
+    describe "custom download path helpers" do
+      it "detects PowerShell scripts from the URL path" do
+        resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom_script", run_context)
+        resource.download_url = "https://some.custom.url/install.ps1?token=abc123"
 
         expect(resource.download_url_script?).to be true
       end
 
-      it 'falls back to a package filename when the URL path has no basename' do
-        resource = Chef::Resource::ChocolateyInstaller.new('fakey_fakerton_custom_path', run_context)
-        resource.download_url = 'https://some.custom.url/'
+      it "falls back to a package filename when the URL path has no basename" do
+        resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom_path", run_context)
+        resource.download_url = "https://some.custom.url/"
 
-        expect(resource.download_destination).to eq(Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), 'chocolatey.nupkg'))
+        expect(resource.download_destination).to eq(Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), "chocolatey.nupkg"))
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
In response to: https://progresssoftware.atlassian.net/browse/CHEF-28099?focusedCommentId=1453894&sourceType=mention

Root cause confirmed: Windows PowerShell 5.1's Invoke-WebRequest -OutFile requires a full file path as the target. When only the directory (chef) is passed, PS 5.1 returns "Access to the path is denied" — PS 7 handles this silently. The original code from PR #15306 was passing the directory directly.

Changes in chocolatey_installer.rb:

Added download_url_path helper — extracts the URI path; handles local Windows paths (C:\..., \\...) without parsing them as URIs.
Added download_url_script? helper — detects .ps1 by extension (including URLs with query strings like ?token=abc).
Added download_destination helper — uses File.basename + CGI.unescape to pull the filename from the URL and joins it to ChefConfig::Config.etc_chef_dir(windows: true), falling back to chocolatey.nupkg if the URL has no filename.
Updated action :install to use download_url_script? and download_destination so Invoke-WebRequest -OutFile always receives a full file path.


Changes in chocolatey_installer_spec.rb:

Added spec: non-.ps1 custom URL generates the correct full-path -OutFile command.
Added spec: query-string .ps1 URLs are correctly detected as scripts.
Added spec: root-path URLs fall back to chocolatey.nupkg filename.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
