### PR TITLE
keyboard bug in reline 0.3.1

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -747,6 +747,7 @@
     "keyname",
     "KEYNAME",
     "keypair",
+    "keypresses",
     "keyrings",
     "keyscan",
     "keysign",

--- a/lib/chef/monkey_patches/reline-windows.rb
+++ b/lib/chef/monkey_patches/reline-windows.rb
@@ -1,0 +1,117 @@
+# Author:: Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# == Background
+#
+# On Windows, Reline's process_key_event emits an ESC byte (0x1B) before every
+# character when the :ALT control key flag is set.  This is correct for true
+# Alt key combos (Meta sequences), but AltGr on European keyboards – most
+# notably German layouts – is reported by Windows as Ctrl+Alt (RIGHT_CTRL +
+# RIGHT_ALT pressed simultaneously).  Characters that require AltGr, such as
+# { } [ ] @ ~ | \, therefore receive both :CTRL and :ALT flags, causing Reline to
+# emit an ESC prefix.  In a terminal the result looks like ^[{ instead of {.
+#
+# The corrupt input leaves IRB's parser in an open-string/block state which
+# re-draws continuation prompts endlessly when multi-line blocks are pasted,
+# making chef-shell unusable for German (and many other European) keyboard users.
+#
+# == Fix
+#
+# Only emit the ESC Meta prefix when :ALT is set WITHOUT :CTRL.  When both
+# flags are present the keypress is AltGr-originated and the raw character
+# bytes are sufficient and correct.
+#
+# == Affected versions
+#
+# Verified against Reline <= 0.3.x (shipped with Ruby 3.1.x in chef-foundation).
+# The issue was resolved upstream in Reline 0.3.2 / irb 1.6.2 (Ruby 3.2+),
+# so the patch is guarded to apply only when the installed Reline version is
+# affected.
+#
+# == References
+#
+# * Upstream report:  https://github.com/ruby/reline/issues/475
+# * Chef PR #9267   (Ruby 2.7 IRB fixes, introduced multiline/singleline wiring)
+# * Chef PR #14919  (Prompt consistency fix for left-arrow on Ruby 3.1/3.2)
+# * Chef PR #15336  (IRB @ALIASES removal compat)
+
+if Gem.win_platform? && defined?(Reline::Windows)
+
+  # Only patch versions where the bug is present.  Reline 0.3.2 fixed it
+  # upstream.  Gem::Version comparison is safe even when reline is a stdlib
+  # default gem without a Gemspec entry in loaded_specs.
+  reline_version = begin
+    Gem::Version.new(Reline::VERSION)
+  rescue StandardError
+    Gem::Version.new("0")
+  end
+
+  if reline_version < Gem::Version.new("0.3.2")
+    Chef::Log.debug("chef-shell: applying Reline::Windows AltGr monkey patch (reline #{Reline::VERSION})")
+
+    class Reline::Windows
+      class << self
+        # Reopen process_key_event and change only the ESC-emission guard.
+        # All other behaviour – surrogate pair handling, KEY_MAP matching, bare
+        # control-key suppression – is preserved verbatim from the original.
+        def process_key_event(repeat_count, virtual_key_code, virtual_scan_code, char_code, control_key_state)
+
+          # ---- surrogate pair handling (unchanged) --------------------------------
+          if 0xD800 <= char_code && char_code <= 0xDBFF
+            @@hsg = char_code
+            return
+          end
+
+          if 0xDC00 <= char_code && char_code <= 0xDFFF
+            if @@hsg
+              char_code = 0x10000 + (@@hsg - 0xD800) * 0x400 + char_code - 0xDC00
+              @@hsg = nil
+            else
+              return # low-surrogate without preceding high-surrogate – ignore
+            end
+          else
+            @@hsg = nil # discard stale high-surrogate
+          end
+          # -------------------------------------------------------------------------
+
+          key = KeyEventRecord.new(virtual_key_code, char_code, control_key_state)
+
+          # KEY_MAP takes priority (arrow keys, Delete, Home, End, Tab, etc.)
+          match = KEY_MAP.find { |args,| key.matches?(**args) }
+          unless match.nil?
+            @@output_buf.concat(match.last)
+            return
+          end
+
+          # Suppress bare modifier-only keypresses (no printable character)
+          return if key.char_code == 0 && key.control_keys.any?
+
+          # ---- THE FIX -----------------------------------------------------------
+          # Original:  @@output_buf.push("\e".ord) if key.control_keys.include?(:ALT)
+          #
+          # AltGr on European keyboards reports as Ctrl+Alt (both :CTRL and :ALT
+          # present).  Only emit the ESC Meta prefix when Alt is pressed WITHOUT
+          # Ctrl – i.e. a genuine Meta/Alt sequence, not an AltGr character.
+          alt_without_ctrl = key.control_keys.include?(:ALT) && !key.control_keys.include?(:CTRL)
+          @@output_buf.push("\e".ord) if alt_without_ctrl
+          # -------------------------------------------------------------------------
+
+          @@output_buf.concat(key.char.bytes)
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/monkey_patches/reline-windows.rb
+++ b/lib/chef/monkey_patches/reline-windows.rb
@@ -55,8 +55,8 @@ if Gem.win_platform? && defined?(Reline::Windows)
   # default gem without a Gemspec entry in loaded_specs.
   reline_version = begin
     Gem::Version.new(Reline::VERSION)
