### PR TITLE
feat(habitat): pin required Habitat version to 1.6.1245 in plan.*

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -35,6 +35,12 @@ pkg_version() {
 
 do_before() {
   do_default_before
+  local required_hab_version="1.6.1245"
+  local hab_version
+  hab_version=$(hab --version | awk '{print $2}' | cut -d'/' -f1)
+  if [ "$(printf '%s\n' "$required_hab_version" "$hab_version" | sort -V | head -n1)" != "$required_hab_version" ]; then
+    exit_with "Hab version is $hab_version; required $required_hab_version or newer." 1
+  fi
   update_pkg_version
   # We must wait until we update the pkg_version to use the pkg_version
   pkg_filename="${pkg_name}-${pkg_version}.tar.gz"

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -24,9 +24,9 @@ $pkg_build_deps=@( "core/git")
 function Invoke-Begin {
     write-output "*** Start Invoke-Begin Function"
     [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
-    if ($hab_version -lt [Version]"0.85.0" ) {
+    if ($hab_version -lt [Version]"1.6.1245" ) {
         Write-Warning "(╯°□°）╯︵ ┻━┻ I CAN'T WORK UNDER THESE CONDITIONS!"
-        Write-Warning ":habicat: I'm being built with $hab_version. I need at least Hab 0.85.0, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."
+        Write-Warning ":habicat: I'm being built with $hab_version. I need at least Hab 1.6.1245, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."
         throw "unable to build: required minimum version of Habitat not installed"
     } else {
         Write-BuildLine ":habicat: I think I have the version I need to build."


### PR DESCRIPTION
<h2>Summary</h2>
<p>Pins the required Habitat version to <code>1.6.1245</code> in both <code>habitat/plan.sh</code> (Linux) and <code>habitat/x86_64-windows/plan.ps1</code> (Windows), ensuring builds fail fast with a clear message if the wrong hab version is present.</p>

<h2>Changes</h2>
<ul>
  <li>Modified: <code>habitat/plan.sh</code> — added version guard in <code>do_before</code> requiring hab &gt;= 1.6.1245</li>
  <li>Modified: <code>habitat/x86_64-windows/plan.ps1</code> — updated <code>Invoke-Begin</code> minimum version check from <code>0.85.0</code> to <code>1.6.1245</code></li>
</ul>

<h2>Notes</h2>
<p><code>.expeditor/scripts/install-hab.sh</code> and <code>.expeditor/scripts/ensure-minimum-viable-hab.ps1</code> already pin to <code>1.6.1245</code>; this change surfaces the same constraint directly in the plan files so the requirement is explicit and self-documenting.</p>

<h2>Risk &amp; Mitigations</h2>
<p><strong>Risk Classification</strong>: Low</p>
<p><strong>Rationale</strong>: Build-time guard only; no runtime behavior changed. Raises the minimum from an already-outdated 0.85.0 to the version the build scripts already install.</p>
<p><strong>Rollback Strategy</strong>: <code>git revert HEAD</code></p>

<h2>DCO</h2>
<p>All commits signed off with Developer Certificate of Origin.</p>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>