### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -10,7 +10,7 @@ jobs:
       checks: read
       contents: read
     steps:
-      - uses: wechuli/allcheckspassed@v2
+      - uses: wechuli/allcheckspassed@204ff63e89eabdc8086f0c50b91f675bcf37c8f6 # v2
         with:
           # Retry every minute for 30 minutes...
           retries: 90

--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -10,7 +10,7 @@ jobs:
       checks: read
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: jaymzh/chronoguard@main
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: jaymzh/chronoguard@d8312ed1b3c2201a82984ab9169287bf66e73c5e # main
         with:
           files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml, habitat/aarch64-linux/plan.sh

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Note that we do NOT checkout the PR code, this is actually
       # 'main', but Danger rules can still use the API to read the PR
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: danger/danger-js@13.0.8
         with:
           args: "--verbose --text-only -f"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -12,12 +12,12 @@ jobs:
     name: DCO Check
     steps:
     - name: Get PR Commits
-      uses: actionshub/get-pr-commits@main
+      uses: actionshub/get-pr-commits@6fc8a0242c2c5853e3e8b86bde9d176682e5c5fb # main
       id: 'get-pr-commits'
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: DCO Check
-      uses: actionshub/dco@main
+      uses: actionshub/dco@736d5885f972dcfd68b3db44da9a940b370cc625 # main
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
         allow-obvious-fix-label: "obvious-fix"