-  rescue StandardError
-    Gem::Version.new("0")
+                   rescue StandardError
+                     Gem::Version.new("0")
   end
 
   if reline_version < Gem::Version.new("0.3.2")
@@ -65,17 +65,16 @@ if Gem.win_platform? && defined?(Reline::Windows)
     class Reline::Windows
       class << self
         # Reopen process_key_event and change only the ESC-emission guard.
-        # All other behaviour – surrogate pair handling, KEY_MAP matching, bare
+        # All other behavior – surrogate pair handling, KEY_MAP matching, bare
         # control-key suppression – is preserved verbatim from the original.
         def process_key_event(repeat_count, virtual_key_code, virtual_scan_code, char_code, control_key_state)
-
           # ---- surrogate pair handling (unchanged) --------------------------------
-          if 0xD800 <= char_code && char_code <= 0xDBFF
+          if char_code.between?(0xD800, 0xDBFF)
             @@hsg = char_code
             return
           end
 
-          if 0xDC00 <= char_code && char_code <= 0xDFFF
+          if char_code.between?(0xDC00, 0xDFFF)
             if @@hsg
               char_code = 0x10000 + (@@hsg - 0xD800) * 0x400 + char_code - 0xDC00
               @@hsg = nil

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -72,6 +72,13 @@ module Shell
     # to get access to the main object before irb starts.
     ::IRB.setup(nil)
 
+    # Apply Windows AltGr input fix for affected Reline versions (< 0.3.2).
+    # European keyboard layouts (e.g. German) use AltGr (Ctrl+Alt) to produce
+    # characters such as { } [ ]. Without this patch Reline emits a spurious ESC
+    # prefix making chef-shell unusable for those users. Safe no-op on non-Windows
+    # and on Reline versions where the upstream fix is already present.
+    require_relative "monkey_patches/reline-windows"
+
     irb_conf[:USE_COLORIZE] = options.config[:use_colorize]
     irb_conf[:USE_SINGLELINE] = options.config[:use_singleline]
     irb_conf[:USE_MULTILINE] = options.config[:use_multiline]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
# chef-shell Windows AltGr Input Corruption

## Summary

