### PR TITLE
fix: add git safe.directory to habitat linux plan to fix verify pipeline

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -41,6 +41,8 @@ do_before() {
 }
 
 do_download() {
+  build_line "Setting up the safe directory for the build"
+  git config --global --add safe.directory /src
   build_line "Locally creating archive of latest repository commit at ${HAB_CACHE_SRC_PATH}/${pkg_filename}"
   # source is in this repo, so we're going to create an archive from the
   # appropriate path within the repo and place the generated tarball in the


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes the verify pipeline failure in <a href='https://github.com/chef/chef/pull/16109'>#16109</a> for the Linux Habitat build.</p>

<h2>Problem</h2>
<p>The Linux Habitat build was failing with:</p>
<pre>fatal: detected dubious ownership in repository at '/src'</pre>
<p>This happens because the <code>git archive</code> command in <code>do_download</code> runs as a different user inside the Habitat studio, causing Git to reject the repository as unsafe.</p>

<h2>Fix</h2>
<p>Add <code>git config --global --add safe.directory /src</code> before the <code>git archive</code> call in <code>habitat/plan.sh</code> <code>do_download</code> — matching the same fix already present in the Chef 19 <code>x86_64-linux</code> and <code>aarch64-linux</code> plans.</p>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>