### PR TITLE
[Chef-18 backport][dnf/python_helper] Optimize dnf_command to reduce shell_outs

### DIFF
--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -42,9 +42,8 @@ class Chef
           def dnf_command
             # platform-python is used for system tools on RHEL 8 and is installed under /usr/libexec
             @dnf_command ||= begin
-                               cmd = which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
-                                 shell_out("#{f} -c 'import dnf'").exitstatus == 0
-                               end
+                               executables = where("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec")
+                               cmd = executables.find { |f| shell_out("#{f} -c 'import dnf'").exitstatus == 0 }
                                raise Chef::Exceptions::Package, "cannot find dnf libraries, you may need to use yum_package" unless cmd
 
                                "#{cmd} #{DNF_HELPER}"

--- a/spec/unit/provider/package/dnf/python_helper_spec.rb
+++ b/spec/unit/provider/package/dnf/python_helper_spec.rb
@@ -34,3 +34,72 @@ describe Chef::Provider::Package::Dnf::PythonHelper, :requires_root, external: e
     expect(helper.compare_versions("0:1.8.29-6.el8.x86_64", "0:1.8.29-6.el8_3.1.x86_64")).to eql(-1)
   end
 end
+
+describe Chef::Provider::Package::Dnf::PythonHelper, "#dnf_command" do
+  let(:helper) do
+    Singleton.__init__(Chef::Provider::Package::Dnf::PythonHelper)
+    Chef::Provider::Package::Dnf::PythonHelper.instance
+  end
+
+  let(:dnf_helper_path) do
+    Chef::Provider::Package::Dnf::PythonHelper::DNF_HELPER
+  end
+
+  let(:success_result) { double("shell_out", exitstatus: 0) }
+  let(:failure_result) { double("shell_out", exitstatus: 1) }
+
+  it "stops shell_out calls after finding the first working python" do
+    allow(helper).to receive(:where).and_return(
+      ["/usr/bin/python3", "/usr/bin/python2", "/usr/bin/python2.7"]
+    )
+
+    expect(helper).to receive(:shell_out)
+      .with("/usr/bin/python3 -c 'import dnf'")
+      .and_return(success_result)
+    expect(helper).not_to receive(:shell_out)
+      .with("/usr/bin/python2 -c 'import dnf'")
+    expect(helper).not_to receive(:shell_out)
+      .with("/usr/bin/python2.7 -c 'import dnf'")
+
+    expect(helper.dnf_command).to eq("/usr/bin/python3 #{dnf_helper_path}")
+  end
+
+  it "tries subsequent executables when earlier ones fail" do
+    allow(helper).to receive(:where).and_return(
+      ["/usr/bin/python3", "/usr/bin/python2", "/usr/bin/python2.7"]
+    )
+
+    expect(helper).to receive(:shell_out)
+      .with("/usr/bin/python3 -c 'import dnf'")
+      .and_return(failure_result)
+    expect(helper).to receive(:shell_out)
+      .with("/usr/bin/python2 -c 'import dnf'")
+      .and_return(success_result)
+
+    expect(helper.dnf_command).to eq("/usr/bin/python2 #{dnf_helper_path}")
+  end
+
+  it "raises when no executable can import dnf" do
+    allow(helper).to receive(:where).and_return(
+      ["/usr/bin/python3"]
+    )
+
+    expect(helper).to receive(:shell_out)
+      .with("/usr/bin/python3 -c 'import dnf'")
+      .and_return(failure_result)
+
+    expect { helper.dnf_command }.to raise_error(
+      Chef::Exceptions::Package,
+      "cannot find dnf libraries, you may need to use yum_package"
+    )
+  end
+
+  it "raises when no executables are found" do
+    allow(helper).to receive(:where).and_return([])
+
+    expect { helper.dnf_command }.to raise_error(
+      Chef::Exceptions::Package,
+      "cannot find dnf libraries, you may need to use yum_package"
+    )
+  end
+end


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Replace `which` (with block) with `where` + `find` in dnf_command.

The old implementation passed a shell_out block to `which`, which internally calls `where`. The `where` method iterates ALL cmd/path combinations and runs the block for every executable found on disk, even after a match is found.

The new implementation calls `where` without a block to cheaply collect all valid executables via filesystem checks, then uses `find` to stop at the first one that can successfully `import dnf`.

This backports https://github.com/chef/chef/pull/15718
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
