### PR TITLE
Bump macOS kitchen.yml fail-after to 2026-07-01

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -227,7 +227,7 @@ jobs:
 #      - name: Kitchen Test
 #        run: kitchen verify ${{ matrix.os }}
 #
-  # disabled due to no hab support for mac yet - fail-after:2026-06-15
+  # disabled due to no hab support for mac yet - fail-after:2026-07-01
   # mac_arm64:
   #   needs: workflow_guard
   #   permissions:


### PR DESCRIPTION
<h2>Summary</h2><p>Updates the disabled macOS Kitchen workflow marker in <code>.github/workflows/kitchen.yml</code> from <code>fail-after:2026-06-15</code> to <code>fail-after:2026-07-01</code>.</p><p>This work was completed with AI assistance following Progress AI policies.</p>