### PR TITLE
Fix AIX update-version lock handling and cookstyle omnibus ignores

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -26,7 +26,7 @@ sed -i -r "s/(^\s+chef\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.loc
 sed -i -r "s/(^\s+chef-bin\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.lock
 sed -i -r "s/(^\s+chef-config\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.lock
 sed -i -r "s/(^\s+chef-utils\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.lock
-sed -i -r "s/(^\s+chef-utils\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile.aix.lock
+sed -i -r "s/(^\s+chef-utils\s+.+)${ORIGINAL_VERSION}(.+)/\1${VERSION}\2/" Gemfile-aix.lock
 
 # Once Expeditor finishes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - "pkg/**/*"
     - "chef-config/pkg/**/*"
     - "habitat/**/*"
+    - "omnibus/**/*"
 Security/Eval:
   Enabled: false
 Lint/UselessAssignment:


### PR DESCRIPTION
## Summary
This PR includes two changes to improve branch maintenance and linting workflow:

1. Updates .expeditor/update_version.sh so AIX lockfile naming in the version-update flow is handled correctly.
2. Updates .rubocop.yml to ignore omnibus folders for cookstyle/chefstyle checks.

## Changes
- Modified: .expeditor/update_version.sh
- Modified: .rubocop.yml