### PR TITLE
fix: delegate FileAccessControl.writable? to TargetIO in target mode on Windows

### DIFF
--- a/lib/chef/file_access_control/windows.rb
+++ b/lib/chef/file_access_control/windows.rb
@@ -33,6 +33,12 @@ class Chef
       module ClassMethods
         # We want to mix these in as class methods
         def writable?(path)
+          # In target mode the path refers to the remote filesystem.  Delegate
+          # to TargetIO so the check runs on the remote host via SSH rather than
+          # against the local Windows filesystem (where Linux paths like /tmp do
+          # not exist and ::File.exist? always returns false).
+          return ::TargetIO::File.writable?(path) if Chef::Config.target_mode?
+
           ::File.exist?(path) && Chef::ReservedNames::Win32::File.file_access_check(
             path, Chef::ReservedNames::Win32::API::Security::FILE_GENERIC_WRITE
           )


### PR DESCRIPTION
<h2>Bug Fix: FileAccessControl.writable? incorrect in target mode on Windows</h2>

<h3>Problem</h3>
<p>When <code>chef-client</code> runs on a <strong>Windows</strong> host in target mode against a Linux SSH target, the <code>directory</code> resource raises <code>Chef::Exceptions::InsufficientPermissions</code> even when the SSH user has full write access on the remote host.</p>

<p>The root cause is in <code>Chef::FileAccessControl::Windows::ClassMethods#writable?</code>:</p>
<pre><code>def writable?(path)
  ::File.exist?(path) &amp;&amp; Chef::ReservedNames::Win32::File.file_access_check(...)
end</code></pre>

<p>This checks the <strong>local Windows filesystem</strong>. When the resource path is a Linux path like <code>/tmp/foo</code>, <code>::File.exist?(&quot;/tmp/foo&quot;)</code> returns <code>false</code> on Windows, so the writable check always fails — regardless of what permissions the SSH user has on the remote target.</p>

<h3>Fix</h3>
<p>Short-circuit to <code>::TargetIO::File.writable?(path)</code> when in target mode. This runs <code>test -w &lt;path&gt;</code> on the remote host via SSH, which is exactly what the Unix <code>FileAccessControl</code> implementation already does.</p>

<h3>Impact</h3>
<ul>
  <li>No behaviour change for normal (non-target-mode) Windows runs</li>
  <li>Fixes target-mode directory and file resource convergence when chef-client runs on Windows managing a Linux SSH target</li>
</ul>

<p>This work was completed with AI assistance following Progress AI policies.</p>