### PR TITLE
[BACKPORT] Removing Chef-PowerShell from Habitat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ PATH
       chef-config (= 18.10.97)
       chef-utils (= 18.10.97)
       chef-vault
-      chef-zero (>= 15.0.21, < 15.2)
+      chef-zero (~> 15.1.11)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 2.1.0, != 1.4.0)
       erubis (~> 2.7)
@@ -82,7 +82,7 @@ PATH
       chef-powershell (~> 18.6.0)
       chef-utils (= 18.10.97)
       chef-vault
-      chef-zero (>= 15.0.21, < 15.2)
+      chef-zero (~> 15.1.11)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 2.1.0, != 1.4.0)
       erubis (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ PATH
       chef-config (= 18.10.97)
       chef-utils (= 18.10.97)
       chef-vault
-      chef-zero (~> 15.1.11)
+      chef-zero (>= 15.0.21, < 15.2)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 2.1.0, != 1.4.0)
       erubis (~> 2.7)
@@ -82,7 +82,7 @@ PATH
       chef-powershell (~> 18.6.0)
       chef-utils (= 18.10.97)
       chef-vault
-      chef-zero (~> 15.1.11)
+      chef-zero (>= 15.0.21, < 15.2)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 2.1.0, != 1.4.0)
       erubis (~> 2.7)

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -17,7 +17,6 @@ $pkg_deps=@(
   "core/libarchive"
   "core/zlib"
   "chef/ruby31-plus-devkit"
-  "chef/chef-powershell-shim"
   "core/visual-cpp-redist-2015/14.0.24215/20240108064521"
 )
 $pkg_build_deps=@( "core/git")

--- a/spec/functional/mixin/powershell_out_spec.rb
+++ b/spec/functional/mixin/powershell_out_spec.rb
@@ -21,6 +21,31 @@ require "chef/mixin/powershell_out"
 describe Chef::Mixin::PowershellOut, :windows_only do
   include Chef::Mixin::PowershellOut
 
+  it "requires PowerShell DLLs and runtimes to be present" do
+    unless chef_powershell_gem_available?
+      raise <<~ERROR
+
+        ╔═══════════════════════════════════════════════════════════════════════════╗
+        ║                          CRITICAL TEST FAILURE                            ║
+        ╠═══════════════════════════════════════════════════════════════════════════╣
+        ║                                                                           ║
+        ║  PowerShell execution environment is NOT available!                       ║
+        ║                                                                           ║
+        ║  Required components missing:                                             ║
+        ║    - chef-powershell gem and/or                                           ║
+        ║    - Chef.PowerShell.dll and/or                                           ║
+        ║    - vcruntime140.dll (Visual C++ Runtime)                                ║
+        ║                                                                           ║
+        ║  PowershellOut mixin tests CANNOT run without these dependencies.         ║
+        ║                                                                           ║
+        ║  Please ensure all required PowerShell runtime components are installed.  ║
+        ║                                                                           ║
+        ╚═══════════════════════════════════════════════════════════════════════════╝
+
+      ERROR
+    end
+  end
+
   describe "#powershell_out" do
     it "runs a powershell command and collects stdout" do
       expect(powershell_out("get-process").run_command.stdout).to match(/Handles/)

--- a/spec/functional/resource/dsc_resource_spec.rb
+++ b/spec/functional/resource/dsc_resource_spec.rb
@@ -33,6 +33,43 @@ describe Chef::Resource::DscResource, :windows_powershell_dsc_only do
     Chef::Resource::DscResource.new("dsc_resource_test", run_context)
   end
 
+  it "requires PowerShell DLLs and runtimes to be present" do
+    unless chef_powershell_gem_available?
+      raise <<~ERROR
+
+        ╔═══════════════════════════════════════════════════════════════════════════╗
+        ║                          CRITICAL TEST FAILURE                            ║
+        ╠═══════════════════════════════════════════════════════════════════════════╣
+        ║                                                                           ║
+        ║  PowerShell execution environment is NOT available!                       ║
+        ║                                                                           ║
+        ║  Required components missing:                                             ║
+        ║    - chef-powershell gem and/or                                           ║
+        ║    - Chef.PowerShell.dll and/or                                           ║
+        ║    - vcruntime140.dll (Visual C++ Runtime)                                ║
+        ║                                                                           ║
+        ║  DSC resource tests CANNOT run without these dependencies.                ║
+        ║                                                                           ║
+        ║  Please ensure all required PowerShell runtime components are installed.  ║
+        ║                                                                           ║
+        ╚═══════════════════════════════════════════════════════════════════════════╝
+
+      ERROR
+    end
+  end
+
+  context "when PowerShell DLLs are missing (mocked)" do
+    it "fails with a clear error message" do
+      allow(self).to receive(:powershell_exec_available?).and_return(false)
+
+      expect {
+        unless powershell_exec_available?
+          raise "PowerShell execution environment is not available"
+        end
+      }.to raise_error(RuntimeError, /PowerShell execution environment is not available/)
+    end
+  end
+
   context "when PowerShell does not support Invoke-DscResource"
   context "when PowerShell supports Invoke-DscResource" do
     before do

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -282,3 +282,73 @@ def pwsh_installed?
 rescue
   false
 end
