### PR TITLE
Revert "Update ffi requirement from >= 1.15.5, <= 1.16.3 to >= 1.15.5…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "18-stable"
 # Nwed to file a bug with rest-client. In the meantime, we can use this until they accept the update.
 gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt_update1"
 
-gem "ffi", ">= 1.15.5", "<= 1.18.0"
+gem "ffi", ">= 1.15.5", "<= 1.17.0"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 2.1.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5, <= 1.17.5)
+      ffi (>= 1.15.5, <= 1.16.3)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (>= 2.2, < 4.0)
       iniparse (~> 1.4)
@@ -86,7 +86,7 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 2.1.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5, <= 1.17.5)
+      ffi (>= 1.15.5, <= 1.16.3)
       ffi-libarchive (~> 1.0, >= 1.0.3)
       ffi-yajl (>= 2.2, < 4.0)
       iniparse (~> 1.4)
@@ -256,9 +256,8 @@ GEM
       net-http (~> 0.5)
     fauxhai-ng (9.3.0)
       net-ssh
-    ffi (1.17.4)
-    ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x64-mingw-ucrt)
+    ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -333,7 +332,8 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.0.9)
+    mixlib-log (3.1.2.1)
+      ffi (< 1.17.0)
     mixlib-shellout (3.4.10)
       chef-utils
     mixlib-shellout (3.4.10-x64-mingw-ucrt)
@@ -535,7 +535,7 @@ DEPENDENCIES
   crack (< 1.0.2)
   ed25519 (~> 1.2)
   fauxhai-ng
-  ffi (>= 1.15.5, <= 1.18.0)
+  ffi (>= 1.15.5, <= 1.17.0)
   inspec-core-bin (>= 5, < 6)
   ohai!
   openssl (= 3.3.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
     s.add_dependency "inspec-core", ">= 5", "< 8"
   end
 
-  s.add_dependency "ffi", ">= 1.15.5", "<= 1.17.5"
+  s.add_dependency "ffi", ">= 1.15.5", "<= 1.16.3"
   s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "net-ftp" # remote_file resource


### PR DESCRIPTION
## Summary
Reverts PR #15969 on chef-18 to restore compatibility in validation pipelines.

## Context
EOL platforms in chef-chef-chef-18-validate-release runs (for example build 544) can fail when ffi 1.17.4 is selected, because that version is incompatible with older GLIBC versions on those platforms.

## Non-AIX details
The remaining failures are upstream on chef-18 and are not related to AIX changes.

| Platforms | Status |
| --- | --- |
| centos-7, amazon-2, debian-9, ubuntu-1604, sles-12-x86_64 | ffi 1.17.4 GLIBC 2.27 incompatibility; pre-existing and reproducible on chef-18 |

Our AIX work is complete. The remaining failures are in the upstream chef-18 branch and not related to anything changed for AIX.

## AI assistance
This work was completed with AI assistance following Progress AI policies.