### PR TITLE
fix: add git safe.directory to habitat linux plan do_download

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -41,6 +41,8 @@ do_before() {
 }
 
 do_download() {
+  build_line "Setting up the safe directory for the build"
+  git config --global --add safe.directory /src
   build_line "Locally creating archive of latest repository commit at ${HAB_CACHE_SRC_PATH}/${pkg_filename}"
   # source is in this repo, so we're going to create an archive from the
   # appropriate path within the repo and place the generated tarball in the


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes a Habitat Linux build failure where <code>git archive</code> errors due to dubious repository ownership inside the Habitat studio.</p>

<h2>Problem</h2>
<p>The Linux Habitat build fails with:</p>
<pre>fatal: detected dubious ownership in repository at '/src'</pre>
<p>Git rejects the <code>/src</code> directory as unsafe when the <code>git archive</code> command runs inside the Habitat studio as a different user than the repo owner. This affects both the <code>chef-18</code> base branch and PR <a href='https://github.com/chef/chef/pull/16109'>#16109</a> (AIX re-addition).</p>

<h2>Fix</h2>
<p>Add <code>git config --global --add safe.directory /src</code> before the <code>git archive</code> call in <code>habitat/plan.sh</code> <code>do_download</code>. This matches the identical fix already present in the Chef 19 <code>x86_64-linux</code> and <code>aarch64-linux</code> plans.</p>

<h2>Files Changed</h2>
<ul>
  <li><code>habitat/plan.sh</code> — added safe.directory config in <code>do_download</code></li>
</ul>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>