### PR TITLE
[chef-18] Lock to specific version of aws-sdk-s3 to keep C7 compat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ PATH
   specs:
     chef (18.10.72)
       addressable
-      aws-sdk-s3 (~> 1.218.0)
+      aws-sdk-s3 (>= 1.218.0, < 1.219.0)
       aws-sdk-secretsmanager (~> 1.46)
       chef-config (= 18.10.72)
       chef-utils (= 18.10.72)
@@ -76,7 +76,7 @@ PATH
       vault (>= 0.18.2, < 0.21.0)
     chef (18.10.72-universal-mingw-ucrt)
       addressable
-      aws-sdk-s3 (~> 1.218.0)
+      aws-sdk-s3 (>= 1.218.0, < 1.219.0)
       aws-sdk-secretsmanager (~> 1.46)
       chef-config (= 18.10.72)
       chef-powershell (~> 18.6.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -74,7 +74,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency "proxifier2", "~> 1.1"
 
-  s.add_dependency "aws-sdk-s3", "~> 1.218.0" # s3 recipe-url support
+  # 1.219 depends (transitively) on bigdecimal 4.1.2 which dodesn't compile
+  # on CentOS7
+  s.add_dependency "aws-sdk-s3", ">= 1.218.0", "< 1.219.0"
   s.add_dependency "aws-sdk-secretsmanager", "~> 1.46"
   s.add_dependency "vault", ">= 0.18.2", "< 0.21.0" # hashi vault official client gem
 

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -162,6 +162,9 @@ function Invoke-Build {
 
         Write-BuildLine " ** 'rake install' any gem sourced as a git reference so they'll look like regular gems."
         foreach($git_gem in (Get-ChildItem "$env:GEM_HOME/bundler/gems")) {
+            if ($git_gem -match "ruby-shadow") {
+                continue
+            }
             try {
                 Push-Location $git_gem
                 Write-BuildLine " -- installing $git_gem"


### PR DESCRIPTION
aws-sdk-s3 1.219 depends on aws-sdk-core 3.246 which depends on
bigdecimal 4.1.2 which won't build on older gcc, so stick to 1.218
on chef-18

```
$ bundle lock
Writing lockfile to /home/phil/src/git/chef/Gemfile.lock
$
```