### PR TITLE
[chef-18] backport chef resource sensitive flag fix

### DIFF
--- a/lib/chef/resource/chef_vault_secret.rb
+++ b/lib/chef/resource/chef_vault_secret.rb
@@ -65,7 +65,7 @@ class Chef
       property :search, String, default: "*:*", desired_state: false,
         description: "Search query that would match the same used for the clients, gets stored as a field in the item."
 
-      property :raw_data, [Hash, Mash], default: {},
+      property :raw_data, [Hash, Mash], default: {}, sensitive: true,
         description: "The raw data, as a Ruby Hash, that will be stored in the item."
 
       property :environment, [String, NilClass], desired_state: false,

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -73,7 +73,7 @@ class Chef
       property :proxy_user, String,
         description: "The username to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_password are set"
 
-      property :proxy_password, String,
+      property :proxy_password, String, sensitive: true,
         description: "The password to use to build a proxy credential with. Will be consumed by the proxy_credential property if both this property and proxy_user are set"
 
       load_current_value do

--- a/lib/chef/resource/chocolatey_package.rb
+++ b/lib/chef/resource/chocolatey_package.rb
@@ -59,7 +59,7 @@ class Chef
         introduced: "15.3",
         description: "The username to authenticate feeds."
 
-      property :password, String,
+      property :password, String, sensitive: true,
         introduced: "15.3",
         description: "The password to authenticate to the source."
 

--- a/lib/chef/resource/habitat/habitat_package.rb
+++ b/lib/chef/resource/habitat/habitat_package.rb
@@ -106,7 +106,7 @@ class Chef
       property :channel, String, default: "stable",
         description: "The release channel to install your package from."
 
-      property :auth_token, String,
+      property :auth_token, String, sensitive: true,
         description: "Auth token for installing a package from a private organization on Habitat builder."
 
       property :binlink, [true, false, :force], default: false,

--- a/lib/chef/resource/habitat/habitat_sup.rb
+++ b/lib/chef/resource/habitat/habitat_sup.rb
@@ -129,10 +129,10 @@ class Chef
       property :auto_update, [true, false], default: false,
         description: "Passes `--auto-update`. This will set the Habitat supervisor to automatically update itself any time a stable version has been released."
 
-      property :auth_token, String,
+      property :auth_token, String, sensitive: true,
         description: "Auth token for accessing a private organization on bldr. This value is templated into the appropriate service file."
 
-      property :gateway_auth_token, String,
+      property :gateway_auth_token, String, sensitive: true,
         description: "Auth token for accessing the supervisor's HTTP gateway. This value is templated into the appropriate service file."
 
       property :update_condition, String,

--- a/lib/chef/resource/habitat_config.rb
+++ b/lib/chef/resource/habitat_config.rb
@@ -53,7 +53,7 @@ class Chef
       property :remote_sup_http, String, default: "127.0.0.1:9631", desired_state: false,
         description: "Address for remote supervisor http port. Used to pull existing."
 
-      property :gateway_auth_token, String, desired_state: false,
+      property :gateway_auth_token, String, sensitive: true, desired_state: false,
         description: "Auth token for accessing the remote supervisor's http port."
 
       property :user, String, desired_state: false,

--- a/lib/chef/resource/habitat_service.rb
+++ b/lib/chef/resource/habitat_service.rb
@@ -118,7 +118,7 @@ class Chef
       property :remote_sup_http, String, default: "127.0.0.1:9631", desired_state: false,
         description: "IP address and port used to communicate with the remote supervisor. If this value is invalid, the resource will update the supervisor configuration each time #{ChefUtils::Dist::Server::PRODUCT} runs."
 
-      property :gateway_auth_token, String, desired_state: false,
+      property :gateway_auth_token, String, sensitive: true, desired_state: false,
         description: "Auth token for accessing the remote supervisor's http port."
 
       property :update_condition, [Symbol, String], equal_to: [:latest, "latest", :'track-channel', "track-channel"], default: :latest, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s },

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -60,7 +60,7 @@ class Chef
         description: "The desired curve of the generated key (if key_type is equal to 'ec'). Run openssl ecparam -list_curves to see available options.",
         default: "prime256v1"
 
