### PR TITLE
fix(habitat): add Habitat glibc lib dir to LD_LIBRARY_PATH for native gem builds (CHEF-35271)

### DIFF
--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -75,6 +75,16 @@ do_setup_environment() {
   set_runtime_env -f SSL_CERT_FILE "$(pkg_path_for cacerts)/ssl/cert.pem"
   set_runtime_env LANG "en_US.UTF-8"
   set_runtime_env LC_CTYPE "en_US.UTF-8"
+
+  # Ensure Habitat's glibc lib dir is in LD_LIBRARY_PATH at runtime so that
+  # native gem extension compilation succeeds on platforms with an older system
+  # glibc (e.g. Rocky Linux 9 ships glibc 2.34, but Habitat's libruby.so.3.4
+  # requires GLIBC_2.38).  When mkmf compiles and runs its conftest binary
+  # during `gem install`, it loads libruby.so.3.4 which in turn requires
+  # glibc symbols not present in the system libm/libc.  Adding Habitat's glibc
+  # lib dir here ensures subprocesses spawned by chef-client (including gem
+  # native extension builds) find the correct glibc before the system one.
+  push_runtime_env LD_LIBRARY_PATH "$(pkg_path_for core/glibc)/lib"
 }
 
 do_prepare() {

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -75,6 +75,16 @@ do_setup_environment() {
   set_runtime_env -f SSL_CERT_FILE "$(pkg_path_for cacerts)/ssl/cert.pem"
   set_runtime_env LANG "en_US.UTF-8"
   set_runtime_env LC_CTYPE "en_US.UTF-8"
+
+  # Ensure Habitat's glibc lib dir is in LD_LIBRARY_PATH at runtime so that
+  # native gem extension compilation succeeds on platforms with an older system
+  # glibc (e.g. Rocky Linux 9 ships glibc 2.34, but Habitat's libruby.so.3.4
+  # requires GLIBC_2.38).  When mkmf compiles and runs its conftest binary
+  # during `gem install`, it loads libruby.so.3.4 which in turn requires
+  # glibc symbols not present in the system libm/libc.  Adding Habitat's glibc
+  # lib dir here ensures subprocesses spawned by chef-client (including gem
+  # native extension builds) find the correct glibc before the system one.
+  push_runtime_env LD_LIBRARY_PATH "$(pkg_path_for core/glibc)/lib"
 }
 
 do_prepare() {


### PR DESCRIPTION
<h2>Summary</h2>
<p>
Fixes native gem extension compilation failures on Linux platforms with an older system glibc
(e.g. Rocky Linux 9 ships glibc 2.34) when running <code>chef_gem</code> or <code>gem install</code>
under Chef 19 (Habitat-based).
</p>

<h2>Issue</h2>
<p><a href="https://progresssoftware.atlassian.net/browse/CHEF-35271">CHEF-35271</a></p>

<h2>Root Cause</h2>
<p>
Chef 19 uses Habitat-packaged Ruby 3.4 whose <code>libruby.so.3.4</code> was compiled against
Habitat&apos;s own glibc 2.41. It therefore requires <code>GLIBC_2.38</code> symbols from
<code>libm</code> and <code>libc</code> at runtime. When mkmf compiles and executes its
<code>conftest</code> test binary during native gem extension builds, that binary loads
<code>libruby.so.3.4</code> which in turn tries to resolve <code>GLIBC_2.38</code> from the
<em>system</em> glibc — and fails on Rocky Linux 9 (system glibc 2.34):
</p>
<pre><code>./conftest: /lib64/libm.so.6: version &apos;GLIBC_2.38&apos; not found
./conftest: /lib64/libc.so.6: version &apos;GLIBC_2.38&apos; not found</code></pre>
<p>
This was not an issue with Chef 18 (Omnibus) because its Ruby 3.1 was compiled against a very old
glibc baseline compatible with all supported Linux platforms.
</p>

<h2>Fix</h2>
<p>
Add <code>push_runtime_env LD_LIBRARY_PATH "$(pkg_path_for core/glibc)/lib"</code> to the
<code>do_setup_environment()</code> hook in both Linux Habitat plans. This causes Habitat to
export <code>LD_LIBRARY_PATH</code> including Habitat&apos;s own glibc <code>lib</code> directory
whenever <code>chef-client</code> runs, so all subprocesses — including native extension compiler
test binaries — find the correct glibc before the system glibc.
<code>core/glibc</code> is already listed in <code>pkg_deps</code> in both plans, so
<code>pkg_path_for</code> resolves correctly at build time.
</p>
<p>
This covers <strong>every</strong> native gem build path: direct <code>gem install</code>,
<code>chef_gem</code> resource, and <code>gem_package</code> resource.
</p>

<h2>Changes</h2>
<ul>
  <li>Modified: <code>habitat/x86_64-linux/plan.sh</code> — added <code>push_runtime_env LD_LIBRARY_PATH</code> in <code>do_setup_environment()</code></li>
  <li>Modified: <code>habitat/aarch64-linux/plan.sh</code> — same fix for ARM64 builds</li>
</ul>

<h2>Tests &amp; Coverage</h2>
<p>
The Habitat plan files are shell scripts executed at build time by the Habitat Supervisor; they do not
have an RSpec test suite. Correctness is verified by:
</p>
<ul>
  <li>Confirming <code>core/glibc</code> is already in <code>pkg_deps</code> in both plans (it is), so <code>pkg_path_for</code> resolves correctly at build time</li>
  <li>Confirming <code>push_runtime_env</code> is the correct Habitat primitive for prepending to an env var — consistent with how <code>GEM_PATH</code> is already set in the same function</li>
</ul>

<h2>Risk &amp; Mitigations</h2>
<p><strong>Risk Classification</strong>: Low</p>
<p><strong>Rationale</strong>: Change is purely additive — prepends a path to <code>LD_LIBRARY_PATH</code> that was previously absent. No existing functionality is removed or altered. On systems with a newer glibc the extra path is loaded but the dynamic linker already finds the correct symbols, so there is no regression.</p>
<p><strong>Rollback Strategy</strong>: <code>git revert 317c5bdd76</code></p>

<h2>AI Assistance</h2>
<p>This work was completed with AI assistance following Progress AI policies.</p>