### PR TITLE
chef_client_config - Added permission overrides for Chef-managed directories

### DIFF
--- a/lib/chef/resource/chef_client_config.rb
+++ b/lib/chef/resource/chef_client_config.rb
@@ -21,6 +21,14 @@ class Chef
   class Resource
     class ChefClientConfig < Chef::Resource
 
+      DIRECTORY_SPEC_DEFAULTS = {
+        config: { mode: "0750", inherits: :auto },
+        client_d: { mode: "0750", inherits: :auto },
+        logs: { mode: "0755", inherits: :auto },
+        cache: { mode: "0750", inherits: :auto },
+        backups: { mode: "0750", inherits: :auto },
+      }.freeze
+
       provides :chef_client_config, target_mode: true
       target_mode support: :full
 
@@ -77,12 +85,12 @@ class Chef
         chef_server_url 'https://chef.example.dmz'
         report_handlers [
           {
-           'class' => 'ReportHandler1Class',
-           'arguments' => ["'FirstArgument'", "'SecondArgument'"],
+            'class' => 'ReportHandler1Class',
+            'arguments' => ["'FirstArgument'", "'SecondArgument'"],
           },
           {
-           'class' => 'ReportHandler2Class',
-           'arguments' => ["'FirstArgument'", "'SecondArgument'"],
+            'class' => 'ReportHandler2Class',
+            'arguments' => ["'FirstArgument'", "'SecondArgument'"],
           },
         ]
       end
@@ -95,6 +103,48 @@ class Chef
         chef_server_url 'https://chef.example.dmz'
         data_collector_server_url 'https://automate.example.dmz'
         data_collector_token 'TEST_TOKEN_TEST'
