### PR TITLE
GHCP -- Run: ex15 Target IO Resilience

### DIFF
--- a/docs/dev/research/target-io-resilience-runbook-2026-05-29.md
+++ b/docs/dev/research/target-io-resilience-runbook-2026-05-29.md
@@ -1,0 +1,65 @@
+# Target IO Resilience Ops Runbook (2026-05-29)
+
+## Scope
+
+- Folder: `lib/chef/target_io/`
+- Pattern: shared timeout and backoff helper in `TargetIO::Resilience`
+
+## External Call Paths and Previous Failure Behavior
+
+- `TargetIO::TrainCompat::Dir.entries`
+
+- External call: remote `ls -1a` via transport `run_command`
+- Previous behavior: one timeout or transient exception failed the call immediately.
+
+- `TargetIO::TrainCompat::Dir.glob`
+
+- External call: remote shell glob expansion via transport `run_command`
+- Previous behavior: one timeout or transient exception failed the call immediately.
+
+- `TargetIO::TrainCompat::FileUtils.cp` (and sibling fileutils commands)
+
+- External call: remote shell command execution via transport `run_command`
+- Previous behavior: one timeout or transient exception failed the operation immediately.
+
+## Resilience Helper
+
+- Helper: `TargetIO::Resilience.with_timeout_and_backoff(operation:)`
+- Applied at: `TargetIO::Support#run_command`
+- Effect: all TargetIO train command executions now use the same timeout/retry/backoff behavior.
+
+## Tuning Parameters
+
+- `CHEF_TARGET_IO_RESILIENCE_ENABLED`
+- Default: `true`
+- Values: `true|false|1|0|yes|no|on|off`
+
+- `CHEF_TARGET_IO_RESILIENCE_MAX_ATTEMPTS`
+- Default: `3`
+- Meaning: total attempts before raising the last error.
+
+- `CHEF_TARGET_IO_RESILIENCE_TIMEOUT_SECONDS`
+- Default: `10.0`
+- Meaning: timeout per attempt.
+
+- `CHEF_TARGET_IO_RESILIENCE_BACKOFF_BASE_SECONDS`
+- Default: `0.25`
+- Meaning: base exponential backoff delay.
+
+- `CHEF_TARGET_IO_RESILIENCE_BACKOFF_MAX_SECONDS`
+- Default: `2.0`
+- Meaning: upper bound for retry delay.
+
+## Escalation Steps
+
+1. Identify repeated warnings matching: `TargetIO resilience retry for`.
+2. Capture failing command and error class from logs.
+3. Increase timeout/backoff if remote links are latent.
+4. If failures persist across all attempts, escalate to transport/network triage with captured command and target host details.
+
+## Rollback
+
+- Fast rollback (runtime): disable helper.
+  - `export CHEF_TARGET_IO_RESILIENCE_ENABLED=false`
+- Code rollback:
+  - `git revert <commit-sha>`

--- a/lib/chef/target_io.rb
+++ b/lib/chef/target_io.rb
@@ -1,5 +1,6 @@
 require_relative "target_io/support"
 require_relative "target_io/feature_flags"
+require_relative "target_io/resilience"
 
 require_relative "target_io/dir"
 require_relative "target_io/etc"

