### PR TITLE
GHCP -- Run: ex2 coverage-improve-baseline

### DIFF
--- a/ai-track-docs/chef-config-train-transport-coverage-change-summary.md
+++ b/ai-track-docs/chef-config-train-transport-coverage-change-summary.md
@@ -1,0 +1,30 @@
+# chef-config train_transport Coverage Change Summary
+
+## Scope
+- Module: chef-config/lib/chef-config/mixin/train_transport.rb
+- Subsystem: chef-config
+- Excluded: vendor/, submodules
+
+## Before/After Evidence
+- Baseline command:
+  - EXCLUDE_TRAIN_TRANSPORT_SPEC=1 /Users/rchawda/github.com/chef/chef/scripts/coverage_chef_config_train_transport.sh
+- After command:
+  - /Users/rchawda/github.com/chef/chef/scripts/coverage_chef_config_train_transport.sh
+- Baseline module coverage: 0.00%
+- After module coverage: 68.25%
+- Absolute improvement: 68.25%
+- Baseline covered/missed lines: 0 / 84
+- After covered/missed lines: 43 / 20
+
+## Regression Check
+- Baseline run: 305 examples, 0 failures
+- After run: 313 examples, 0 failures
+
+## Rollback Guidance
+- Revert the coverage commit:
+  - git revert <commit_sha>
+- Or discard only these files:
+  - git checkout -- chef-config/Gemfile
+  - git checkout -- chef-config/spec/unit/train_transport_spec.rb
+  - git checkout -- scripts/coverage_chef_config_train_transport.sh
+  - git checkout -- ai-track-docs/chef-config-train-transport-coverage-change-summary.md

--- a/chef-config/Gemfile
+++ b/chef-config/Gemfile
@@ -7,4 +7,5 @@ gemspec
 group(:development, :test) do
   gem "rake", ">= 12.3.3"
   gem "rspec"
+  gem "simplecov", require: false
 end

--- a/chef-config/spec/unit/train_transport_spec.rb
+++ b/chef-config/spec/unit/train_transport_spec.rb
@@ -1,0 +1,130 @@
+#
+# Copyright:: Copyright (c) 2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+
+require "spec_helper"
+require "tmpdir"
+require "chef-config/mixin/train_transport"
+
+RSpec.describe ChefConfig::Mixin::TrainTransport do
+  let(:logger) do
+    instance_double(
+      "Logger",
+      warn: nil,
+      debug: nil,
+      trace: nil,
+      error: nil
+    )
+  end
+
+  let(:target_mode_config) do
+    instance_double(
+      "TargetModeConfig",
+      host: "host.example.org",
+      credentials_file: nil,
+      protocol: "ssh",
+      to_hash: { host: "host.example.org", protocol: "ssh" }
+    )
+  end
+
+  let(:config) do
+    instance_double(
+      "Config",
+      target_mode: target_mode_config,
+      target_mode?: true,
+      platform_specific_path: "/etc/chef/host.example.org/credentials"
+    )
+  end
+
+  let(:test_class) do
+    Class.new do
+      include ChefConfig::Mixin::TrainTransport
+
+      attr_reader :config
+
+      def initialize(logger, config)
+        super(logger)
+        @config = config
+      end
+    end
+  end
+
+  subject(:test_obj) { test_class.new(logger, config) }
+
+  describe "#contains_split_fqdn?" do
+    it "returns the terminal hash when fqdn is represented as nested hashes" do
+      nested = { "host" => { "example" => { "org" => {} } } }
+      expect(test_obj.contains_split_fqdn?(nested, "host.example.org")).to eq({})
+    end
+
+    it "returns false when fqdn is not split" do
+      normal = { "host.example.org" => { "user" => "admin" } }
+      expect(test_obj.contains_split_fqdn?(normal, "host.example.org")).to be(false)
+    end
+
+    it "returns nil when profile does not look like fqdn" do
+      expect(test_obj.contains_split_fqdn?({}, "localhost")).to be_nil
+    end
+  end
+
+  describe "#load_credentials" do
+    it "warns for split fqdn keys and returns symbolized credentials" do
+      credentials = { "host.example.org" => { "user" => "admin", "port" => 22 } }
+      allow(test_obj).to receive(:parse_credentials_file).and_return(credentials)
+      allow(test_obj).to receive(:contains_split_fqdn?).and_return(true)
+      allow(test_obj).to receive(:resolve_secrets)
+      allow(test_obj).to receive(:credentials_file_path).and_return("/tmp/credentials.toml")
+
+      expect(logger).to receive(:warn).with(/contains target 'host\.example\.org' as a Hash/)
+      expect(logger).to receive(:warn).with(/Hostnames must be surrounded by single quotes/)
+
+      expect(test_obj.load_credentials("host.example.org")).to eq(user: "admin", port: 22)
+    end
+
+    it "returns nil when the profile does not exist" do
+      allow(test_obj).to receive(:parse_credentials_file).and_return({ "other" => { "user" => "admin" } })
+      allow(test_obj).to receive(:contains_split_fqdn?).and_return(false)
+      allow(test_obj).to receive(:resolve_secrets)
+
+      expect(test_obj.load_credentials("host.example.org")).to be_nil
+    end
+  end
+
+  describe "#credentials_file_path" do
+    around do |example|
+      old_env = ENV.to_hash
+      begin
+        ENV.delete("CHEF_CREDENTIALS_FILE")
+        example.run
+      ensure
+        ENV.clear
+        ENV.update(old_env)
+      end
+    end
+
+    it "prefers CHEF_CREDENTIALS_FILE when it exists" do
+      Dir.mktmpdir("train-cred") do |dir|
+        env_file = File.join(dir, "credentials")
+        File.write(env_file, "[default]\n")
+        ENV["CHEF_CREDENTIALS_FILE"] = env_file
+
+        expect(test_obj.credentials_file_path).to eq(env_file)
+      end
+    end
+
+    it "raises when no candidate credentials file exists" do
+      allow(config).to receive(:platform_specific_path).and_return("/nonexistent/system_credentials")
+      allow(ChefConfig::PathHelper).to receive(:home).and_return(nil)
+
+      expect { test_obj.credentials_file_path }.to raise_error(ArgumentError, /No credentials file found/)
+    end
+  end
+
+  describe "#build_transport" do
+    it "returns nil when target mode is disabled" do
+      allow(config).to receive(:target_mode?).and_return(false)
+      expect(test_obj.build_transport).to be_nil
+    end
+  end
+end

