### PR TITLE
Remove kitchen-dokken install to patch old kitchen-dokken

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -310,9 +310,6 @@ jobs:
           kitchen --version
           # chef-cli is needed for some kitchen operations
           sudo -E hab pkg install --binlink --force chef/chef-cli --channel unstable
-      - name: Install the kitchen-dokken driver latest to pick up docker fix
-        run: |
-          sudo -E hab pkg exec chef/chef-test-kitchen-enterprise gem install kitchen-dokken --version 2.22.2
       - name: Generate fake Habitat Origin Key
         run: |
           hab origin key generate "$HAB_ORIGIN"

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -386,9 +386,6 @@ jobs:
           sudo -E hab pkg install --binlink --force chef/chef-test-kitchen-enterprise/2.0.12 --channel unstable
           kitchen --version
           sudo -E hab pkg install --binlink --force chef/chef-cli --channel unstable
-      - name: Install the kitchen-dokken driver latest to pick up docker fix
-        run: |
-          sudo -E hab pkg exec chef/chef-test-kitchen-enterprise gem install kitchen-dokken --version 2.22.2
       - name: Generate fake Habitat Origin Key
         run: |
           hab origin key generate "$HAB_ORIGIN"

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           $env:HAB_VERSION = "2.0.504"
           & "${{ github.workspace }}\.expeditor\scripts\ensure-minimum-viable-hab.ps1"
-          $env:PATH = "C:\Program Files\Habitat;C:\hab\bin;C:\opscode\chef-workstation\bin;C:\opscode\chef-workstation\embedded\bin;" + $env:PATH
+          $env:PATH = "C:\Program Files\Habitat;C:\hab\bin;" + $env:PATH
           echo "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           hab license accept
           hab --version
@@ -107,9 +107,11 @@ jobs:
           Write-Host "Installed Chef Infra Client version:"
           chef-client --version
 
-      - name: Install Chef Workstation (for kitchen CLI)
+      - name: Install Test-Kitchen-Enterprise
         shell: pwsh
-        run: choco install -y chef-workstation
+        run: |
+          hab pkg install --binlink --force chef/chef-test-kitchen-enterprise/2.0.12 --channel unstable
+          kitchen --version
 
       - name: Kitchen Test
         shell: pwsh

--- a/kitchen-tests/cookbooks/end_to_end/metadata.rb
+++ b/kitchen-tests/cookbooks/end_to_end/metadata.rb
@@ -9,7 +9,7 @@ depends          "chrony"
 depends          "openssh", "< 3.0"
 depends          "resolver"
 depends          "users"
-depends          "git"
+depends          "git", "< 13.0.0"
 
 supports         "ubuntu"
 supports         "debian"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Stop installing kitchen-dokken for the docker patch as test-kitchen-enterprise version also has it, and we want to use the kitchen-dokken packaged with test-kitchen-enterprise.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
