### PR TITLE
GHCP -- Run: ex13 Target IO Feature Flag

### DIFF
--- a/docs/dev/research/target-io-feature-flag-helper-2026-05-29.md
+++ b/docs/dev/research/target-io-feature-flag-helper-2026-05-29.md
@@ -1,0 +1,42 @@
+# Target IO Feature Flag Helper Rollout (2026-05-29)
+
+## Flag
+
+- Name: `CHEF_TARGET_IO_BACKEND_HELPER`
+- Scope: `TargetIO` wrappers (`File`, `Dir`, `IO`, `FileUtils`)
+- Default: disabled (`false` when unset)
+- Enable: set `CHEF_TARGET_IO_BACKEND_HELPER=true`
+
+## Purpose
+
+This flag gates adoption of a centralized backend selection helper in `TargetIO` wrappers. It reduces rollout risk for higher-impact refactors by preserving legacy behavior when disabled.
+
+## Toggle Mechanism
+
+`TargetIO::FeatureFlags.target_io_backend_helper_enabled?` reads `ENV["CHEF_TARGET_IO_BACKEND_HELPER"]` and treats `1`, `true`, `yes`, and `on` as enabled.
+
+## Telemetry
+
+When the flag state is evaluated, an info log is emitted once per state transition:
+
+- `TargetIO feature flag CHEF_TARGET_IO_BACKEND_HELPER=true`
+- `TargetIO feature flag CHEF_TARGET_IO_BACKEND_HELPER=false`
+
+When the helper path is enabled, backend selection is also debug logged.
+
+## Rollback Path
+
+Immediate rollback is configuration-only:
+
+1. Unset `CHEF_TARGET_IO_BACKEND_HELPER`, or
+2. Set `CHEF_TARGET_IO_BACKEND_HELPER=false`
+
+This returns `TargetIO` wrappers to the legacy inline backend-switch logic without code rollback.
+
+## Validation Evidence
+
+Validation is captured by unit tests in both modes:
+
+- OFF mode: wrapper specs force helper off and assert legacy backend switch is used.
+- ON mode: wrapper specs force helper on and assert helper-based backend selection is used.
+- Telemetry: feature flag spec asserts expected info log lines for both `true` and `false` states.

--- a/lib/chef/target_io.rb
+++ b/lib/chef/target_io.rb
@@ -1,4 +1,5 @@
 require_relative "target_io/support"
+require_relative "target_io/feature_flags"
 
 require_relative "target_io/dir"
 require_relative "target_io/etc"

--- a/lib/chef/target_io/dir.rb
+++ b/lib/chef/target_io/dir.rb
@@ -4,7 +4,11 @@ module TargetIO
       def method_missing(m, *args, **kwargs, &block)
         Chef::Log.debug format("Dir::%s(%s)", m.to_s, args.join(", "))
 
-        backend = ChefConfig::Config.target_mode? ? TrainCompat::Dir : ::Dir
+        backend = if TargetIO::FeatureFlags.target_io_backend_helper_enabled?
+                    TargetIO::FeatureFlags.choose_backend(name: "TargetIO::Dir", target_backend: TrainCompat::Dir, local_backend: ::Dir)
+                  else
+                    ChefConfig::Config.target_mode? ? TrainCompat::Dir : ::Dir
+                  end
         backend.send(m, *args, **kwargs, &block)
       end
     end

--- a/lib/chef/target_io/feature_flags.rb
+++ b/lib/chef/target_io/feature_flags.rb
@@ -1,0 +1,35 @@
+module TargetIO
+  module FeatureFlags
+    TARGET_IO_BACKEND_HELPER_ENV = "CHEF_TARGET_IO_BACKEND_HELPER".freeze
+    TRUE_VALUES = %w{1 true yes on}.freeze
+
+    class << self
+      def target_io_backend_helper_enabled?
+        enabled = TRUE_VALUES.include?(ENV[TARGET_IO_BACKEND_HELPER_ENV].to_s.strip.downcase)
+        telemetry_log_flag_state(enabled)
+        enabled
+      end
+
+      def choose_backend(name:, target_backend:, local_backend:)
+        target_mode = ChefConfig::Config.target_mode?
+        backend = target_mode ? target_backend : local_backend
+        Chef::Log.debug("#{name} backend selected: #{backend} (target_mode=#{target_mode})")
+        backend
+      end
+
+      # Test helper to ensure each example can assert telemetry independently.
+      def reset_flag_state_for_testing!
+        @last_logged_state = nil
+      end
+
+      private
+
+      def telemetry_log_flag_state(enabled)
+        return if @last_logged_state == enabled
+
+        @last_logged_state = enabled
+        Chef::Log.info("TargetIO feature flag #{TARGET_IO_BACKEND_HELPER_ENV}=#{enabled}")
+      end
+    end
+  end
+end

