### PR TITLE
Update linux-fips name

### DIFF
--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
 
-  linux:
+  linux-fips:
     needs: workflow_guard
     permissions:
       contents: read


### PR DESCRIPTION
https://github.com/chef/chef/pull/16183 added an exemption for the
linux-fips test, except the job name is actually "linux"

But we don't want to exempt "linux", that's a bad idea, so change the
name to be "linux-fips"
