### PR TITLE
[chef-18] Lock Gemfile to pry-byebug 3.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,13 @@ group(:omnibus_package, :pry) do
   # some work is ongoing? https://github.com/deivid-rodriguez/pry-byebug/issues/343
   gem "pry", "0.15.2"
   # byebug does not install on freebsd on ruby 3.0
-  gem "pry-byebug" unless RUBY_PLATFORM.match?(/freebsd/i)
+  #
+  # byebyg 13 and pry-byebug 3.12 both require Ruby 3.2, so we must
+  # lock them to less than that.
+  unless RUBY_PLATFORM.match?(/freebsd/i)
+    gem "byebug", "< 13"
+    gem "pry-byebug", "< 3.12"
+  end
   gem "pry-stack_explorer"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,6 +528,7 @@ PLATFORMS
 
 DEPENDENCIES
   appbundler
+  byebug (< 13)
   chef!
   chef-bin!
   chef-config!
@@ -543,7 +544,7 @@ DEPENDENCIES
   ohai!
   openssl (= 3.3.0)
   pry (= 0.15.2)
-  pry-byebug
+  pry-byebug (< 3.12)
   pry-stack_explorer
   rake (>= 12.3.3)
   rb-readline

--- a/post-bundle-install.rb
+++ b/post-bundle-install.rb
@@ -20,7 +20,7 @@ Dir["#{gem_home}/bundler/gems/*"].each do |gempath|
   # FIXME: should omit the gem which is in the current directory and not hard code chef
   next if %w{chef chef-universal-mingw-ucrt proxifier}.include?(gem_name)
 
-  next if gem_name.match?(/ruby.shadow/) && RUBY_PLATFORM.include?("aix")
+  next if gem_name.match?(/ruby.shadow/) && RUBY_PLATFORM =~ /aix|mswin|mingw|windows/
 
   puts "re-installing #{gem_name}..."
 


### PR DESCRIPTION
Otherwise dependabot fails when trying to update it.

We ALSO have it in the ignore list, but that just says don't make
a PR for it... though it will get pulled in by other requirements,
which is what's happening here.

And to make this not all break on windows, fix post-bundle-install
to ignore ruby-shadow on windows, and add the deps via 'bundle lock'

```
$ bundle lock
Writing lockfile to /home/phil/src/git/chef/Gemfile.lock
```

Signed-off-by: Phil Dibowitz <phil@ipom.com>