-      property :key_pass, String,
+      property :key_pass, String, sensitive: true,
         description: "The desired passphrase for the key."
 
       property :key_cipher, String,

--- a/lib/chef/resource/openssl_ec_public_key.rb
+++ b/lib/chef/resource/openssl_ec_public_key.rb
@@ -56,10 +56,10 @@ class Chef
       property :private_key_path, String,
         description: "The path to the private key file."
 
-      property :private_key_content, String,
+      property :private_key_content, String, sensitive: true,
         description: "The content of the private key including new lines. This property is used in place of private_key_path in instances where you want to avoid having to first write the private key to disk"
 
-      property :private_key_pass, String,
+      property :private_key_pass, String, sensitive: true,
         description: "The passphrase of the provided private key."
 
       property :owner, [String, Integer],

--- a/lib/chef/resource/openssl_rsa_private_key.rb
+++ b/lib/chef/resource/openssl_rsa_private_key.rb
@@ -59,7 +59,7 @@ class Chef
         description: "The desired bit length of the generated key.",
         default: 2048
 
-      property :key_pass, String,
+      property :key_pass, String, sensitive: true,
         description: "The desired passphrase for the key."
 
       property :key_cipher, String,

--- a/lib/chef/resource/openssl_rsa_public_key.rb
+++ b/lib/chef/resource/openssl_rsa_public_key.rb
@@ -57,10 +57,10 @@ class Chef
       property :private_key_path, String,
         description: "The path to the private key file."
 
-      property :private_key_content, String,
+      property :private_key_content, String, sensitive: true,
         description: "The content of the private key, including new lines. This property is used in place of private_key_path in instances where you want to avoid having to first write the private key to disk."
 
-      property :private_key_pass, String,
+      property :private_key_pass, String, sensitive: true,
         description: "The passphrase of the provided private key."
 
       property :owner, [String, Integer],

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -115,7 +115,7 @@ class Chef
       property :key_file, String,
         description: "The path to a certificate key file on the filesystem. If the key_file property is specified, the resource will attempt to source a key from this location. If no key file is found, the resource will generate a new key file at this location. If the key_file property is not specified, the resource will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate."
 
-      property :key_pass, String,
+      property :key_pass, String, sensitive: true,
         description: "The passphrase for an existing key's passphrase."
 
       property :key_type, String,

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -102,7 +102,7 @@ class Chef
       property :key_file, String,
         description: "The path to a certificate key file on the filesystem. If the `key_file` property is specified, the resource will attempt to source a key from this location. If no key file is found, the resource will generate a new key file at this location. If the `key_file` property is not specified, the resource will generate a key file in the same directory as the generated certificate, with the same name as the generated certificate."
 
-      property :key_pass, String,
+      property :key_pass, String, sensitive: true,
         description: "The passphrase for an existing key's passphrase."
 
       property :key_type, String,

--- a/lib/chef/resource/powershell_package_source.rb
+++ b/lib/chef/resource/powershell_package_source.rb
@@ -143,7 +143,7 @@ class Chef
         introduced: "17.6",
         description: "A username that, as part of a credential object, is used to register a repository or other package source with."
 
-      property :password, String,
+      property :password, String, sensitive: true,
         introduced: "17.6",
         description: "A password that, as part of a credential object, is used to register a repository or other package source with."
 

--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -53,7 +53,7 @@ class Chef
       property :username, String,
         description: "The username to use when registering. This property is not applicable if using an activation key. If specified, password and environment properties are also required."
 
-      property :password, String,
+      property :password, String, sensitive: true,
         description: "The password to use when registering. This property is not applicable if using an activation key. If specified, username and environment are also required."
 
       property :system_name, String,

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -65,7 +65,7 @@ class Chef
         description: "The domain user that will be used to join the domain.",
         required: true
 
-      property :domain_password, String,
+      property :domain_password, String, sensitive: true,
         description: "The password for the domain user. Note that this resource is set to hide sensitive information by default. ",
         required: true
 

--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -65,7 +65,7 @@ class Chef
         description: "The source file (for `create` and `acl_add`), thumbprint (for `delete`, `export`, and `acl_add`), or subject (for `delete` or `export`) if it differs from the resource block's name.",
         name_property: true
 
