### PR TITLE
Fix chef_client_* resource in non-hab builds

### DIFF
--- a/lib/chef/resource/helpers/path_helpers.rb
+++ b/lib/chef/resource/helpers/path_helpers.rb
@@ -29,8 +29,8 @@ class Chef
         # return path for any bin/chef-* names
         return path.sub(bin, ChefUtils::Dist::Infra::CLIENT) if bin =~ /^chef-[a-z-]+$/
 
-        # Return empty string if no valid path is found
-        ""
+        # Fall back to legacy path if no valid path is found
+        which(ChefUtils::Dist::Infra::CLIENT)
       end
 
       # once the binstubs under hab package have been fixed,


### PR DESCRIPTION
Resources like `chef_client_systemd_timer` silently fail when using recipes not launched by chef-client, such as chef-zero, since `chef_binary_path` falls back to `""`.

Example of this path working on a non-hab build:
```
cinc (19.3.14)> which(ChefUtils::Dist::Infra::CLIENT)
 => "/usr/bin/cinc-client" 
```
