### PR TITLE
disable chrony tests on oraclelinux 10

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -71,7 +71,8 @@ include_recipe "::_packages"
 
 unless (amazon? && node["platform_version"] >= "2023") ||
     (platform?("almalinux") && node["platform_version"].to_i >= 10) ||
-    (platform?("rocky") && node["platform_version"].to_i >= 10) # TODO: look into chrony service issue
+    (platform?("rocky") && node["platform_version"].to_i >= 10) || # TODO: look into chrony service issue
+    (platform?("oracle") && node["platform_version"].to_i >= 10)
   include_recipe value_for_platform(
     opensuseleap: { "default" => "ntp" },
     amazon: { "2" => "ntp" },


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
disabling chrony tests on oraclelinux tests since it fails to start inside the docker container

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
