### PR TITLE
fix: skip Windows load_resource_attributes guard in target mode

### DIFF
--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -472,11 +472,14 @@ class Chef
       end
 
       def load_resource_attributes_from_file(resource)
-        if ChefUtils.windows?
+        if ChefUtils.windows? && !Chef::Config.target_mode?
           # This is a work around for CHEF-3554.
           # OC-6534: is tracking the real fix for this workaround.
           # Add support for Windows equivalent, or implicit resource
           # reporting won't work for Windows.
+          # In target mode on Windows, we still read remote attributes via
+          # TargetIO (ScanAccessControl is TargetIO-aware), so idempotency
+          # checks work correctly when targeting a remote Linux host.
           return
         end
 


### PR DESCRIPTION
<h2>Problem</h2>
<p>On Windows, <code>Chef::Provider::File#load_resource_attributes_from_file</code> unconditionally returns early as a workaround for CHEF-3554. This means <code>current_resource.mode</code>, <code>.owner</code>, and <code>.group</code> are <strong>never</strong> populated when running on Windows.</p>
<p>In target mode, Chef is running on a Windows host but managing a remote Linux target via SSH. <code>ScanAccessControl</code> is fully TargetIO-aware — it calls <code>::TargetIO::File.stat</code>, <code>::TargetIO::Etc.getpwuid</code>, etc. — so it would correctly read file attributes from the remote. But the early return prevents it from ever running.</p>
<p>The result: every <code>file</code> and <code>directory</code> resource is <strong>non-idempotent</strong> when running <code>chef-client --target</code> from Windows. The current mode always appears as <code>nil</code>/<code>''</code>, so a <code>chmod</code> is triggered on every single converge, even when the remote file already has the correct mode.</p>

<h2>Fix</h2>
<p>Add <code>&amp;&amp; !Chef::Config.target_mode?</code> to the guard. Normal Windows runs are unaffected. In target mode on Windows, execution falls through to <code>ScanAccessControl.set_all!</code> which reads remote attributes correctly via TargetIO.</p>

<h2>Related</h2>
<ul>
  <li>PR #15979 — <code>FileAccessControl::Windows#writable?</code> checks local filesystem in target mode</li>
  <li>PR #15980 — <code>FileAccessControl</code> uses Win32 ACL APIs on remote Linux paths in target mode</li>
</ul>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>