+      end
+      ```
+
+      **Set Linux directory ownership and modes**:
+
+      ```ruby
+      chef_client_config 'Create client.rb' do
+        chef_server_url 'https://chef.example.dmz'
+        user 'root'
+        group 'root'
+        file_cache_path '/var/chef/cache'
+        file_backup_path '/var/chef/backups'
+        log_location '/var/log/chef/client.log'
+        directory_specs(
+          config: { owner: 'root', group: 'root', mode: '0700' },
+          client_d: { owner: 'root', group: 'root', mode: '0700' },
+          logs: { owner: 'root', group: 'root', mode: '0750' },
+          cache: { owner: 'root', group: 'root', mode: '0750' },
+          backups: { owner: 'root', group: 'root', mode: '0750' }
+        )
+      end
+      ```
+
+      **Set Windows directory inheritance and rights**:
+
+      ```ruby
+      chef_client_config 'Create client.rb' do
+        chef_server_url 'https://chef.example.dmz'
+        config_directory 'C:/chef'
+        file_cache_path 'C:/chef/cache'
+        file_backup_path 'C:/chef/backups'
+        log_location 'C:/chef/log/client.log'
+        directory_specs(
+          config: {
+            owner: 'Administrators',
+            inherits: false,
+            rights: {
+              'Administrators' => :full_control,
+              'SYSTEM' => :full_control,
+            },
+          }
+        )
       end
       ```
       DOC
@@ -120,7 +170,7 @@ class Chef
       property :config_directory, String,
         description: "The directory to store the client.rb in.",
         default: ChefConfig::Config.etc_chef_dir,
-        default_description: "`/etc/chef/` on *nix-like systems and `C:\\chef\\` on Windows"
+        default_description: '`/etc/chef/` on *nix-like systems and `C:\\chef\\` on Windows'
 
       property :user, String,
         description: "The user that should own the client.rb file and the configuration directory if it needs to be created. Note: The configuration directory will not be created if it already exists, which allows you to further control the setup of that directory outside of this resource."
@@ -212,7 +262,7 @@ class Chef
         default: []
 
       property :rubygems_url, [String, Array],
-        description: "The location to source rubygems. It can be set to a string or array of strings for URIs to set as rubygems sources. This allows individuals to setup an internal mirror of rubygems for “airgapped” environments.",
+        description: 'The location to source rubygems. It can be set to a string or array of strings for URIs to set as rubygems sources. This allows individuals to setup an internal mirror of rubygems for "airgapped" environments.',
         introduced: "17.11"
 
       property :exception_handlers, Array,
@@ -255,21 +305,83 @@ class Chef
         description: "The data collector token to interact with the data collector server URL (Automate). Note: If possible, use Chef Infra Server to do all data collection reporting, as this removes the need to distribute tokens to individual nodes.",
         introduced: "17.8"
 
-      action :create, description: "Create a client.rb config file and folders for configuring #{ChefUtils::Dist::Infra::PRODUCT}." do
-        [
-          new_resource.config_directory,
-          (::File.dirname(new_resource.log_location) if new_resource.log_location.is_a?(String) && !%w{STDOUT STDERR}.include?(new_resource.log_location) && !new_resource.log_location.empty?),
-          new_resource.file_backup_path,
-          new_resource.file_cache_path,
-          ::File.join(new_resource.config_directory, "client.d"),
-          (::File.dirname(new_resource.pid_file) unless new_resource.pid_file.nil?),
-        ].compact.each do |dir_path|
+      property :directory_specs, Hash,
+        description: <<~DESC,
+          Permission overrides for Chef-managed directories.
+          This must be a hash of hashes: top-level keys are directory names, values are per-directory option hashes.
 
-          directory dir_path do
-            user new_resource.user unless new_resource.user.nil?
-            group new_resource.group unless new_resource.group.nil?
-            mode dir_path == ::File.dirname(new_resource.log_location.to_s) ? "0755" : "0750"
-            recursive true
+          Use this property like:
+            directory_specs(
+              config: { owner: "root", group: "root", mode: "0700" },
+              client_d: { owner: "root", group: "root", mode: "0700" },
+              logs: { owner: "root", group: "root", mode: "0700" },
+              cache: { owner: "root", group: "root", mode: "0700" },
+              backups: { owner: "root", group: "root", mode: "0700" }
+            )
+
+          Directory keys: :config, :client_d, :logs, :cache, :backups
+          Override keys: :owner, :group, :mode, :rights, :inherits (:rights and :inherits are Windows-only)
+        DESC
+        callbacks: {
+          "keys must be one of :config, :client_d, :logs, :cache, :backups" => lambda { |v|
+            valid_keys = %i{config client_d logs cache backups}
+            v.keys.all? { |k| valid_keys.include?(k) }
+          },
+          "values must be a hash with keys only from :owner, :group, :mode, :rights, :inherits" => lambda { |v|
+            valid_inner_keys = %i{owner group mode rights inherits}
+            v.values.all? { |value| value.is_a?(Hash) && value.keys.all? { |k| valid_inner_keys.include?(k) } }
+          },
+        },
+        default: DIRECTORY_SPEC_DEFAULTS,
+        coerce: proc { |v|
+          DIRECTORY_SPEC_DEFAULTS.merge(v) do |_key, base, override|
+            override.is_a?(Hash) ? base.merge(override) : override
+          end
+        }
+
+      property :client_rb_mode, String,
+        description: "The mode to set on the client.rb file that is written out by this resource (e.g., 0600).",
+        default: "0640"
+
+      action :create, description: "Create a client.rb config file and folders for configuring #{ChefUtils::Dist::Infra::PRODUCT}." do
+        # The logs directory is derived from log_location, which may be a symbol
+        # or a stream name (STDOUT/STDERR) rather than a file path. Only raise if
+        # the user customized logs specs but log_location is not a usable file path.
+        if new_resource.directory_specs[:logs] != DIRECTORY_SPEC_DEFAULTS[:logs] && log_directory.nil?
+          raise ArgumentError, "Invalid directory_specs: logs requires :logs (file path)"
+        end
+
+        # Build path map for each managed directory. For cache and backups, fall
+        # back to ChefConfig defaults when not explicitly set so that directory_specs
+        # overrides are applied even if the user didn't configure a custom path in client.rb.
+        spec_paths = {
+          config: new_resource.config_directory,
+          client_d: ::File.join(new_resource.config_directory, "client.d"),
+          logs: log_directory,
+          cache: new_resource.file_cache_path || ChefConfig::Config.file_cache_path,
+          backups: new_resource.file_backup_path || ChefConfig::Config.file_backup_path,
+        }
+
+        # Build directory specs based on user input and defaults
+        specs = {}
+        new_resource.directory_specs.each do |key, overrides|
+          path = spec_paths[key]
+          next if path.nil?
+
+          specs[key] = DirectorySpec.new(
+            path: path,
+            owner: overrides[:owner] || new_resource.user,
+            group: overrides[:group] || new_resource.group,
+            mode: overrides[:mode],
+            rights: overrides[:rights],
+            inherits: overrides[:inherits]
+          )
+        end
+
+        # Converge directories
+        specs.each_value do |spec|
+          directory spec.path do
+            spec.apply(self)
           end
         end
 
@@ -310,7 +422,7 @@ class Chef
             data_collector_server_url: new_resource.data_collector_server_url,
             data_collector_token: new_resource.data_collector_token
           )
-          mode "0640"
+          mode new_resource.client_rb_mode
           action :create
         end
       end
@@ -333,6 +445,60 @@ class Chef
           handler_data = handler_property.map do |handler|
             "#{handler["class"]}.new(#{handler["arguments"].join(",")})"
           end
+        end
+
+        # A helper class to encapsulate directory spec data and application logic for both *nix and Windows.
+        # This allows us to keep the logic for how to apply permissions to directories in one place and makes it easier to test.
+        class DirectorySpec
+          attr_reader :path, :owner, :group, :mode, :rights, :inherits
+
+          def initialize(path:, owner: nil, group: nil, mode: nil, rights: nil, inherits: :auto)
+            @path   = path
+            @owner  = owner
+            @group  = group
+            @mode   = mode
+            @rights = rights
+            @inherits = inherits
+          end
+
+          def windows?
+            Chef::Platform.windows?
+          end
+
+          def apply(resource)
+            resource.recursive true
+
+            if windows?
+              if rights && !rights.empty?
+                resource.inherits(inherits == :auto ? false : inherits)
+
+                rights.each do |principal, permission|
+                  resource.rights(permission, principal)
+                end
+              else
+                # Ensure defaults can restore inherited ACL behavior after custom rights were applied.
+                resource.inherits(inherits == :auto ? true : inherits)
+                resource.mode(mode) if mode
+              end
+
+              resource.owner(owner) if owner
+            else
+              resource.owner(owner) if owner
+              resource.group(group) if group
+              resource.mode(mode) if mode
+            end
+          end
+        end
+
+        # A helper method to determine the directory to apply log permissions to based on the log_location property.
+        # If log_location is a file path, this returns the directory containing that file.
+        # If log_location is not a file path (e.g., it's a symbol for syslog or win_evt, or it's STDOUT/STDERR),
+        # this returns nil since there is no directory to apply permissions to.
+        def log_directory
+          return unless new_resource.log_location.is_a?(String)
+          return if %w{STDOUT STDERR}.include?(new_resource.log_location)
+
+          ::File.dirname(new_resource.log_location)
         end
       end
     end

--- a/spec/unit/resource/chef_client_config_spec.rb
+++ b/spec/unit/resource/chef_client_config_spec.rb
@@ -362,6 +362,7 @@ describe Chef::Resource::ChefClientConfig do
     end
 
     it "passes user and group from the resource to all managed directories without directory_specs" do
+      allow(Chef::Platform).to receive(:windows?).and_return(false)
       resource.config_directory("/etc/chef")
       resource.user("chefuser")
       resource.group("chefgroup")

--- a/spec/unit/resource/chef_client_config_spec.rb
+++ b/spec/unit/resource/chef_client_config_spec.rb
@@ -142,4 +142,353 @@ describe Chef::Resource::ChefClientConfig do
       expect { resource.rubygems_url(["https://rubygems.east.example.com", "https://rubygems.west.example.com"]) }.not_to raise_error
     end
   end
+
+  describe "directory_specs property" do
+    it "has defaults for all managed directory specs" do
+      expect(resource.directory_specs).to eql(
+        config: { mode: "0750", inherits: :auto },
+        client_d: { mode: "0750", inherits: :auto },
+        logs: { mode: "0755", inherits: :auto },
+        cache: { mode: "0750", inherits: :auto },
+        backups: { mode: "0750", inherits: :auto }
+      )
+    end
+
+    it "merges overrides with defaults" do
+      resource.directory_specs(config: { owner: "chefuser", mode: "0700" })
+
+      expect(resource.directory_specs[:config]).to eql(mode: "0700", inherits: :auto, owner: "chefuser")
+      expect(resource.directory_specs[:client_d]).to eql(mode: "0750", inherits: :auto)
+      expect(resource.directory_specs[:logs]).to eql(mode: "0755", inherits: :auto)
+      expect(resource.directory_specs[:cache]).to eql(mode: "0750", inherits: :auto)
+      expect(resource.directory_specs[:backups]).to eql(mode: "0750", inherits: :auto)
+    end
+
+    it "raises if a nested override key is not supported" do
+      expect { resource.directory_specs(config: { inherit: true }) }.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+
+    it "raises if a nested override value is not a hash" do
+      expect { resource.directory_specs(config: "0750") }.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+
+    it "accepts supported nested override keys" do
+      expect {
+        resource.directory_specs(
+          config: {
+            owner: "root",
+            group: "root",
+            mode: "0700",
+            rights: { "Administrators" => :full_control },
+            inherits: false,
+          }
+        )
+      }.not_to raise_error
+    end
+  end
+
+  describe "create action directory behavior" do
+    before do
+      resource.chef_server_url("https://chef.example.dmz")
+    end
+
+    def stub_template_resource
+      allow(provider).to receive(:template) do |_path, &block|
+        template_resource = double("template").as_null_object
+        allow(template_resource).to receive(:new_resource).and_return(resource)
+        template_resource.instance_exec(&block) if block
+      end
+    end
+
+    def capture_directory_specs
+      captured = {}
+
+      allow(provider).to receive(:directory) do |path, &block|
+        dir_resource = double("directory")
+        allow(dir_resource).to receive(:recursive) { |value| captured[path] ||= {}; captured[path][:recursive] = value }
+        allow(dir_resource).to receive(:owner) { |value| captured[path] ||= {}; captured[path][:owner] = value }
+        allow(dir_resource).to receive(:group) { |value| captured[path] ||= {}; captured[path][:group] = value }
+        allow(dir_resource).to receive(:mode) { |value| captured[path] ||= {}; captured[path][:mode] = value }
+        allow(dir_resource).to receive(:inherits) { |value| captured[path] ||= {}; captured[path][:inherits] = value }
+        allow(dir_resource).to receive(:rights) do |permission, principal|
+          captured[path] ||= {}
+          captured[path][:rights] ||= []
+          captured[path][:rights] << [ permission, principal ]
+        end
+
+        dir_resource.instance_exec(&block) if block
+      end
+
+      captured
+    end
+
+    it "applies directory_specs overrides for mode, owner, and group" do
+      allow(Chef::Platform).to receive(:windows?).and_return(false)
+      resource.user("chefuser")
+      resource.group("chefgroup")
+      resource.config_directory("/etc/chef")
+      resource.file_cache_path("/var/chef/cache")
+      resource.file_backup_path("/var/chef/backups")
+      resource.log_location("/var/log/chef/client.log")
+      resource.directory_specs(
+        config: { mode: "0700" },
+        cache: { owner: "cache_user", group: "cache_group", mode: "0710" }
+      )
+
+      stub_template_resource
+      captured = capture_directory_specs
+
+      provider.run_action(:create)
+
+      expect(captured["/etc/chef"][:mode]).to eql("0700")
+      expect(captured["/etc/chef"][:owner]).to eql("chefuser")
+      expect(captured["/etc/chef"][:group]).to eql("chefgroup")
+
+      expect(captured["/var/chef/cache"][:mode]).to eql("0710")
+      expect(captured["/var/chef/cache"][:owner]).to eql("cache_user")
+      expect(captured["/var/chef/cache"][:group]).to eql("cache_group")
+
+      expect(captured["/var/chef/backups"][:mode]).to eql("0750")
+      expect(captured["/var/log/chef"][:mode]).to eql("0755")
+    end
+
+    it "applies inherits override on windows" do
+      resource.config_directory("C:/chef")
+      resource.directory_specs(config: { inherits: false })
+      stub_template_resource
+      captured = capture_directory_specs
+      allow(Chef::Platform).to receive(:windows?).and_return(true)
+
+      provider.run_action(:create)
+
+      expect(captured["C:/chef"][:inherits]).to eql(false)
+      expect(captured["C:/chef/client.d"][:inherits]).to eql(true)
+    end
+
+    it "raises when overriding logs without log_location file path" do
+      resource.directory_specs(logs: { mode: "0700" })
+
+      expect { provider.run_action(:create) }
+        .to raise_error(ArgumentError, "Invalid directory_specs: logs requires :logs (file path)")
+    end
+
+    it "applies rights and defaults inherits to false on windows when rights are specified" do
+      resource.config_directory("C:/chef")
+      resource.directory_specs(
+        config: {
+          rights: { "Administrators" => :full_control, "SYSTEM" => :full_control },
+        }
+      )
+      stub_template_resource
+      captured = capture_directory_specs
+      allow(Chef::Platform).to receive(:windows?).and_return(true)
+
+      provider.run_action(:create)
+
+      expect(captured["C:/chef"][:inherits]).to eql(false)
+      expect(captured["C:/chef"][:rights]).to include([:full_control, "Administrators"])
+      expect(captured["C:/chef"][:rights]).to include([:full_control, "SYSTEM"])
+    end
+
+    it "applies mode on windows when no rights are specified" do
+      resource.config_directory("C:/chef")
+      resource.directory_specs(config: { mode: "0700" })
+      stub_template_resource
+      captured = capture_directory_specs
+      allow(Chef::Platform).to receive(:windows?).and_return(true)
+
+      provider.run_action(:create)
+
+      expect(captured["C:/chef"][:mode]).to eql("0700")
+    end
+
+    it "uses a custom client_rb_mode when specified" do
+      resource.config_directory("/etc/chef")
+      resource.client_rb_mode("0600")
+      captured_mode = nil
+      allow(provider).to receive(:template) do |_path, &block|
+        t = double("template").as_null_object
+        allow(t).to receive(:mode) { |v| captured_mode = v }
+        allow(t).to receive(:new_resource).and_return(resource)
+        t.instance_exec(&block) if block
+      end
+      capture_directory_specs
+
+      provider.run_action(:create)
+
+      expect(captured_mode).to eql("0600")
+    end
+  end
+
+  # Backwards compatibility tests verify that the introduction of directory_specs
+  # and client_rb_mode does not change the permissions applied when neither
+  # property is set. The original resource managed directories with:
+  #   - mode "0750" for config, client.d, cache, and backup directories
+  #   - mode "0755" for the log directory (when log_location is a file path)
+  #   - mode "0640" hardcoded on the client.rb template
+  #   - user/group taken directly from the resource's user/group properties
+  #
+  # The cache and backup directories are always managed using ChefConfig defaults
+  # as a fallback, since the Chef Infra Client uses those paths regardless of
+  # whether file_cache_path/file_backup_path are configured in client.rb.
+  describe "backwards compatibility" do
+    before do
+      resource.chef_server_url("https://chef.example.dmz")
+    end
+
+    def capture_directories_and_template
+      captured_dirs = {}
+      captured_template = {}
+
+      allow(provider).to receive(:directory) do |path, &block|
+        dir_resource = double("directory")
+        allow(dir_resource).to receive(:recursive)
+        allow(dir_resource).to receive(:owner) { |v| captured_dirs[path] ||= {}; captured_dirs[path][:owner] = v }
+        allow(dir_resource).to receive(:group) { |v| captured_dirs[path] ||= {}; captured_dirs[path][:group] = v }
+        allow(dir_resource).to receive(:mode) { |v| captured_dirs[path] ||= {}; captured_dirs[path][:mode] = v }
+        allow(dir_resource).to receive(:inherits) { |v| captured_dirs[path] ||= {}; captured_dirs[path][:inherits] = v }
+        allow(dir_resource).to receive(:rights)
+        dir_resource.instance_exec(&block) if block
+      end
+
+      allow(provider).to receive(:template) do |path, &block|
+        t = double("template").as_null_object
+        allow(t).to receive(:mode) { |v| captured_template[:mode] = v }
+        allow(t).to receive(:new_resource).and_return(resource)
+        t.instance_exec(&block) if block
+      end
+
+      [captured_dirs, captured_template]
+    end
+
+    it "passes user and group from the resource to all managed directories without directory_specs" do
+      resource.config_directory("/etc/chef")
+      resource.user("chefuser")
+      resource.group("chefgroup")
+      resource.file_cache_path("/var/chef/cache")
+      resource.file_backup_path("/var/chef/backup")
+      resource.log_location("/var/log/chef/client.log")
+      dirs, = capture_directories_and_template
+
+      provider.run_action(:create)
+
+      %w{/etc/chef /etc/chef/client.d /var/chef/cache /var/chef/backup /var/log/chef}.each do |dir|
+        expect(dirs[dir][:owner]).to eql("chefuser"), "expected #{dir} owner to be chefuser"
+        expect(dirs[dir][:group]).to eql("chefgroup"), "expected #{dir} group to be chefgroup"
+      end
+    end
+
+    it "keeps default directory behavior when directory_specs is not provided" do
+      allow(ChefConfig::Config).to receive(:file_cache_path).and_return("/var/chef/cache")
+      allow(ChefConfig::Config).to receive(:file_backup_path).and_return("/var/chef/backup")
+      resource.config_directory("/etc/chef")
+      dirs, = capture_directories_and_template
+
+      provider.run_action(:create)
+
+      expect(dirs).to include("/etc/chef")
+      expect(dirs).to include("/etc/chef/client.d")
+      # The Chef Infra Client uses these paths by default regardless of whether
+      # file_cache_path/file_backup_path are set in client.rb. The resource
+      # falls back to ChefConfig defaults so that directory_specs overrides
+      # (owner, mode, etc.) are always applied to the paths the client will use.
+      expect(dirs).to include("/var/chef/cache")
+      expect(dirs).to include("/var/chef/backup")
+      expect(dirs["/etc/chef"][:mode]).to eql("0750")
+      expect(dirs["/etc/chef/client.d"][:mode]).to eql("0750")
+      expect(dirs["/var/chef/cache"][:mode]).to eql("0750")
+      expect(dirs["/var/chef/backup"][:mode]).to eql("0750")
+    end
+
+    it "uses mode 0755 for the log directory by default when log_location is a file path" do
+      resource.config_directory("/etc/chef")
+      resource.log_location("/var/log/chef/client.log")
+      dirs, = capture_directories_and_template
+
+      provider.run_action(:create)
+
+      expect(dirs["/var/log/chef"][:mode]).to eql("0755")
+    end
+
+    it "does not manage a log directory when log_location is a symbol or stream" do
+      allow(ChefConfig::Config).to receive(:file_cache_path).and_return("/var/chef/cache")
+      allow(ChefConfig::Config).to receive(:file_backup_path).and_return("/var/chef/backup")
+      resource.config_directory("/etc/chef")
+
+      [:syslog, :win_evt, "STDOUT", "STDERR"].each do |location|
+        resource.log_location(location)
+        dirs, = capture_directories_and_template
+
+        provider.run_action(:create)
+
+        expect(dirs.keys.none? { |k| k.include?("log") }).to be(true),
+          "expected no log directory to be managed for log_location #{location.inspect}, got: #{dirs.keys.inspect}"
+      end
+    end
+
+    it "writes client.rb with mode 0640, preserving the original hardcoded value" do
+      resource.config_directory("/etc/chef")
+      _, template = capture_directories_and_template
+
+      provider.run_action(:create)
+
+      expect(template[:mode]).to eql("0640")
+    end
+
+    context "on Windows" do
+      before do
+        allow(Chef::Platform).to receive(:windows?).and_return(true)
+      end
+
+      it "sets inherits to true on all directories by default (no rights specified)" do
+        resource.config_directory("C:/chef")
+        resource.file_cache_path("C:/chef/cache")
+        resource.file_backup_path("C:/chef/backup")
+        dirs, = capture_directories_and_template
+
+        provider.run_action(:create)
+
+        %w{C:/chef C:/chef/client.d C:/chef/cache C:/chef/backup}.each do |dir|
+          expect(dirs[dir][:inherits]).to eql(true), "expected #{dir} inherits to be true"
+        end
+      end
+
+      it "passes owner from resource user to Windows directories without directory_specs" do
+        resource.config_directory("C:/chef")
+        resource.user("Administrator")
+        resource.file_cache_path("C:/chef/cache")
+        resource.file_backup_path("C:/chef/backup")
+        resource.log_location("C:/chef/log/client.log")
+        dirs, = capture_directories_and_template
+
+        provider.run_action(:create)
+
+        %w{C:/chef C:/chef/client.d C:/chef/cache C:/chef/backup C:/chef/log}.each do |dir|
+          expect(dirs[dir][:owner]).to eql("Administrator"), "expected #{dir} owner to be Administrator"
+        end
+      end
+
+      it "does not set group on Windows directories without directory_specs" do
+        resource.config_directory("C:/chef")
+        resource.group("Administrators")
+        dirs, = capture_directories_and_template
+
+        provider.run_action(:create)
+
+        # On Windows, group ownership is not set on directories - only owner is.
+        # The original resource set group on Windows, but Chef's directory resource
+        # on Windows does not use the group property.
+        expect(dirs["C:/chef"][:group]).to be_nil
+      end
+
+      it "writes client.rb with mode 0640 on Windows, preserving the original hardcoded value" do
+        resource.config_directory("C:/chef")
+        _, template = capture_directories_and_template
+
+        provider.run_action(:create)
+
+        expect(template[:mode]).to eql("0640")
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

### chef_client_config: Add directory_specs and client_rb_mode properties

- Added `directory_specs` property to allow per-directory permission overrides
  for all Chef-managed directories (`:config`, `:client_d`, `:logs`, `:cache`,
  `:backups`). Supports `:owner`, `:group`, `:mode` on all platforms and
  `:rights`, `:inherits` on Windows. Unspecified directories continue to use
  existing defaults.
- Added `client_rb_mode` property to configure the file mode of the generated
  `client.rb` file. Defaults to `"0640"` preserving existing behavior.
- Cache and backup directories now fall back to `ChefConfig` defaults when
  `file_cache_path`/`file_backup_path` are not explicitly set, ensuring
  `directory_specs` overrides are always applied to the paths Chef Infra Client
  uses at runtime.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
