### PR TITLE
fix: pin http-accept ~> 2.1 and inject rest-client fork in external tests (CHEF-35270)

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -80,6 +80,15 @@ Gem::Specification.new do |s|
 
   s.add_dependency "proxifier2", "~> 1.1"
 
+  # Explicitly pin http-accept to prevent a Gem::LoadError version conflict on Windows.
+  # Chef uses a fork of rest-client (Gemfile) that requires http-accept (~> 2.1.0), but the
+  # official rest-client gem on RubyGems.org allows http-accept >= 1.7.0, < 2.0. If a user
+  # installs the official rest-client into Chef's gem environment, it pulls in http-accept-1.7.0,
+  # which conflicts with the version appbundler pins in the chef-client binstub.
+  # Declaring this as a direct dependency ensures the correct version is always enforced.
+  # See: https://progresssoftware.atlassian.net/browse/CHEF-35270
+  s.add_dependency "http-accept", "~> 2.1"
+
   s.add_dependency "aws-sdk-s3", "~> 1.91" # s3 recipe-url support
   s.add_dependency "aws-sdk-secretsmanager", "~> 1.46"
   s.add_dependency "vault", ">= 0.18.2", "< 0.21.0" # hashi vault official client gem

--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -20,9 +20,13 @@ git_thing = ARGV.shift
 build_dir = Dir.pwd
 
 env = {
+  # Chef's rest-client fork requires http-accept (~> 2.1.0). Without injecting the fork here,
+  # external test bundles resolve the official rest-client which requires http-accept < 2.0,
+  # conflicting with the constraint in chef.gemspec. See: CHEF-35270
   "GEMFILE_MOD" => "gem 'chef', path: '#{build_dir}'; " \
     "gem 'ohai', git: 'https://github.com/chef/ohai.git', branch: 'main'; " \
-    "gem 'ffi-yajl', '2.6.0'", # hold ffi-yajl back until chef/chef Gemfile.lock is upgraded to 2.7.5 or later
+    "gem 'ffi-yajl', '2.6.0'; " \
+    "gem 'rest-client', git: 'https://github.com/chef/rest-client', branch: 'jfm/ucrt_update1'",
   "CHEF_LICENSE" => "accept-no-persist",
 }
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>
  Two-part fix for a <code>Gem::LoadError</code> version conflict that causes <code>chef-client</code>
  to fail on startup on Windows when certain third-party gems are installed into Chef's gem environment.
</p>

<h2>Problem</h2>
<p>
  Chef uses a fork of <code>rest-client</code> (via <code>Gemfile</code>) that requires
  <code>http-accept (~> 2.1.0)</code>. The official <code>rest-client</code> gem published to
  RubyGems.org constrains <code>http-accept</code> to <code>>= 1.7.0, &lt; 2.0</code> — an
  incompatible range.
</p>
<p>
  When a user installs the official <code>rest-client</code> into Chef's Habitat gem environment
  on Windows, it pulls in <code>http-accept-1.7.0</code>. Since the official gem shares the same
  name and version (<code>rest-client 2.1.0</code>) as Chef's fork, its gemspec can shadow
  the fork on disk. The appbundler binstub then fails when activating its pinned
  <code>http-accept-2.1.1</code>:
</p>
<pre><code>can't activate http-accept-2.1.1, already activated http-accept-1.7.0 (Gem::LoadError)</code></pre>

<h2>Why a single gemspec change is not enough</h2>
<p>
  Adding <code>http-accept ~> 2.1</code> to <code>chef.gemspec</code> alone causes CI failures
  in the external test jobs (chef-zero, chefspec, berkshelf, cheffish). Those jobs use
  <code>tasks/bin/run_external_test</code> which injects <code>gem 'chef'</code> into the
  external gem's Gemfile but does <em>not</em> inject Chef's <code>rest-client</code> fork.
  Bundler resolves the official <code>rest-client</code> which requires <code>http-accept &lt; 2.0</code>,
  directly conflicting with the gemspec pin.
</p>

<h2>Fix</h2>
<ul>
  <li>
    <strong><code>chef.gemspec</code></strong>: declare <code>http-accept (~> 2.1)</code> as a
    direct dependency. This ensures RubyGems enforces the correct version regardless of what else
    is installed in the gem environment.
  </li>
  <li>
    <strong><code>tasks/bin/run_external_test</code></strong>: inject Chef's
    <code>rest-client</code> fork into <code>GEMFILE_MOD</code> alongside <code>chef</code>,
    <code>ohai</code>, and <code>ffi-yajl</code>. This ensures external test bundles resolve
    <code>http-accept</code> via the fork (<code>~> 2.1.0</code>), keeping them consistent
    with the gemspec constraint.
  </li>
</ul>

<h2>Changes</h2>
<ul>
  <li>Modified: <code>chef.gemspec</code> — added <code>s.add_dependency "http-accept", "~> 2.1"</code></li>
  <li>Modified: <code>tasks/bin/run_external_test</code> — added Chef's rest-client fork to <code>GEMFILE_MOD</code></li>
</ul>

<h2>Tests &amp; Coverage</h2>
<p>No logic changes — dependency constraints and CI script only. The external test pipelines (chef-zero, chefspec, berkshelf, cheffish) validate the fix end-to-end.</p>

<table>
  <tr><th>File</th><th>Change Type</th><th>Effect</th></tr>
  <tr><td>chef.gemspec</td><td>New direct dependency constraint</td><td>Forces correct http-accept version at gem activation time</td></tr>
  <tr><td>tasks/bin/run_external_test</td><td>GEMFILE_MOD injection</td><td>Ensures external test bundles use the same rest-client fork as Chef</td></tr>
</table>

<h2>Risk &amp; Mitigations</h2>
<p><strong>Risk Classification</strong>: Low</p>
<p><strong>Rationale</strong>: No logic changes. The http-accept constraint is consistent with what Chef's rest-client fork already requires and what is already locked in <code>Gemfile.lock</code>. The <code>run_external_test</code> change mirrors the existing pattern used for <code>ohai</code> and <code>ffi-yajl</code> overrides.</p>
<p><strong>Rollback Strategy</strong>: <code>git revert ef41b80e61</code></p>