### PR TITLE
promote to base alongside base-2025

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -83,6 +83,7 @@ artifact_channels:
   - current
   - stable
   - base-2025
+  - base
 
 subscriptions:
   # These actions are taken, in order they are specified, anytime a Pull Request is merged.

--- a/.expeditor/scripts/base-2025-promote.sh
+++ b/.expeditor/scripts/base-2025-promote.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-echo "--- Promoting Habitat package from stable to base-2025"
+echo "--- Promoting Habitat package from stable to base-2025 and base"
 
 # Expeditor provides these environment variables automatically
 echo "Package Origin: ${EXPEDITOR_PKG_ORIGIN}"
@@ -22,5 +22,13 @@ export HAB_AUTH_TOKEN
 
 echo "--- Promoting ${EXPEDITOR_PKG_IDENT} to ${TARGET_CHANNEL} channel"
 hab pkg promote "${EXPEDITOR_PKG_IDENT}" "${TARGET_CHANNEL}"
+
+# TEMPORARY: This is a workaround for the scenario mentioned here since
+# longer term flow should be native support in expeditor for promoting
+# habitat packages.
+# Habitat 2.0+ uses 'base' as the default channel for chef origin packages.
+# Promote to 'base' alongside 'base-2025' to ensure packages are discoverable.
+echo "--- Promoting ${EXPEDITOR_PKG_IDENT} to base channel"
+hab pkg promote "${EXPEDITOR_PKG_IDENT}" "base"
 
 echo "--- Promotion completed successfully!"


### PR DESCRIPTION
## Description

This is a workaround for getting packages into `base` channel since that is the default for chef packages from hab 2.0.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