On Windows with European keyboard layouts (most commonly German), typing characters
that require **AltGr** (e.g. `{`, `}`, `[`, `]`, `@`, `~`, `\`, `|`) inside
`chef-shell` causes spurious escape-sequence prefixes to appear — for example `{`
becomes `^[{`. This makes interactive use of `chef-shell`, and in particular
`recipe_mode`, unreliable or completely unusable.

A second related complaint — "resources duplicating endlessly and never executing" —
is a combination of this input corruption **and** a misunderstanding of how
`recipe_mode` works (see [Expected Behavior](#expected-behavior-of-recipe_mode)
below).

---

## Affected Configurations

| Factor | Affected value |
|---|---|
| OS | Windows (any) |
| Keyboard layout | Any European layout using AltGr for brackets/braces (German, French, Czech, Polish, …) |
| Ruby version | 3.1.x (ships with Chef Infra Client 18.x via chef-foundation) |
| Reline version | < 0.3.2 (embedded: 0.3.1 as of Chef 18.10) |
| Chef version | 17.x and 18.x both affected at runtime; 18.x receives the patch |

---

## Root Cause

### Windows key event reporting

The Windows Console API reports **AltGr** as a simultaneous **Right-Ctrl + Right-Alt**
key press (`RIGHT_CTRL_PRESSED | RIGHT_ALT_PRESSED`). This is by design in the Windows
API; AltGr is not a separate virtual key.

### Reline's key handler (the bug)

Reline's `Reline::Windows.process_key_event` method (in
`lib/reline/windows.rb`) converts Win32 key events into byte sequences for IRB.
In versions ≤ 0.3.1, the logic was:

```ruby
@@output_buf.push("\e".ord) if key.control_keys.include?(:ALT)
@@output_buf.concat(key.char.bytes)
```

`control_keys` is set to `[:ALT]` for a plain Alt keypress and to `[:ALT, :CTRL]`
for an AltGr keypress. Because the guard only checks for `:ALT` — without excluding
the `:CTRL` co-flag — **AltGr characters also get an ESC prefix**.

### Effect in IRB / chef-shell

IRB interprets the ESC byte as the start of a terminal escape sequence or a
Meta-key sequence. It either:

1. Corrupts the typed character (displays `^[{` instead of `{`), or  
2. Leaves the parser in a partially-open statement that redisplays continuation
   prompts on every new line, giving the appearance of "endless duplication".

### Why it changed between Chef 17 and Chef 18

The `lib/chef/shell.rb` source itself was **unchanged** across the 17→18 major
version boundary. What changed was the embedded Ruby runtime:

- Chef 17 shipped with **Ruby 2.7.x**, which carried an older IRB/Reline stack that
  handled AltGr differently.
- Chef 18 introduced **Ruby 3.1.x** (via the chef-foundation omnibus component),
  which bundles Reline 0.3.1. This version contains the buggy ALT-prefix logic.

The upstream fix landed in **Reline 0.3.2 / IRB 1.6.2** (Ruby 3.2), which is not
yet shipped in the Chef 18 / chef-foundation Ruby 3.1 runtime.

---

## The Fix

### What it does

The patch overrides `Reline::Windows.process_key_event` and changes only the
ESC-emission guard:

```ruby
# Before (buggy):
@@output_buf.push("\e".ord) if key.control_keys.include?(:ALT)

# After (fixed):
alt_without_ctrl = key.control_keys.include?(:ALT) && !key.control_keys.include?(:CTRL)
@@output_buf.push("\e".ord) if alt_without_ctrl
```

ESC is now emitted only for genuine Alt-key Meta sequences. AltGr characters
(Ctrl+Alt combination) pass through as plain character bytes.

### Where it lives

| File | Purpose |
|---|---|
| [`lib/chef/monkey_patches/reline-windows.rb`](../../../lib/chef/monkey_patches/reline-windows.rb) | The patch itself |
| [`lib/chef/shell.rb`](../../../lib/chef/shell.rb) | Loads the patch after `IRB.setup(nil)` |

### Patch safety guards

The patch is active **only** when all three conditions are true:

1. `Gem.win_platform?` — non-Windows hosts are entirely unaffected.
2. `defined?(Reline::Windows)` — the Windows Reline backend is loaded.
3. `Reline::VERSION < "0.3.2"` — the upstream fix is not already present.

All other behaviour in `process_key_event` (surrogate pair handling, KEY_MAP
lookup, bare modifier suppression) is preserved verbatim.

---

## Expected Behavior of `recipe_mode`

A separate customer concern — "the code duplicates endlessly and never executes" —
is partially expected by design and partially caused by the input bug above.

### How `recipe_mode` actually works

`recipe_mode` in chef-shell switches the IRB context to a `Chef::Recipe` object.
Defining resources in this context **only adds them to the resource collection**.
They are **not converged** (executed) until you explicitly call `run_chef`.

```
# Correct chef-shell workflow
chef-shell> recipe_mode
chef-shell:recipe> registry_key "My Key" do
chef-shell:recipe>   key "HKCU\\Software\\Test"
chef-shell:recipe>   action :create
chef-shell:recipe> end
# => resource added to collection, nothing applied yet
chef-shell:recipe> run_chef
# => NOW the resource converges on the node
```

Alternatively, load a recipe file from disk and converge in one step:

```
chef-shell> recipe_mode
chef-shell:recipe> instance_eval(IO.read("C:/path/to/recipe.rb"))
chef-shell:recipe> run_chef
```

### Why it looked like "endless duplication" before

Input corruption from the AltGr bug leaves IRB's parser with an unclosed
block/string token. Every subsequent Enter key appends a line to the same
expression rather than evaluating it, which re-prompts with a continuation
indicator. This gave the visual impression of code being repeated infinitely.
After the patch, the parser receives clean input and completes blocks normally.

---

## Customer Workarounds (Until Patched)

If a patched Chef 18 build is not yet available, customers have two options:

### Option A — Load from file (recommended)

Avoid interactive typing/pasting of brace-heavy blocks entirely:

1. Write the recipe to a `.rb` file on the Windows node.
2. Inside chef-shell:

```ruby
recipe_mode
instance_eval(IO.read("C:/Users/yourname/recipe.rb"))
run_chef
```

### Option B — Temporary US keyboard layout

Switching the Windows input language to **English (US)** before opening
chef-shell avoids AltGr-based key combinations. Characters like `{` and `}`
can then be typed with their US-layout positions. Return to the German layout
after exiting chef-shell.

---

## Related Issues and PRs

| Reference | Description |
|---|---|
| [ruby/reline#475](https://github.com/ruby/reline/issues/475) | Upstream report: inserting brackets on Windows broken (German keyboard, AltGr) |
| [chef/chef#9267](https://github.com/chef/chef/pull/9267) | Ruby 2.7 IRB fixes — introduced current multiline/singleline/colorize wiring in chef-shell |
| [chef/chef#14919](https://github.com/chef/chef/pull/14919) | Prompt consistency fix for left-arrow cursor position on Ruby 3.1/3.2 |
| [chef/chef#15336](https://github.com/chef/chef/pull/15336) | Remove `@ALIASES` manipulation for IRB compat across versions |
| [chef/chef#6447](https://github.com/chef/chef/pull/6447) | Force UTF-8 encoding in chef-shell launcher (earlier encoding hardening) |

---

## Long-Term Resolution

The correct long-term fix is to upgrade the embedded Ruby in chef-foundation to
**3.2.x or later**, which ships Reline ≥ 0.3.2 and contains the upstream fix.
The monkey patch in this PR serves as a targeted backport for the Chef 18 / Ruby
3.1 runtime until that upgrade occurs. The version guard (`< "0.3.2"`) ensures
the patch becomes a no-op automatically once the runtime is upgraded.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
