### PR TITLE
Don't require `Expeditor Config Validation` for now

### DIFF
--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@v2
         with:
-          # SonarCloud - never works for forks
-          checks_exclude: ".*(SonarCloud Code Analysis).*"
+          # Expeditor Config Validation has been hanging - fail-after:2026-05-05
+          checks_exclude: ".*(Expeditor Config Validation).*"
           # Retry every minute for 30 minutes...
           retries: 90
           verbose: true


### PR DESCRIPTION
@tpowell-progress and I keep seeing this hang, so making it not
required for now since there's no way to "retry" it.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
