### PR TITLE
[chef-18] Disable chrony kitchen test for Rocky Linux 10

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -68,11 +68,11 @@ end
 include_recipe "::_packages"
 include_recipe "::_chef_gem"
 
-# TODO: look into chrony service issue
 unless (amazon? && node["platform_version"] >= "2023") ||
     (platform?("almalinux") && node["platform_version"].to_i >= 10) ||
+    (platform?("rocky") && node["platform_version"].to_i >= 10) ||
     (ubuntu? && node["platform_version"].start_with?("20.04")) ||
-    (fedora? && node["platform_version"] == "41")
+    (fedora? && node["platform_version"] == "41") # TODO: look into chrony service issue
   include_recipe value_for_platform(
     opensuseleap: { "default" => "ntp" },
     amazon: { "2" => "ntp" },


### PR DESCRIPTION
<h2>Summary</h2><p>Backport of #16082 to chef-18: disable chrony kitchen coverage on Rocky Linux 10 while keeping Rocky Linux 10 in the kitchen matrix.</p><h2>Details</h2><ul><li>Resolved cherry-pick conflict in <code>kitchen-tests/cookbooks/end_to_end/recipes/linux.rb</code> by preserving chef-18-specific exclusions and adding Rocky Linux 10 chrony exclusion.</li><li>No kitchen matrix entries were removed.</li></ul><p>This work was completed with AI assistance following Progress AI policies.</p>