### PR TITLE
[backport] [chef-18] fix intermittent failures on trusted certs test

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
@@ -25,13 +25,12 @@ cert.sign(key, OpenSSL::Digest.new("SHA256"))
 
 cert_pem = cert.to_pem
 
-# Start a local HTTPS server in the background serving a test page
 server = WEBrick::HTTPServer.new(
   Port: 9443,
   SSLEnable: true,
   SSLCertificate: cert,
   SSLPrivateKey: key,
-  Logger: WEBrick::Log.new("/dev/null"),
+  Logger: WEBrick::Log.new(File::NULL),
   AccessLog: []
 )
 server.mount_proc("/index.html") { |_req, res| res.body = "trusted cert test OK" }

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef_client_trusted_certificate.rb
@@ -1,21 +1,55 @@
-# First grab the cert. While this wouldn't ordinarily be secure, this isn't
-# trying to secure something, we simply want to make sure that if we
-# have said a certificate is trusted, it will be trusted. So lets grab it, trust
-# it, and then try to use it.
+# This test verifies that the chef_client_trusted_certificate resource correctly
+# installs a certificate into Chef's trusted_certs_dir and that the SSL trust
+# chain works end-to-end (set_custom_certs -> OpenSSL::X509::Store -> TLS handshake).
 
-# First, grab it
-out = Mixlib::ShellOut.new(
-  %w{openssl s_client -servername self-signed.badssl.com -showcerts -connect self-signed.badssl.com:443}
-).run_command.stdout
+require "openssl"
+require "webrick"
+require "webrick/https"
 
-cert = Mixlib::ShellOut.new(%w{openssl x509}, input: out).run_command.stdout
+# Generate a self-signed certificate for localhost
+key = OpenSSL::PKey::RSA.new(2048)
+cert = OpenSSL::X509::Certificate.new
+cert.version = 2
+cert.serial = 1
+cert.subject = OpenSSL::X509::Name.parse("/CN=localhost")
+cert.issuer = cert.subject
+cert.public_key = key.public_key
+cert.not_before = Time.now
+cert.not_after = Time.now + 3600
 
-# Second trust it
-chef_client_trusted_certificate "self-signed.badssl.com" do
-  certificate cert
+ef = OpenSSL::X509::ExtensionFactory.new
+ef.subject_certificate = cert
+ef.issuer_certificate = cert
+cert.add_extension(ef.create_extension("subjectAltName", "DNS:localhost,IP:127.0.0.1", false))
+cert.sign(key, OpenSSL::Digest.new("SHA256"))
+
+cert_pem = cert.to_pem
+
+# Start a local HTTPS server in the background serving a test page
+server = WEBrick::HTTPServer.new(
+  Port: 9443,
+  SSLEnable: true,
+  SSLCertificate: cert,
+  SSLPrivateKey: key,
+  Logger: WEBrick::Log.new("/dev/null"),
+  AccessLog: []
+)
+server.mount_proc("/index.html") { |_req, res| res.body = "trusted cert test OK" }
+Thread.new { server.start }
+
+# Trust our self-signed cert via the Chef resource (exercises chef_client_trusted_certificate -> file write)
+chef_client_trusted_certificate "localhost" do
+  certificate cert_pem
 end
 
-# see if we can fetch from our new trusted domain
+# Fetch from the local HTTPS server — this exercises the full SSL trust chain:
+# trusted_certs_dir -> set_custom_certs -> OpenSSL::X509::Store -> TLS peer verification
 remote_file ::File.join(Chef::Config[:file_cache_path], "index.html") do
-  source "https://self-signed.badssl.com/index.html"
+  source "https://localhost:9443/index.html"
+  notifies :run, "ruby_block[stop local https server]", :immediately
+end
+
+ruby_block "stop local https server" do
+  block { server.shutdown }
+  action :nothing
 end


### PR DESCRIPTION
## Description
backport of https://github.com/chef/chef/pull/15923

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
