### PR TITLE
CHEF-14144: Limit excessive output from template errors

### DIFF
--- a/lib/chef/formatters/error_description.rb
+++ b/lib/chef/formatters/error_description.rb
@@ -59,10 +59,17 @@ class Chef
 
       private
 
+      MAX_DISPLAY_TEXT_LENGTH = 10_000
+
       def display_section(heading, text, out)
         out.puts heading
         out.puts "-" * heading.size
-        out.puts text
+        if text.is_a?(String) && text.length > MAX_DISPLAY_TEXT_LENGTH
+          out.puts text[0, MAX_DISPLAY_TEXT_LENGTH]
+          out.puts "\n... [truncated #{text.length - MAX_DISPLAY_TEXT_LENGTH} characters of output]"
+        else
+          out.puts text
+        end
         out.puts "\n"
       end
 

--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -278,7 +278,7 @@ class Chef
           if @context.respond_to?(:template_name) && @context.template_name
             location_parts << "template: #{@context.template_name}"
           end
-          location_hint = location_parts.empty? ? "" : " (#{location_parts.join(', ')})"
+          location_hint = location_parts.empty? ? "" : " (#{location_parts.join(", ")})"
 
           "\n\n#{self.class} (#{message}) #{source_location}#{location_hint}:\n\n" +
             "#{source_listing}\n\n  #{original_exception.backtrace.join("\n  ")}\n\n"

--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -271,7 +271,16 @@ class Chef
         end
 
         def to_s
-          "\n\n#{self.class} (#{message}) #{source_location}:\n\n" +
+          location_parts = []
+          if @context.respond_to?(:cookbook_name) && @context.cookbook_name
+            location_parts << "cookbook: #{@context.cookbook_name}"
+          end
+          if @context.respond_to?(:template_name) && @context.template_name
+            location_parts << "template: #{@context.template_name}"
+          end
+          location_hint = location_parts.empty? ? "" : " (#{location_parts.join(', ')})"
+
+          "\n\n#{self.class} (#{message}) #{source_location}#{location_hint}:\n\n" +
             "#{source_listing}\n\n  #{original_exception.backtrace.join("\n  ")}\n\n"
         end
       end

--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -93,6 +93,12 @@ class Chef
           @_extension_modules = []
         end
 
+        # Provide a compact inspect so exception messages do not dump the full
+        # template context, including node attributes and secrets.
+        def inspect
+          "#<#{self.class} template_name=#{@template_name.inspect} cookbook_name=#{@cookbook_name.inspect}>"
+        end
+
         ###
         # USER FACING API
         ###
@@ -220,8 +226,15 @@ class Chef
           @original_exception, @template, @context, @options = original_exception, template, context, options
         end
 
+        MAX_MESSAGE_LENGTH = 10_000
+
         def message
-          @original_exception.message
+          msg = @original_exception.message
+          if msg.length > MAX_MESSAGE_LENGTH
+            msg[0, MAX_MESSAGE_LENGTH] + "\n... [truncated #{msg.length - MAX_MESSAGE_LENGTH} characters]"
+          else
+            msg
+          end
         end
 
         def line_number

--- a/spec/unit/formatters/error_description_spec.rb
+++ b/spec/unit/formatters/error_description_spec.rb
@@ -118,19 +118,21 @@ describe Chef::Formatters::ErrorDescription do
         # reset on global values.
         Chef.set_node({ "platform" => "openvms", "platform_version" => "8.4-2L1" })
         subject.display(out)
-        expect(out.out.string).to eq(
-          "================================================================================\n" \
-          "test title\n" \
-          "================================================================================\n\n" \
-          "System Info:\n" \
-          "------------\n" \
-          "chef_version=1.2.3\n" \
-          "platform=openvms\n" \
-          "platform_version=8.4-2L1\n" \
-          "ruby=ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]\n" \
-          "program_name=chef-client\n" \
-          "executable=/test/bin/chef-client\n\n"
-        )
+        expect(out.out.string).to eq <<~END
+          ================================================================================
+          test title
+          ================================================================================
+
+          System Info:
+          ------------
+          chef_version=1.2.3
+          platform=openvms
+          platform_version=8.4-2L1
+          ruby=ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
+          program_name=chef-client
+          executable=/test/bin/chef-client
+
+        END
       end
     end
 

--- a/spec/unit/formatters/error_description_spec.rb
+++ b/spec/unit/formatters/error_description_spec.rb
@@ -110,7 +110,6 @@ describe Chef::Formatters::ErrorDescription do
 
         END
       end
-
     end
 
     context "when node object is available" do
@@ -119,23 +118,36 @@ describe Chef::Formatters::ErrorDescription do
         # reset on global values.
         Chef.set_node({ "platform" => "openvms", "platform_version" => "8.4-2L1" })
         subject.display(out)
-        expect(out.out.string).to eq <<~END
-          ================================================================================
-          test title
-          ================================================================================
+        expect(out.out.string).to eq(
+          "================================================================================\n" \
+          "test title\n" \
+          "================================================================================\n\n" \
+          "System Info:\n" \
+          "------------\n" \
+          "chef_version=1.2.3\n" \
+          "platform=openvms\n" \
+          "platform_version=8.4-2L1\n" \
+          "ruby=ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]\n" \
+          "program_name=chef-client\n" \
+          "executable=/test/bin/chef-client\n\n"
+        )
+      end
+    end
 
