### PR TITLE
Fix fork workflows

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           clean: true
@@ -139,6 +140,7 @@ jobs:
   #   - name: Checkout PR code
   #     uses: actions/checkout@v7
   #     with:
+  #       allow-unsafe-pr-checkout: true
   #       ref: ${{ github.event.pull_request.head.sha }}
   #       persist-credentials: false
   #       clean: true
@@ -247,6 +249,7 @@ jobs:
   #     - name: Checkout PR code
   #       uses: actions/checkout@v7
   #       with:
+  #         allow-unsafe-pr-checkout: true
   #         ref: ${{ github.event.pull_request.head.sha }}
   #         persist-credentials: false
   #         clean: true
@@ -299,6 +302,7 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           clean: true
@@ -377,6 +381,7 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           clean: true
@@ -441,6 +446,7 @@ jobs:
 #      - name: Checkout PR code
 #        uses: actions/checkout@v7
 #        with:
+#          allow-unsafe-pr-checkout: true
 #          ref: ${{ github.event.pull_request.head.sha }}
 #          persist-credentials: false
 #          clean: true

--- a/.github/workflows/macos_verify.yml
+++ b/.github/workflows/macos_verify.yml
@@ -45,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
           clean: true
@@ -82,6 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
           clean: true

--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Checkout trusted code only
         uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
           clean: false

--- a/.github/workflows/windows-fips.yml
+++ b/.github/workflows/windows-fips.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           clean: true

--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
           clean: true


### PR DESCRIPTION
The upgrade of actions/checkout to v7 broke all PRT tests for fork-based
workers and now requires an explicit allowing of it.

This re-enables it with the explicit flag.

And of course, because of PRT, this has to be force-merged. :(

Signed-off-by: Phil Dibowitz <phil@ipom.com>
