### PR TITLE
Dependabot: Lock pry-byebug version on chef-18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,15 +25,19 @@ updates:
     labels:
       - "Type: Chore"
     ignore:
-      # Due to FIPS builds and having to couple the openssl
-      # build itself, we don't let dependabot bump openssl
+        # Due to FIPS builds and having to couple the openssl
+        # build itself, we don't let dependabot bump openssl
       - dependency-name: "openssl"
-      # chef-18 needs to stay on inspec 5, the pre-license version
+        # chef-18 needs to stay on inspec 5, the pre-license version
       - dependency-name: "inspec-core-bin"
         versions: [">= 6"]
-      # chef-18 needs to stay on toml 1 which is less strict
+        # chef-18 needs to stay on toml 1 which is less strict
       - dependency-name: "tomlrb"
         versions: [">= 2"]
+        # chef-18 is locked to Ruby 3.1, which means we cannot move
+        # past pry-byebug 3.11
+      - dependency-name: "pry-byebug"
+        versions: [">= 3.12.0"]
     # don't automatically rebase on every single time we're out of date with
     # base (whith is always) because it kills CI capacity
     rebase-strategy: disabled


### PR DESCRIPTION
pry-byebug 3.12 erquires a ruby too new for chef-18:
https://github.com/chef/chef/network/updates/1332212130

Signed-off-by: Phil Dibowitz <phil@ipom.com>