-      property :pfx_password, String,
+      property :pfx_password, String, sensitive: true,
         description: "The password to access the object with if it is a PFX file."
 
       property :private_key_acl, Array,

--- a/lib/chef/resource/windows_service.rb
+++ b/lib/chef/resource/windows_service.rb
@@ -228,7 +228,7 @@ class Chef
         default: "localsystem",
         coerce: proc(&:downcase)
 
-      property :run_as_password, String,
+      property :run_as_password, String, sensitive: true,
         description: "The password for the user specified by `run_as_user`.",
         default: ""
     end

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -164,7 +164,7 @@ class Chef
         default: lazy { Chef::ReservedNames::Win32::Security::SID.LocalSystem.account_simple_name if ChefUtils.windows_ruby? },
         default_description: "The localized SYSTEM user for the node."
 
-      property :password, String,
+      property :password, String, sensitive: true,
         description: "The user's password. The user property must be set if using this property."
 
       property :run_level, Symbol, equal_to: %i{highest limited},

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -146,14 +146,14 @@ class Chef
       property :options, Hash,
         description: "Specifies the repository options."
 
-      property :password, String,
+      property :password, String, sensitive: true,
         description: "Password to use with the username for basic authentication."
 
       property :priority, String, regex: /^(\d?[1-9]|[0-9][0-9])$/,
         description: "Assigns a priority to a repository where the priority value is between `1` and `99` inclusive. Priorities are used to enforce ordered protection of repositories. Packages from repositories with a lower priority (higher numerical value) will never be used to upgrade packages that were installed from a repository with a higher priority (lower numerical value). The repositories with the lowest numerical priority number have the highest priority.",
         validation_message: "The priority property must be a numeric value from 1-99!"
 
-      property :proxy_password, String,
+      property :proxy_password, String, sensitive: true,
         description: "Password for this proxy."
 
       property :proxy_username, String,

--- a/spec/unit/resource/chef_vault_secret_spec.rb
+++ b/spec/unit/resource/chef_vault_secret_spec.rb
@@ -37,4 +37,10 @@ describe Chef::Resource::ChefVaultSecret do
     expect { resource.action :create_if_missing }.not_to raise_error
     expect { resource.action :delete }.not_to raise_error
   end
+
+  describe "sensitive property masking" do
+    it "marks raw_data as sensitive" do
+      expect(Chef::Resource::ChefVaultSecret.properties[:raw_data].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -218,4 +218,10 @@ describe Chef::Resource::ChocolateyInstaller do
       end
     end
   end
+
+  describe "sensitive property masking" do
+    it "marks proxy_password as sensitive" do
+      expect(Chef::Resource::ChocolateyInstaller.properties[:proxy_password].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/chocolatey_package_spec.rb
+++ b/spec/unit/resource/chocolatey_package_spec.rb
@@ -103,4 +103,10 @@ describe Chef::Resource::ChocolateyPackage do
       expect(resource.returns).to eql(val)
     end
   end
+
+  describe "sensitive property masking" do
+    it "marks password as sensitive" do
+      expect(Chef::Resource::ChocolateyPackage.properties[:password].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/habitat/habitat_package_spec.rb
+++ b/spec/unit/resource/habitat/habitat_package_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Resource::HabitatPackage do
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::HabitatPackage.new("core/redis", run_context) }
+
+  describe "sensitive property masking" do
+    it "marks auth_token as sensitive" do
+      expect(Chef::Resource::HabitatPackage.properties[:auth_token].sensitive?).to be true
+    end
+  end
+end

--- a/spec/unit/resource/habitat/habitat_sup_spec.rb
+++ b/spec/unit/resource/habitat/habitat_sup_spec.rb
@@ -1,0 +1,35 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Resource::HabitatSup do
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::HabitatSup.new("default", run_context) }
+
+  describe "sensitive property masking" do
+    it "marks auth_token as sensitive" do
+      expect(Chef::Resource::HabitatSup.properties[:auth_token].sensitive?).to be true
+    end
+
+    it "marks gateway_auth_token as sensitive" do
+      expect(Chef::Resource::HabitatSup.properties[:gateway_auth_token].sensitive?).to be true
+    end
+  end
+end

--- a/spec/unit/resource/habitat_config_spec.rb
+++ b/spec/unit/resource/habitat_config_spec.rb
@@ -1,0 +1,35 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Resource::HabitatConfig do
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::HabitatConfig.new("default", run_context) }
+
+  describe "sensitive property masking" do
+    it "marks gateway_auth_token as sensitive" do
+      expect(Chef::Resource::HabitatConfig.properties[:gateway_auth_token].sensitive?).to be true
+    end
+
+    it "excludes gateway_auth_token from desired state" do
+      expect(Chef::Resource::HabitatConfig.properties[:gateway_auth_token].desired_state?).to be false
+    end
+  end
+end

