### PR TITLE
Disable chrony kitchen test for Rocky Linux 10

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -69,7 +69,9 @@ end
 
 include_recipe "::_packages"
 
-unless (amazon? && node["platform_version"] >= "2023") || (platform?("almalinux") && node["platform_version"].to_i >= 10) # TODO: look into chrony service issue
+unless (amazon? && node["platform_version"] >= "2023") ||
+    (platform?("almalinux") && node["platform_version"].to_i >= 10) ||
+    (platform?("rocky") && node["platform_version"].to_i >= 10) # TODO: look into chrony service issue
   include_recipe value_for_platform(
     opensuseleap: { "default" => "ntp" },
     amazon: { "2" => "ntp" },


### PR DESCRIPTION
<h2>Summary</h2><p>Disable the chrony kitchen coverage on Rocky Linux 10 in end-to-end linux recipe tests while keeping Rocky Linux 10 in the kitchen matrix.</p><h2>Details</h2><ul><li>Added a Rocky Linux 10 guard alongside existing Amazon Linux 2023 and AlmaLinux 10 chrony exclusions.</li><li>No kitchen matrix entries were removed.</li></ul><p>This work was completed with AI assistance following Progress AI policies.</p>