### PR TITLE
[Backport chef-18] Fix: Compliance Phase runs twice when reboot is scheduled during Chef Infra Client run

### DIFF
--- a/lib/chef/compliance/runner.rb
+++ b/lib/chef/compliance/runner.rb
@@ -72,13 +72,31 @@ class Chef
         logger.debug("#{self.class}##{__method__}: enabling Compliance Phase")
 
         report_with_interval
+        @compliance_phase_completed = true
       end
 
-      def run_failed(_exception, _run_status)
+      def run_failed(exception, _run_status)
         # If the run has failed because our own validation of compliance
         # phase configuration has failed, we don't want to submit a report
         # because we're still not configured correctly.
         return unless enabled? && @validation_passed
+
+        # A reboot exception is not a real failure — it is an expected outcome
+        # when a reboot resource fires :reboot_now.  In that case run_completed
+        # has already executed the Compliance Phase, so running it again here
+        # would produce a duplicate scan (and the second scan may be killed by
+        # the pending reboot).
+        if exception.is_a?(Chef::Exceptions::Reboot)
+          logger.debug("#{self.class}##{__method__}: skipping Compliance Phase because a reboot was requested")
+          return
+        end
+
+        # Guard against any other code path that might trigger both run_completed
+        # and run_failed in the same client run.
+        if @compliance_phase_completed
+          logger.debug("#{self.class}##{__method__}: skipping Compliance Phase because it has already run in this client run")
+          return
+        end
 
         logger.debug("#{self.class}##{__method__}: enabling Compliance Phase")
 

--- a/spec/unit/compliance/runner_spec.rb
+++ b/spec/unit/compliance/runner_spec.rb
@@ -293,6 +293,65 @@ describe Chef::Compliance::Runner do
     end
   end
 
+  describe "#run_completed" do
+    before do
+      allow(runner).to receive(:enabled?).and_return(true)
+      allow(runner).to receive(:report_with_interval)
+    end
+
+    it "runs the Compliance Phase" do
+      expect(runner).to receive(:report_with_interval)
+      runner.run_completed(node, nil)
+    end
+
+    it "sets @compliance_phase_completed to true after running" do
+      runner.run_completed(node, nil)
+      expect(runner.instance_variable_get(:@compliance_phase_completed)).to be true
+    end
+
+    it "does nothing when not enabled" do
+      allow(runner).to receive(:enabled?).and_return(false)
+      expect(runner).not_to receive(:report_with_interval)
+      runner.run_completed(node, nil)
+    end
+  end
+
+  describe "#run_failed" do
+    before do
+      allow(runner).to receive(:enabled?).and_return(true)
+      allow(runner).to receive(:report_with_interval)
+      runner.instance_variable_set(:@validation_passed, true)
+    end
+
+    it "runs the Compliance Phase on a normal failure" do
+      expect(runner).to receive(:report_with_interval)
+      runner.run_failed(StandardError.new("something went wrong"), nil)
+    end
+
+    it "skips the Compliance Phase when the exception is Chef::Exceptions::Reboot" do
+      expect(runner).not_to receive(:report_with_interval)
+      runner.run_failed(Chef::Exceptions::Reboot.new("rebooting"), nil)
+    end
+
+    it "skips the Compliance Phase when it has already run in this client run" do
+      runner.instance_variable_set(:@compliance_phase_completed, true)
+      expect(runner).not_to receive(:report_with_interval)
+      runner.run_failed(StandardError.new("something went wrong"), nil)
+    end
+
+    it "does nothing when not enabled" do
+      allow(runner).to receive(:enabled?).and_return(false)
+      expect(runner).not_to receive(:report_with_interval)
+      runner.run_failed(StandardError.new("something went wrong"), nil)
+    end
+
+    it "does nothing when validation has not passed" do
+      runner.instance_variable_set(:@validation_passed, false)
+      expect(runner).not_to receive(:report_with_interval)
+      runner.run_failed(StandardError.new("something went wrong"), nil)
+    end
+  end
+
   describe "interval running" do
     let(:tempdir) { Dir.mktmpdir("chef-compliance-tests") }
 


### PR DESCRIPTION
## Problem

When a cookbook resource uses `action :reboot_now`, the Compliance Phase executes **twice** in a single Chef Infra Client run. If the second execution outlasts the reboot delay timer, the OS reboots mid-scan and kills the `chef-client` process. This is reproducible on both Windows and RHEL.

---

## Root Cause — Detailed Analysis

### The Event Dispatch Architecture

`Chef::Compliance::Runner` extends `EventDispatch::Base` and subscribes to two lifecycle events:

| Event | Purpose |
|---|---|
| `run_completed` | Fired when the client run finishes successfully |
| `run_failed` | Fired when the client run raises an unhandled exception |

Under normal circumstances these are mutually exclusive — exactly one fires per client run. The bug arises because a **reboot request causes both to fire in sequence**.