+
+# Check if the chef-powershell gem is properly installed
+# This checks that the gem specification exists without forcing it to be loaded
+def chef_powershell_gem_available?
+  return false unless windows?
+
+  begin
+    # Check if gem is installed without forcing a require
+    spec = Gem.loaded_specs["chef-powershell"] || Gem.specification.find_all_by_name("chef-powershell").first
+    return false unless spec
+
+    # Verify runtime dependencies are available
+    powershell_runtime_available?
+    powershell_exec_available?
+  rescue => e
+    Chef::Log.warn("Error checking chef-powershell gem availability: #{e.class} - #{e.message}")
+    false
+  end
+end
+
+# Check if PowerShell execution via chef-powershell is available
+# Checks that both the gem and the execution mixin can be loaded
+def powershell_exec_available?
+  return false unless windows?
+
+  begin
+    require "chef/mixin/powershell_exec"
+    true
+  rescue => e
+    Chef::Log.debug("PowerShell execution mixin not available: #{e.class} - #{e.message}")
+    false
+  end
+end
+
+# Check if the required runtime dependencies are available
+# Specifically checks for vcruntime140.dll on Windows
+def powershell_runtime_available?
+  return false unless windows?
+
+  begin
+    require "ruby_installer"
+    # Check if we can load the PowerShell DLL which requires vcruntime140.dll
+    match_path = "bin/ruby_bin_folder/#{ENV["PROCESSOR_ARCHITECTURE"]}/Chef.PowerShell.dll"
+    matched_paths = Dir.glob("{#{Gem.dir},C:/hab}/**/#{match_path}").map { |f| File.expand_path(f) }
+
+    unless matched_paths.empty?
+      dll_path = matched_paths.first
+      dll_dir = File.dirname(dll_path)
+
+      # Verify vcruntime140.dll is accessible in the same directory
+      vcruntime_path = File.join(dll_dir, "vcruntime140.dll")
+
+      if File.exist?(vcruntime_path)
+        return true
+      else
+        Chef::Log.warn("vcruntime140.dll not found at #{dll_dir}")
+        return false
+      end
+    end
+
+    # If no DLL found via gem paths, check if PowerShell can still be loaded
+    true
+  rescue LoadError
+    # ruby_installer not available - not using RubyInstaller runtime
+    true
+  rescue => e
+    Chef::Log.warn("Error checking PowerShell runtime availability: #{e.class} - #{e.message}")
+    false
+  end
+end

--- a/spec/support/ruby_installer.rb
+++ b/spec/support/ruby_installer.rb
@@ -14,26 +14,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def load_dlls(match_path)
+# Helper to verify that required runtime dependencies exist alongside a DLL
+def verify_dependencies_for_dll(dll_dir, dll_name)
+  required_runtimes = ["vcruntime140.dll", "msvcp140.dll"]
+
+  missing_runtimes = required_runtimes.select do |runtime_dll|
+    !File.exist?(File.join(dll_dir, runtime_dll))
+  end
+
+  if missing_runtimes.any?
+    $stderr.puts "\n!!!!"
+    $stderr.puts "CRITICAL ERROR: Missing required runtime dependencies for #{dll_name}"
+    $stderr.puts "Location: #{dll_dir}"
+    $stderr.puts "Missing DLLs: #{missing_runtimes.join(", ")}"
+    $stderr.puts "\nThis will cause PowerShell tests to fail or behave unexpectedly."
+    $stderr.puts "!!!!\n"
+    return false
+  end
+
+  true
+end
+
+def load_dlls(match_path, is_powershell_dll = false)
   require "ruby_installer"
   matched_paths = Dir.glob("{#{Gem.dir},C:/hab}/**/#{match_path}").map { |f| File.expand_path(f) }
   if matched_paths.empty?