--- a/spec/unit/resource/habitat_service_spec.rb
+++ b/spec/unit/resource/habitat_service_spec.rb
@@ -1,0 +1,35 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Resource::HabitatService do
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::HabitatService.new("core/redis", run_context) }
+
+  describe "sensitive property masking" do
+    it "marks gateway_auth_token as sensitive" do
+      expect(Chef::Resource::HabitatService.properties[:gateway_auth_token].sensitive?).to be true
+    end
+
+    it "excludes gateway_auth_token from desired state" do
+      expect(Chef::Resource::HabitatService.properties[:gateway_auth_token].desired_state?).to be false
+    end
+  end
+end

--- a/spec/unit/resource/openssl_ec_private_key_spec.rb
+++ b/spec/unit/resource/openssl_ec_private_key_spec.rb
@@ -61,4 +61,10 @@ describe Chef::Resource::OpensslEcPrivateKey do
     expect(resource.force).to eql(false)
   end
 
+  describe "sensitive property masking" do
+    it "marks key_pass as sensitive" do
+      expect(Chef::Resource::OpensslEcPrivateKey.properties[:key_pass].sensitive?).to be true
+    end
+  end
+
 end

--- a/spec/unit/resource/openssl_ec_public_key_spec.rb
+++ b/spec/unit/resource/openssl_ec_public_key_spec.rb
@@ -40,4 +40,14 @@ describe Chef::Resource::OpensslEcPublicKey do
   it "has a default mode of '0640'" do
     expect(resource.mode).to eql("0640")
   end
