### PR TITLE
Block install hook on arm until next release

### DIFF
--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jaymzh/chronoguard@main
         with:
-          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml
+          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml, habitat/aarch64-linux/plan.sh

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -40,7 +40,8 @@ pkg_deps=(
 pkg_svc_user=root
 pkg_svc_group=root
 
-# TODO: Remove this conditional logic once a hab version >= 2.0.507 is released.
+
+# TODO: Remove this conditional logic once a hab version >= 2.0.507 is released. - fail-after:2026-05-15
 # Check if hab version is >= 2.0.507 for aarch64-linux
 # The install hook requires hab >= 2.0.507 on arm64 architecture
 # Bumped to 2.0.507 because 2.0.504 did not fix the issue

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -40,11 +40,12 @@ pkg_deps=(
 pkg_svc_user=root
 pkg_svc_group=root
 
-# TODO: Remove this conditional logic once a hab version >= 2.0.495 is released.
-# Check if hab version is >= 2.0.495 for aarch64-linux
-# The install hook requires hab >= 2.0.495 on arm64 architecture
+# TODO: Remove this conditional logic once a hab version >= 2.0.507 is released.
+# Check if hab version is >= 2.0.507 for aarch64-linux
+# The install hook requires hab >= 2.0.507 on arm64 architecture
+# Bumped to 2.0.507 because 2.0.504 did not fix the issue
 hab_version=$(hab --version 2>/dev/null | awk '{print $2}')
-required_version="2.0.495"
+required_version="2.0.507"
 
 if [[ -z "$hab_version" ]]; then
   build_line "WARNING: Unable to determine Habitat version"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Set the install hook deletion to the current version of hab (which is > the last release) in order to block the arm install hook until another release happens.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