-    $stderr.puts <<~EOL
+    error_msg = <<~EOL
       !!!!
         We couldn't find any matches for #{match_path} in #{Gem.dir} or C:/hab
 
-        If this is running in a CI/CD environment, this may end up causing failures
-        in the tests. If this is not running in a CI/CD
-        environment then it may be safe to ignore this. That is especially true if
-        you're not using the Ruby Installer as your Ruby runtime.
+        If this is running in a CI/CD environment, this will cause test failures.
+        If this is not running in a CI/CD environment then it may be safe to ignore this
+        (only if you're not using the Ruby Installer as your Ruby runtime).
       !!!!
     EOL
+    $stderr.puts error_msg
+
+    # For PowerShell DLL, this is a critical error - fail fast
+    if is_powershell_dll
+      raise "CRITICAL: Required runtime DLLs missing for PowerShell - tests will fail"
+    end
+
     return
   end
 
   $stderr.puts "\nFound the following dll paths:\n\n#{matched_paths.map { |f| "- #{f}\n" }.join}\n\n"
   dll_path = matched_paths.first
   dll_dir = File.dirname(dll_path)
+
+  # Verify runtime dependencies are present for PowerShell DLL
+  if is_powershell_dll
+    unless verify_dependencies_for_dll(dll_dir, File.basename(dll_path))
+      raise "CRITICAL: Required runtime DLLs missing for PowerShell - tests will fail"
+    end
+  end
 
   if defined?(RubyInstaller::Build) && RubyInstaller::Build.methods.include?(:add_dll_directory)
     $stderr.puts "Adding #{dll_dir} as a DLL load path using RubyInstaller::Build#add_dll_directory"
@@ -50,5 +84,5 @@ end
 
 if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
   load_dlls("libarchive.dll")
-  load_dlls("bin/ruby_bin_folder/#{ENV["PROCESSOR_ARCHITECTURE"]}/Chef.PowerShell.dll")
+  load_dlls("bin/ruby_bin_folder/#{ENV["PROCESSOR_ARCHITECTURE"]}/Chef.PowerShell.dll", true)
 end

--- a/spec/unit/mixin/powershell_exec_spec.rb
+++ b/spec/unit/mixin/powershell_exec_spec.rb
@@ -24,6 +24,17 @@ describe Chef::Mixin::PowershellExec, :windows_only do
   subject(:object) { powershell_mixin.new }
 
   describe "#powershell_exec" do
+    context "ensuring runtime dependencies are available" do
+      it "raises an error if the chef-powershell gem is not available" do
+        # even though the method is checking for the "gem", it actually verifies the runtime libraries are available, so we can use this test to verify that the runtime dependencies are present as well.
+        unless chef_powershell_gem_available?
+          raise <<~ERROR
+            The Chef PowerShell gem is not available. Please install it to run these tests.
+          ERROR
+        end
+      end
+    end
+
     context "not specifying an interpreter" do
       it "runs a basic command and returns a Chef::PowerShell object" do
         expect(object.powershell_exec("$PSVersionTable")).to be_kind_of(ChefPowerShell::PowerShell)

--- a/spec/unit/mixin/powershell_out_spec.rb
+++ b/spec/unit/mixin/powershell_out_spec.rb
@@ -27,6 +27,14 @@ describe Chef::Mixin::PowershellOut, :windows_only do
   end
 
   describe "#powershell_out" do
+    it "ensures that the runtime dependencies are available" do
+      unless chef_powershell_gem_available?
+        raise <<~ERROR
+          The Chef PowerShell gem is not available. Please install it to run these tests.
+        ERROR
+      end
+    end
+
     it "runs a command and returns the shell_out object" do
       ret = double("Mixlib::ShellOut")
       expect(object).to receive(:shell_out).with(
@@ -54,7 +62,6 @@ describe Chef::Mixin::PowershellOut, :windows_only do
     end
 
     it "raises error if interpreter is invalid" do
-      ret = double("Mixlib::ShellOut")
       expect { object.powershell_out("Get-Process", :blah, timeout: 600) }.to raise_error(ArgumentError)
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This is a backport of this PR: https://github.com/chef/chef/pull/15611.

We remove the Hab package dependency and tighten up testing so we stop getting the errors about missing files. Chef-PowerShell is dependent on a couple of MSVC runtime libraries and we want to ensure that they are packaged and available after chef installation completes.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
