### PR TITLE
Remove experimental tag warning from target mode

### DIFF
--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -219,8 +219,7 @@ class Chef::Application::Base < Chef::Application
   option :target,
     short: "-t TARGET",
     long: "--target TARGET",
-    description: "Target #{ChefUtils::Dist::Infra::PRODUCT} against a remote system or device",
-    proc: lambda { |target| target }
+    description: "Target #{ChefUtils::Dist::Infra::PRODUCT} against a remote system or device"
 
   option :disable_config,
     long: "--disable-config",

--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -221,7 +221,6 @@ class Chef::Application::Base < Chef::Application
     long: "--target TARGET",
     description: "Target #{ChefUtils::Dist::Infra::PRODUCT} against a remote system or device",
     proc: lambda { |target|
-      Chef::Log.warn "-- EXPERIMENTAL -- Target mode activated, resources and dsl may change without warning -- EXPERIMENTAL --"
       target
     }
 

--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -220,9 +220,7 @@ class Chef::Application::Base < Chef::Application
     short: "-t TARGET",
     long: "--target TARGET",
     description: "Target #{ChefUtils::Dist::Infra::PRODUCT} against a remote system or device",
-    proc: lambda { |target|
-      target
-    }
+    proc: lambda { |target| target }
 
   option :disable_config,
     long: "--disable-config",


### PR DESCRIPTION
<h2>Summary</h2><p>Removes the EXPERIMENTAL warning log emitted when <code>--target</code> is used so target mode no longer presents itself as experimental.</p><h2>Issue</h2><p>Fixes <a href='https://github.com/chef/chef/issues/15987'>#15987</a>.</p><h2>Validation</h2><ul><li><code>bundle exec rspec spec/unit/application/base_spec.rb spec/unit/application/client_spec.rb --format progress</code></li></ul><p>This work was completed with AI assistance following Progress AI policies.</p>