### PR TITLE
CHEF-35271: Use unstable channel for core/ruby3_4 in linux habitat plans

### DIFF
--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,4 +1,6 @@
-export HAB_BLDR_CHANNEL="base-2025"
+export HAB_BLDR_CHANNEL="unstable"
+export HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL="unstable"
+export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="base-2025"
 SRC_PATH="$(dirname "$(dirname "$PLAN_CONTEXT")")"
 _chef_client_ruby="core/ruby3_4/3.4.8"
 pkg_name="chef-infra-client"
@@ -85,9 +87,9 @@ do_prepare() {
   export CPPFLAGS="${CPPFLAGS} ${CFLAGS} -I$(pkg_path_for core/glibc)/include"
   export CFLAGS="${CPPFLAGS}"
   export LDFLAGS="${LDFLAGS} -L$(pkg_path_for core/glibc)/lib"
-  export HAB_BLDR_CHANNEL="base-2025"
+  export HAB_BLDR_CHANNEL="unstable"
   export HAB_STUDIO_SECRET_NODE_OPTIONS="--dns-result-order=ipv4first"
-  export HAB_STUDIO_SECRET_HAB_BLDR_CHANNEL="base-2025"
+  export HAB_STUDIO_SECRET_HAB_BLDR_CHANNEL="unstable"
   build_line " ** Securing the /src directory"
   git config --global --add safe.directory /src
 

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -1,4 +1,6 @@
-export HAB_BLDR_CHANNEL="base-2025"
+export HAB_BLDR_CHANNEL="unstable"
+export HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL="unstable"
+export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="base-2025"
 SRC_PATH="$(dirname "$(dirname "$PLAN_CONTEXT")")"
 _chef_client_ruby="core/ruby3_4/3.4.8"
 pkg_name="chef-infra-client"
@@ -85,9 +87,9 @@ do_prepare() {
   export CPPFLAGS="${CPPFLAGS} ${CFLAGS} -I$(pkg_path_for core/glibc)/include"
   export CFLAGS="${CPPFLAGS}"
   export LDFLAGS="${LDFLAGS} -L$(pkg_path_for core/glibc)/lib"
-  export HAB_BLDR_CHANNEL="base-2025"
+  export HAB_BLDR_CHANNEL="unstable"
   export HAB_STUDIO_SECRET_NODE_OPTIONS="--dns-result-order=ipv4first"
-  export HAB_STUDIO_SECRET_HAB_BLDR_CHANNEL="base-2025"
+  export HAB_STUDIO_SECRET_HAB_BLDR_CHANNEL="unstable"
   build_line " ** Securing the /src directory"
   git config --global --add safe.directory /src
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>This PR updates the Habitat plan files for Linux (x86_64 and aarch64) to use the <strong>unstable</strong> channel so the Chef Infra Client 19 build picks up the fixed <code>core/ruby3_4</code> package available in the unstable channel (see <a href='https://github.com/habitat-sh/enterprise-packages/pull/295'>enterprise-packages PR #295</a>).</p>

<h2>Changes</h2>
<ul>
  <li><code>habitat/x86_64-linux/plan.sh</code> — updated channel settings</li>
  <li><code>habitat/aarch64-linux/plan.sh</code> — updated channel settings</li>
</ul>

<h3>Channel configuration applied</h3>
<pre>
HAB_BLDR_CHANNEL: unstable
HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: unstable
HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: base-2025
</pre>

<p><strong>Note:</strong> This is a temporary change for testing purposes. Once the <code>core/ruby3_4</code> fix is promoted to stable/base-2025, the channel settings should be reverted.</p>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>