### The Reboot Code Path (Before Fix)

**Step 1 — Reboot resource fires `:reboot_now`**

`lib/chef/resource/reboot.rb` executes:

```ruby
throw :end_client_run_early
```

This unwinds the converge block early. `Chef::Client#run` wraps the converge in `catch(:end_client_run_early)`, so execution resumes immediately after that catch block.

**Step 2 — `run_completed` fires → Compliance Phase runs (1st time)**

After the catch block, `Chef::Client#run` continues normally:

```ruby
run_completed_successfully
events.run_completed(node, run_status)   # <-- Compliance Phase #1
end_profiling
Chef::Platform::Rebooter.reboot_if_needed!(node)  # <-- raises next
```

**Step 3 — `Rebooter.reboot_if_needed!` raises `Chef::Exceptions::Reboot`**

`lib/chef/platform/rebooter.rb`:

```ruby
def reboot!(node)
  # ... shells out to OS shutdown command ...
  raise Chef::Exceptions::Reboot.new(msg)   # <-- raised after scheduling OS reboot
end
```

This exception propagates up and is caught by the outer `rescue Exception => run_error` block in `Chef::Client#run`.

**Step 4 — `run_failed` fires → Compliance Phase runs (2nd time)**

```ruby
rescue Exception => run_error
  run_status.exception = run_error
  run_failed
  events.run_failed(run_error, run_status)  # <-- Compliance Phase #2 (BUG)
  raise run_error
```

**Step 5 — Race condition with the reboot timer**

The OS reboot was already scheduled (e.g. `shutdown /r /t 60`) back in Step 3. The second Compliance Phase scan now races against that 60-second countdown. If InSpec takes longer than the remaining time, the OS reboots mid-scan and kills the process.

### Why Neither Handler Had a Guard

`Chef::Compliance::Runner#run_failed` only checked:

```ruby
return unless enabled? && @validation_passed
```

It had no awareness that:
- `run_completed` had already fired and completed the scan, or
- the exception it received was a deliberate, expected reboot signal rather than an actual error.

---

## Fix

Two complementary guards were added to `lib/chef/compliance/runner.rb`.

### Guard 1 — `Chef::Exceptions::Reboot` short-circuit in `run_failed`

`Chef::Exceptions::Reboot` is **not** an error. It is the intentional signalling mechanism used by `Rebooter` to inform the rest of the stack that a reboot has been scheduled. When this exception is the cause of `run_failed`, `run_completed` has already successfully executed the Compliance Phase. We simply skip:

```ruby
if exception.is_a?(Chef::Exceptions::Reboot)
  logger.debug("#{self.class}##{__method__}: skipping Compliance Phase because a reboot was requested")
  return
end
```

### Guard 2 — `@compliance_phase_completed` idempotency flag

`run_completed` now sets a flag after the scan finishes:

```ruby
def run_completed(_node, _run_status)
  return unless enabled?
  report_with_interval
  @compliance_phase_completed = true   # new
end
```

`run_failed` checks this flag as a belt-and-suspenders defence against any future code path that might fire both events in the same run:

```ruby
if @compliance_phase_completed
  logger.debug("#{self.class}##{__method__}: skipping Compliance Phase because it has already run in this client run")
  return
end
```

---

## Execution Sequence Comparison

**Before fix:**

```
converge
  └─ throw :end_client_run_early
       └─ run_completed fires  ──► Compliance Phase (1st)  ✓
       └─ Rebooter raises Chef::Exceptions::Reboot
            └─ run_failed fires ──► Compliance Phase (2nd) ✗  BUG
                 └─ OS reboot may kill 2nd scan mid-execution
```

**After fix:**

```
converge
  └─ throw :end_client_run_early
       └─ run_completed fires  ──► Compliance Phase (1st)  ✓
                                   @compliance_phase_completed = true
       └─ Rebooter raises Chef::Exceptions::Reboot
            └─ run_failed fires ──► is_a?(Chef::Exceptions::Reboot) → skip ✓
```

---

## Files Changed

| File | Change |
|---|---|
| `lib/chef/compliance/runner.rb` | Added `Chef::Exceptions::Reboot` check and `@compliance_phase_completed` flag |
| `spec/unit/compliance/runner_spec.rb` | Added 7 new tests covering both handlers |

---

## Tests Added

```
Chef::Compliance::Runner
  #run_completed
    runs the Compliance Phase
    sets @compliance_phase_completed to true after running
    does nothing when not enabled
  #run_failed
    runs the Compliance Phase on a normal failure
    skips when exception is Chef::Exceptions::Reboot
    skips when @compliance_phase_completed is already true
    does nothing when not enabled
    does nothing when validation has not passed
```

All 45 examples pass, 0 failures.

---

## Affected Platforms

Windows and RHEL (any platform where both a reboot resource and Compliance Phase profiles are present in the same client run).

---

_This work was completed with AI assistance following Progress AI policies._
