### PR TITLE
Disable chrony kitchen-tests on AlmaLinux 10 and document branching conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,7 +96,13 @@ When implementing tasks in this repository, follow this comprehensive workflow:
 
 When prompted to create a PR:
 
-- Use GitHub CLI (`gh`) to create a branch named after the Jira ID
+- Use GitHub CLI (`gh`) for branch and PR operations
+- Branch naming:
+  - Ask for preferred developer initials the first time encountered
+  - If a Jira ID is provided, include it in the branch name
+  - For work based on `main`, create branches as `{dev-initials}/{jira-id}-{short-description}` (or `{dev-initials}/{short-description}` when no Jira ID exists)
+  - For work based on a release branch (for example `chef-18`), create branches as `{dev-initials}/{release-branch}-{jira-id}-{short-description}` (or `{dev-initials}/{release-branch}-{short-description}` when no Jira ID exists)
+- Create commits with DCO sign-off (`git commit -s`)
 - Push changes to the new branch
 - Create a PR with:
   - **Title**: Clear, descriptive title referencing the Jira ID
@@ -125,12 +131,22 @@ When working with Jira integration:
 ### Branch and PR Management
 
 ```bash
-# Create and switch to new branch (using Jira ID as branch name)
+# Create and switch to a new branch from main
 gh repo view --json defaultBranch | jq -r '.defaultBranch' # Check default branch
-git checkout -b JIRA-123 # Replace with actual Jira ID
+git checkout main
+git pull --ff-only origin main
+git checkout -b tp/JIRA-123-short-description
+
+# Create and switch to a new branch from a release branch (example: chef-18)
+git checkout chef-18
+git pull --ff-only origin chef-18
+git checkout -b tp/chef-18-JIRA-123-short-description
+
+# Commit with DCO sign-off
+git commit -s -m "JIRA-123: Brief description"
 
 # Push changes and create PR
-git push origin JIRA-123
+git push origin tp/JIRA-123-short-description
 gh pr create --title "JIRA-123: Brief description" \
   --body "<h2>Summary</h2><p>Description of changes</p>"
 ```

--- a/cspell.json
+++ b/cspell.json
@@ -42,6 +42,7 @@
     "allowlists",
     "allowselfservice",
     "alnum",
+    "almalinux",
     "alwayslastline",
     "amazonlinux",
     "Anson",

--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -69,7 +69,7 @@ end
 
 include_recipe "::_packages"
 
-unless amazon? && node["platform_version"] >= "2023" # TODO: look into chrony service issue
+unless (amazon? && node["platform_version"] >= "2023") || (platform?("almalinux") && node["platform_version"].to_i >= 10) # TODO: look into chrony service issue
   include_recipe value_for_platform(
     opensuseleap: { "default" => "ntp" },
     amazon: { "2" => "ntp" },


### PR DESCRIPTION
<h2>Summary</h2><ul><li>Disable chrony recipe inclusion in kitchen-tests for AlmaLinux 10 while preserving existing Amazon Linux 2023 exemption.</li><li>Update global Copilot instructions with branch naming conventions for main and release branches, including Jira-aware naming.</li><li>Document DCO sign-off requirement in PR workflow guidance.</li></ul><p>This work was completed with AI assistance following Progress AI policies.</p>