### PR TITLE
Fixing chocolatey download bug (cherry-pick from chef-18 PR #15925)

### DIFF
--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -1,3 +1,6 @@
+require "cgi" unless defined?(CGI)
+require "uri" unless defined?(URI)
+
 class Chef
   class Resource
     class ChocolateyInstaller < Chef::Resource
@@ -91,6 +94,25 @@ class Chef
         Gem::Version.new(get_choco_version)
       end
 
+      def download_url_path
+        return download_url if download_url.match?(%r{^[a-zA-Z]:[\\/]}) || download_url.start_with?("\\\\")
+
+        ::URI.parse(download_url).path
+      rescue URI::InvalidURIError
+        download_url
+      end
+
+      def download_url_script?
+        ::File.extname(download_url_path).casecmp(".ps1") == 0
+      end
+
+      def download_destination
+        filename = ::File.basename(::CGI.unescape(download_url_path.to_s))
+        filename = "chocolatey.nupkg" if filename.empty? || ["/", "\\", "."].include?(filename)
+
+        Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), filename)
+      end
+
       def define_resource_requirements
         requirements.assert(:install, :upgrade).each do |a|
           a.assertion do
@@ -131,16 +153,28 @@ class Chef
         # note that Invoke-Expression is being called on the downloaded script (outer parens),
         # not triggering the script download (inner parens)
         converge_if_changed do
-          powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))").error!
+          if new_resource.download_url
+            Chef::Log.info("Using custom download URL for Chocolatey installation: #{new_resource.download_url}")
+            # If it's a PowerShell script, execute it directly (original behavior)
+            if download_url_script?
+              powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{new_resource.download_url}'))").error!
+            else
+              # Assume it's a direct link to a nupkg or other file and handle accordingly
+              destination = download_destination
+
+              powershell_exec("Invoke-WebRequest '#{new_resource.download_url}' -OutFile '#{destination}'").error!
+              Chef::Log.info("Downloaded file from #{new_resource.download_url} to #{destination}")
+            end
+          else
+            powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))").error!
+          end
         end
       end
 
       action :upgrade, description: "Upgrades the Chocolatey package manager" do
-        if new_resource.chocolatey_version
-          proposed_version = Gem::Version.new(new_resource.chocolatey_version)
-        else
-          proposed_version = nil
-        end
+        proposed_version = if new_resource.chocolatey_version
+                             Gem::Version.new(new_resource.chocolatey_version)
+                           end
 
         if new_resource.download_url
           powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value #{new_resource.download_url}")

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -21,6 +21,9 @@ describe Chef::Resource::ChocolateyInstaller do
   include RecipeDSLHelper
 
   let(:resource) { Chef::Resource::ChocolateyInstaller.new("fakey_fakerton") }
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:config) do
     <<-CONFIG
       <?xml version="1.0" encoding="utf-8"?>
@@ -92,6 +95,50 @@ describe Chef::Resource::ChocolateyInstaller do
         allow(::File).to receive(:exist?).with('C:\ProgramData\chocolatey\bin\choco.exe').and_return(false)
         expect { Chef::Log.warn("Chocolatey is already uninstalled.") }.not_to output.to_stderr
       end
+
+      it "can install Chocolatey with a custom PS1 download URL" do
+        resource.download_url = "https://some.custom.url/install.ps1"
+        expect { resource.action :install }.not_to raise_error
+      end
+
+      it "downloads non-script URLs to a full path in the chef directory" do
+        resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom_download", run_context)
+        resource.download_url = "https://some.custom.url/packages/chocolatey.2.0.0.nupkg"
+        expected_destination = Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), "chocolatey.2.0.0.nupkg")
+        install_provider = resource.provider_for_action(:install)
+
+        commands = []
+        shell_out = instance_double("Mixlib::ShellOut", error!: nil)
+
+        allow(resource).to receive(:provider_for_action).with(:install).and_return(install_provider)
+        allow(resource).to receive(:is_choco_installed?).and_return(false)
+        allow(install_provider).to receive(:powershell_exec) do |command|
+          commands << command
+          shell_out
+        end
+        allow(Chef::Log).to receive(:info)
+
+        resource.run_action(:install)
+
+        expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value https://some.custom.url/packages/chocolatey.2.0.0.nupkg")
+        expect(commands).to include("Invoke-WebRequest 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg' -OutFile '#{expected_destination}'")
+      end
+    end
+  end
+
+  describe "custom download path helpers" do
+    it "detects PowerShell scripts from the URL path" do
+      resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom_script", run_context)
+      resource.download_url = "https://some.custom.url/install.ps1?token=abc123"
+
+      expect(resource.download_url_script?).to be true
+    end
+
+    it "falls back to a package filename when the URL path has no basename" do
+      resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom_path", run_context)
+      resource.download_url = "https://some.custom.url/"
+
+      expect(resource.download_destination).to eq(Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), "chocolatey.nupkg"))
     end
   end
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>This PR ports the chocolatey download URL bug fix from <a href='https://github.com/chef/chef/pull/15925'>PR #15925</a> (chef-18) to Chef-19 (<code>main</code>).</p>

<h2>Problem</h2>
<p>Chef-19's <code>chocolatey_installer</code> resource was missing the download URL handling logic entirely. When a user provided a non-PS1 <code>download_url</code> (e.g., a <code>.nupkg</code> file), the resource would silently fall through to downloading from <code>chocolatey.org</code>, ignoring the user's URL. Additionally, the helper methods needed for correct URL parsing were absent.</p>

<h2>Changes</h2>
<ul>
  <li>Added <code>require 'cgi'</code> and <code>require 'uri'</code> for URL parsing</li>
  <li>Added <code>download_url_path</code> helper — extracts the path component from URLs, handling query strings and local Windows paths (UNC and drive-letter paths)</li>
  <li>Added <code>download_url_script?</code> helper — correctly detects <code>.ps1</code> files even when URLs contain query parameters (e.g., <code>install.ps1?token=abc123</code>)</li>
  <li>Added <code>download_destination</code> helper — computes a proper full file path (not just a directory) using <code>CGI.unescape</code> for encoded filenames, with a safe fallback to <code>chocolatey.nupkg</code></li>
  <li>Updated <code>action :install</code> to properly branch on <code>download_url</code>: PS1 scripts are executed directly, nupkg/other files are downloaded to the computed full destination path</li>
  <li>Cleaned up <code>proposed_version</code> assignment style in <code>action :upgrade</code></li>
  <li>Added unit tests covering the new helper methods and download behaviour</li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Added spec for PS1 detection via <code>download_url_script?</code> with query-string URLs</li>
  <li>Added spec for <code>download_destination</code> fallback to <code>chocolatey.nupkg</code></li>
  <li>Added spec verifying <code>Invoke-WebRequest</code> is called with a full file path, not a directory</li>
</ul>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>