### PR TITLE
GHCP -- Run: ex3 controlled-multifile-refactor

### DIFF
--- a/ai-track-docs/chef-config-dot-d-refactor-change-summary.md
+++ b/ai-track-docs/chef-config-dot-d-refactor-change-summary.md
@@ -1,0 +1,42 @@
+# chef-config DotD Scoped Refactor Summary
+
+## Scope
+- Subsystem: chef-config
+- Folder focus: chef-config/lib/chef-config/mixin and related loader integration tests
+- Excluded: vendor/, submodules
+
+## Patch Plan
+1. Refactor DotD internals to improve readability and testability without changing public behavior.
+2. Keep API and behavior stable:
+   - find_dot_d(path) still returns sorted regular .rb files
+   - load_dot_d(path) still reads and applies each file
+3. Add deterministic integration tests in workstation loader spec for:
+   - lexical load order of .rb files
+   - ignoring directories ending in .rb
+4. Document deterministic DotD loading behavior at the call site.
+
+## Files Changed
+- chef-config/lib/chef-config/mixin/dot_d.rb
+- chef-config/lib/chef-config/workstation_config_loader.rb
+- chef-config/spec/unit/workstation_config_loader_spec.rb
+
+## Before/After Evidence
+- Before: no explicit integration assertion for lexical ordering in config_d loading.
+- Before: no explicit integration assertion for ignoring directories ending in .rb.
+- After: focused spec includes deterministic assertions for both behaviors.
+- Validation command:
+  - bundle exec ruby -S rspec --format progress chef-config/spec/unit/workstation_config_loader_spec.rb
+- Validation result:
+  - 42 examples, 0 failures
+
+## Risk
+- Low: refactor is internal-only for DotD and keeps public method signatures and behavior unchanged.
+
+## Rollback Guidance
+- Revert refactor commit:
+  - git revert <commit_sha>
+- Or discard only the scoped changes:
+  - git checkout -- chef-config/lib/chef-config/mixin/dot_d.rb
+  - git checkout -- chef-config/lib/chef-config/workstation_config_loader.rb
+  - git checkout -- chef-config/spec/unit/workstation_config_loader_spec.rb
+  - git checkout -- ai-track-docs/chef-config-dot-d-refactor-change-summary.md

--- a/chef-config/lib/chef-config/mixin/dot_d.rb
+++ b/chef-config/lib/chef-config/mixin/dot_d.rb
@@ -20,13 +20,14 @@ module ChefConfig
   module Mixin
     module DotD
       # Find available configuration files in a `.d/` style include directory.
-      # Make sure we exclude anything that's not a file so we avoid directories ending in .rb (just in case)
+      # Files are returned in deterministic lexical order.
+      # Make sure we exclude anything that's not a file so we avoid directories ending in .rb (just in case).
       #
       # @api internal
       # @param path [String] Base .d/ path to load from.
       # @return [Array<String>]
       def find_dot_d(path)
-        Dir["#{PathHelper.escape_glob_dir(path)}/*.rb"].select { |entry| File.file?(entry) }.sort
+        dot_d_entries(path).select { |entry| File.file?(entry) }.sort
       end
 
       # Load configuration from a `.d/` style include directory.
@@ -36,8 +37,22 @@ module ChefConfig
       # @return [void]
       def load_dot_d(path)
         find_dot_d(path).each do |conf|
-          apply_config(IO.read(conf), conf)
+          apply_dot_d_config(conf)
         end
+      end
+
+      private
+
+      def dot_d_entries(path)
+        Dir[dot_d_glob(path)]
+      end
+
+      def dot_d_glob(path)
+        "#{PathHelper.escape_glob_dir(path)}/*.rb"
+      end
+
+      def apply_dot_d_config(path)
+        apply_config(IO.read(path), path)
       end
     end
   end

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -84,6 +84,7 @@ module ChefConfig
         apply_config(IO.read(config_location), config_location)
       end
 
+      # DotD applies only regular *.rb files and loads them in deterministic lexical order.
       load_dot_d(Config[:config_d_dir]) if Config[:config_d_dir]
 
       apply_defaults

--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -391,6 +391,16 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
           config_loader.load
           expect(ChefConfig::Config.config_d_file_evaluated).to be(true)
         end
+
+        it "loads config files in lexical order" do
+          File.write(File.join(tempdir, "20-later.rb"), "config_d_order << 'later'")
+          File.write(File.join(tempdir, "10-first.rb"), "config_d_order << 'first'")
+          ChefConfig::Config[:config_d_order] = []
+
+          config_loader.load
+
+          expect(ChefConfig::Config.config_d_order).to eq(%w{first later})
+        end
       end
 
       context "and has a syntax error" do
@@ -417,15 +427,30 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
           expect(ChefConfig::Config.config_d_file_evaluated).to be(true)
         end
       end
+
+      context "has a directory ending in .rb" do
+        let(:config_content) { "config_d_file_evaluated(true)" }
+
+        before do
+          Dir.mkdir(File.join(tempdir, "ignored.rb"))
+        end
+
+        it "does not try to load the directory" do
+          expect { config_loader.load }.not_to raise_error
+          expect(ChefConfig::Config.config_d_file_evaluated).to be(true)
+        end
+      end
     end
 
     context "when the conf.d directory does not exist" do
       before do
         ChefConfig::Config[:config_d_dir] = "/nope/nope/nope/nope/notdoingit"
+        allow(config_loader).to receive(:config_location).and_return(nil)
       end
 
       it "does not load anything" do
         expect(config_loader).not_to receive(:apply_config)
+        expect { config_loader.load }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Summary
- Performed a controlled, behavior-preserving multi-file refactor in chef-config for DotD config loading.
- Patch plan:
  - Refactor internal DotD flow for readability/testability while preserving public behavior.
  - Add deterministic integration tests for lexical load order and directory filtering.
  - Document deterministic loading behavior and rollback path.
- Files/paths/folders touched:
  - chef-config/lib/chef-config/mixin/dot_d.rb
  - chef-config/lib/chef-config/workstation_config_loader.rb
  - chef-config/spec/unit/workstation_config_loader_spec.rb
  - ai-track-docs/chef-config-dot-d-refactor-change-summary.md

Evidence
- Before/after metrics or screenshots:
  - Before: no explicit integration assertion for lexical ordering of config_d .rb files.
  - Before: no explicit integration assertion for ignoring directories ending in .rb.
  - After: both deterministic assertions are now present and passing in workstation loader spec.
- Tests/logs/metrics:
  - Command: bundle exec ruby -S rspec --format progress chef-config/spec/unit/workstation_config_loader_spec.rb
  - Result: 42 examples, 0 failures
- Delegation checklist completed: yes (subagent proposal reviewed before patch application)

Risk & Rollback
- Risk: low
- Rollback: revert 525f57b8ea
- Rollback commands:
  - git revert 525f57b8ea
  - git checkout -- chef-config/lib/chef-config/mixin/dot_d.rb chef-config/lib/chef-config/workstation_config_loader.rb chef-config/spec/unit/workstation_config_loader_spec.rb ai-track-docs/chef-config-dot-d-refactor-change-summary.md

Track
- Level: Run
- Exercise: ex3

This work was completed with AI assistance following Progress AI policies.
