### PR TITLE
fix: Constrain ffi-yajl to < 3.0 for Ruby 3.2+ compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
       # Due to FIPS builds and having to couple the openssl
       # build itself, we don't let dependabot bump openssl
       - dependency-name: "openssl"
+      - dependency-name: "ffi-yajl"
+        # Locking to 2.x until ffi-yajl 3.x gets the allocator fix https://github.com/chef/ffi-yajl/pull/126 fail-after:2026-08-22
+        versions: ["3.x"]
     # don't automatically rebase on every single time we're out of date with
     # base (whith is always) because it kills CI capacity
     rebase-strategy: disabled

--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jaymzh/chronoguard@main
         with:
-          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml, habitat/aarch64-linux/plan.sh
+          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml, habitat/aarch64-linux/plan.sh, .github/dependabot.yml

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
   s.add_dependency "inspec-core", "~> 7.1.7"
 
   s.add_dependency "ffi", ">= 1.15.5", "< 1.18.0"
-  s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"
+  s.add_dependency "ffi-yajl", ">= 2.2", "< 3.0"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "net-ftp" # remote_file resource
   s.add_dependency "ed25519", "~> 1.2" # ssh-ed25519 support for target mode


### PR DESCRIPTION
<h2>Summary</h2>
<p>Pin ffi-yajl to &lt; 3.0 to use the 2.7.x branch which contains the allocator warning fix for Ruby 3.2+. ffi-yajl 3.0.0 does not include this fix.</p>

<h2>Changes Made</h2>
<ul>
  <li>Updated ffi-yajl dependency constraint from <code>&lt; 4.0</code> to <code>&lt; 3.0</code> in <code>chef.gemspec</code></li>
  <li>Added dependabot ignore for ffi-yajl 3.x on main branch with <code>fail-after:2026-08-22</code> so chronoguard reminds us to revisit this pin</li>
  <li>Added <code>.github/dependabot.yml</code> to chronoguard watched files</li>
</ul>

<h2>Why</h2>
<p>The ffi-yajl 3.0.0 release does not include the fix for Ruby 3.2+ allocator warnings that was implemented in ffi-yajl 2.7.x. By pinning to &lt; 3.0, we use the fixed 2.7.x versions.</p>

<h2>References</h2>
<ul>
  <li><a href="https://github.com/chef/ffi-yajl/pull/126">ffi-yajl PR #126</a></li>
  <li>Related: chef/ohai#1955</li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Style checks pass</li>
  <li>All existing tests pass</li>
</ul>

<hr>
<p>This work was completed with AI assistance following Progress AI policies.</p>