### PR TITLE
Obvious fix: Fix sysctl resource idempotency

### DIFF
--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -219,7 +219,7 @@ class Chef
       def get_sysctld_value(key)
         raise unless ::TargetIO::File.exist?("/etc/sysctl.d/99-chef-#{key.tr("/", ".")}.conf")
 
-        k, v = ::Target_IO::File.read("/etc/sysctl.d/99-chef-#{key.tr("/", ".")}.conf").match(/(.*) = (.*)/).captures
+        k, v = ::TargetIO::File.read("/etc/sysctl.d/99-chef-#{key.tr("/", ".")}.conf").match(/(.*) = (.*)/).captures
         raise "Unknown sysctl key!" if k.nil?
         raise "Unknown sysctl value!" if v.nil?
 


### PR DESCRIPTION
There's an unnecessary underscore in the systctl resource when loading the current value that causes it to execute each run.

## Related Issue
Closes #15786

## Replication

```
cinc (19.3.14)> ::Target_IO::File.read("/tmp/sdfsdf")
(irb):1:in '<main>': uninitialized constant Target_IO (NameError)
	from <internal:kernel>:168:in 'Kernel#loop'
	from /opt/cinc/embedded/lib/ruby/gems/3.4.0/gems/chef-19.3.14/lib/chef/shell.rb:102:in 'block in Shell.start'
	from /opt/cinc/embedded/lib/ruby/gems/3.4.0/gems/chef-19.3.14/lib/chef/shell.rb:101:in 'Kernel#catch'
	from /opt/cinc/embedded/lib/ruby/gems/3.4.0/gems/chef-19.3.14/lib/chef/shell.rb:101:in 'Shell.start'
	from /opt/cinc/embedded/lib/ruby/gems/3.4.0/gems/chef-bin-19.3.14/bin/cinc-shell:30:in '<top (required)>'
	from /usr/bin/cinc-shell:208:in 'Kernel.load'
	from /usr/bin/cinc-shell:208:in '<main>'
```
vs
```
cinc (19.3.14)> ::TargetIO::File.read("/tmp/sdfsdf")
 => "" 
```

