### PR TITLE
Add Chef::Telemetry::OtelHandler for OpenTelemetry run tracing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,12 @@ group(:development, :test) do
   gem "fauxhai-ng" # for chef-utils gem
 end
 
+# OpenTelemetry tracing support for Chef::Telemetry::OtelHandler. The handler
+# soft-requires these, so they only need to be present when tracing is enabled
+# (and in development/test for the handler specs).
+gem "opentelemetry-sdk", "~> 1.4", group: %i{development test packaging}
+gem "opentelemetry-exporter-otlp", "~> 0.29", group: :packaging
+
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
 
 # If you want to load debugging tools into the bundle exec sandbox,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,20 @@ GEM
     ffi-yajl (2.7.11-universal-mingw-ucrt)
       libyajl2 (>= 2.1)
     fuzzyurl (0.9.0)
+    google-protobuf (4.35.0)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x64-mingw-ucrt)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    googleapis-common-protos-types (1.23.0)
+      google-protobuf (~> 4.26)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
     hashdiff (1.2.1)
@@ -394,6 +408,27 @@ GEM
     nori (2.7.1)
       bigdecimal
     openssl (3.3.1)
+    opentelemetry-api (1.10.0)
+      logger
+    opentelemetry-common (0.25.0)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-exporter-otlp (0.34.0)
+      google-protobuf (>= 3.18)
+      googleapis-common-protos-types (~> 1.3)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-sdk (~> 1.10)
+      opentelemetry-semantic_conventions
+    opentelemetry-registry (0.6.0)
+      opentelemetry-api (~> 1.1)
+    opentelemetry-sdk (1.12.0)
+      logger
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-registry (~> 0.2)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.40.0)
+      opentelemetry-api (~> 1.0)
     ostruct (0.6.3)
     parallel (1.28.0)
     parser (3.3.11.1)
@@ -586,6 +621,8 @@ DEPENDENCIES
   inspec-core-bin (= 7.0.107)
   ohai!
   openssl (= 3.3.1)
