### PR TITLE
fix: use Unix file access control in target mode when running on Windows

### DIFF
--- a/lib/chef/file_access_control.rb
+++ b/lib/chef/file_access_control.rb
@@ -28,6 +28,7 @@ class Chef
 
     if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
       require_relative "file_access_control/windows"
+      require_relative "file_access_control/unix"
       include FileAccessControl::Windows
     else
       require_relative "file_access_control/unix"
@@ -55,6 +56,15 @@ class Chef
       @current_resource, @resource, @provider = current_resource, new_resource, provider
       @file = @current_resource.path
       @modified = false
+
+      # When running on Windows in target mode the remote host is a Unix
+      # system managed via SSH.  Extend this instance with the Unix access
+      # control module so that permissions are applied via TargetIO
+      # (chmod/chown over SSH) rather than Win32 security APIs against a
+      # path that does not exist on the local Windows filesystem.
+      if RUBY_PLATFORM.match?(/mswin|mingw|windows/) && ChefConfig::Config.target_mode?
+        extend FileAccessControl::Unix
+      end
     end
 
     def modified?

--- a/lib/chef/file_access_control.rb
+++ b/lib/chef/file_access_control.rb
@@ -26,12 +26,13 @@ class Chef
   # the values specified by a value object, usually a Chef::Resource.
   class FileAccessControl
 
+    require_relative "file_access_control/unix"
+
     if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
       require_relative "file_access_control/windows"
-      require_relative "file_access_control/unix"
+
       include FileAccessControl::Windows
     else
-      require_relative "file_access_control/unix"
       include FileAccessControl::Unix
     end
 


### PR DESCRIPTION
<h2>Bug Fix: FileAccessControl uses Win32 ACL APIs against remote Linux paths in target mode</h2>

<h3>Problem</h3>
<p>When <code>chef-client</code> runs on <strong>Windows</strong> in target mode against a Linux SSH target, the <code>directory</code> or <code>file</code> resource raises <code>Chef::Exceptions::Win32APIError</code> after successfully creating the remote path:</p>
<pre><code>Chef::Exceptions::Win32APIError: The system cannot find the path specified.
get_named_security_info(/tmp/chef_tm_test, SE_FILE_OBJECT, 7)</code></pre>

<p>The root cause: <code>FileAccessControl</code> selects its platform module (<code>Windows</code> vs <code>Unix</code>) at <strong>class load time</strong> via <code>RUBY_PLATFORM</code>. On Windows it always includes <code>FileAccessControl::Windows</code>, which calls Win32 security APIs (<code>get_named_security_info</code>, <code>set_dacl</code>) against the local filesystem. Linux paths like <code>/tmp/foo</code> don't exist locally, so these calls fail.</p>

<h3>Fix</h3>
<p>On Windows, also <code>require</code> <code>file_access_control/unix</code>. In <code>initialize</code>, when in target mode, call <code>extend FileAccessControl::Unix</code> on the instance. Ruby's <code>extend</code> gives the Unix singleton methods precedence over the included Windows methods <strong>for that instance only</strong>, leaving all normal Windows runs completely unaffected.</p>
<p>The Unix methods use <code>TargetIO</code> (<code>chmod</code>/<code>chown</code> over SSH), which is correct for a remote Linux target.</p>

<h3>Impact</h3>
<ul>
  <li>No behaviour change for normal (non-target-mode) Windows runs</li>
  <li>Fixes <code>directory</code> and <code>file</code> resource convergence when chef-client runs on Windows managing a Linux SSH target</li>
  <li>Companion fix to PR #15979 (<code>writable?</code> check)</li>
</ul>

<p>This work was completed with AI assistance following Progress AI policies.</p>