--- a/lib/chef/target_io/resilience.rb
+++ b/lib/chef/target_io/resilience.rb
@@ -1,0 +1,99 @@
+require "timeout" unless defined?(Timeout)
+
+module TargetIO
+  module Resilience
+    ENABLED_ENV = "CHEF_TARGET_IO_RESILIENCE_ENABLED".freeze
+    MAX_ATTEMPTS_ENV = "CHEF_TARGET_IO_RESILIENCE_MAX_ATTEMPTS".freeze
+    TIMEOUT_SECONDS_ENV = "CHEF_TARGET_IO_RESILIENCE_TIMEOUT_SECONDS".freeze
+    BACKOFF_BASE_SECONDS_ENV = "CHEF_TARGET_IO_RESILIENCE_BACKOFF_BASE_SECONDS".freeze
+    BACKOFF_MAX_SECONDS_ENV = "CHEF_TARGET_IO_RESILIENCE_BACKOFF_MAX_SECONDS".freeze
+
+    DEFAULT_ENABLED = true
+    DEFAULT_MAX_ATTEMPTS = 3
+    DEFAULT_TIMEOUT_SECONDS = 10.0
+    DEFAULT_BACKOFF_BASE_SECONDS = 0.25
+    DEFAULT_BACKOFF_MAX_SECONDS = 2.0
+
+    class << self
+      def with_timeout_and_backoff(operation:)
+        return yield unless enabled?
+
+        attempt = 0
+        begin
+          attempt += 1
+          Timeout.timeout(timeout_seconds) { return yield }
+        rescue Timeout::Error, StandardError => e
+          raise if attempt >= max_attempts
+
+          delay = retry_delay_seconds(attempt)
+          Chef::Log.warn("TargetIO resilience retry for #{operation} (attempt #{attempt}/#{max_attempts}, #{e.class}: #{e.message})")
+          sleep_for(delay)
+          retry
+        end
+      end
+
+      def enabled?
+        parse_bool(ENABLED_ENV, DEFAULT_ENABLED)
+      end
+
+      def max_attempts
+        value = parse_integer(MAX_ATTEMPTS_ENV, DEFAULT_MAX_ATTEMPTS)
+        [value, 1].max
+      end
+
+      def timeout_seconds
+        value = parse_float(TIMEOUT_SECONDS_ENV, DEFAULT_TIMEOUT_SECONDS)
+        [value, 0.01].max
+      end
+
+      def backoff_base_seconds
+        value = parse_float(BACKOFF_BASE_SECONDS_ENV, DEFAULT_BACKOFF_BASE_SECONDS)
+        [value, 0.0].max
+      end
+
+      def backoff_max_seconds
+        value = parse_float(BACKOFF_MAX_SECONDS_ENV, DEFAULT_BACKOFF_MAX_SECONDS)
+        [value, 0.0].max
+      end
+
+      def retry_delay_seconds(attempt)
+        base = backoff_base_seconds
+        max = backoff_max_seconds
+        delay = base * (2**(attempt - 1))
+
+        [delay, max].min
+      end
+
+      def sleep_for(seconds)
+        sleep(seconds) if seconds.positive?
+      end
+
+      private
+
+      def parse_bool(key, default)
+        value = ENV[key]
+        return default if value.nil? || value.empty?
+
+        %w{1 true yes on}.include?(value.strip.downcase)
+      end
+
+      def parse_integer(key, default)
+        value = ENV[key]
+        return default if value.nil? || value.empty?
+
+        Integer(value)
+      rescue ArgumentError
+        default
+      end
+
+      def parse_float(key, default)
+        value = ENV[key]
+        return default if value.nil? || value.empty?
+
+        Float(value)
+      rescue ArgumentError
+        default
+      end
+    end
+  end
+end

--- a/lib/chef/target_io/support.rb
+++ b/lib/chef/target_io/support.rb
@@ -1,4 +1,5 @@
 require "tempfile" unless defined?(::Tempfile)
+require_relative "resilience"
 
 module TargetIO
   module Support
@@ -56,7 +57,9 @@ module TargetIO
     end
 
     def run_command(cmd)
-      transport_connection.run_command(cmd)
+      TargetIO::Resilience.with_timeout_and_backoff(operation: "run_command #{cmd}") do
+        transport_connection.run_command(cmd)
+      end
     end
 
     def sudo?

--- a/spec/unit/target_io/resilience_spec.rb
+++ b/spec/unit/target_io/resilience_spec.rb
@@ -1,0 +1,68 @@
+#
+# Copyright:: Copyright (c) 2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "spec_helper"
+require "chef/target_io"
+
+RSpec.describe TargetIO::Resilience do
+  before do
+    allow(described_class).to receive(:enabled?).and_return(true)
+    allow(described_class).to receive(:max_attempts).and_return(3)
+    allow(described_class).to receive(:timeout_seconds).and_return(0.1)
+    allow(described_class).to receive(:retry_delay_seconds).and_return(0)
+    allow(described_class).to receive(:sleep_for)
+  end
+
+  describe ".with_timeout_and_backoff" do
+    it "retries timeout failures and eventually succeeds" do
+      calls = 0
+      result = described_class.with_timeout_and_backoff(operation: "test timeout") do
+        calls += 1
+        raise Timeout::Error, "timeout" if calls == 1
+
+        :ok
+      end
+
+      expect(result).to eq(:ok)
+      expect(calls).to eq(2)
+      expect(described_class).to have_received(:sleep_for).with(0)
+    end
+
+    it "retries standard errors and eventually succeeds" do
+      calls = 0
+      result = described_class.with_timeout_and_backoff(operation: "test standard error") do
+        calls += 1
+        raise RuntimeError, "boom" if calls == 1
+
+        :ok
+      end
+
+      expect(result).to eq(:ok)
+      expect(calls).to eq(2)
+      expect(described_class).to have_received(:sleep_for).with(0)
+    end
+
+    it "raises when max attempts are exhausted" do
+      allow(described_class).to receive(:max_attempts).and_return(2)
+
+      expect do
+        described_class.with_timeout_and_backoff(operation: "always fail") do
+          raise Timeout::Error, "still timing out"
+        end
+      end.to raise_error(Timeout::Error)
+    end
+  end
+end

