### PR TITLE
modify habitat version updates

### DIFF
--- a/.expeditor/scripts/chef_adhoc_build.sh
+++ b/.expeditor/scripts/chef_adhoc_build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 hab_target="${1:-x86_64-linux}"
 
-# ensure habitat 2.0.504 is installed
+# ensure minimum viable habitat is installed
 ./.expeditor/scripts/install-hab.sh "$hab_target"
 
 export HAB_ORIGIN='chef'

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -19,18 +19,10 @@ function Install-HabitatVersion {
 try {
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]$HabitatVersion) {
-        Write-Host "--- :habicat: Installing Habitat $HabitatVersion"
-        Install-HabitatVersion
-    } elseif ($hab_version -gt [Version]$HabitatVersion) {
-        Write-Host "--- :habicat: Habitat $hab_version detected (greater than required $HabitatVersion). Removing with prejudice..."
-        $habPath = (Get-Command hab -ErrorAction SilentlyContinue).Source | Split-Path -Parent
-        if ($habPath) {
-            Remove-Item -Path $habPath -Recurse -Force -ErrorAction Continue
-            Write-Host "--- :habicat: Deleted Habitat from $habPath"
-        }
+        Write-Host "--- :habicat: Habitat $hab_version detected (below minimum $HabitatVersion). Installing..."
         Install-HabitatVersion
     } else {
-        Write-Host "--- :habicat: :thumbsup: Habitat $HabitatVersion is already installed"
+        Write-Host "--- :habicat: :thumbsup: Habitat $hab_version is installed (>= $HabitatVersion)"
     }
 }
 catch {

--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -16,6 +16,8 @@ function Install-HabitatVersion {
     }
 }
 
+Write-Host "--- :habicat: Ensuring minimum viable habitat installation.."
+
 try {
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]$HabitatVersion) {
@@ -26,6 +28,7 @@ try {
     }
 }
 catch {
+    Write-Host "hab not found or version check failed: $_"
     Write-Host "--- :habicat: Installing Habitat $HabitatVersion..."
     Install-HabitatVersion
 }

--- a/.expeditor/scripts/install-hab.sh
+++ b/.expeditor/scripts/install-hab.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 export HAB_LICENSE="accept"
 export HAB_NONINTERACTIVE="true"
 
+HAB_VERSION="${HAB_VERSION:-2.0.504}"
 hab_target="$1"
 
 # print error message followed by usage and exit
@@ -18,6 +19,25 @@ error () {
 
 [[ -n "$hab_target" ]] || error 'no hab target provided'
 
-echo "--- :habicat: Installing latest version of Habitat"
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash -s -- -t "$hab_target" -v "2.0.504"
-hab license accept
+install_habitat() {
+  echo "--- :habicat: Installing Habitat $HAB_VERSION"
+  curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash -s -- -t "$hab_target" -v "$HAB_VERSION"
+  hab license accept
+}
+
+# Returns 0 if $1 >= $2 (minimum version met), 1 if $1 < $2
+version_at_least() {
+  [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n 1)" = "$2" ]
+}
+
+if command -v hab &>/dev/null; then
+  current_version=$(hab --version 2>/dev/null | awk '{print $2}' | cut -d'/' -f1 || true)
+  if version_at_least "$current_version" "$HAB_VERSION"; then
+    echo "--- :habicat: :thumbsup: Habitat $current_version is installed (>= $HAB_VERSION)"
+  else
+    echo "--- :habicat: Habitat $current_version detected (below minimum $HAB_VERSION). Installing..."
+    install_habitat
+  fi
+else
+  install_habitat
+fi

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Install Habitat CLI
         shell: pwsh
         run: |
-          $env:HAB_VERSION = "2.0.504"
           & "${{ github.workspace }}\.expeditor\scripts\ensure-minimum-viable-hab.ps1"
           $env:PATH = "C:\Program Files\Habitat;C:\hab\bin;" + $env:PATH
           echo "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -49,8 +49,6 @@ jobs:
 
       - name: 'Install Habitat CLI'
         run: |
-          # Ensure pinned Habitat version on Windows CI
-          $env:HAB_VERSION = "2.0.504"
           & "${{ github.workspace }}\.expeditor\scripts\ensure-minimum-viable-hab.ps1"
           # Add hab to PATH
           $env:PATH = "C:\Program Files\Habitat;" + $env:PATH

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -29,9 +29,9 @@ $pkg_build_deps=@(
 function Invoke-Begin {
     write-output "*** Start Invoke-Begin Function"
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
-    if ($hab_version -lt [Version]"0.85.0" ) {
+    if ($hab_version -lt [Version]"2.0.504" ) {
         Write-Warning "(╯°□°）╯︵ ┻━┻ I CAN'T WORK UNDER THESE CONDITIONS!"
-        Write-Warning ":habicat: I'm being built with $hab_version. I need at least Hab 0.85.0, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."
+        Write-Warning ":habicat: I'm being built with $hab_version. I need at least Hab 2.0.504."
         throw "unable to build: required minimum version of Habitat not installed"
     } else {
         Write-BuildLine ":habicat: I think I have the version I need to build."


### PR DESCRIPTION
## Description
This PR changes the following with regards to habitat version management in CI:
- Only install habitat if minimum constraint (currently 2.0.504) is not met. version greater than equal to 2.0.504 will be allowed and will skip installation. This will ensure we are relying on habitat provided by agents while also providing us a way to upgrade if needed later without having to wait for CI update. 
- Update old habitat version constraint in windows plan file.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
