### PR TITLE
Document CVE PR label requirements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -107,6 +107,7 @@ When prompted to create a PR:
 - Create a PR with:
   - **Title**: Clear, descriptive title referencing the Jira ID
   - **Description**: HTML-formatted summary of changes made
+- For CVE fixes, add the `CVE` label and prefix the PR description with `[CVE]`
 - All operations should be performed on the local repository
 
 ## MCP Server Integration


### PR DESCRIPTION
<h2>Summary</h2><ul><li>Add the <code>CVE</code> label and <code>[CVE]</code> prefix guidance for PRs that fix CVEs.</li></ul><p>This work was completed with AI assistance following Progress AI policies.</p>