### PR TITLE
CHEF-14144: Limit Template Error Output - chef-18 backport

### DIFF
--- a/spec/unit/formatters/error_description_spec.rb
+++ b/spec/unit/formatters/error_description_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Jordan Running (<jr@chef.io>)
 #
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,7 +110,6 @@ describe Chef::Formatters::ErrorDescription do
 
         END
       end
-
     end
 
     context "when node object is available" do
@@ -135,7 +134,22 @@ describe Chef::Formatters::ErrorDescription do
 
         END
       end
+    end
 
+    context "when a section has excessively long text" do
+      let(:huge_text) { "x" * 50_000 }
+
+      before do
+        subject.section("Huge Section", huge_text)
+      end
+
+      it "should truncate the section text to MAX_DISPLAY_TEXT_LENGTH" do
+        subject.display(out)
+        output = out.out.string
+        expect(output).to include("Huge Section")
+        expect(output).to include("[truncated")
+        expect(output.length).to be < (Chef::Formatters::ErrorDescription::MAX_DISPLAY_TEXT_LENGTH + 1000)
+      end
     end
   end
 end


### PR DESCRIPTION
<h2>Backport of PR #16073 to chef-18 branch</h2><p>This is a backport of the template error output limiting changes to the chef-18 release branch.</p><p><strong>Changes:</strong></p><ul><li>Include cookbook and template name in TemplateError#to_s</li><li>Fix RuboCop Layout/MultilineMethodCallBraceLayout</li><li>Fix interpolation string quote style</li><li>Restore original HEREDOC</li></ul><p>This work was completed with AI assistance following Progress AI policies</p>