+  opentelemetry-exporter-otlp (~> 0.29)
+  opentelemetry-sdk (~> 1.4)
   pry (~> 0.16.0)
   pry-byebug
   pry-stack_explorer

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -31,3 +31,4 @@ A good first start is our [How Chef Infra Is Built](./design_documents/how_chef_
 - [Client Exit Codes](./design_documents/client_exit_codes.md)
 - [Server Enforced Recipes](./design_documents/server_enforced_recipes.md)
 - [Bootstrap with Train](./design_documents/bootstrap_with_train.md)
+- [OpenTelemetry Run Tracing](./design_documents/otel_run_tracing.md)

--- a/docs/dev/design_documents/otel_run_tracing.md
+++ b/docs/dev/design_documents/otel_run_tracing.md
@@ -1,0 +1,86 @@
+---
+title: OpenTelemetry Run Tracing
+---
+
+# OpenTelemetry Run Tracing
+
+`Chef::Telemetry::OtelHandler` emits an OpenTelemetry trace for each chef-client run: a `chef.run` root span, a child span for each run phase (node load, cookbook sync, compilation, converge, ...) and one span per resource action. The trace makes it easy to see where run time is spent and to correlate failed or slow runs with the rest of your distributed tracing in a backend such as Tempo or Jaeger.
+
+Like the Data Collector, the handler is a `Chef::EventDispatch::Base` subscriber. The event stream is the only interface that delivers live, paired start/complete events for every phase and resource action, which map one-to-one onto span open/close with real wall-clock timestamps. Report/exception handlers only run at the end of the run (and not at all if the run crashes hard), and output formatters are operator-selected for human display, so neither is a suitable hook for telemetry.
+
+## Enabling tracing
+
+Add the following to `client.rb` (or `solo.rb`):
+
+```ruby
+require "chef/telemetry/otel_handler"
+Chef::Telemetry::OtelHandler.register!
+```
+
+`register!` is idempotent: applications such as chef-solo evaluate the config file more than once, and only one handler is ever registered.
+
+The exporter and endpoint are configured through the standard `OTEL_*` environment variables, for example:
+
+```shell
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+The handler soft-requires the `opentelemetry-sdk` gem (plus `opentelemetry-exporter-otlp` for the default OTLP exporter). If the gems are not installed, the handler logs a warning and does nothing. If span emission ever raises mid-run, the handler disables itself for the rest of the run rather than letting the error propagate — tracing can never break a converge.
+
+If something else in the process has already configured the global OpenTelemetry SDK before the handler loads, that configuration (including its resource attributes) is used as-is.
+
+## Service name and tenant
+
+The service name defaults to `chef-client` and can be overridden with `OTEL_SERVICE_NAME`.
+
+Spans can be tagged with a `__tenant` resource attribute (used by Tempo multi-tenancy for search and tail-sampling routing) either through the standard env var:
+
+```shell
+OTEL_RESOURCE_ATTRIBUTES=__tenant=controlplane
+```
+
+or explicitly at registration, which takes precedence over the env var:
+
+```ruby
+Chef::Telemetry::OtelHandler.register!(tenant: "controlplane")
+```
+
+## Span structure
+
+```text
+chef.run                          chef.version, chef.run_id, chef.node.name, chef.environment
+├─ chef.registration
+├─ chef.node_load
+├─ chef.cookbook_resolution
+├─ chef.cookbook_clean
+├─ chef.cookbook_sync
+├─ chef.cookbook_gems
+├─ chef.cookbook_compilation
+│  ├─ chef.library_load
+│  ├─ chef.ohai_plugin_load
+│  ├─ chef.compliance_load
+│  ├─ chef.attribute_load
+│  ├─ chef.lwrp_load
+│  ├─ chef.definition_load
+│  └─ chef.recipe_load
+├─ chef.converge
+│  └─ one span per resource action, named e.g. file[/etc/motd]
+└─ chef.handlers
+```
+
+Each resource span carries `chef.resource.type`, `chef.resource.name`, `chef.resource.action`, `chef.resource.cookbook` and `chef.resource.recipe`, plus outcome detail:
+
+* `chef.resource.updated` — `true`/`false` for converged resources
+* `chef.resource.skipped` and `chef.resource.skip_reason` — for resources skipped by a guard or `action :nothing`
+* `chef.resource.notification_type` and `chef.resource.notifying_resource` — when the action ran due to a notification
+* failed resources record the exception on the span and set error status; retries appear as `retry` span events
+
+The `chef.run` root span ends with OK status on success, or error status (with the exception recorded) when the run fails. Deprecation warnings are attached as `deprecation` span events. An immediately-notified resource's span is a sibling of its notifier under `chef.converge` (the notifier's span closes before the notification fires); the relationship is preserved by the `chef.resource.notifying_resource` attribute.
+
+## Testing locally
+
+The SDK's console exporter prints spans to stdout, which is handy for verifying output without a collector:
+
+```shell
+OTEL_TRACES_EXPORTER=console chef-solo -c solo.rb -o 'recipe[my_cookbook]'
+```

--- a/lib/chef/telemetry/otel_handler.rb
+++ b/lib/chef/telemetry/otel_handler.rb
@@ -1,0 +1,263 @@
+#
+# Author:: Jason Cook (<jasonc@simpleideas.org>)
+# Copyright:: Copyright (c) Jason Cook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../event_dispatch/base"
+require_relative "../log"
+require_relative "../config"
+
+class Chef
+  module Telemetry
+    # Emits an OpenTelemetry trace for the chef-client run: a root span for
+    # the run, child spans for each phase (node load, cookbook sync,
+    # compilation, converge, ...) and one span per resource action.
+    #
+    # Enable it from client.rb (or solo.rb):
+    #
+    #   require "chef/telemetry/otel_handler"
+    #   Chef::Telemetry::OtelHandler.register!
+    #
+    # Exporter and endpoint are configured through the standard OTEL_*
+    # environment variables. Requires the opentelemetry-sdk gem (and
+    # opentelemetry-exporter-otlp for the default exporter); if they are not
+    # installed the handler logs a warning and does nothing.
+    #
+    # Spans can be tagged with a __tenant resource attribute (used by Tempo
+    # multi-tenancy for search and tail-sampling routing) either through the
+    # standard env var:
+    #
+    #   OTEL_RESOURCE_ATTRIBUTES=__tenant=controlplane
+    #
+    # or explicitly, which takes precedence over the env var:
+    #
+    #   Chef::Telemetry::OtelHandler.register!(tenant: "controlplane")
+    class OtelHandler < Chef::EventDispatch::Base
+      # Adds the handler to Chef::Config[:event_handlers]. Idempotent, because
+      # some applications (chef-solo) evaluate the config file more than once
+      # and a second handler would emit every span twice.
+      def self.register!(**opts)
+        return if Chef::Config[:event_handlers].any? { |handler| handler.is_a?(self) }
+
+        Chef::Config[:event_handlers] << new(**opts)
+      end
+
+      def initialize(tracer_provider: nil, tenant: nil)
+        @stack = []
+        @tracer_provider = tracer_provider || default_tracer_provider(tenant)
+        @tracer = @tracer_provider&.tracer("chef", Chef::VERSION)
+      end
+
+      def run_start(version, run_status)
+        start_span("chef.run", {
+          "chef.version" => version.to_s,
+          "chef.run_id" => run_status.run_id.to_s,
+        })
+      end
+
+      def run_completed(node, run_status)
+        end_span("chef.run", ok: true)
+        @tracer_provider&.force_flush
+      end
+
+      def run_failed(exception, run_status)
+        end_span("chef.run", error: exception)
+        @tracer_provider&.force_flush
+      end
+
+      def node_load_success(node)
+        root_span&.set_attribute("chef.node.name", node.name.to_s)
+        root_span&.set_attribute("chef.environment", node.chef_environment.to_s)
+      end
+
+      def ohai_completed(node)
+        current_span&.add_event("ohai_completed")
+      end
+
+      def deprecation(message, location = nil)
+        text = message.respond_to?(:message) ? message.message.to_s : message.to_s
+        attributes = { "chef.deprecation.message" => text }
+        attributes["chef.deprecation.location"] = location.to_s if location
+        current_span&.add_event("deprecation", attributes: attributes)
+      end
+
+      # Paired phase events: the start event opens a span, the end event
+      # closes it. Event arguments are not recorded on phase spans.
+      {
+        "chef.registration" => %i{registration_start registration_completed},
+        "chef.node_load" => %i{node_load_start node_load_completed},
+        "chef.cookbook_resolution" => %i{cookbook_resolution_start cookbook_resolution_complete},
+        "chef.cookbook_clean" => %i{cookbook_clean_start cookbook_clean_complete},
+        "chef.cookbook_sync" => %i{cookbook_sync_start cookbook_sync_complete},
+        "chef.cookbook_gems" => %i{cookbook_gem_start cookbook_gem_finished},
+        "chef.cookbook_compilation" => %i{cookbook_compilation_start cookbook_compilation_complete},
+        "chef.library_load" => %i{library_load_start library_load_complete},
+        "chef.lwrp_load" => %i{lwrp_load_start lwrp_load_complete},
+        "chef.ohai_plugin_load" => %i{ohai_plugin_load_start ohai_plugin_load_complete},
+        "chef.attribute_load" => %i{attribute_load_start attribute_load_complete},
+        "chef.definition_load" => %i{definition_load_start definition_load_complete},
+        "chef.recipe_load" => %i{recipe_load_start recipe_load_complete},
+        "chef.compliance_load" => %i{compliance_load_start compliance_load_complete},
+        "chef.converge" => %i{converge_start converge_complete},
+        "chef.handlers" => %i{handlers_start handlers_completed},
+      }.each do |span_name, (start_event, end_event)|
+        define_method(start_event) { |*_args| start_span(span_name) }
+        define_method(end_event) { |*_args| end_span(span_name) }
+      end
+
+      # Failure events close their phase span with error status; the value is
+      # the position of the exception in the event's arguments.
+      {
+        registration_failed: ["chef.registration", 1],
+        node_load_failed: ["chef.node_load", 1],
+        run_list_expand_failed: ["chef.node_load", 1],
+        cookbook_resolution_failed: ["chef.cookbook_resolution", 1],
+        cookbook_sync_failed: ["chef.cookbook_sync", 1],
+        cookbook_gem_failed: ["chef.cookbook_gems", 0],
+        converge_failed: ["chef.converge", 0],
+      }.each do |event, (span_name, exception_index)|
+        define_method(event) { |*args| end_span(span_name, error: args[exception_index]) }
+      end
+
+      def resource_action_start(resource, action, notification_type = nil, notifier = nil)
+        attributes = {
+          "chef.resource.type" => resource.resource_name.to_s,
+          "chef.resource.name" => resource.name.to_s,
+          "chef.resource.action" => action.to_s,
+        }
+        attributes["chef.resource.cookbook"] = resource.cookbook_name.to_s if resource.cookbook_name
+        attributes["chef.resource.recipe"] = resource.recipe_name.to_s if resource.recipe_name
+        attributes["chef.resource.notification_type"] = notification_type.to_s if notification_type
+        attributes["chef.resource.notifying_resource"] = notifier.to_s if notifier
+        start_span(resource.to_s, attributes)
+      end
+
+      def resource_updated(resource, action)
+        current_span&.set_attribute("chef.resource.updated", true)
+      end
+
+      def resource_up_to_date(resource, action)
+        current_span&.set_attribute("chef.resource.updated", false)
+      end
+
+      def resource_skipped(resource, action, conditional)
+        span = current_span
+        return unless span
+
+        span.set_attribute("chef.resource.skipped", true)
+        span.set_attribute("chef.resource.skip_reason", conditional.to_text)
+      end
+
+      def resource_failed(resource, action, exception)
+        span = current_span
+        return unless span
+
+        span.record_exception(exception)
+        span.status = OpenTelemetry::Trace::Status.error(exception.message)
+      end
+
+      def resource_failed_retriable(resource, action, retry_count, exception)
+        current_span&.add_event("retry", attributes: {
+          "chef.resource.retries_remaining" => retry_count,
+          "exception.message" => exception.message,
+        })
+      end
+
+      def resource_completed(resource)
+        end_span(resource.to_s)
+      end
+
+      private
+
+      def current_span
+        @stack.last && @stack.last[1]
+      end
+
+      def root_span
+        @stack.first && @stack.first[1]
+      end
+
+      # Opens a span as a child of whatever span is currently innermost and
+      # pushes it on the stack. Events arrive synchronously on one thread, so
+      # the stack mirrors the nesting of the run.
+      def start_span(name, attributes = {})
+        return unless @tracer
+
+        parent = @stack.last
+        context = parent ? OpenTelemetry::Trace.context_with_span(parent[1]) : OpenTelemetry::Context.current
+        @stack << [name, @tracer.start_span(name, with_parent: context, attributes: attributes)]
+      end
+
+      # Finishes the named span. If intervening spans were left open (an end
+      # event that never fired), they are finished too; if the named span is
+      # not open at all, this is a no-op.
+      def end_span(name, error: nil, ok: false)
+        return unless @stack.any? { |n, _| n == name }
+
+        loop do
+          span_name, span = @stack.pop
+          if span_name == name
+            if error
+              span.record_exception(error)
+              span.status = OpenTelemetry::Trace::Status.error(error.message)
+            elsif ok
+              span.status = OpenTelemetry::Trace::Status.ok
+            end
+          end
+          span.finish
+          break if span_name == name
+        end
+      end
+
+      def default_tracer_provider(tenant = nil)
+        require "opentelemetry/sdk"
+        unless OpenTelemetry.tracer_provider.is_a?(OpenTelemetry::SDK::Trace::TracerProvider)
+          OpenTelemetry::SDK.configure do |config|
+            config.service_name = ENV["OTEL_SERVICE_NAME"] || "chef-client"
+            # Configurator#resource= merges into the default resource, which
+            # already carries OTEL_RESOURCE_ATTRIBUTES, so an explicit tenant
+            # wins over the env var.
+            config.resource = OpenTelemetry::SDK::Resources::Resource.create("__tenant" => tenant.to_s) if tenant
+          end
+        end
+        OpenTelemetry.tracer_provider
+      rescue LoadError
+        Chef::Log.warn("opentelemetry-sdk is not installed; OTel tracing of the chef run is disabled")
+        nil
+      end
+
+      # Tracing must never break the chef run: if any event method raises,
+      # log it and ignore all further events instead of letting the error
+      # propagate into the event dispatcher. Defined last so it wraps every
+      # event method above.
+      crash_guard = Module.new do
+        OtelHandler.public_instance_methods(false).each do |event|
+          define_method(event) do |*args|
+            return if @broken
+
+            begin
+              super(*args)
+            rescue Exception => e # rubocop:disable Lint/RescueException
+              @broken = true
+              Chef::Log.warn("OTel tracing handler failed (#{e.class}: #{e.message}); tracing disabled for the rest of this run")
+            end
+          end
+        end
+      end
+      prepend crash_guard
+    end
+  end
+end

--- a/spec/unit/telemetry/otel_handler_spec.rb
+++ b/spec/unit/telemetry/otel_handler_spec.rb
@@ -1,0 +1,373 @@
+#
+# Author:: Jason Cook (<jasonc@simpleideas.org>)
+# Copyright:: Copyright (c) Jason Cook
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "opentelemetry/sdk"
+require "chef/telemetry/otel_handler"
+
+describe Chef::Telemetry::OtelHandler do
+  let(:exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
+  let(:provider) do
+    OpenTelemetry::SDK::Trace::TracerProvider.new.tap do |p|
+      p.add_span_processor(OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter))
+    end
+  end
+  let(:handler) { described_class.new(tracer_provider: provider) }
+  let(:run_status) { instance_double(Chef::RunStatus, run_id: "run-id-123") }
+  let(:node) { Chef::Node.new.tap { |n| n.name("client.example.com") } }
+
+  def finished_spans
+    exporter.finished_spans
+  end
+
+  def span_named(name)
+    finished_spans.find { |s| s.name == name }
+  end
+
+  it "emits a chef.run root span with ok status for a successful run" do
+    handler.run_start("19.3.14", run_status)
+    handler.run_completed(node, run_status)
+
+    span = span_named("chef.run")
+    expect(span).not_to be_nil
+    expect(span.attributes["chef.version"]).to eq("19.3.14")
+    expect(span.attributes["chef.run_id"]).to eq("run-id-123")
+    expect(span.status.code).to eq(OpenTelemetry::Trace::Status::OK)
+  end
+
+  it "marks the chef.run span as errored and records the exception when the run fails" do
+    handler.run_start("19.3.14", run_status)
+    handler.run_failed(RuntimeError.new("converge blew up"), run_status)
+
+    span = span_named("chef.run")
+    expect(span).not_to be_nil
+    expect(span.status.code).to eq(OpenTelemetry::Trace::Status::ERROR)
+    exception_event = span.events.find { |e| e.name == "exception" }
+    expect(exception_event.attributes["exception.message"]).to eq("converge blew up")
+  end
+
+  it "emits phase spans as children of the run span" do
+    handler.run_start("19.3.14", run_status)
+    handler.converge_start(double("run_context"))
+    handler.converge_complete
+    handler.run_completed(node, run_status)
+
+    run_span = span_named("chef.run")
+    converge_span = span_named("chef.converge")
+    expect(converge_span).not_to be_nil
+    expect(converge_span.parent_span_id).to eq(run_span.span_id)
+    expect(converge_span.trace_id).to eq(run_span.trace_id)
+  end
+
+  it "emits a span for every paired phase event" do
+    phases = {
+      "chef.registration" => [[:registration_start, "node", {}], [:registration_completed]],
+      "chef.node_load" => [[:node_load_start, "node", {}], [:node_load_completed, node, [], {}]],
+      "chef.cookbook_resolution" => [[:cookbook_resolution_start, []], [:cookbook_resolution_complete, double("cookbooks")]],
+      "chef.cookbook_clean" => [[:cookbook_clean_start], [:cookbook_clean_complete]],
+      "chef.cookbook_sync" => [[:cookbook_sync_start, 5], [:cookbook_sync_complete]],
+      "chef.cookbook_gems" => [[:cookbook_gem_start, []], [:cookbook_gem_finished]],
+      "chef.cookbook_compilation" => [[:cookbook_compilation_start, double("run_context")], [:cookbook_compilation_complete, double("run_context")]],
+      "chef.library_load" => [[:library_load_start, 1], [:library_load_complete]],
+      "chef.lwrp_load" => [[:lwrp_load_start, 1], [:lwrp_load_complete]],
+      "chef.ohai_plugin_load" => [[:ohai_plugin_load_start, 1], [:ohai_plugin_load_complete]],
+      "chef.attribute_load" => [[:attribute_load_start, 1], [:attribute_load_complete]],
+      "chef.definition_load" => [[:definition_load_start, 1], [:definition_load_complete]],
+      "chef.recipe_load" => [[:recipe_load_start, 1], [:recipe_load_complete]],
+      "chef.compliance_load" => [[:compliance_load_start], [:compliance_load_complete]],
+      "chef.handlers" => [[:handlers_start, 0], [:handlers_completed]],
+    }
+
+    handler.run_start("19.3.14", run_status)
+    phases.each_value do |start_call, end_call|
+      handler.public_send(*start_call)
+      handler.public_send(*end_call)
+    end
+    handler.run_completed(node, run_status)
+
+    run_span = span_named("chef.run")
+    phases.each_key do |span_name|
+      span = span_named(span_name)
+      expect(span).not_to be_nil, "expected a #{span_name} span"
+      expect(span.parent_span_id).to eq(run_span.span_id), "expected #{span_name} to be a child of chef.run"
+    end
+  end
+
+  it "records the exception and error status when a phase fails" do
+    failures = {
+      "chef.registration" => [[:registration_start, "node", {}], [:registration_failed, "node", RuntimeError.new("boom"), {}]],
+      "chef.node_load" => [[:node_load_start, "node", {}], [:node_load_failed, "node", RuntimeError.new("boom"), {}]],
+      "chef.cookbook_resolution" => [[:cookbook_resolution_start, []], [:cookbook_resolution_failed, [], RuntimeError.new("boom")]],
+      "chef.cookbook_sync" => [[:cookbook_sync_start, 5], [:cookbook_sync_failed, [], RuntimeError.new("boom")]],
+      "chef.cookbook_gems" => [[:cookbook_gem_start, []], [:cookbook_gem_failed, RuntimeError.new("boom")]],
+      "chef.converge" => [[:converge_start, double("run_context")], [:converge_failed, RuntimeError.new("boom")]],
+    }
+
+    handler.run_start("19.3.14", run_status)
+    failures.each_value do |start_call, fail_call|
+      handler.public_send(*start_call)
+      handler.public_send(*fail_call)
+    end
+    handler.run_failed(RuntimeError.new("run failed"), run_status)
+
+    failures.each_key do |span_name|
+      span = span_named(span_name)
+      expect(span.status.code).to eq(OpenTelemetry::Trace::Status::ERROR), "expected #{span_name} to have error status"
+      expect(span.events.find { |e| e.name == "exception" }).not_to be_nil, "expected #{span_name} to record its exception"
+    end
+  end
+
+  it "closes the node_load span when run list expansion fails" do
+    handler.run_start("19.3.14", run_status)
+    handler.node_load_start("node", {})
+    handler.run_list_expand_failed(node, RuntimeError.new("expand failed"))
+    handler.run_failed(RuntimeError.new("run failed"), run_status)
+
+    span = span_named("chef.node_load")
+    expect(span.status.code).to eq(OpenTelemetry::Trace::Status::ERROR)
+  end
+
+  describe "resource spans" do
+    let(:resource) do
+      Chef::Resource::File.new("/tmp/greeting.txt").tap do |r|
+        r.cookbook_name = "greetings"
+        r.recipe_name = "default"
+      end
+    end
+
+    def converge(&block)
+      handler.run_start("19.3.14", run_status)
+      handler.converge_start(double("run_context"))
+      yield
+      handler.converge_complete
+      handler.run_completed(node, run_status)
+    end
+
+    it "emits a resource span with resource attributes under the converge span" do
+      converge do
+        handler.resource_action_start(resource, :create)
+        handler.resource_updated(resource, :create)
+        handler.resource_completed(resource)
+      end
+
+      span = span_named("file[/tmp/greeting.txt]")
+      expect(span).not_to be_nil
+      expect(span.parent_span_id).to eq(span_named("chef.converge").span_id)
+      expect(span.attributes["chef.resource.type"]).to eq("file")
+      expect(span.attributes["chef.resource.name"]).to eq("/tmp/greeting.txt")
+      expect(span.attributes["chef.resource.action"]).to eq("create")
+      expect(span.attributes["chef.resource.cookbook"]).to eq("greetings")
+      expect(span.attributes["chef.resource.recipe"]).to eq("default")
+      expect(span.attributes["chef.resource.updated"]).to be true
+    end
+
+    it "marks up-to-date resources as not updated" do
+      converge do
+        handler.resource_action_start(resource, :create)
+        handler.resource_up_to_date(resource, :create)
+        handler.resource_completed(resource)
+      end
+
+      expect(span_named("file[/tmp/greeting.txt]").attributes["chef.resource.updated"]).to be false
+    end
+
+    it "marks skipped resources with the conditional that skipped them" do
+      conditional = double("conditional", to_text: "not_if { ::File.exist?('/tmp/greeting.txt') }")
+      converge do
+        handler.resource_action_start(resource, :create)
+        handler.resource_skipped(resource, :create, conditional)
+        handler.resource_completed(resource)
+      end
+
+      span = span_named("file[/tmp/greeting.txt]")
+      expect(span.attributes["chef.resource.skipped"]).to be true
+      expect(span.attributes["chef.resource.skip_reason"]).to eq("not_if { ::File.exist?('/tmp/greeting.txt') }")
+    end
+
+    it "records the exception and error status on a failed resource" do
+      converge do
+        handler.resource_action_start(resource, :create)
+        handler.resource_failed(resource, :create, RuntimeError.new("EACCES"))
+        handler.resource_completed(resource)
+      end
+
+      span = span_named("file[/tmp/greeting.txt]")
+      expect(span.status.code).to eq(OpenTelemetry::Trace::Status::ERROR)
+      expect(span.events.find { |e| e.name == "exception" }.attributes["exception.message"]).to eq("EACCES")
+    end
+
+    it "adds a retry event for retriable failures" do
+      converge do
+        handler.resource_action_start(resource, :create)
+        handler.resource_failed_retriable(resource, :create, 2, RuntimeError.new("flaky"))
+        handler.resource_completed(resource)
+      end
+
+      span = span_named("file[/tmp/greeting.txt]")
+      retry_event = span.events.find { |e| e.name == "retry" }
+      expect(retry_event).not_to be_nil
+      expect(retry_event.attributes["chef.resource.retries_remaining"]).to eq(2)
+      expect(span.status.code).not_to eq(OpenTelemetry::Trace::Status::ERROR)
+    end
+
+    it "nests sub-resource spans under the outer resource span" do
+      inner = Chef::Resource::Execute.new("update-cache")
+      converge do
+        handler.resource_action_start(resource, :create)
+        handler.resource_action_start(inner, :run)
+        handler.resource_completed(inner)
+        handler.resource_completed(resource)
+      end
+
+      outer_span = span_named("file[/tmp/greeting.txt]")
+      inner_span = span_named("execute[update-cache]")
+      expect(inner_span.parent_span_id).to eq(outer_span.span_id)
+    end
+
+    it "records how a notified resource was triggered" do
+      notifier = Chef::Resource::Execute.new("update-cache")
+      converge do
+        handler.resource_action_start(resource, :create, :delayed, notifier)
+        handler.resource_completed(resource)
+      end
+
+      span = span_named("file[/tmp/greeting.txt]")
+      expect(span.attributes["chef.resource.notification_type"]).to eq("delayed")
+      expect(span.attributes["chef.resource.notifying_resource"]).to eq("execute[update-cache]")
+    end
+
+    it "finishes all open spans when the run fails mid-resource" do
+      handler.run_start("19.3.14", run_status)
+      handler.converge_start(double("run_context"))
+      handler.resource_action_start(resource, :create)
+      handler.run_failed(RuntimeError.new("client crashed"), run_status)
+
+      expect(finished_spans.map(&:name)).to contain_exactly("file[/tmp/greeting.txt]", "chef.converge", "chef.run")
+      expect(span_named("chef.run").status.code).to eq(OpenTelemetry::Trace::Status::ERROR)
+    end
+  end
+
+  it "records the node name and environment on the run span once the node is loaded" do
+    handler.run_start("19.3.14", run_status)
+    handler.node_load_start("client.example.com", {})
+    handler.node_load_success(node)
+    handler.node_load_completed(node, [], {})
+    handler.run_completed(node, run_status)
+
+    span = span_named("chef.run")
+    expect(span.attributes["chef.node.name"]).to eq("client.example.com")
+    expect(span.attributes["chef.environment"]).to eq("_default")
+  end
+
+  it "annotates the current span with ohai completion and deprecations" do
+    handler.run_start("19.3.14", run_status)
+    handler.ohai_completed(node)
+    handler.converge_start(double("run_context"))
+    handler.deprecation(double("deprecation", message: "old and busted"), "recipes/default.rb:1")
+    handler.converge_complete
+    handler.run_completed(node, run_status)
+
+    expect(span_named("chef.run").events.find { |e| e.name == "ohai_completed" }).not_to be_nil
+    deprecation_event = span_named("chef.converge").events.find { |e| e.name == "deprecation" }
+    expect(deprecation_event.attributes["chef.deprecation.message"]).to eq("old and busted")
+  end
+
+  it "force flushes the tracer provider when the run ends" do
+    expect(provider).to receive(:force_flush).and_call_original
+    handler.run_start("19.3.14", run_status)
+    handler.run_completed(node, run_status)
+  end
+
+  it "does nothing when the OpenTelemetry SDK is not available" do
+    allow_any_instance_of(described_class).to receive(:default_tracer_provider).and_return(nil)
+    disabled = described_class.new
+
+    expect do
+      disabled.run_start("19.3.14", run_status)
+      disabled.converge_start(double("run_context"))
+      disabled.resource_action_start(Chef::Resource::File.new("/tmp/x"), :create)
+      disabled.resource_completed(Chef::Resource::File.new("/tmp/x"))
+      disabled.converge_complete
+      disabled.run_completed(node, run_status)
+    end.not_to raise_error
+  end
+
+  describe ".register!" do
+    it "registers exactly one handler even when the config file is evaluated twice" do
+      Chef::Config[:event_handlers] = []
+      described_class.register!(tracer_provider: provider)
+      described_class.register!(tracer_provider: provider)
+
+      expect(Chef::Config[:event_handlers].count { |h| h.is_a?(described_class) }).to eq(1)
+    end
+  end
+
+  describe "SDK auto-configuration" do
+    let(:configurator) { double("configurator") }
+
+    before do
+      allow(OpenTelemetry::SDK).to receive(:configure).and_yield(configurator)
+      allow(OpenTelemetry).to receive(:tracer_provider).and_return(double("global provider", tracer: double("tracer")))
+    end
+
+    it "defaults the service name to chef-client" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("OTEL_SERVICE_NAME").and_return(nil)
+
+      expect(configurator).to receive(:service_name=).with("chef-client")
+      described_class.new
+    end
+
+    it "respects OTEL_SERVICE_NAME when set" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("OTEL_SERVICE_NAME").and_return("my-service")
+
+      expect(configurator).to receive(:service_name=).with("my-service")
+      described_class.new
+    end
+
+    it "tags spans with a __tenant resource attribute when tenant: is given" do
+      allow(configurator).to receive(:service_name=)
+
+      expect(configurator).to receive(:resource=) do |resource|
+        expect(resource.attribute_enumerator.to_h).to eq("__tenant" => "controlplane")
+      end
+      described_class.new(tenant: "controlplane")
+    end
+
+    it "leaves the resource alone when no tenant is given, so OTEL_RESOURCE_ATTRIBUTES applies" do
+      allow(configurator).to receive(:service_name=)
+
+      expect(configurator).not_to receive(:resource=)
+      described_class.new
+    end
+  end
+
+  it "disables itself instead of raising into the run when span emission fails" do
+    broken_tracer = double("tracer")
+    allow(broken_tracer).to receive(:start_span).and_raise("otel exploded")
+    allow(provider).to receive(:tracer).and_return(broken_tracer)
+    expect(Chef::Log).to receive(:warn).with(/otel exploded/).once
+
+    expect do
+      handler.run_start("19.3.14", run_status)
+      handler.converge_start(double("run_context"))
+      handler.run_completed(node, run_status)
+    end.not_to raise_error
+  end
+end


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
Emits a span tree for the chef-client run via the event dispatch stream: a chef.run root span, spans for each run phase, and one span per resource action with update/skip/failure detail. Registered from client.rb with Chef::Telemetry::OtelHandler.register! (idempotent, since chef-solo evaluates the config twice). Soft-requires opentelemetry-sdk and disables itself if span emission ever fails, so tracing can never break a run.

Spans can be tagged with a __tenant resource attribute (for Tempo multi-tenancy search and tail-sampling routing) via the standard OTEL_RESOURCE_ATTRIBUTES env var or explicitly with register!(tenant: "..."), which takes precedence.

Adds opentelemetry-sdk and opentelemetry-exporter-otlp gem dependencies and updates Gemfile.lock accordingly.  Additive only, no changes to existing dependencies to report from updates to Gemfile.lock.

## Related Issue
https://github.com/chef/chef/issues/16097

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