--- a/spec/unit/target_io/support_spec.rb
+++ b/spec/unit/target_io/support_spec.rb
@@ -87,6 +87,16 @@ RSpec.describe TargetIO::Support do
       expect(transport_connection).to receive(:run_command).with("ls -la /tmp").and_return(result)
       expect(helper.run_command("ls -la /tmp")).to eq(result)
     end
+
+    it "routes execution through the resilience helper" do
+      result = double("cmd_result", exit_status: 0, stdout: "output\n")
+      expect(TargetIO::Resilience).to receive(:with_timeout_and_backoff)
+        .with(operation: "run_command ls -la /tmp")
+        .and_yield
+      expect(transport_connection).to receive(:run_command).with("ls -la /tmp").and_return(result)
+
+      expect(helper.run_command("ls -la /tmp")).to eq(result)
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────

--- a/spec/unit/target_io/train/dir_spec.rb
+++ b/spec/unit/target_io/train/dir_spec.rb
@@ -42,6 +42,25 @@ RSpec.describe TargetIO::TrainCompat::Dir do
         .with("ls -1a /etc").and_return(double(stdout: ".\n..\nhosts\npasswd\n"))
       expect(described_class.entries("/etc")).to eq([".", "..", "hosts", "passwd"])
     end
+
+    it "retries once on timeout and succeeds" do
+      allow(TargetIO::Resilience).to receive(:enabled?).and_return(true)
+      allow(TargetIO::Resilience).to receive(:max_attempts).and_return(2)
+      allow(TargetIO::Resilience).to receive(:timeout_seconds).and_return(0.1)
+      allow(TargetIO::Resilience).to receive(:retry_delay_seconds).and_return(0)
+      allow(TargetIO::Resilience).to receive(:sleep_for)
+
+      first = true
+      allow(transport_connection).to receive(:run_command).with("ls -1a /etc") do
+        if first
+          first = false
+          raise Timeout::Error, "timed out"
+        end
+        double(stdout: ".\n..\nresolv.conf\n")
+      end
+
+      expect(described_class.entries("/etc")).to eq([".", "..", "resolv.conf"])
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────

--- a/spec/unit/target_io/train/fileutils_spec.rb
+++ b/spec/unit/target_io/train/fileutils_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe TargetIO::TrainCompat::FileUtils do
       expect(transport_connection).not_to receive(:run_command)
       described_class.cp("/src", "/dest", noop: true)
     end
+
+    it "retries once on transient errors and succeeds" do
+      allow(TargetIO::Resilience).to receive(:enabled?).and_return(true)
+      allow(TargetIO::Resilience).to receive(:max_attempts).and_return(2)
+      allow(TargetIO::Resilience).to receive(:timeout_seconds).and_return(0.1)
+      allow(TargetIO::Resilience).to receive(:retry_delay_seconds).and_return(0)
+      allow(TargetIO::Resilience).to receive(:sleep_for)
+
+      first = true
+      allow(transport_connection).to receive(:run_command).with("cp /src /dest") do
+        if first
+          first = false
+          raise RuntimeError, "temporary cp error"
+        end
+        cmd_ok
+      end
+
+      expect { described_class.cp("/src", "/dest") }.not_to raise_error
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Title: GHCP -- Run: ex15 Target IO Resilience

Summary
- Added a shared resilience helper (`TargetIO::Resilience`) with per-attempt timeout and exponential backoff retries, and wired it into `TargetIO::Support#run_command` so transport command execution uses one consistent reliability pattern.
- Applied helper pattern to multiple external call paths in the target folder via shared `run_command`: `TrainCompat::Dir.entries`, `TrainCompat::Dir.glob`, and `TrainCompat::FileUtils.cp` (plus sibling fileutils command paths that call `run_command`).
- Updated ops runbook with tuning parameters, escalation flow, and rollback controls.

Evidence
- Before/after metrics or screenshots: before this change, these command paths failed immediately on first timeout/exception (documented in runbook); after this change, retries/timeouts are handled through the shared helper and failure simulations pass.
- Tests/logs/metrics: `bundle exec rspec spec/unit/target_io/resilience_spec.rb spec/unit/target_io/support_spec.rb spec/unit/target_io/train/dir_spec.rb spec/unit/target_io/train/fileutils_spec.rb --format documentation` => 66 examples, 0 failures; includes timeout retry, transient error retry, and max-attempt exhaustion assertions.
- Delegation checklist completed: yes

Risk & Rollback
- Risk: low/medium
- Rollback: revert `7dc5d12429` or disable resilience at runtime with `CHEF_TARGET_IO_RESILIENCE_ENABLED=false`.
- Rollback commands: `git revert 7dc5d12429` or `export CHEF_TARGET_IO_RESILIENCE_ENABLED=false`

Track
- Level: Run
- Exercise: ex15
