### PR TITLE
Fix SHA exit consistency in selfhosted FIPS Linux workflow; skip in allchecks until 2026-07-22

### DIFF
--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -15,3 +15,5 @@ jobs:
           # Retry every minute for 30 minutes...
           retries: 90
           verbose: true
+          # ponytail: fail-after:2026-07-22 — self-hosted FIPS runner is intermittently unavailable; re-enable once runner is stable
+          checks_exclude: "linux-fips"

--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -16,4 +16,4 @@ jobs:
           retries: 90
           verbose: true
           # ponytail: fail-after:2026-07-22 — self-hosted FIPS runner is intermittently unavailable; re-enable once runner is stable
-          checks_exclude: "linux-fips"
+          checks_exclude: ".*linux-fips.*"

--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -211,6 +211,7 @@ jobs:
             echo "--- SHA256 Log excerpt ---"
             tail -50 /tmp/chef-client-sha256.log
             echo "--- End SHA256 log ---"
+            exit 1
           fi
           echo ""
 
@@ -225,6 +226,7 @@ jobs:
             echo "--- SHA512 Log excerpt ---"
             tail -50 /tmp/chef-client-sha512.log
             echo "--- End SHA512 log ---"
+            exit 1
           fi
           echo ""
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>Two small fixes to the self-hosted FIPS Linux CI workflow:</p>
<ul>
  <li><strong>SHA exit consistency</strong>: SHA256 and SHA512 failure evaluation paths now call <code>exit 1</code> immediately on failure, matching the existing MD5 failure path behavior. Previously they silently fell through to the summary block.</li>
  <li><strong>allchecks exclusion</strong>: The <code>linux-fips</code> check is excluded from <code>allchecks.yml</code> until the self-hosted runner is stable. Marked with <code>fail-after:2026-07-22</code> chronoguard comment to ensure it doesn't get forgotten.</li>
</ul>
<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>