--- a/scripts/coverage_chef_config_train_transport.sh
+++ b/scripts/coverage_chef_config_train_transport.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHEF_CONFIG_DIR="$ROOT_DIR/chef-config"
+TARGET_FILE="$CHEF_CONFIG_DIR/lib/chef-config/mixin/train_transport.rb"
+COVERAGE_DIR="$CHEF_CONFIG_DIR/coverage-train-transport"
+EXCLUDE_SPEC="${EXCLUDE_TRAIN_TRANSPORT_SPEC:-0}"
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+  echo "Missing target file: $TARGET_FILE" >&2
+  exit 1
+fi
+
+rm -rf "$COVERAGE_DIR"
+
+cd "$CHEF_CONFIG_DIR"
+
+TARGET_FILE="$TARGET_FILE" COVERAGE_DIR="$COVERAGE_DIR" EXCLUDE_SPEC="$EXCLUDE_SPEC" bundle exec ruby <<'RUBY'
+require "simplecov"
+require "rspec/core"
+
+target_file = ENV.fetch("TARGET_FILE")
+coverage_dir = ENV.fetch("COVERAGE_DIR")
+exclude_spec = ENV.fetch("EXCLUDE_SPEC", "0") == "1"
+spec_files = Dir["spec/unit/*_spec.rb"].sort
+spec_files.reject! { |f| File.basename(f) == "train_transport_spec.rb" } if exclude_spec
+
+SimpleCov.coverage_dir(coverage_dir)
+SimpleCov.start do
+  track_files target_file
+  add_filter "/spec/"
+end
+
+exit_code = RSpec::Core::Runner.run(spec_files)
+result = SimpleCov.result
+file_result = result.files.find { |f| f.filename == target_file }
+
+if file_result
+  puts format("MODULE_COVERAGE=%.2f", file_result.covered_percent)
+  puts "MODULE_COVERED_LINES=#{file_result.covered_lines.count}"
+  puts "MODULE_MISSED_LINES=#{file_result.missed_lines.count}"
+else
+  puts "MODULE_COVERAGE=0.00"
+  puts "MODULE_COVERED_LINES=0"
+  puts "MODULE_MISSED_LINES=0"
+end
+
+result.format!
+exit(exit_code)
+RUBY


### PR DESCRIPTION
Summary
- Raised module coverage for chef-config/lib/chef-config/mixin/train_transport.rb using deterministic unit tests.
- Added a module-scoped coverage runner to produce repeatable before/after module metrics.
- Files/paths/folders touched:
  - chef-config/Gemfile
  - chef-config/spec/unit/train_transport_spec.rb
  - scripts/coverage_chef_config_train_transport.sh
  - ai-track-docs/chef-config-train-transport-coverage-change-summary.md

Evidence
- Before/after metrics or screenshots:
  - Baseline module coverage: 0.00%
  - After module coverage: 68.25%
  - Absolute improvement: 68.25%
  - Baseline covered/missed lines: 0 / 84
  - After covered/missed lines: 43 / 20
  - Source: ai-track-docs/chef-config-train-transport-coverage-change-summary.md
- Tests/logs/metrics:
  - Baseline command: EXCLUDE_TRAIN_TRANSPORT_SPEC=1 /Users/rchawda/github.com/chef/chef/scripts/coverage_chef_config_train_transport.sh
    - Result: 305 examples, 0 failures; MODULE_COVERAGE=0.00
  - After command: /Users/rchawda/github.com/chef/chef/scripts/coverage_chef_config_train_transport.sh
    - Result: 313 examples, 0 failures; MODULE_COVERAGE=68.25
- Delegation checklist completed: no

Risk & Rollback
- Risk: low
- Rollback: revert 0d97bd22a5
- Rollback commands:
  - git revert 0d97bd22a5
  - git checkout -- chef-config/Gemfile chef-config/spec/unit/train_transport_spec.rb scripts/coverage_chef_config_train_transport.sh ai-track-docs/chef-config-train-transport-coverage-change-summary.md

Track
- Level: Run
- Exercise: ex2

This work was completed with AI assistance following Progress AI policies.
