### PR TITLE
build aarch64-darwin plan and set up github workflows

### DIFF
--- a/.github/workflows/macos_verify.yml
+++ b/.github/workflows/macos_verify.yml
@@ -1,0 +1,94 @@
+---
+name: macos_verify
+
+"on":
+  pull_request:
+    branches: [main, "chef-*"]
+  push:
+    branches: [main, "chef-*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-verify-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CHEF_LICENSE: accept-no-persist
+  FORCE_FFI_YAJL: ext
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────
+  # Job 1: Integration tests (equivalent to
+  #         prep_and_run_tests.sh Integration)
+  # ──────────────────────────────────────────────────────────────────
+  integration:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14]
+        ruby: ["3.4"]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
+
+      - run: bundle install
+
+      - run: bundle exec rake spec:integration
+
+  # ──────────────────────────────────────────────────────────────────
+  # Job 2: Habitat plan build + test.darwin.sh (equivalent to
+  #         verify-plan.sh)
+  # ──────────────────────────────────────────────────────────────────
+  habitat-plan:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    env:
+      HAB_ORIGIN: gha
+      HAB_BLDR_CHANNEL: base-2025
+      HAB_REFRESH_CHANNEL: base-2025
+      HAB_AUTH_TOKEN: ${{ secrets.HAB_AUTH_TOKEN }}
+      HAB_LICENSE: accept-no-persist
+      HAB_NONINTERACTIVE: "true"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+
+      - name: Install Habitat CLI
+        run: |
+          curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo -E bash -s -- -t aarch64-darwin
+          hab license accept
+          hab --version
+
+      - name: Generate Habitat Origin Key
+        run: hab origin key generate "$HAB_ORIGIN"
+
+      - name: Build Habitat Package
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          hab pkg build .
+
+      - name: Install Habitat Package
+        run: |
+          source ./results/last_build.env
+          echo "Installing: $pkg_ident ($pkg_artifact)"
+          sudo -E hab pkg install "./results/$pkg_artifact"
+
+      - name: Run test.darwin.sh
+        run: |
+          source ./results/last_build.env
+          sudo -E ./habitat/tests/test.darwin.sh "$pkg_ident"

--- a/.github/workflows/macos_verify.yml
+++ b/.github/workflows/macos_verify.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   CHEF_LICENSE: accept-no-persist
+  CHEF_LICENSE_SERVER: http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/
   FORCE_FFI_YAJL: ext
 
 jobs:

--- a/cspell.json
+++ b/cspell.json
@@ -335,6 +335,7 @@
     "dslocal",
     "DUPEUX",
     "DWORDLONG",