--- a/lib/chef/target_io/file.rb
+++ b/lib/chef/target_io/file.rb
@@ -4,7 +4,11 @@ module TargetIO
       def method_missing(m, *args, **kwargs, &block)
         Chef::Log.debug format("File::%s(%s)", m.to_s, args.join(", "))
 
-        backend = ChefConfig::Config.target_mode? ? TrainCompat::File : ::File
+        backend = if TargetIO::FeatureFlags.target_io_backend_helper_enabled?
+                    TargetIO::FeatureFlags.choose_backend(name: "TargetIO::File", target_backend: TrainCompat::File, local_backend: ::File)
+                  else
+                    ChefConfig::Config.target_mode? ? TrainCompat::File : ::File
+                  end
         backend.send(m, *args, **kwargs, &block)
       end
     end

--- a/lib/chef/target_io/fileutils.rb
+++ b/lib/chef/target_io/fileutils.rb
@@ -4,7 +4,11 @@ module TargetIO
       def method_missing(m, *args, **kwargs, &block)
         Chef::Log.debug format("FileUtils::%s(%s)", m.to_s, args.join(", "))
 
-        backend = ChefConfig::Config.target_mode? ? TrainCompat::FileUtils : ::FileUtils
+        backend = if TargetIO::FeatureFlags.target_io_backend_helper_enabled?
+                    TargetIO::FeatureFlags.choose_backend(name: "TargetIO::FileUtils", target_backend: TrainCompat::FileUtils, local_backend: ::FileUtils)
+                  else
+                    ChefConfig::Config.target_mode? ? TrainCompat::FileUtils : ::FileUtils
+                  end
         backend.send(m, *args, **kwargs, &block)
       end
     end

--- a/lib/chef/target_io/io.rb
+++ b/lib/chef/target_io/io.rb
@@ -4,7 +4,11 @@ module TargetIO
       def method_missing(m, *args, **kwargs, &block)
         Chef::Log.debug format("IO::%s(%s)", m.to_s, args.join(", "))
 
-        backend = ChefConfig::Config.target_mode? ? TrainCompat::IO : ::IO
+        backend = if TargetIO::FeatureFlags.target_io_backend_helper_enabled?
+                    TargetIO::FeatureFlags.choose_backend(name: "TargetIO::IO", target_backend: TrainCompat::IO, local_backend: ::IO)
+                  else
+                    ChefConfig::Config.target_mode? ? TrainCompat::IO : ::IO
+                  end
         backend.send(m, *args, **kwargs, &block)
       end
     end

--- a/spec/unit/target_io/dir_spec.rb
+++ b/spec/unit/target_io/dir_spec.rb
@@ -19,8 +19,27 @@ require "chef/target_io"
 
 RSpec.describe TargetIO::Dir do
   describe ".method_missing dispatch" do
+    context "when helper flag is enabled" do
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(true)
+      end
+
+      it "uses the helper to choose backend" do
+        expect(TargetIO::FeatureFlags).to receive(:choose_backend)
+          .with(name: "TargetIO::Dir", target_backend: TargetIO::TrainCompat::Dir, local_backend: ::Dir)
+          .and_return(TargetIO::TrainCompat::Dir)
+        expect(TargetIO::TrainCompat::Dir).to receive(:entries).with("/etc").and_return([".", ".."])
+
+        expect(described_class.entries("/etc")).to eq([".", ".."])
+      end
+    end
+
     context "when target mode is enabled" do
-      before { allow(ChefConfig::Config).to receive(:target_mode?).and_return(true) }
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
 
       it "delegates to TargetIO::TrainCompat::Dir" do
         expect(TargetIO::TrainCompat::Dir).to receive(:entries).with("/etc").and_return([".", ".."])
@@ -34,7 +53,10 @@ RSpec.describe TargetIO::Dir do
     end
 
     context "when target mode is disabled" do
-      before { allow(ChefConfig::Config).to receive(:target_mode?).and_return(false) }
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(false)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
 
       it "delegates to ::Dir" do
         expect(::Dir).to receive(:exist?).with("/etc").and_return(true)

