### PR TITLE
[CVE] Bump faraday to 2.14.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     ed25519 (1.4.0)
     erubi (1.13.1)
     erubis (2.7.0)
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
```
Faraday 2.14.1 has 2 big CVE's in it:
faraday 2.14.1 2.14.3 gem https://github.com/advisories/GHSA-98m9-hrrm-r99r High 0.3% (21st) 0.2
faraday 2.14.1 2.14.2 gem https://github.com/advisories/GHSA-5rv5-xj5j-3484 Low 0.3% (18th) < 0.1


❯ bundle update --conservative faraday
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using rake 13.4.2
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      stringio (>= 0)
      Available/installed versions of this gem:
      - 3.2.0
      - 3.1.9
      - 3.1.8
      - 3.1.7
      - 3.0.1.2
      erb (>= 0)
      Available/installed versions of this gem:
      - 4.0.4.1
      - 4.0.4
      - 2.2.3
      tsort (>= 0)
      Available/installed versions of this gem:
      - 0.2.0
      - 0.1.0
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
Using public_suffix 6.0.2
Using ast 2.4.3
Using aws-partitions 1.1234.0
Using bigdecimal 4.1.1
Using logger 1.5.3
Using benchmark 0.5.0
Using debug_inspector 1.2.0
Using builder 3.3.0
Using libyajl2 2.1.0
Using mixlib-log 3.0.9
Using rack 3.2.6
Using aws-eventstream 1.4.0
Using mixlib-cli 2.1.8
Using uuidtools 3.0.0
Using base64 0.3.0
Using erubis 2.7.0
Using iniparse 1.5.0
Using jmespath 1.6.2
Using language_server-protocol 3.17.0.5
Fetching ffi 1.17.4 (arm64-darwin)
Using bundler 2.3.27
Using parallel 1.28.0
Using racc 1.8.1
Fetching concurrent-ruby 1.3.7
Using tomlrb 1.3.0
Using regexp_parser 2.12.0
Using byebug 12.0.0
Fetching json 2.19.9
Using fuzzyurl 0.9.0
Using prism 1.9.0
Using unicode-display_width 2.6.0
Using uri 1.1.1
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using webrick 1.9.2
Using tty-screen 0.8.2
Using diff-lcs 1.6.2
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 2.0.0
Using coderay 1.1.3
Using rspec-support 3.13.7
Using rubyzip 2.4.1
Using tty-cursor 0.7.1
Using wisper 2.0.1
Using thor 1.4.0
Using net-ssh 7.3.2
Using mixlib-authentication 3.0.10
Using semverse 3.0.2
Using timeout 0.6.0
Using sslshake 1.3.1
Using lint_roller 1.1.0
Using wmi-lite 1.0.7
Using unicode_utils 1.4.0
Using proxifier2 1.1.0
Using date 3.5.1
Using domain_name 0.6.20240107
Using mime-types-data 3.2026.0203
Using netrc 0.11.0
Using rexml 3.4.4
Using erubi 1.13.1
Using mutex_m 0.3.0
Using little-plugger 1.1.4
Using multi_json 1.19.1
Using ruby-progressbar 1.13.0
Using csv 3.3.5
Using socksify 1.8.1
Using unf_ext 0.0.9.1
Using ed25519 1.4.0
Using connection_pool 2.5.5
Using ipaddress 0.8.3
Using ruby-shadow 2.5.0 from https://github.com/chef/ruby-shadow (at lcg/ruby-3.0@3b8ea40)
Using rainbow 3.1.1
Using addressable 2.9.0
Using plist 3.7.2
Using syslog 0.4.0
Using nori 2.7.0
Using binding_of_caller 2.0.0
Using hashdiff 1.2.1
Using syslog-logger 1.6.8
Using aws-sigv4 1.12.1
Using rackup 2.3.1
Using rubyntlm 0.6.5
Using parser 3.3.11.1
Using mixlib-config 3.0.27
Using net-http 0.9.1
Using pastel 0.8.0
Using pry 0.15.2
Using rspec-core 3.13.6
Using rspec-expectations 3.13.5
Using rspec-mocks 3.13.8
Using tty-reader 0.9.0
Using mixlib-archive 1.3.3
Using hashie 5.1.0
Using net-sftp 4.0.0
Using net-protocol 0.2.2
Using strings 0.2.1
Using fauxhai-ng 9.3.0
Using http-cookie 1.1.0
Using mime-types 3.7.0
Using chef-gyoku 1.5.0
Using httpclient 2.9.0
Using crack 1.0.1
Using http-accept 2.1.1
Using net-http-persistent 4.0.8
Using net-scp 4.1.0
Using time 0.4.2
Using rubocop-ast 1.49.1
Using logging 2.4.0
Using aws-sdk-core 3.244.0
Using rb-readline 0.5.5
Using ffi-yajl 2.7.11
Using faraday-net_http 3.4.2
Fetching chef-vault 4.2.12
Using tty-prompt 0.23.1
Using tty-box 0.7.0
Using rspec 3.13.2
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@4725c8b)
Using rspec-its 2.0.0
Using tty-table 0.12.0
Using pry-byebug 3.11.0
Using vault 0.20.1
Using pry-stack_explorer 0.6.3
Using webmock 3.26.2
Using chef-zero 15.1.11
Using license-acceptance 2.1.13
Using aws-sdk-kms 1.123.0
Using aws-sdk-secretsmanager 1.129.0
Using net-ftp 0.3.9
Using aws-sdk-s3 1.218.0
Installing chef-vault 4.2.12
Installing json 2.19.9 with native extensions
Installing concurrent-ruby 1.3.7
Installing ffi 1.17.4 (arm64-darwin)
Using chef-utils 18.11.3 from source at `chef-utils`
Using mixlib-shellout 3.4.10
Using cheffish 17.1.8
Using chef-config 18.11.3 from source at `chef-config`
Using appbundler 0.13.4
Using chef-telemetry 1.1.1
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.14
Using gssapi 1.3.1
Using chef-winrm 2.5.0
Using chef-winrm-fs 1.4.2
Using chef-winrm-elevated 1.2.5
Using train-winrm 0.4.3
Using rubocop 1.84.2
Fetching faraday 2.14.3 (was 2.14.1)
Using cookstyle 8.6.10
Fetching train-core 3.16.5
Installing train-core 3.16.5
Installing faraday 2.14.3 (was 2.14.1)
Using ohai 18.2.20 from https://github.com/chef/ohai.git (at 18-stable@31b00ef)
Using train-rest 0.5.0
Using faraday-follow_redirects 0.5.0
Fetching inspec-core 5.24.24
Installing inspec-core 5.24.24
Using chef 18.11.3 from source at `.`
Using chef-bin 18.11.3 from source at `chef-bin` and installing its executables
Fetching inspec-core-bin 5.24.24
Installing inspec-core-bin 5.24.24
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
