### PR TITLE
[chef-18] Move, securely, to pull_request_target for kitchen (#15602)

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,7 +1,9 @@
 ---
 name: danger
 
-on: pull_request
+on: pull_request_target
+
+permissions: {}
 
 concurrency:
   group: danger-${{ github.ref }}
@@ -13,10 +15,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # oddly, needed to comment on PRs
+      issues: write
     steps:
+      # Note that we do NOT checkout the PR code, this is actually
+      # 'main', but Danger rules can still use the API to read the PR
       - uses: actions/checkout@v6
       - uses: danger/danger-js@13.0.5
         with:
           args: "--verbose --text-only -f"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_SECRET }}

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -2,21 +2,35 @@
 name: kitchen
 
 "on":
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - chef-18
 
+  # allow manual runs
+  workflow_dispatch:
+
 concurrency:
   group: kitchen-${{ github.ref }}
   cancel-in-progress: true
+
+permissions: {}
 
 defaults:
   run:
     working-directory: kitchen-tests
 
 jobs:
+  workflow_guard:
+    uses: chef/chef/.github/workflows/workflow-change-guard.yml@main
+    permissions:
+      contents: read
+
   win_x86_64:
+    needs: workflow_guard
+    permissions:
+      contents: read
+    # temporarily adding this back for inspec testing until we can get Kitchen Enterprise working for Windows.
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +50,9 @@ jobs:
       run: kitchen test end-to-end-${{ matrix.os }}
 
   mac_arm64:
+    needs: workflow_guard
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -48,9 +65,11 @@ jobs:
       CHEF_LICENSE: accept-no-persist
       KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
     steps:
-      - name: Check out code
+      - name: Checkout PR code
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
           clean: true
       - name: Install Chef
         uses: actionshub/chef-install@5.0.2
@@ -58,6 +77,11 @@ jobs:
         run: kitchen test end-to-end-${{ matrix.os }}
 
   docr_lnx_x86_64:
+    name: dokr_lnx_x86_64_hab
+    needs: workflow_guard
+    permissions:
+      contents: read
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -86,8 +110,12 @@ jobs:
       CHEF_LICENSE: accept-no-persist
       KITCHEN_LOCAL_YAML: kitchen.dokken.yml
     steps:
-      - name: Check out code
+      - name: Checkout PR code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          clean: true
       - name: Install Chef
         uses: actionshub/chef-install@5.0.2
       - name: Downgrade Docker to 28.0.4
@@ -140,7 +168,12 @@ jobs:
 #      CHEF_LICENSE: accept-no-persist
 #      KITCHEN_LOCAL_YAML: kitchen.linux.ci.yml
 #    steps:
-#      - uses: actions/checkout@v6
+#      - name: Checkout PR code
+#        uses: actions/checkout@v6
+#        with:
+#          ref: ${{ github.event.pull_request.head.sha }}
+#          persist-credentials: false
+#          clean: true
 #      - name: Install Vagrant and VirtualBox
 #        run: |
 #          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg

--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -1,0 +1,61 @@
+name: workflow-change-guard
+
+on:
+  workflow_call:
+    outputs:
+      workflow_changed:
+        description: "Whether workflow files were modified"
+        value: ${{ jobs.detect.outputs.workflow_changed }}
+
+permissions: {}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      workflow_changed: ${{ steps.diff.outputs.changed }}
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Fetch PR head
+        run: git fetch origin ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect workflow file changes
+        id: diff
+        run: |
+          set -euo pipefail
+
+          CHANGED=$(git diff --name-only \
+            ${{ github.event.pull_request.base.sha }} \
+            ${{ github.event.pull_request.head.sha }} \
+            | grep '^.github/workflows/' || true)
+
+          if [ -n "$CHANGED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Workflow files changed:"
+            echo "$CHANGED"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No workflow changes detected."
+          fi
+
+  approve:
+    needs: detect
+    if: (github.event_name == 'pull_request_target' && needs.detect.outputs.workflow_changed == 'true')
+    runs-on: ubuntu-latest
+
+    # Approval happens ONLY here
+    environment: workflow_guard
+
+    permissions: {}
+
+    steps:
+      - run: echo "Workflow changes approved"

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -63,5 +63,109 @@ if (danger.git.modified_files.includes("Gemfile.lock") &&
     }
 }
 
