### PR TITLE
security: harden encrypted data bag secret URL loading

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -31,3 +31,4 @@ A good first start is our [How Chef Infra Is Built](./design_documents/how_chef_
 - [Client Exit Codes](./design_documents/client_exit_codes.md)
 - [Server Enforced Recipes](./design_documents/server_enforced_recipes.md)
 - [Bootstrap with Train](./design_documents/bootstrap_with_train.md)
+- [Encrypted Data Bag Secret Loading Security](./design_documents/encrypted_data_bag_secret_loading_security.md)

--- a/docs/dev/design_documents/encrypted_data_bag_secret_loading_security.md
+++ b/docs/dev/design_documents/encrypted_data_bag_secret_loading_security.md
@@ -1,0 +1,28 @@
+# Encrypted Data Bag Secret Loading Security
+
+This note documents security controls for loading encrypted data bag secrets in Chef Infra.
+
+## Remote Secret URL Controls
+
+When `Chef::EncryptedDataBagItem.load_secret` is passed a URL, Chef now enforces:
+
+- Allowed schemes: `http` and `https` only
+- Required host in URL
+- Embedded credentials (`user:pass@host`) are rejected
+- Remote reads use explicit `open_timeout` and `read_timeout`
+
+These checks reduce the risk of accidentally accepting unsafe URL formats or hanging indefinitely on remote reads.
+
+## Local Verification Script
+
+Use this script to validate the hardening is present:
+
+```bash
+scripts/security/check_encrypted_data_bag_secret_loading.sh
+```
+
+The script checks for:
+
+- No `Kernel.open(path)` usage in secret loading
+- Presence of `URI.open` with timeout options
+- Presence of URL scheme and credential guards

--- a/lib/chef/encrypted_data_bag_item.rb
+++ b/lib/chef/encrypted_data_bag_item.rb
@@ -128,6 +128,7 @@ class Chef::EncryptedDataBagItem
 
   def self.load_secret(path = nil)
     require "open-uri" unless defined?(OpenURI)
+    require "uri"
     path ||= Chef::Config[:encrypted_data_bag_secret]
     unless path
       raise ArgumentError, "No secret specified and no secret found at #{Chef::Config.platform_specific_path(ChefConfig::Config.etc_chef_dir) + "/encrypted_data_bag_secret"}"
@@ -137,11 +138,23 @@ class Chef::EncryptedDataBagItem
              when %r{^\w+://}
                # We have a remote key
                begin
-                 Kernel.open(path).read.strip
+                 uri = URI.parse(path)
+                 unless uri.is_a?(URI::HTTP) && uri.host
+                   raise ArgumentError, "Remote key URL must use http or https and include a host: '#{path}'"
+                 end
+                 if uri.user || uri.password
+                   raise ArgumentError, "Remote key URL must not include user credentials: '#{path}'"
+                 end
+
+                 URI.open(uri, open_timeout: 5, read_timeout: 5).read.strip
+               rescue URI::InvalidURIError
+                 raise ArgumentError, "Remote key URL is invalid: '#{path}'"
                rescue Errno::ECONNREFUSED
                  raise ArgumentError, "Remote key not available from '#{path}'"
                rescue OpenURI::HTTPError
                  raise ArgumentError, "Remote key not found at '#{path}'"
+               rescue Timeout::Error
+                 raise ArgumentError, "Remote key request timed out for '#{path}'"
                end
              else
                unless File.exist?(path)

--- a/scripts/security/check_encrypted_data_bag_secret_loading.sh
+++ b/scripts/security/check_encrypted_data_bag_secret_loading.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+target_file="lib/chef/encrypted_data_bag_item.rb"
+
+echo "Checking encrypted data bag secret loading hardening in ${target_file}"
+
+if grep -q "Kernel.open(path)" "$target_file"; then
+  echo "FAIL: Kernel.open(path) is still present"
+  exit 1
+fi
+
+if ! grep -q "URI.open(uri, open_timeout: 5, read_timeout: 5)" "$target_file"; then
+  echo "FAIL: URI.open with explicit timeout options is missing"
+  exit 1
+fi
+
+if ! grep -q "must use http or https" "$target_file"; then
+  echo "FAIL: URL scheme validation guard is missing"
+  exit 1
+fi
+
+if ! grep -q "must not include user credentials" "$target_file"; then
+  echo "FAIL: URL userinfo validation guard is missing"
+  exit 1
+fi
+
+echo "PASS: encrypted data bag secret loading security checks passed"

--- a/spec/unit/encrypted_data_bag_item_spec.rb
+++ b/spec/unit/encrypted_data_bag_item_spec.rb
@@ -428,11 +428,27 @@ describe Chef::EncryptedDataBagItem do
 
     context "path argument is a URL" do
       before do
-        allow(Kernel).to receive(:open).with("http://www.opscode.com/").and_return(StringIO.new(secret))
+        allow(URI).to receive(:open)
+          .with(instance_of(URI::HTTP), open_timeout: 5, read_timeout: 5)
+          .and_return(StringIO.new(secret))
       end
 
       it "reads from the URL" do
         expect(Chef::EncryptedDataBagItem.load_secret("http://www.opscode.com/")).to eq secret
+      end
+    end
+
+    context "path argument is a URL with an unsupported scheme" do
+      it "rejects the URL" do
+        expect { Chef::EncryptedDataBagItem.load_secret("ftp://www.opscode.com/secret") }
+          .to raise_error(ArgumentError, /must use http or https/)
+      end
+    end
+
+    context "path argument is a URL with embedded credentials" do
+      it "rejects the URL" do
+        expect { Chef::EncryptedDataBagItem.load_secret("https://user:pass@www.opscode.com/secret") }
+          .to raise_error(ArgumentError, /must not include user credentials/)
       end
     end
   end


### PR DESCRIPTION
## Goal / Outcome
Improve security posture in the encrypted data bag secret-loading subsystem with small, low-risk hardening changes and repeatable verification guidance.

## What Changed
1. Hardened remote secret URL handling in `Chef::EncryptedDataBagItem.load_secret`:
- replaced `Kernel.open(path)` with `URI.open(uri, open_timeout: 5, read_timeout: 5)`
- validated URL scheme is `http` or `https`
- required URL host to be present
- rejected embedded credentials (`user:pass@host`)
- normalized invalid URL and timeout errors to clear `ArgumentError` messages

2. Added/updated targeted unit tests in `spec/unit/encrypted_data_bag_item_spec.rb`:
- updated remote URL read test to assert `URI.open` with timeout options
- added rejection test for unsupported URL scheme
- added rejection test for embedded credentials in URL

3. Updated security guidance:
- added `docs/dev/design_documents/encrypted_data_bag_secret_loading_security.md`
- linked it from `docs/dev/README.md`

4. Added repeatable scripted verification:
- `scripts/security/check_encrypted_data_bag_secret_loading.sh`
- verifies hardened code patterns are present and risky pattern is absent

## Security Justification
- `Kernel.open` has broader behavior and can increase risk in URL/file ambiguity contexts. `URI.open` narrows intent for URL reads.
- Enforcing `http/https` plus host and credential restrictions reduces accidental unsafe URL usage and credential leakage risks.
- Explicit network timeouts reduce risk of indefinite waits against remote secret endpoints.

## Side-Effect Review
- Scope is limited to encrypted data bag secret-loading path and associated tests/docs/script only.
- Local file secret loading behavior remains unchanged.
- Remote URL behavior now fails fast for unsupported schemes and credentialed URLs.

## Validation Evidence
Before:
- Open security alert present in repo: `faraday` advisory `GHSA-5rv5-xj5j-3484` / `CVE-2026-33637` (queried with `gh api /repos/chef/chef/dependabot/alerts?state=open`).
- Existing risky pattern in subsystem: `Kernel.open(path)` in `lib/chef/encrypted_data_bag_item.rb`.

After:
- Repeatable script passed:
  - `scripts/security/check_encrypted_data_bag_secret_loading.sh`
  - Output: `PASS: encrypted data bag secret loading security checks passed`
- Ruby syntax checks passed:
  - `ruby -c lib/chef/encrypted_data_bag_item.rb`
  - `ruby -c spec/unit/encrypted_data_bag_item_spec.rb`

Test note:
- Attempted: `bundle exec rspec spec/unit/encrypted_data_bag_item_spec.rb`
- Environment blocked by missing dependency checkout (`https://github.com/chef/ohai.git ... is not yet checked out. Run bundle install first.`)

## Repeatable Patch/Verification Approach
Run this any time to verify the hardening remains in place:

```bash
scripts/security/check_encrypted_data_bag_secret_loading.sh
```

## Acceptance Mapping
- At least one meaningful security improvement applied: ✅
- Security documentation updated: ✅
- Changes reviewed for side effects: ✅
- Evidence or justification included in PR: ✅
- Scripted or repeatable patch approach documented: ✅

## AI Assistance
This work was completed with AI assistance following Progress AI policies.