-          System Info:
-          ------------
-          chef_version=1.2.3
-          platform=openvms
-          platform_version=8.4-2L1
-          ruby=ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
-          program_name=chef-client
-          executable=/test/bin/chef-client
+    context "when a section has excessively long text" do
+      let(:huge_text) { "x" * 50_000 }
 
-        END
+      before do
+        subject.section("Huge Section", huge_text)
       end
 
+      it "should truncate the section text to MAX_DISPLAY_TEXT_LENGTH" do
+        subject.display(out)
+        output = out.out.string
+        expect(output).to include("Huge Section")
+        expect(output).to include("[truncated")
+        expect(output.length).to be < (Chef::Formatters::ErrorDescription::MAX_DISPLAY_TEXT_LENGTH + 1000)
+      end
     end
   end
 end

--- a/spec/unit/mixin/template_spec.rb
+++ b/spec/unit/mixin/template_spec.rb
@@ -336,8 +336,7 @@ describe Chef::Mixin::Template, "render_template" do
       huge_message = "undefined method `platform?' for " + ("x" * 20_000)
       original_exception = double("exception",
         message: huge_message,
-        backtrace: ["(erubis):1"]
-      )
+        backtrace: ["(erubis):1"])
       template_error = Chef::Mixin::Template::TemplateError.new(
         original_exception, "<%= platform? %>", {}, {}
       )
@@ -351,8 +350,7 @@ describe Chef::Mixin::Template, "render_template" do
     it "should not truncate short error messages" do
       original_exception = double("exception",
         message: "undefined method `platform?'",
-        backtrace: ["(erubis):1"]
-      )
+        backtrace: ["(erubis):1"])
       template_error = Chef::Mixin::Template::TemplateError.new(
         original_exception, "<%= platform? %>", {}, {}
       )

--- a/spec/unit/mixin/template_spec.rb
+++ b/spec/unit/mixin/template_spec.rb
@@ -312,6 +312,23 @@ describe Chef::Mixin::Template, "render_template" do
         expect(@exception.to_s).to include("  2: bar\n  3: baz\n  4: <%= this_is_not_defined %>\n  5: quin\n  6: qunx")
         expect(@exception.to_s).to include(@exception.original_exception.backtrace.first)
       end
+
+      it "does not dump large node data in end-to-end template error output" do
+        @context[:node] = { "platform" => "centos", "large_data" => "x" * 100_000 }
+        @context[:template_name] = "test.erb"
+        @context[:cookbook_name] = "my_cookbook"
+
+        begin
+          @context.render_template_from_string("<%= this_is_not_defined %>")
+        rescue Chef::Mixin::Template::TemplateError => e
+          output = e.to_s
+          expect(output).to include("undefined local variable or method")
+          expect(output).to include("my_cookbook")
+          expect(output).to include("test.erb")
+          expect(output).not_to include("large_data")
+          expect(output.length).to be < 12_000
+        end
+      end
     end
   end
 

--- a/spec/unit/mixin/template_spec.rb
+++ b/spec/unit/mixin/template_spec.rb
@@ -314,4 +314,50 @@ describe Chef::Mixin::Template, "render_template" do
       end
     end
   end
+
+  describe "TemplateContext#inspect" do
+    it "should return a compact string instead of dumping all instance variables" do
+      context = Chef::Mixin::Template::TemplateContext.new({})
+      context[:node] = { "platform" => "centos", "large_data" => "x" * 100_000 }
+      context[:template_name] = "test.erb"
+      context[:cookbook_name] = "my_cookbook"
+
+      result = context.inspect
+      expect(result).to include("Chef::Mixin::Template::TemplateContext")
+      expect(result).to include("my_cookbook")
+      expect(result).to include("test.erb")
+      expect(result.length).to be < 200
+      expect(result).not_to include("large_data")
+    end
+  end
+
+  describe "TemplateError message truncation (CHEF-14144)" do
+    it "should truncate excessively long error messages" do
+      huge_message = "undefined method `platform?' for " + ("x" * 20_000)
+      original_exception = double("exception",
+        message: huge_message,
+        backtrace: ["(erubis):1"]
+      )
+      template_error = Chef::Mixin::Template::TemplateError.new(
+        original_exception, "<%= platform? %>", {}, {}
+      )
+
+      msg = template_error.message
+      expect(msg.length).to be < (Chef::Mixin::Template::TemplateError::MAX_MESSAGE_LENGTH + 200)
+      expect(msg).to include("[truncated")
+      expect(msg).to include("undefined method `platform?'")
+    end
+
+    it "should not truncate short error messages" do
+      original_exception = double("exception",
+        message: "undefined method `platform?'",
+        backtrace: ["(erubis):1"]
+      )
+      template_error = Chef::Mixin::Template::TemplateError.new(
+        original_exception, "<%= platform? %>", {}, {}
+      )
+
+      expect(template_error.message).to eq("undefined method `platform?'")
+    end
+  end
 end


### PR DESCRIPTION
<h2>Summary</h2><p>Limits oversized template error output so exceptions and formatter output stay compact.</p><h2>Validation</h2><p>Focused regression specs were run for the template and formatter paths.</p><h2>AI Assistance</h2><p>This work was completed with AI assistance following Progress AI policies.</p>

Supercedes #15924 