### PR TITLE
Move to actionshub DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -12,11 +12,12 @@ jobs:
     name: DCO Check
     steps:
     - name: Get PR Commits
-      uses: tim-actions/get-pr-commits@master
+      uses: actionshub/get-pr-commits@main
       id: 'get-pr-commits'
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: DCO Check
-      uses: tim-actions/dco@master
+      uses: actionshub/dco@main
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
+        allow-obvious-fix-label: "obvious-fix"


### PR DESCRIPTION
`actionshub` has forked the dco checks from `tim-actions`, since that
appears to be unmaintained.

This moves to the version with lots of updates, as well as enables
the new 'bypass dco with a label' feature to get party with the
Expeditor one.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
