### PR TITLE
Upgrade the GH labeler - backport to chef-18

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,7 @@
 documentation:
-  - 'README.md'
-  - 'CODE_OF_CONDUCT.md'
-  - 'CONTRIBUTING.md'
-  - 'lib/chef/resource/**/*'
-
+  - changed-files:
+      - any-glob-to-any-file:
+        - 'README.md'
+        - 'CODE_OF_CONDUCT.md'
+        - 'CONTRIBUTING.md'
+        - 'lib/chef/resource/**/*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4.3.0
+      - uses: actions/labeler@v6.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Replaces #15958, and backports the whole change from `main`,
because they most be done together.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
