### PR TITLE
Suppress future dependabot ffi >= 1.17 on chef-18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # ffi >= 1.17 requires glibc 2.17+ which drops Amazon Linux 2, CentOS 7,
+      # Debian 9, Ubuntu 16.04, and SLES 12.5 — all still supported on chef-18.
+      # See: https://github.com/chef/chef/pull/16163
+      # ponytail: revisit when those platforms are removed from chef-18 support matrix
+      - dependency-name: "ffi"
+        versions: [">= 1.17.0"]


### PR DESCRIPTION
<h2>Summary</h2>
<p>Adds a Dependabot ignore rule to prevent the #16167 from being re-proposed.</p>

<h2>Issue</h2>
<p>ffi >= 1.17 requires glibc 2.17+, which breaks support for platforms still in the chef-18 support matrix. See <a href="https://github.com/chef/chef/pull/16163">#16163</a> for the original analysis.</p>
<p>Affected platforms:</p>
<ul>
  <li>Amazon Linux 2 (EOL 2026-06-30)</li>
  <li>CentOS 7 (EOL 2024-06-30)</li>
  <li>Debian 9 (EOL 2022-06-30)</li>
  <li>Ubuntu 16.04 (Security EOL 2026-04-02)</li>
  <li>SLES 12.5 (LTS 2027-12-31)</li>
</ul>

<h2>Changes</h2>
<ul>
  <li>Reverted: <code>chef.gemspec</code> — ffi constraint back to <code>&lt;= 1.16.3</code></li>
  <li>Reverted: <code>Gemfile.lock</code> — ffi pinned back to 1.16.3</li>
  <li>Added: <code>.github/dependabot.yml</code> — ignore ffi >= 1.17.0 on chef-18</li>
</ul>

<h2>Tests &amp; Coverage</h2>
<p>No logic changes. Dependency version revert only.</p>

<h2>Risk &amp; Mitigations</h2>
<p><strong>Risk Classification</strong>: Low</p>
<p><strong>Rationale</strong>: Restores the exact state from before #16167 merged. The Dependabot ignore rule prevents recurrence without blocking other ffi updates.</p>
<p><strong>Rollback Strategy</strong>: <code>git revert HEAD</code></p>

<h2>DCO</h2>
<p>All commits signed off with Developer Certificate of Origin.</p>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>