--- a/.github/workflows/func_spec.yml
+++ b/.github/workflows/func_spec.yml
@@ -45,13 +45,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install native deps (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: false
@@ -124,7 +124,7 @@ jobs:
       options: --privileged
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install native deps (dnf)
         if: matrix.pkg_mgr == 'dnf'
         run: dnf install -y --enablerepo=devel openssl-devel libarchive-devel libffi-devel libyaml-devel readline-devel zlib-devel
@@ -155,8 +155,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: false
@@ -174,8 +174,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: false

--- a/.github/workflows/gem_tests.yml
+++ b/.github/workflows/gem_tests.yml
@@ -26,14 +26,14 @@ jobs:
       PEDANT_OPTS: "--skip-oc_id"
       CHEF_FS: "true"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           clean: true
       - name: Install native deps
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "3.4.8"
           bundler-cache: false
@@ -49,14 +49,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           clean: true
       - name: Install native deps
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "3.4.8"
           bundler-cache: false
@@ -72,14 +72,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           clean: true
       - name: Install native deps
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "3.4.8"
           bundler-cache: false
@@ -95,14 +95,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           clean: true
       - name: Install native deps
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev graphviz
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "3.4.8"
           bundler-cache: false

--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -50,7 +50,7 @@ jobs:
       HAB_LICENSE: accept-no-persist
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -137,7 +137,7 @@ jobs:
   #     HAB_AUTH_TOKEN: ${{ secrets.HAB_AUTH_TOKEN }}
   #   steps:
   #   - name: Checkout PR code
-  #     uses: actions/checkout@v6
+  #     uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
   #     with:
   #       ref: ${{ github.event.pull_request.head.sha }}
   #       persist-credentials: false
@@ -216,11 +216,11 @@ jobs:
 #      KITCHEN_LOCAL_YAML: kitchen.exec.macos.yml
 #    steps:
 #      - name: Check out code
-#        uses: actions/checkout@v5
+#        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 #        with:
 #            clean: true
 #      - name: Install Chef
-#        uses: actionshub/chef-install@main
+#        uses: actionshub/chef-install@f3b35943a257c25f3ca69e3b773fa4e0e99b58d6 # main
 #        with:
 #          version: "25.5.1084"
 #      - name: Kitchen Test
@@ -245,13 +245,13 @@ jobs:
   #     GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   #   steps:
   #     - name: Checkout PR code
-  #       uses: actions/checkout@v6
+  #       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
   #       with:
   #         ref: ${{ github.event.pull_request.head.sha }}
   #         persist-credentials: false
   #         clean: true
   #     - name: Install Chef
-  #       uses: actionshub/chef-install@main
+  #       uses: actionshub/chef-install@f3b35943a257c25f3ca69e3b773fa4e0e99b58d6 # main
   #       with:
   #         version: "25.5.1084"
   #     - name: Kitchen Test
@@ -297,7 +297,7 @@ jobs:
       HAB_LICENSE: accept-no-persist
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -375,7 +375,7 @@ jobs:
       HAB_LICENSE: accept-no-persist
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -439,7 +439,7 @@ jobs:
 #      KITCHEN_LOCAL_YAML: kitchen.linux.ci.yml
 #    steps:
 #      - name: Checkout PR code
-#        uses: actions/checkout@v6
+#        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 #        with:
 #          ref: ${{ github.event.pull_request.head.sha }}
 #          persist-credentials: false
@@ -455,7 +455,7 @@ jobs:
 #          sudo vagrant --version
 #          sudo VBoxManage --version
 #      - name: Install Chef
-#        uses: actionshub/chef-install@main
+#        uses: actionshub/chef-install@f3b35943a257c25f3ca69e3b773fa4e0e99b58d6 # main
 #      - name: Kitchen Test
 #        run: |
 #          # To debug, uncomment these

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6.1.0
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,12 +17,12 @@ jobs:
     env:
       BUNDLE_WITHOUT: ruby_shadow:packaging
     steps:
-      - uses: actions/checkout@v6
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: 3.4
           bundler-cache: false
-      - uses: r7kamura/rubocop-problem-matchers-action@v1  # this shows the failures in the PR
+      - uses: r7kamura/rubocop-problem-matchers-action@f8a7c58ca427edfb72c8463afa0c301f74f30c0a # v1  # this shows the failures in the PR
       - run: |
           bundle install
           bundle exec cookstyle --chefstyle -c .rubocop.yml
@@ -30,17 +30,17 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: |
           curl --location 'https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt' --output chef_dictionary.txt
-      - uses: streetsidesoftware/cspell-action@v8.4.0
+      - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
 
   linelint:
     runs-on: ubuntu-latest
     name: Check if all files end in newline
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Linelint
-        uses: fernandrone/linelint@master
+        uses: fernandrone/linelint@7907a5dca0c28ea7dd05c6d8d8cacded713aca11 # master
         id: linelint

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -23,12 +23,12 @@ jobs:
     if: ${{ false }}
     runs-on: ip-range-controlled
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
     - name: SonarQube Scan
-      uses: sonarsource/sonarqube-scan-action@master
+      uses: sonarsource/sonarqube-scan-action@45f27363d4ff7d6b16baa0516490f10c52bdd5fc # master
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/target_mode_integration.yml
+++ b/.github/workflows/target_mode_integration.yml
@@ -51,14 +51,14 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install native deps
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "3.4"
           bundler-cache: false
@@ -176,9 +176,9 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "3.4"
           bundler-cache: false
@@ -193,7 +193,7 @@ jobs:
         shell: pwsh
         run: wsl --set-default-version 2
 
-      - uses: Vampire/setup-wsl@v7
+      - uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7
         with:
           distribution: Ubuntu-24.04
           use-cache: "true"

--- a/.github/workflows/target_mode_specs.yml
+++ b/.github/workflows/target_mode_specs.yml
@@ -30,7 +30,7 @@ jobs:
       core_changed: ${{ steps.detect.outputs.core_changed }}
       resource_files: ${{ steps.detect.outputs.resource_files }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           clean: true
 
@@ -102,7 +102,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "3.4"
           bundler-cache: false
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           clean: true
 
@@ -137,7 +137,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "3.4"
           bundler-cache: false

--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -49,7 +49,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
         shell: pwsh
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           clean: true
       - name: Install native deps (Ubuntu)
@@ -57,7 +57,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: false
@@ -112,7 +112,7 @@ jobs:
     container: ${{ matrix.container }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           clean: true
       - name: Install native deps (dnf)

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -41,7 +41,7 @@ jobs:
       CHEF_LICENSE_KEY: ${{ secrets.CHEF_LICENSE_KEY }}
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false

--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Defense against supply-chain attacks via mutable tags. Version tags retained as inline comments. See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions