### PR TITLE
have kitchen-dokken use HAB_AUTH_TOKEN variable

### DIFF
--- a/.expeditor/scripts/chef_adhoc_build.ps1
+++ b/.expeditor/scripts/chef_adhoc_build.ps1
@@ -4,12 +4,6 @@
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-# Ensuring habitat 2.0.504 is installed
-# $ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
-# & "$ScriptRoute"
-
-iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1) } -Version 2.0.504"
-
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 $env:Path += ";C:\buildkite-agent\bin"
 

--- a/.expeditor/scripts/chef_adhoc_build.ps1
+++ b/.expeditor/scripts/chef_adhoc_build.ps1
@@ -5,8 +5,10 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
 # Ensuring habitat 2.0.504 is installed
-$ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
-& "$ScriptRoute"
+# $ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
+# & "$ScriptRoute"
+
+iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1) } -Version 2.0.504"
 
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 $env:Path += ";C:\buildkite-agent\bin"

--- a/.expeditor/scripts/chef_adhoc_build.ps1
+++ b/.expeditor/scripts/chef_adhoc_build.ps1
@@ -4,6 +4,10 @@
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+# Ensuring habitat 2.0.504 is installed
+$ScriptRoute = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "ensure-minimum-viable-hab.ps1"))
+& "$ScriptRoute"
+
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 $env:Path += ";C:\buildkite-agent\bin"
 

--- a/.expeditor/scripts/chef_adhoc_build.sh
+++ b/.expeditor/scripts/chef_adhoc_build.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 hab_target="${1:-x86_64-linux}"
 
+# ensure habitat 2.0.504 is installed
+./.expeditor/scripts/install-hab.sh "$hab_target"
+
 export HAB_ORIGIN='chef'
 export PLAN='chef-infra-client'
 export CHEF_LICENSE="accept-no-persist"

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -2,18 +2,21 @@ $HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '2.0.504' }
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 
-$installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
-$installScriptPath = Join-Path $env:TEMP "hab-install-$HabitatVersion.ps1"
+function Stop-HabitatProcesses {
+    # Stop any running hab-related processes to release file locks (e.g. concrt140.dll)
+    # that would prevent the installer from overwriting existing files.
+    $habProcesses = Get-Process -Name hab*, hab-launch*, hab-sup* -ErrorAction SilentlyContinue
+    if ($habProcesses) {
+        Write-Host "Stopping running Habitat processes to release file locks..."
+        $habProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
+    }
+}
 
 function Install-HabitatVersion {
-    Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
-    try {
-        & $installScriptPath -Version $HabitatVersion
-        if (-not $?) { throw "Failed to install Habitat $HabitatVersion" }
-    }
-    finally {
-        Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue
-    }
+    Stop-HabitatProcesses
+    iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1) } -Version $HabitatVersion"
+    if (-not $?) { throw "Failed to install Habitat $HabitatVersion" }
 }
 
 try {
@@ -22,12 +25,7 @@ try {
         Write-Host "--- :habicat: Installing Habitat $HabitatVersion"
         Install-HabitatVersion
     } elseif ($hab_version -gt [Version]$HabitatVersion) {
-        Write-Host "--- :habicat: Habitat $hab_version detected (greater than required $HabitatVersion). Removing with prejudice..."
-        $habPath = (Get-Command hab -ErrorAction SilentlyContinue).Source | Split-Path -Parent
-        if ($habPath) {
-            Remove-Item -Path $habPath -Recurse -Force -ErrorAction Continue
-            Write-Host "--- :habicat: Deleted Habitat from $habPath"
-        }
+        Write-Host "--- :habicat: Installing Habitat $HabitatVersion (replacing $hab_version)"
         Install-HabitatVersion
     } else {
         Write-Host "--- :habicat: :thumbsup: Habitat $HabitatVersion is already installed"

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,4 +1,4 @@
-$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '2.0.488' }
+$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '2.0.504' }
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -2,21 +2,18 @@ $HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '2.0.504' }
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 
-function Stop-HabitatProcesses {
-    # Stop any running hab-related processes to release file locks (e.g. concrt140.dll)
-    # that would prevent the installer from overwriting existing files.
-    $habProcesses = Get-Process -Name hab*, hab-launch*, hab-sup* -ErrorAction SilentlyContinue
-    if ($habProcesses) {
-        Write-Host "Stopping running Habitat processes to release file locks..."
-        $habProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
-        Start-Sleep -Seconds 2
-    }
-}
+$installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
+$installScriptPath = Join-Path $env:TEMP "hab-install-$HabitatVersion.ps1"
 
 function Install-HabitatVersion {
-    Stop-HabitatProcesses
-    iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1) } -Version $HabitatVersion"
-    if (-not $?) { throw "Failed to install Habitat $HabitatVersion" }
+    Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
+    try {
+        & $installScriptPath -Version $HabitatVersion
+        if (-not $?) { throw "Failed to install Habitat $HabitatVersion" }
+    }
+    finally {
+        Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 try {
@@ -25,7 +22,12 @@ try {
         Write-Host "--- :habicat: Installing Habitat $HabitatVersion"
         Install-HabitatVersion
     } elseif ($hab_version -gt [Version]$HabitatVersion) {
-        Write-Host "--- :habicat: Installing Habitat $HabitatVersion (replacing $hab_version)"
+        Write-Host "--- :habicat: Habitat $hab_version detected (greater than required $HabitatVersion). Removing with prejudice..."
+        $habPath = (Get-Command hab -ErrorAction SilentlyContinue).Source | Split-Path -Parent
+        if ($habPath) {
+            Remove-Item -Path $habPath -Recurse -Force -ErrorAction Continue
+            Write-Host "--- :habicat: Deleted Habitat from $habPath"
+        }
         Install-HabitatVersion
     } else {
         Write-Host "--- :habicat: :thumbsup: Habitat $HabitatVersion is already installed"

--- a/.expeditor/scripts/install-hab.sh
+++ b/.expeditor/scripts/install-hab.sh
@@ -19,5 +19,5 @@ error () {
 [[ -n "$hab_target" ]] || error 'no hab target provided'
 
 echo "--- :habicat: Installing latest version of Habitat"
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash -s -- -t "$hab_target"
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash -s -- -t "$hab_target" -v "2.0.504"
 hab license accept

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Habitat CLI
         shell: pwsh
         run: |
-          $env:HAB_VERSION = "2.0.488"
+          $env:HAB_VERSION = "2.0.504"
           & "${{ github.workspace }}\.expeditor\scripts\ensure-minimum-viable-hab.ps1"
           $env:PATH = "C:\Program Files\Habitat;C:\hab\bin;C:\opscode\chef-workstation\bin;C:\opscode\chef-workstation\embedded\bin;" + $env:PATH
           echo "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -50,7 +50,7 @@ jobs:
       - name: 'Install Habitat CLI'
         run: |
           # Ensure pinned Habitat version on Windows CI
-          $env:HAB_VERSION = "2.0.488"
+          $env:HAB_VERSION = "2.0.504"
           & "${{ github.workspace }}\.expeditor\scripts\ensure-minimum-viable-hab.ps1"
           # Add hab to PATH
           $env:PATH = "C:\Program Files\Habitat;" + $env:PATH

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -45,22 +45,22 @@ pkg_svc_group=root
 # Check if hab version is >= 2.0.507 for aarch64-linux
 # The install hook requires hab >= 2.0.507 on arm64 architecture
 # Bumped to 2.0.507 because 2.0.504 did not fix the issue
-hab_version=$(hab --version 2>/dev/null | awk '{print $2}')
-required_version="2.0.507"
+# hab_version=$(hab --version 2>/dev/null | awk '{print $2}')
+# required_version="2.0.507"
 
-if [[ -z "$hab_version" ]]; then
-  build_line "WARNING: Unable to determine Habitat version"
-  pkg_svc_user_default=root
-elif [[ "$(printf '%s\n' "$required_version" "$hab_version" | sort -V | head -n 1)" = "$required_version" ]]; then
-  build_line "Habitat version $hab_version meets requirement ($required_version). Install hook will be used."
-  pkg_svc_user_default=root
-else
-  build_line "Habitat version $hab_version is less than $required_version. Excluding install hook for aarch64-linux."
-  # Remove the install hook directory to prevent it from being packaged
-  if [[ -f "$PLAN_CONTEXT/hooks/install" ]]; then
-    rm -f "$PLAN_CONTEXT/hooks/install"
-  fi
-fi
+# if [[ -z "$hab_version" ]]; then
+#   build_line "WARNING: Unable to determine Habitat version"
+#   pkg_svc_user_default=root
+# elif [[ "$(printf '%s\n' "$required_version" "$hab_version" | sort -V | head -n 1)" = "$required_version" ]]; then
+#   build_line "Habitat version $hab_version meets requirement ($required_version). Install hook will be used."
+#   pkg_svc_user_default=root
+# else
+#   build_line "Habitat version $hab_version is less than $required_version. Excluding install hook for aarch64-linux."
+#   # Remove the install hook directory to prevent it from being packaged
+#   if [[ -f "$PLAN_CONTEXT/hooks/install" ]]; then
+#     rm -f "$PLAN_CONTEXT/hooks/install"
+#   fi
+# fi
 
 pkg_version() {
   cat "${SRC_PATH}/VERSION"

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -56,7 +56,7 @@ lifecycle:
     - remote: sh -c "if [ ! -f /chef-infra-client-latest.hart ]; then echo 'Habitat package not found!'; exit 1; fi"
 
     - remote: echo "****Installing Habitat package for Chef Infra Client****"
-    - remote: sh -c "HAB_LICENSE=accept-no-persist hab pkg install /chef-infra-client-latest.hart --auth \"$(cat /hab_token)\""
+    - remote: sh -c "HAB_LICENSE=accept-no-persist HAB_AUTH_TOKEN=\"$(cat /hab_token)\" hab pkg install /chef-infra-client-latest.hart"
     - remote: echo "****Installed chef-infra-client version:****"
     - remote: sh -c "HAB_LICENSE=accept-no-persist hab pkg exec gha/chef-infra-client chef-client -v"
 

--- a/kitchen-tests/kitchen.dokken.yml
+++ b/kitchen-tests/kitchen.dokken.yml
@@ -47,6 +47,8 @@ lifecycle:
       includes:
         - centos-7
         - oraclelinux-7
+    - remote: echo "****[DEBUG] Habitat version****"
+    - remote: sh -c "hab --version"
     - remote: echo "****Importing Habitat Origin Key****"
     - remote: sh -c "cat /gha-key.tar.gz | HAB_LICENSE=accept-no-persist hab origin key import"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
There is a new hab bug where it does not honor the "--auth" command line parameter but DOES honor the environment variable. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