--- a/spec/unit/target_io/feature_flags_spec.rb
+++ b/spec/unit/target_io/feature_flags_spec.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: Copyright (c) 2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "spec_helper"
+require "chef/target_io"
+
+RSpec.describe TargetIO::FeatureFlags do
+  before do
+    described_class.reset_flag_state_for_testing!
+    allow(ENV).to receive(:[]).and_call_original
+  end
+
+  describe ".target_io_backend_helper_enabled?" do
+    it "is disabled by default and logs the state" do
+      allow(ENV).to receive(:[]).with("CHEF_TARGET_IO_BACKEND_HELPER").and_return(nil)
+      expect(Chef::Log).to receive(:info).with("TargetIO feature flag CHEF_TARGET_IO_BACKEND_HELPER=false")
+
+      expect(described_class.target_io_backend_helper_enabled?).to be false
+    end
+
+    it "is enabled when CHEF_TARGET_IO_BACKEND_HELPER=true and logs the state" do
+      allow(ENV).to receive(:[]).with("CHEF_TARGET_IO_BACKEND_HELPER").and_return("true")
+      expect(Chef::Log).to receive(:info).with("TargetIO feature flag CHEF_TARGET_IO_BACKEND_HELPER=true")
+
+      expect(described_class.target_io_backend_helper_enabled?).to be true
+    end
+  end
+
+  describe ".choose_backend" do
+    let(:target_backend) { double("TargetBackend") }
+    let(:local_backend) { double("LocalBackend") }
+
+    it "returns target backend in target mode" do
+      allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+
+      expect(described_class.choose_backend(name: "TargetIO::File", target_backend: target_backend, local_backend: local_backend)).to eq(target_backend)
+    end
+
+    it "returns local backend when target mode is disabled" do
+      allow(ChefConfig::Config).to receive(:target_mode?).and_return(false)
+
+      expect(described_class.choose_backend(name: "TargetIO::File", target_backend: target_backend, local_backend: local_backend)).to eq(local_backend)
+    end
+  end
+end

--- a/spec/unit/target_io/file_spec.rb
+++ b/spec/unit/target_io/file_spec.rb
@@ -21,8 +21,41 @@ RSpec.describe TargetIO::File do
   let(:path) { "/tmp/foo" }
 
   describe ".method_missing dispatch" do
+    context "when target mode is enabled and the helper flag is on" do
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(true)
+      end
+
+      it "selects backend via the feature flag helper" do
+        expect(TargetIO::FeatureFlags).to receive(:choose_backend)
+          .with(name: "TargetIO::File", target_backend: TargetIO::TrainCompat::File, local_backend: ::File)
+          .and_return(TargetIO::TrainCompat::File)
+        expect(TargetIO::TrainCompat::File).to receive(:exist?).with(path).and_return(true)
+
+        expect(described_class.exist?(path)).to be true
+      end
+    end
+
+    context "when target mode is enabled and the helper flag is off" do
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
+
+      it "keeps the legacy backend switch" do
+        expect(TargetIO::FeatureFlags).not_to receive(:choose_backend)
+        expect(TargetIO::TrainCompat::File).to receive(:exist?).with(path).and_return(true)
+
+        expect(described_class.exist?(path)).to be true
+      end
+    end
+
     context "when target mode is enabled" do
-      before { allow(ChefConfig::Config).to receive(:target_mode?).and_return(true) }
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
 
       it "delegates to TargetIO::TrainCompat::File" do
         expect(TargetIO::TrainCompat::File).to receive(:exist?).with(path).and_return(true)
@@ -48,7 +81,10 @@ RSpec.describe TargetIO::File do
     end
 
     context "when target mode is disabled" do
-      before { allow(ChefConfig::Config).to receive(:target_mode?).and_return(false) }
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(false)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
 
       it "delegates to ::File" do
         expect(::File).to receive(:exist?).with(path).and_return(false)

--- a/spec/unit/target_io/fileutils_spec.rb
+++ b/spec/unit/target_io/fileutils_spec.rb
@@ -21,8 +21,27 @@ RSpec.describe TargetIO::FileUtils do
   let(:dir_path) { "/new/dir" }
 
   describe ".method_missing dispatch" do
+    context "when helper flag is enabled" do
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(true)
+      end
+
+      it "uses the helper to choose backend" do
+        expect(TargetIO::FeatureFlags).to receive(:choose_backend)
+          .with(name: "TargetIO::FileUtils", target_backend: TargetIO::TrainCompat::FileUtils, local_backend: ::FileUtils)
+          .and_return(TargetIO::TrainCompat::FileUtils)
+        expect(TargetIO::TrainCompat::FileUtils).to receive(:mkdir_p).with(dir_path).and_return(nil)
+
+        described_class.mkdir_p(dir_path)
+      end
+    end
+
     context "when target mode is enabled" do
