### PR TITLE
[chef-18] fix habitat build failures

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,3 +1,5 @@
+export HAB_BLDR_CHANNEL="stable"
+export HAB_REFRESH_CHANNEL="stable"
 _chef_client_ruby="core/ruby31"
 pkg_name="chef-infra-client"
 pkg_origin="chef"

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -227,28 +227,62 @@ function Invoke-Install {
     }
 }
 
+function Remove-DirectoryWithRetry {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [String]
+        $Path,
+        [int]
+        $MaxRetries = 5
+    )
+    if (-not (Test-Path $Path)) { return }
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            Remove-Item $Path -Recurse -Force -ErrorAction Stop
+            return
+        } catch {
+            if ($attempt -lt $MaxRetries) {
+                Write-BuildLine " ** Removing ${Path}: attempt $attempt failed, retrying..."
+                Start-Sleep -Seconds 2
+            } else {
+                throw "Failed to remove ${Path} after $MaxRetries attempts: $_"
+            }
+        }
+    }
+}
+
 function Invoke-After {
     write-output "*** invoke after"
     # Trim the fat before packaging
 
-    # We don't need the cache of downloaded .gem files ...
-    Remove-Item $pkg_prefix/vendor/cache -Recurse -Force
-    # ... or bundler's cache of git-ref'd gems
-    Remove-Item $pkg_prefix/vendor/bundler -Recurse -Force
+    # We don't need the cache of downloaded .gem files,
+    # bundler's cache of git-ref'd gems, or the gem docs.
+    foreach ($dir in @("cache", "bundler", "doc")) {
+        write-output "removing vendor/$dir"
+        Remove-DirectoryWithRetry -Path "$pkg_prefix/vendor/$dir"
+    }
 
-    # We don't need the gem docs.
-    Remove-Item $pkg_prefix/vendor/doc -Recurse -Force
+    write-output "removing spec directories from vendored gems"
     # We don't need to ship the test suites for every gem dependency,
     # only Chef's for package verification.
-    Get-ChildItem $pkg_prefix/vendor/gems -Filter "spec" -Directory -Recurse -Depth 1 `
-        | Where-Object -FilterScript { $_.FullName -notlike "*chef-$pkg_version*" }   `
+    $specDirs = Get-ChildItem "$pkg_prefix/vendor/gems" -Filter "spec" -Directory -Recurse -Depth 1 `
+        | Where-Object -FilterScript { $_.FullName -notlike "*chef-$pkg_version*" }
+    foreach ($specDir in $specDirs) {
+        Remove-DirectoryWithRetry -Path $specDir.FullName
+    }
+
+    write-output "removing .github directories from vendored gems"
+    # Remove .github directories from vendored gems so that GitHub Actions workflow
+    # files are not shipped and do not trigger grype vulnerability reports.
+    Get-ChildItem "$pkg_prefix/vendor/gems" -Filter ".github" -Directory -Recurse `
         | Remove-Item -Recurse -Force
+
+    write-output "removing native extension build byproducts"
     # Remove the byproducts of compiling gems with extensions
-    Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
+    Get-ChildItem "$pkg_prefix/vendor/gems" -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
 
-    # Disable long file name support
-    Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 0 -Force
+    write-output "Invoke-After completed successfully"
 }
 
 function Remove-StudioPathFrom {

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -1,4 +1,5 @@
 $env:HAB_BLDR_CHANNEL = "stable"
+$env:HAB_REFRESH_CHANNEL = "stable"
 $pkg_name="chef-infra-client"
 $pkg_origin="chef"
 $pkg_version=(Get-Content $PLAN_CONTEXT/../../VERSION)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This introduces changes for build failure on chef 18
- habitat plan was getting built against base channel because that's the default since hab 2.x. Setting `HAB_BLDR_CHANNEL` and `HAB_REFRESH_CHANNEL` to `stable` in plan file to get correct packages.
- Updated clean up stage in `Invoke-After` to account for the windows file lock issue by retrying 5 times. otherwise skip. This takes care of it most of the times. Same solution as on main branch.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