+    "DYLD",
     "DYNALINK",
     "DYNLINK",
     "EAGAIN",

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -80,6 +80,7 @@ do_verify() {
 
 do_setup_environment() {
   push_runtime_env GEM_PATH "${pkg_prefix}/vendor"
+  push_runtime_env GEM_HOME "${pkg_prefix}/vendor"
 
   set_runtime_env APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
   set_runtime_env -f SSL_CERT_FILE "$(pkg_path_for cacerts)/ssl/cert.pem"

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -1,0 +1,244 @@
+export HAB_BLDR_CHANNEL="base-2025"
+SRC_PATH="$(dirname "$(dirname "$PLAN_CONTEXT")")"
+_chef_client_ruby="core/ruby3_4/3.4.2"
+pkg_name="chef-infra-client"
+pkg_origin="chef"
+pkg_maintainer="The Chef Maintainers <humans@chef.io>"
+pkg_description="The Chef Infra Client"
+pkg_license=('Apache-2.0')
+pkg_bin_dirs=(
+  bin
+  vendor/bin
+)
+pkg_build_deps=(
+  core/make
+  core/xcode
+  core/git
+)
+
+pkg_deps=(
+  $_chef_client_ruby
+  core/libxml2
+  core/libxslt
+  core/libiconv
+  core/xz
+  core/zlib
+  core/openssl
+  core/cacerts
+  core/libffi
+  core/coreutils
+  core/libarchive
+)
+pkg_svc_user=root
+pkg_svc_group=root
+
+# Sandbox profile for macOS builds.
+# core/xcode's RUNTIME_SANDBOX already covers:
+#   file*/process-exec/process-fork/network-outbound for /usr/lib, /System/Library,
+#   /Library/Apple, /Applications/Xcode.app, and /private/var/folders (clang temp artifacts).
+# We add only what xcode does not cover: write access to our build paths, broad
+# process-exec/fork/network for Ruby+bundler+gem-fetch, and Ruby IPC primitives.
+# Note: /tmp is a symlink to /private/tmp on macOS; the kernel resolves it before
+# sandbox path matching, so /private/tmp covers /tmp accesses as well.
+buildtime_sandbox() {
+	echo "(version 1)
+(allow file-read*)
+(allow file* (subpath \"/Users\"))
+(allow file* (subpath \"/opt/hab\"))
+(allow file* (subpath \"/private/var/root\"))
+(allow file* (subpath \"/private/tmp\"))
+(allow process-exec*)
+(allow process-fork)
+(allow signal)
+(allow mach*)
+(allow ipc*)
+(allow sysctl-read)
+(allow network-outbound)
+"
+}
+
+pkg_version() {
+  cat "${SRC_PATH}/VERSION"
+}
+
+do_before() {
+  do_default_before
+  update_pkg_version
+  # We must wait until we update the pkg_version to use the pkg_version
+  pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
+}
+
+do_download() {
+  pushd $SRC_PATH
+  build_line "Setting up the safe directory for the build. $SRC_PATH. $PWD"
+  HOME=$PWD git config --global --add safe.directory $SRC_PATH
+
+  build_line "$(HOME=$PWD git config -l)"
+
+
+  build_line "Locally creating archive of latest repository commit at ${HAB_CACHE_SRC_PATH}/${pkg_filename}"
+  HOME=$PWD git archive --format=tar.gz --prefix="${pkg_name}-${pkg_version}/" --output="${HAB_CACHE_SRC_PATH}/${pkg_filename}" HEAD
+  build_line "Done"
+
+  popd
+}
+
+do_verify() {
+  build_line "Skipping checksum verification on the archive we just created."
+  return 0
+}
+
+do_setup_environment() {
+  push_runtime_env GEM_PATH "${pkg_prefix}/vendor"
+
+  set_runtime_env APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
+  set_runtime_env -f SSL_CERT_FILE "$(pkg_path_for cacerts)/ssl/cert.pem"
+  set_runtime_env LANG "en_US.UTF-8"
+  set_runtime_env LC_CTYPE "en_US.UTF-8"
+}
+
+do_prepare() {
+  export GEM_HOME="${pkg_prefix}/vendor"
+  export OPENSSL_DIR="$(pkg_path_for openssl)"
+  export OPENSSL_INCLUDE_DIR="$(pkg_path_for openssl)/include"
+  export SSL_CERT_FILE="$(pkg_path_for cacerts)/ssl/cert.pem"
+  export HAB_BLDR_CHANNEL="base-2025"
+  export HAB_STUDIO_SECRET_NODE_OPTIONS="--dns-result-order=ipv4first"
+  export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="base-2025"
+  build_line " ** Securing the /src directory"
+  HOME=$SRC_PATH git config --global --add safe.directory /src
+
+  ( cd "$CACHE_PATH"
+    bundle config --local build.nokogiri "--use-system-libraries \
+        --with-zlib-dir=$(pkg_path_for zlib) \
+        --with-xslt-dir=$(pkg_path_for libxslt) \
+        --with-xml2-include=$(pkg_path_for libxml2)/include/libxml2 \
+        --with-xml2-lib=$(pkg_path_for libxml2)/lib"
+    bundle config --local build.ffi "-Wl,-rpath,'${LD_RUN_PATH}'"
+    bundle config --local jobs "$(nproc)"
+    bundle config --local without server docgen maintenance pry travis integration ci
+    bundle config --local shebang "$(pkg_path_for "$_chef_client_ruby")/bin/ruby"
+    bundle config --local retry 5
+    bundle config --local silence_root_warning 1
+  )
+
+  # Needed for appbundler-updater to work properly
+  build_line "Extracting bundler version from Gemfile.lock"
+  BUNDLER_VERSION=$(grep -A 1 "BUNDLED WITH" "$CACHE_PATH/Gemfile.lock" | tail -n 1 | tr -d '[:space:]')
+  if [[ -z "$BUNDLER_VERSION" ]]; then
+    exit_with "Failed to extract bundler version from Gemfile.lock" 1
+  fi
+  build_line "Installing bundler version $BUNDLER_VERSION"
+  gem install bundler --version "$BUNDLER_VERSION" --no-document
+
+  build_line "Setting link for /usr/bin/env to 'coreutils'"
+  if [[ ! -f /usr/bin/env ]]; then
+    ln -s "$(pkg_interpreter_for core/coreutils bin/env)" /usr/bin/env
+  fi
+}
+
+do_build() {
+  ( cd "$CACHE_PATH" || exit_with "unable to enter hab-cache directory" 1
+    build_line "Installing gem dependencies ..."
+    bundle install --jobs=3 --retry=3
+
+    build_line "Installing gems from git repos properly ..."
+    ruby ./post-bundle-install.rb
+
+    ruby ./scripts/cleanup_lint_roller.rb
+
+    build_line "Installing this project's gems ..."
+    bundle exec rake install:local
+  )
+}
+
+do_install() {
+
+  # Copy NOTICE to the package directory
+  if [[ -f "$PLAN_CONTEXT/../../NOTICE" ]]; then
+    build_line "Copying NOTICE to package directory"
+    cp "$PLAN_CONTEXT/../../NOTICE" "$pkg_prefix/"
+  else
+    build_line "Error: NOTICE not found at $PLAN_CONTEXT/../../NOTICE"
+    exit 1
+  fi
+
+  ( cd "$pkg_prefix" || exit_with "unable to enter pkg prefix directory" 1
+    export BUNDLE_GEMFILE="${CACHE_PATH}/Gemfile"
+    # Test if artifactory-internal.ps.chef.co is reachable
+    build_line "Testing connectivity to artifactory-internal.ps.chef.co..."
+    artifactory_url="https://artifactory-internal.ps.chef.co/artifactory/omnibus-gems-local/"
+
+    if wget --spider --timeout=30 --tries=1 --quiet "$artifactory_url" > /dev/null 2>&1; then
+      build_line "Artifactory is reachable, proceeding with chef-official-distribution installation"
+
+      echo "***************** INSTALLING  chef-official-distribution *****************"
+      gem sources --add "$artifactory_url"
+      gem install chef-official-distribution
+      gem sources --remove "$artifactory_url"
+
+      # verify installation
+      echo "***************** VERIFYING  chef-official-distribution *****************"
+      gem list chef-official-distribution
+
+      if [[ $? -ne 0 ]]; then
+        exit 1
+      fi
+    else
+      build_line "WARNING: Artifactory is not reachable, skipping chef-official-distribution installation"
+    fi
+
+    build_line "** fixing binstub shebangs"
+    fix_interpreter "${pkg_prefix}/vendor/bin/*" "$_chef_client_ruby" bin/ruby
+
+    for gem in chef-bin chef inspec-core-bin ohai; do
+      build_line "** generating binstubs for $gem with precise version pins"
+      "${pkg_prefix}/vendor/bin/appbundler" $CACHE_PATH $pkg_prefix/bin $gem
+    done
+
+    build_line "** patching binstubs to allow running directly"
+    for binstub in ${pkg_prefix}/bin/*; do
+      sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../binstub_patch.rb" "$binstub"
+    done
+  )
+}
+
+do_after() {
+  build_line "Trimming the fat ..."
+
+  # We don't need the cache of downloaded .gem files ...
+  rm -r "$pkg_prefix/vendor/cache"
+  # ... or bundler's cache of git-ref'd gems
+  rm -r "$pkg_prefix/vendor/bundler"
+  # We don't need the gem docs.
+  rm -r "$pkg_prefix/vendor/doc"
+  # We don't need to ship the test suites for every gem dependency,
+  # only Chef's for package verification.
+  find "$pkg_prefix/vendor/gems" -name spec -type d | grep -v "chef-${pkg_version}" | grep -v "knife-" \
+      | while read spec_dir; do rm -rf "$spec_dir"; done
+  # Remove .github directories from vendored gems so that GitHub Actions workflow
+  # files are not shipped and do not trigger grype vulnerability reports.
+  # NOTE: this is temporary and can be removed once upstream dependencies
+  # fix their file exclusions.
+  find "$pkg_prefix/vendor/gems" -type d -name ".github" \
+      | while read github_dir; do rm -rf "$github_dir"; done
+
+  # we need the built gems outside of the studio
+  build_line "Copying gems to ${SRC_PATH}"
+  mkdir -p "${SRC_PATH}/pkg" "${SRC_PATH}/chef-bin/pkg" "${SRC_PATH}/chef-config/pkg" "${SRC_PATH}/chef-utils/pkg"
+  cp "${CACHE_PATH}/pkg/chef-${pkg_version}.gem" "${SRC_PATH}/pkg"
+  cp "${CACHE_PATH}/chef-bin/pkg/chef-bin-${pkg_version}.gem" "${SRC_PATH}/chef-bin/pkg"
+  cp "${CACHE_PATH}/chef-config/pkg/chef-config-${pkg_version}.gem" "${SRC_PATH}/chef-config/pkg"
+  cp "${CACHE_PATH}/chef-utils/pkg/chef-utils-${pkg_version}.gem" "${SRC_PATH}/chef-utils/pkg"
+}
+
+do_end() {
+  if [[ "$(readlink /usr/bin/env)" = "$(pkg_interpreter_for core/coreutils bin/env)" ]]; then
+    build_line "Removing the symlink we created for '/usr/bin/env'"
+    rm /usr/bin/env
+  fi
+}
+
+do_strip() {
+  return 0
+}

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -1,5 +1,6 @@
+export HAB_BLDR_CHANNEL="base-2025"
 SRC_PATH="$(dirname "$(dirname "$PLAN_CONTEXT")")"
-_chef_client_ruby="core/ruby3_4/3.4.2"
+_chef_client_ruby="core/ruby3_4/3.4.8"
 pkg_name="chef-infra-client"
 pkg_origin="chef"
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
@@ -36,11 +37,6 @@ pkg_deps=(
 pkg_svc_user=root
 pkg_svc_group=root
 
-# (allow file-read-data (subpath \"/opt/hab\"))
-# (allow file-read-data (subpath \"/private/var\"))
-# (allow file-read-data (subpath \"/dev\"))
-# (allow file-read-data (subpath \"/usr/share\"))
-# (allow file* (subpath \"/Users\"))
 # We need the following setting as the 'git commands keep cribbing if we miss
 # some read permissions.
 buildtime_sandbox() {

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -1,4 +1,3 @@
-export HAB_BLDR_CHANNEL="base-2025"
 SRC_PATH="$(dirname "$(dirname "$PLAN_CONTEXT")")"
 _chef_client_ruby="core/ruby3_4/3.4.2"
 pkg_name="chef-infra-client"
@@ -12,9 +11,14 @@ pkg_bin_dirs=(
 )
 pkg_build_deps=(
   core/make
-  core/xcode
+  core/clang
   core/git
 )
+
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib64)
+pkg_pconfig_dirs=(lib64/pkgconfig)
 
 pkg_deps=(
   $_chef_client_ruby
@@ -32,28 +36,17 @@ pkg_deps=(
 pkg_svc_user=root
 pkg_svc_group=root
 
-# Sandbox profile for macOS builds.
-# core/xcode's RUNTIME_SANDBOX already covers:
-#   file*/process-exec/process-fork/network-outbound for /usr/lib, /System/Library,
-#   /Library/Apple, /Applications/Xcode.app, and /private/var/folders (clang temp artifacts).
-# We add only what xcode does not cover: write access to our build paths, broad
-# process-exec/fork/network for Ruby+bundler+gem-fetch, and Ruby IPC primitives.
-# Note: /tmp is a symlink to /private/tmp on macOS; the kernel resolves it before
-# sandbox path matching, so /private/tmp covers /tmp accesses as well.
+# (allow file-read-data (subpath \"/opt/hab\"))
+# (allow file-read-data (subpath \"/private/var\"))
+# (allow file-read-data (subpath \"/dev\"))
+# (allow file-read-data (subpath \"/usr/share\"))
+# (allow file* (subpath \"/Users\"))
+# We need the following setting as the 'git commands keep cribbing if we miss
+# some read permissions.
 buildtime_sandbox() {
 	echo "(version 1)
 (allow file-read*)
-(allow file* (subpath \"/Users\"))
-(allow file* (subpath \"/opt/hab\"))
-(allow file* (subpath \"/private/var/root\"))
-(allow file* (subpath \"/private/tmp\"))
 (allow process-exec*)
-(allow process-fork)
-(allow signal)
-(allow mach*)
-(allow ipc*)
-(allow sysctl-read)
-(allow network-outbound)
 "
 }
 

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -59,14 +59,15 @@ do_before() {
 
 do_download() {
   pushd $SRC_PATH
+  export HOME=$SRC_PATH # need to set home otherwise fails
   build_line "Setting up the safe directory for the build. $SRC_PATH. $PWD"
-  HOME=$PWD git config --global --add safe.directory $SRC_PATH
+  git config --global --add safe.directory $SRC_PATH
 
-  build_line "$(HOME=$PWD git config -l)"
+  build_line "$(git config -l)"
 
 
   build_line "Locally creating archive of latest repository commit at ${HAB_CACHE_SRC_PATH}/${pkg_filename}"
-  HOME=$PWD git archive --format=tar.gz --prefix="${pkg_name}-${pkg_version}/" --output="${HAB_CACHE_SRC_PATH}/${pkg_filename}" HEAD
+  git archive --format=tar.gz --prefix="${pkg_name}-${pkg_version}/" --output="${HAB_CACHE_SRC_PATH}/${pkg_filename}" HEAD
   build_line "Done"
 
   popd
@@ -87,6 +88,7 @@ do_setup_environment() {
 }
 
 do_prepare() {
+  export HOME=$SRC_PATH # need to set home otherwise ruby and git fail
   export GEM_HOME="${pkg_prefix}/vendor"
   export OPENSSL_DIR="$(pkg_path_for openssl)"
   export OPENSSL_INCLUDE_DIR="$(pkg_path_for openssl)/include"
@@ -95,7 +97,7 @@ do_prepare() {
   export HAB_STUDIO_SECRET_NODE_OPTIONS="--dns-result-order=ipv4first"
   export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="base-2025"
   build_line " ** Securing the /src directory"
-  HOME=$SRC_PATH git config --global --add safe.directory /src
+  git config --global --add safe.directory /src
 
   ( cd "$CACHE_PATH"
     bundle config --local build.nokogiri "--use-system-libraries \

--- a/habitat/tests/test.darwin.sh
+++ b/habitat/tests/test.darwin.sh
@@ -40,7 +40,7 @@ done
 export DYLD_LIBRARY_PATH="$(hab pkg path core/libarchive)/lib"
 
 echo "--- :construction: Gotta find RSPEC so testing doesn't immediately fail"
-results=($(find /hab/pkgs -name "rspec" -type f))
+results=($(find /opt/hab/pkgs -name "rspec" -type f))
 echo "${results[1]}"
 
 echo "--- :mag_right: Testing ${pkg_ident} functionality"

--- a/habitat/tests/test.darwin.sh
+++ b/habitat/tests/test.darwin.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Darwin (macOS) test script for the chef-infra-client Habitat package.
+# Usage: ./habitat/tests/test.darwin.sh <pkg_ident>
+#   pkg_ident: e.g. chef/chef-infra-client/19.3.24/20260602032309
+
+set -euo pipefail
+
+export CHEF_LICENSE="accept-no-persist"
+export HAB_LICENSE="accept-no-persist"
+export HAB_NONINTERACTIVE="true"
+export HAB_BLDR_CHANNEL="base-2025"
+
+project_root="$(git rev-parse --show-toplevel)"
+pkg_ident="$1"
+
+# print error message and exit
+error() {
+  local message="$1"
+  echo -e "\nERROR: ${message}\n" >&2
+  exit 1
+}
+
+[[ -n "$pkg_ident" ]] || error 'no hab package identity provided'
+
+package_version=$(awk -F / '{print $3}' <<<"$pkg_ident")
+
+cd "${project_root}"
+
+echo "--- :mag_right: Testing ${pkg_ident} executables"
+actual_version=$(hab pkg exec "${pkg_ident}" chef-client -- --version | sed 's/.*: //')
+[[ "$package_version" = "$actual_version" ]] || error "chef-client is not the expected version. Expected '$package_version', got '$actual_version'"
+
+for executable in 'chef-client' 'ohai' 'chef-shell' 'chef-apply' 'chef-solo'; do
+  echo -en "\t$executable = "
+  hab pkg exec "${pkg_ident}" "${executable}" -- --version || error "${executable} failed to execute properly"
+done
+
+# On macOS, use DYLD_LIBRARY_PATH instead of LD_LIBRARY_PATH to make
+# libarchive available to the Ruby runtime during tests.
+export DYLD_LIBRARY_PATH="$(hab pkg path core/libarchive)/lib"
+
+echo "--- :construction: Gotta find RSPEC so testing doesn't immediately fail"
+results=($(find /hab/pkgs -name "rspec" -type f))
+echo "${results[1]}"
+
+echo "--- :mag_right: Testing ${pkg_ident} functionality"
+# rspec is not on the path by default; insert the directory we found above.
+rspec_path=$(dirname "${results[1]}")
+export PATH="${rspec_path}:${PATH}"
+export HAB_TEST="true"
+
+hab pkg exec "${pkg_ident}" rspec --profile -f documentation -- ./spec/unit
+hab pkg exec "${pkg_ident}" rspec --profile -f documentation -- ./spec/functional
+hab pkg exec "${pkg_ident}" rspec --profile -f documentation -- ./spec/integration


### PR DESCRIPTION
## Description
This PR adds an `aarch64-darwin` habitat plan along with a CI setup for integration tests and habitat package tests in GitHub Workflow.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-33820
https://progresssoftware.atlassian.net/browse/CHEF-33819
https://progresssoftware.atlassian.net/browse/CHEF-33823

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