+// Check if PR description has been properly filled out
+async function checkPRDescription() {
+    const body = danger.github.pr.body || ""
+
+    if (danger.github.pr.user.type === "Bot") {
+        return
+    }
+
+    // Extract the Description section (between "Description" and "Related Issue" or "Types of changes" headers)
+    const descriptionMatch = body.match(/##?\s*Description\s*\n([\s\S]*?)(?=##?\s*(?:Related Issue|Types of changes)|$)/i)
+
+    if (!descriptionMatch) {
+        fail("❌ PR description is missing a 'Description' section. Please provide a description of your changes.")
+        return
+    }
+
+    const descriptionSection = descriptionMatch[1].trim()
+
+    // Remove HTML comments to get the actual content
+    const contentWithoutComments = descriptionSection.replace(/<!---.*?--->/gs, '').replace(/<!--.*?-->/gs, '').trim()
+
+    // Check if description still contains the template text
+    const templateText = "Describe your changes in detail, what problems does it solve?"
+    if (descriptionSection.includes(templateText)) {
+        fail("❌ PR description contains unedited template text. Please replace '<!--- Describe your changes in detail, what problems does it solve? --->' with an actual description of your changes.")
+        return
+    }
+
+    // Check if description is empty or too short (less than 20 characters of actual content)
+    if (contentWithoutComments.length < 20) {
+        fail("❌ PR description is too short or empty. Please provide a meaningful description of your changes (at least 20 characters).")
+    }
+}
+
+async function stickyWorkflowChangeReminder() {
+    if (danger.github.pr.user.type === "Bot") {
+        return
+    }
+
+    const workflowChanges = danger.git.modified_files.filter(file =>
+        file.startsWith(".github/workflows/")
+    )
+
+    if (workflowChanges.length === 0) {
+        return
+    }
+
+    const filesList = workflowChanges.map(f => `- \`${f}\``).join("\n")
+
+    const body = `
+### ⚠️ Workflow changes detected
+
+This PR modifies GitHub Actions workflow files:
+
+${filesList}
+
+**Reviewer reminder – please double-check for:**
+- [ ] Changes to **secrets usage** or new secret references
+- [ ] Workflow **permissions** increases (especially \`contents\`, \`actions\`, or \`id-token\`)
+- [ ] Any way secrets could be **exfiltrated** (logs, artifacts, uploads)
+
+These workflow changes are gated for manual approval — please review carefully before approving.
+`
+
+    const api = danger.github.api
+    const issue = danger.github.pr.number
+    const repo = danger.github.thisPR.repo
+    const owner = danger.github.thisPR.owner
+
+    const { data: comments } = await api.issues.listComments({
+        owner,
+        repo,
+        issue_number: issue,
+        per_page: 100,
+    })
+
+    const existing = comments.find(c =>
+        c.user?.login === "github-actions[bot]" &&
+        c.body?.includes("⚠️ Workflow changes detected")
+    )
+
+    if (existing) {
+        await api.issues.updateComment({
+            owner,
+            repo,
+            comment_id: existing.id,
+            body,
+        })
+    } else {
+        await api.issues.createComment({
+            owner,
+            repo,
+            issue_number: issue,
+            body,
+        })
+    }
+}
+
 // Check for chef gem version changes
 schedule(checkChefGemVersions())
+
+// Check PR description
+schedule(checkPRDescription())
+
+// Remind reviewers about workflow changes
+schedule(stickyWorkflowChangeReminder)


### PR DESCRIPTION
This is a backport of #15602 and #15886

Moves kitchen tests to a reasonably locked down version of
pull_request_target. See the above PRs for details.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
