### PR TITLE
bump required hab in ci to 2.1.23

### DIFF
--- a/.expeditor/scripts/ensure-minimum-viable-hab.ps1
+++ b/.expeditor/scripts/ensure-minimum-viable-hab.ps1
@@ -1,4 +1,4 @@
-$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '2.0.504' }
+$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '2.1.23' }
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 

--- a/.expeditor/scripts/install-hab.sh
+++ b/.expeditor/scripts/install-hab.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 export HAB_LICENSE="accept"
 export HAB_NONINTERACTIVE="true"
 
-HAB_VERSION="${HAB_VERSION:-2.0.504}"
+HAB_VERSION="${HAB_VERSION:-2.1.23}"
 hab_target="$1"
 
 # print error message followed by usage and exit


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating minimum habitat version to 2.1.23 because the release introduced darwin support. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