+
+  describe "sensitive property masking" do
+    it "marks private_key_content as sensitive" do
+      expect(Chef::Resource::OpensslEcPublicKey.properties[:private_key_content].sensitive?).to be true
+    end
+
+    it "marks private_key_pass as sensitive" do
+      expect(Chef::Resource::OpensslEcPublicKey.properties[:private_key_pass].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/openssl_rsa_private_key_spec.rb
+++ b/spec/unit/resource/openssl_rsa_private_key_spec.rb
@@ -61,4 +61,10 @@ describe Chef::Resource::OpensslRsaPrivateKey do
     expect(resource.force).to eql(false)
   end
 
+  describe "sensitive property masking" do
+    it "marks key_pass as sensitive" do
+      expect(Chef::Resource::OpensslRsaPrivateKey.properties[:key_pass].sensitive?).to be true
+    end
+  end
+
 end

--- a/spec/unit/resource/openssl_rsa_public_key_spec.rb
+++ b/spec/unit/resource/openssl_rsa_public_key_spec.rb
@@ -40,4 +40,14 @@ describe Chef::Resource::OpensslRsaPublicKey do
   it "has a default mode of '0640'" do
     expect(resource.mode).to eql("0640")
   end
+
+  describe "sensitive property masking" do
+    it "marks private_key_content as sensitive" do
+      expect(Chef::Resource::OpensslRsaPublicKey.properties[:private_key_content].sensitive?).to be true
+    end
+
+    it "marks private_key_pass as sensitive" do
+      expect(Chef::Resource::OpensslRsaPublicKey.properties[:private_key_pass].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/openssl_x509_certificate_spec.rb
+++ b/spec/unit/resource/openssl_x509_certificate_spec.rb
@@ -69,4 +69,10 @@ describe Chef::Resource::OpensslX509Certificate do
     expect { resource.mode "644" }.not_to raise_error
     expect { resource.mode 644 }.not_to raise_error
   end
+
+  describe "sensitive property masking" do
+    it "marks key_pass as sensitive" do
+      expect(Chef::Resource::OpensslX509Certificate.properties[:key_pass].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/openssl_x509_request_spec.rb
+++ b/spec/unit/resource/openssl_x509_request_spec.rb
@@ -65,4 +65,10 @@ describe Chef::Resource::OpensslX509Request do
     expect { resource.mode "644" }.not_to raise_error
     expect { resource.mode 644 }.not_to raise_error
   end
+
+  describe "sensitive property masking" do
+    it "marks key_pass as sensitive" do
+      expect(Chef::Resource::OpensslX509Request.properties[:key_pass].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/powershell_package_source_spec.rb
+++ b/spec/unit/resource/powershell_package_source_spec.rb
@@ -217,4 +217,10 @@ describe Chef::Resource::PowershellPackageSource do
   #     expect(provider.get_package_source_details.result).to eql("Unregistered")
   #   end
   # end
+
+  describe "sensitive property masking" do
+    it "marks password as sensitive" do
+      expect(Chef::Resource::PowershellPackageSource.properties[:password].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/rhsm_register_spec.rb
+++ b/spec/unit/resource/rhsm_register_spec.rb
@@ -305,4 +305,10 @@ describe Chef::Resource::RhsmRegister do
       end
     end
   end
+
+  describe "sensitive property masking" do
+    it "marks password as sensitive" do
+      expect(Chef::Resource::RhsmRegister.properties[:password].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/windows_ad_join_spec.rb
+++ b/spec/unit/resource/windows_ad_join_spec.rb
@@ -52,4 +52,10 @@ describe Chef::Resource::WindowsAdJoin do
     expect { resource.reboot :never }.not_to raise_error
     expect { resource.reboot :nopenope }.to raise_error(ArgumentError)
   end
+
+  describe "sensitive property masking" do
+    it "marks domain_password as sensitive" do
+      expect(Chef::Resource::WindowsAdJoin.properties[:domain_password].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/windows_certificate_spec.rb
+++ b/spec/unit/resource/windows_certificate_spec.rb
@@ -92,4 +92,10 @@ describe Chef::Resource::WindowsCertificate do
     resource.exportable true
     expect { resource.action :create }.not_to raise_error
   end
+
+  describe "sensitive property masking" do
+    it "marks pfx_password as sensitive" do
+      expect(Chef::Resource::WindowsCertificate.properties[:pfx_password].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/windows_service_spec.rb
+++ b/spec/unit/resource/windows_service_spec.rb
@@ -119,4 +119,10 @@ describe Chef::Resource::WindowsService, "initialize" do
     resource.run_as_user = "JohnDoe"
     expect(resource.run_as_user).to eq("johndoe")
   end
+
+  describe "sensitive property masking" do
+    it "marks run_as_password as sensitive" do
+      expect(Chef::Resource::WindowsService.properties[:run_as_password].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -400,4 +400,10 @@ describe Chef::Resource::WindowsTask, :windows_only do
       expect(resource.send(:sec_to_dur, 604801)).to eql("PT604801S")
     end
   end
+
+  describe "sensitive property masking" do
+    it "marks password as sensitive" do
+      expect(Chef::Resource::WindowsTask.properties[:password].sensitive?).to be true
+    end
+  end
 end

--- a/spec/unit/resource/yum_repository_spec.rb
+++ b/spec/unit/resource/yum_repository_spec.rb
@@ -153,4 +153,14 @@ describe Chef::Resource::YumRepository do
       expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
     end
   end
+
+  describe "sensitive property masking" do
+    it "marks password as sensitive" do
+      expect(Chef::Resource::YumRepository.properties[:password].sensitive?).to be true
+    end
+
+    it "marks proxy_password as sensitive" do
+      expect(Chef::Resource::YumRepository.properties[:proxy_password].sensitive?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Description
Backport of #16107 

This pull request backports a security issue from #16107 that implements proper sensitive property masking across 20 Chef Infra resources. The changes ensure that sensitive data such as passwords, authentication tokens, private keys, and other credentials are correctly marked with the `sensitive: true` flag. This prevents these sensitive values from being exposed in logs, stack traces, error messages, or state reporting mechanisms.

Please see original PR description for more detailed breakdown.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