-      before { allow(ChefConfig::Config).to receive(:target_mode?).and_return(true) }
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
 
       it "delegates to TargetIO::TrainCompat::FileUtils" do
         expect(TargetIO::TrainCompat::FileUtils).to receive(:mkdir_p).with(dir_path).and_return(nil)
@@ -36,7 +55,10 @@ RSpec.describe TargetIO::FileUtils do
     end
 
     context "when target mode is disabled" do
-      before { allow(ChefConfig::Config).to receive(:target_mode?).and_return(false) }
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(false)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
 
       it "delegates to ::FileUtils" do
         expect(::FileUtils).to receive(:mkdir_p).with(dir_path).and_return([dir_path])

--- a/spec/unit/target_io/io_spec.rb
+++ b/spec/unit/target_io/io_spec.rb
@@ -22,8 +22,27 @@ RSpec.describe TargetIO::IO do
   let(:hosts_content) { "127.0.0.1 localhost" }
 
   describe ".method_missing dispatch" do
+    context "when helper flag is enabled" do
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(true)
+      end
+
+      it "uses the helper to choose backend" do
+        expect(TargetIO::FeatureFlags).to receive(:choose_backend)
+          .with(name: "TargetIO::IO", target_backend: TargetIO::TrainCompat::IO, local_backend: ::IO)
+          .and_return(TargetIO::TrainCompat::IO)
+        expect(TargetIO::TrainCompat::IO).to receive(:read).with(hosts_path).and_return(hosts_content)
+
+        expect(described_class.read(hosts_path)).to eq(hosts_content)
+      end
+    end
+
     context "when target mode is enabled" do
-      before { allow(ChefConfig::Config).to receive(:target_mode?).and_return(true) }
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(true)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
 
       it "delegates to TargetIO::TrainCompat::IO" do
         expect(TargetIO::TrainCompat::IO).to receive(:read).with(hosts_path).and_return(hosts_content)
@@ -32,7 +51,10 @@ RSpec.describe TargetIO::IO do
     end
 
     context "when target mode is disabled" do
-      before { allow(ChefConfig::Config).to receive(:target_mode?).and_return(false) }
+      before do
+        allow(ChefConfig::Config).to receive(:target_mode?).and_return(false)
+        allow(TargetIO::FeatureFlags).to receive(:target_io_backend_helper_enabled?).and_return(false)
+      end
 
       it "delegates to ::IO" do
         expect(::IO).to receive(:read).with(hosts_path).and_return(hosts_content)


### PR DESCRIPTION
Summary
- Added a feature-flag helper for TargetIO backend selection to reduce rollout risk, applied helper-gated dispatch across TargetIO wrappers, and preserved legacy behavior when the flag is OFF.
- Patch plan reference: docs/dev/research/target-io-feature-flag-helper-2026-05-29.md
- Files/paths/folders touched: lib/chef/target_io/, spec/unit/target_io/, docs/dev/research/target-io-feature-flag-helper-2026-05-29.md

Evidence
- Before/after metrics or screenshots: TargetIO unit suite increased from 17 examples (baseline wrappers) to 26 examples (helper + ON/OFF + telemetry), all passing.
- Tests/logs/metrics: bundle exec rspec --format documentation spec/unit/target_io/file_spec.rb spec/unit/target_io/dir_spec.rb spec/unit/target_io/io_spec.rb spec/unit/target_io/fileutils_spec.rb => 17 examples, 0 failures; bundle exec rspec spec/unit/target_io/feature_flags_spec.rb spec/unit/target_io/file_spec.rb spec/unit/target_io/dir_spec.rb spec/unit/target_io/io_spec.rb spec/unit/target_io/fileutils_spec.rb => 26 examples, 0 failures; CHEF_TARGET_IO_BACKEND_HELPER=false bundle exec ruby -Ilib -e '...' => helper_enabled=false; CHEF_TARGET_IO_BACKEND_HELPER=true bundle exec ruby -Ilib -e '...' => helper_enabled=true.
- Delegation checklist completed: yes

Risk & Rollback
- Risk: low
- Rollback: revert b18e73ab8d or toggle CHEF_TARGET_IO_BACKEND_HELPER
- Rollback commands: git revert b18e73ab8d ; or export CHEF_TARGET_IO_BACKEND_HELPER=false

Track
- Level: Run
- Exercise: ex13
