### PR TITLE
GHCP -- Run: ex4 subsystem-docs-maintainability

### DIFF
--- a/ai-track-docs/chef-config-dot-d-refactor-change-summary.md
+++ b/ai-track-docs/chef-config-dot-d-refactor-change-summary.md
@@ -1,5 +1,8 @@
 # chef-config DotD Scoped Refactor Summary
 
+Related maintainability guide:
+- ai-track-docs/chef-config-workstation-dotd-maintainability.md
+
 ## Scope
 - Subsystem: chef-config
 - Folder focus: chef-config/lib/chef-config/mixin and related loader integration tests

--- a/ai-track-docs/chef-config-workstation-dotd-maintainability.md
+++ b/ai-track-docs/chef-config-workstation-dotd-maintainability.md
@@ -1,0 +1,63 @@
+# chef-config Workstation DotD Maintainability Guide
+
+## Scope
+- Subsystem: chef-config workstation configuration loading
+- Workflow: loading base config plus config.d snippets
+- Primary code paths:
+  - chef-config/lib/chef-config/workstation_config_loader.rb
+  - chef-config/lib/chef-config/mixin/dot_d.rb
+  - chef-config/spec/unit/workstation_config_loader_spec.rb
+
+## Current Behavior (Verified Against Code)
+1. Base config is loaded first when present.
+- Code path: chef-config/lib/chef-config/workstation_config_loader.rb (load)
+- Behavior: if config_location exists, loader reads and applies that file before config.d.
+
+2. config.d loading is optional and guarded by config_d_dir.
+- Code path: chef-config/lib/chef-config/workstation_config_loader.rb (load)
+- Behavior: load_dot_d is called only when Config[:config_d_dir] is set.
+
+3. DotD loads only top-level .rb files and ignores non-files.
+- Code path: chef-config/lib/chef-config/mixin/dot_d.rb (find_dot_d, dot_d_glob)
+- Behavior: glob is path/*.rb and then filtered by File.file?.
+
+4. DotD load order is deterministic.
+- Code path: chef-config/lib/chef-config/mixin/dot_d.rb (find_dot_d)
+- Behavior: entries are sorted lexically before loading.
+
+5. DotD parsing/evaluation errors bubble up.
+- Code path: chef-config/lib/chef-config/mixin/dot_d.rb (load_dot_d -> apply_dot_d_config)
+- Behavior: apply_config exceptions are not swallowed.
+
+## Test Coverage for This Workflow
+- Integration test file: chef-config/spec/unit/workstation_config_loader_spec.rb
+- Relevant examples:
+  - lexical order for config.d files
+  - ignore non-.rb files
+  - ignore directories ending in .rb
+  - syntax error propagation from config.d entries
+
+## Extension Guidance
+1. If adding new config.d rules, keep deterministic ordering intact.
+- Avoid introducing non-deterministic ordering based on filesystem iteration.
+
+2. If changing file matching behavior, update both dot_d mixin docs and loader integration tests.
+- Keep path filter explicit so users know what will load.
+
+3. If adding recursive loading, implement it behind an explicit option and add migration notes.
+- Current behavior is non-recursive and top-level only.
+
+4. Preserve error visibility for bad snippets.
+- Swallowing config.d errors can hide broken deployments.
+
+## Risk Notes
+- Runtime config risks: changing order can alter final ChefConfig::Config values when keys overlap.
+- Operational risk: broadening file matching can unintentionally execute files not meant as config snippets.
+- Debuggability risk: suppressing parse errors can make misconfigurations hard to diagnose.
+
+## Safe Rollback
+- Revert this documentation/code-alignment update:
+  - git revert <commit_sha>
+- Or restore just scoped files:
+  - git checkout -- chef-config/lib/chef-config/mixin/dot_d.rb
+  - git checkout -- ai-track-docs/chef-config-workstation-dotd-maintainability.md

--- a/chef-config/lib/chef-config/mixin/dot_d.rb
+++ b/chef-config/lib/chef-config/mixin/dot_d.rb
@@ -20,6 +20,7 @@ module ChefConfig
   module Mixin
     module DotD
       # Find available configuration files in a `.d/` style include directory.
+      # Only top-level `*.rb` files are considered (no recursive traversal).
       # Files are returned in deterministic lexical order.
       # Make sure we exclude anything that's not a file so we avoid directories ending in .rb (just in case).
       #
@@ -31,6 +32,7 @@ module ChefConfig
       end
 
       # Load configuration from a `.d/` style include directory.
+      # Exceptions from apply_config are allowed to bubble up to the caller.
       #
       # @api internal
       # @param path [String] Base .d/ path to load from.


### PR DESCRIPTION
Summary
- Updated subsystem maintainability documentation for chef-config workstation DotD workflow and aligned code comments to current behavior boundaries.
- What changed and why:
  - Added a maintainability guide tied to real code paths and tests to reduce future drift.
  - Added explicit behavior boundaries in DotD comments (top-level .rb only, exception bubbling) so code intent matches docs.
- Files/paths/folders touched:
  - ai-track-docs/chef-config-workstation-dotd-maintainability.md
  - ai-track-docs/chef-config-dot-d-refactor-change-summary.md
  - chef-config/lib/chef-config/mixin/dot_d.rb

Evidence
- Before/after metrics or screenshots:
  - Before: existing doc was refactor-summary focused and lacked extension guidance plus explicit risk notes tied to file-level behavior boundaries.
  - After: new guide documents real code paths, extension guidance, risks, and rollback for one key workflow.
  - Updated docs:
    - ai-track-docs/chef-config-workstation-dotd-maintainability.md
    - ai-track-docs/chef-config-dot-d-refactor-change-summary.md
- Tests/logs/metrics:
  - Command: bundle exec ruby -S rspec --format progress chef-config/spec/unit/workstation_config_loader_spec.rb
  - Result: 42 examples, 0 failures
- Delegation checklist completed: yes (doc-vs-code audit delegated before edits)

Risk & Rollback
- Risk: low
- Rollback: revert 09cc3d0ee4
- Rollback commands:
  - git revert 09cc3d0ee4
  - git checkout -- chef-config/lib/chef-config/mixin/dot_d.rb ai-track-docs/chef-config-workstation-dotd-maintainability.md ai-track-docs/chef-config-dot-d-refactor-change-summary.md

Track
- Level: Run
- Exercise: ex4

This work was completed with AI assistance following Progress AI policies.
