### PR TITLE
Chocolately nupkg files not installing correctly from custom url

### DIFF
--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -116,9 +116,9 @@ class Chef
       def define_resource_requirements
         requirements.assert(:install, :upgrade).each do |a|
           a.assertion do
-            # This is an exclusive OR - XOR - we're trying to coax an error out if one, but not both,
-            # parameters are empty.
-            new_resource.proxy_user.nil? != new_resource.proxy_password.nil?
+            # Both proxy_user and proxy_password must be provided together or not at all.
+            # The assertion must return true when the state is valid (both set or both nil).
+            new_resource.proxy_user.nil? == new_resource.proxy_password.nil?
           end
           a.failure_message(Chef::Exceptions::ValidationFailed, "You must specify both a proxy_user and a proxy_password")
           a.whyrun("Assuming that if you have configured a 'proxy_user' you must also supply a 'proxy_password'")
@@ -127,11 +127,11 @@ class Chef
 
       action :install, description: "Installs Chocolatey package manager" do
         if new_resource.download_url
-          powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value #{new_resource.download_url}")
+          powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value '#{new_resource.download_url}'")
         end
 
         if new_resource.chocolatey_version
-          powershell_exec("Set-Item -path env:ChocolateyVersion -Value #{new_resource.chocolatey_version}")
+          powershell_exec("Set-Item -path env:ChocolateyVersion -Value '#{new_resource.chocolatey_version}'")
         end
 
         if new_resource.use_native_unzip
@@ -143,11 +143,11 @@ class Chef
         end
 
         if new_resource.proxy_url
-          powershell_exec("Set-Item -path env:ChocolateyProxyLocation -Value #{new_resource.proxy_url}")
+          powershell_exec("Set-Item -path env:ChocolateyProxyLocation -Value '#{new_resource.proxy_url}'")
         end
 
         if new_resource.proxy_user && new_resource.proxy_password
-          powershell_exec("Set-Item -path env:ChocolateyProxyUser -Value #{new_resource.proxy_user}; Set-Item -path env:ChocolateyProxyPassword -Value #{new_resource.proxy_password}")
+          powershell_exec("Set-Item -path env:ChocolateyProxyUser -Value '#{new_resource.proxy_user}'; Set-Item -path env:ChocolateyProxyPassword -Value '#{new_resource.proxy_password}'")
         end
 
         # Handle custom download URLs appropriately based on file type
@@ -161,11 +161,11 @@ class Chef
               # nupkg or archive: fully air-gapped environment support.
               # A Chocolatey .nupkg is a ZIP archive containing tools/chocolateyInstall.ps1,
               # which is the actual bootstrapper. Download (if remote), extract, and run it.
-              is_filesystem_path = new_resource.download_url.match?(%r{^[a-zA-Z]:[\\/::]}) || new_resource.download_url.start_with?("\\\\")
+              is_filesystem_path = new_resource.download_url.match?(%r{^[a-zA-Z]:[\\/]}) || new_resource.download_url.start_with?("\\\\")
               nupkg_path = is_filesystem_path ? new_resource.download_url : download_destination
 
               unless is_filesystem_path
-                powershell_exec("Invoke-WebRequest '#{new_resource.download_url}' -OutFile '#{nupkg_path}'").error!
+                powershell_exec("Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing -OutFile '#{nupkg_path}'").error!
                 Chef::Log.info("Downloaded Chocolatey package from #{new_resource.download_url} to #{nupkg_path}")
               end
 
@@ -204,11 +204,11 @@ class Chef
                            end
 
         if new_resource.download_url
-          powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value #{new_resource.download_url}")
+          powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value '#{new_resource.download_url}'")
         end
 
         if new_resource.chocolatey_version
-          powershell_exec("Set-Item -path env:ChocolateyVersion -Value #{new_resource.chocolatey_version}")
+          powershell_exec("Set-Item -path env:ChocolateyVersion -Value '#{new_resource.chocolatey_version}'")
         end
 
         if new_resource.use_native_unzip
@@ -220,17 +220,17 @@ class Chef
         end
 
         if new_resource.proxy_url
-          powershell_exec("Set-Item -path env:ChocolateyProxyLocation -Value #{new_resource.proxy_url}")
+          powershell_exec("Set-Item -path env:ChocolateyProxyLocation -Value '#{new_resource.proxy_url}'")
         end
 
         if new_resource.proxy_user && new_resource.proxy_password
-          powershell_exec("Set-Item -path env:ChocolateyProxyUser -Value #{new_resource.proxy_user}; Set-Item -path env:ChocolateyProxyPassword -Value #{new_resource.proxy_password}")
+          powershell_exec("Set-Item -path env:ChocolateyProxyUser -Value '#{new_resource.proxy_user}'; Set-Item -path env:ChocolateyProxyPassword -Value '#{new_resource.proxy_password}'")
         end
 
         if proposed_version && existing_version < proposed_version
-          powershell_exec("Set-Item -path env:ChocolateyVersion -Value #{proposed_version}")
+          powershell_exec("Set-Item -path env:ChocolateyVersion -Value '#{proposed_version}'")
         else
-          powershell_exec("Remove-Item -path env:ChocolateyVersion")
+          powershell_exec("Remove-Item -path env:ChocolateyVersion -ErrorAction SilentlyContinue")
         end
 
         converge_by("upgrade choco version") do
@@ -239,8 +239,8 @@ class Chef
       end
 
       action :uninstall, description: "Uninstall Chocolatey package manager" do
-        path = 'c:\\programdata\\chocolatey\\bin'
-        if File.exists?(path)
+        path = "#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin"
+        if File.exist?(path)
           converge_by("Uninstall Choco") do
             powershell_code = <<~CODE
               Remove-Item $env:ALLUSERSPROFILE\\chocolatey -Recurse -Force
@@ -260,8 +260,9 @@ class Chef
             CODE
             powershell_exec(powershell_code).error!
           end
+        else
+          Chef::Log.warn("Chocolatey is already uninstalled.")
         end
-        Chef::Log.warn("Chocolatey is already uninstalled.")
       end
     end
   end

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -171,6 +171,7 @@ class Chef
 
               ps_code = <<~PS
                 # Pre-steps equivalent to those in Chocolatey's install.ps1
+                # We need to enable TLS 1.2 support so we set the SecurityProtocol property with a "bitwise or" operation.
                 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
                 if (-not $env:ChocolateyInstall) {
                   $env:ChocolateyInstall = Join-Path $env:ALLUSERSPROFILE 'chocolatey'

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -239,7 +239,9 @@ class Chef
       end
 
       action :uninstall, description: "Uninstall Chocolatey package manager" do
+        # rubocop:disable Style/StringLiteralsInInterpolation
         path = "#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin"
+        # rubocop:enable Style/StringLiteralsInInterpolation
         if File.exist?(path)
           converge_by("Uninstall Choco") do
             powershell_code = <<~CODE

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -56,7 +56,7 @@ class Chef
       allowed_actions :install, :uninstall, :upgrade
 
       property :download_url, String,
-        description: "The URL to download Chocolatey from. This sets the value of $env:ChocolateyDownloadUrl and causes the installer to choose an alternate download location. If this is not set, Chocolatey installs fall back to the official Chocolatey community repository to download Chocolatey from. It can also be used for offline installation by providing a path to a Chocolatey.nupkg. If the provided URL is a PowerShell script (ending in .ps1), that script will be downloaded and executed directly. If it is any other file type, it will be downloaded to the Chef client directory. ChefConfig::Config.etc_chef_dir(windows: true) is used to find that location."
+        description: "A custom URL or path to a Chocolatey package or install script, for use in air-gapped environments or when hosting your own Chocolatey server. Accepts HTTPS URLs, local drive paths (e.g. C:\\packages\\chocolatey.nupkg), and UNC paths to SMB shares (e.g. \\\\server\\share\\chocolatey.nupkg). If not provided, Chocolatey is installed from the official Chocolatey community repository. This sets the value of $env:ChocolateyDownloadUrl so the Chocolatey installer fetches the package from your specified location. If the value points to a PowerShell script (ending in .ps1), that script will be downloaded and executed directly. If it points to a Chocolatey package (.nupkg or similar), the file contents are extracted and the bundled installer is executed."
 
       property :chocolatey_version, String,
         description: "Specifies a target version of Chocolatey to install. By default, the latest stable version is installed. This will use the value in $env:ChocolateyVersion by default, if that environment variable is present. This parameter is ignored if download_url is set."
@@ -154,15 +154,42 @@ class Chef
         converge_if_changed do
           if new_resource.download_url
             Chef::Log.info("Using custom download URL for Chocolatey installation: #{new_resource.download_url}")
-            # If it's a PowerShell script, execute it directly (original behavior)
+            # If it's a PowerShell script, download and execute it directly
             if download_url_script?
               powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{new_resource.download_url}'))").error!
             else
-              # Assume it's a direct link to a nupkg or other file and handle accordingly
-              destination = download_destination
+              # nupkg or archive: fully air-gapped environment support.
+              # A Chocolatey .nupkg is a ZIP archive containing tools/chocolateyInstall.ps1,
+              # which is the actual bootstrapper. Download (if remote), extract, and run it.
+              is_filesystem_path = new_resource.download_url.match?(%r{^[a-zA-Z]:[\\/::]}) || new_resource.download_url.start_with?("\\\\")
+              nupkg_path = is_filesystem_path ? new_resource.download_url : download_destination
 
-              powershell_exec("Invoke-WebRequest '#{new_resource.download_url}' -OutFile '#{destination}'").error!
-              Chef::Log.info("Downloaded file from #{new_resource.download_url} to #{destination}")
+              unless is_filesystem_path
+                powershell_exec("Invoke-WebRequest '#{new_resource.download_url}' -OutFile '#{nupkg_path}'").error!
+                Chef::Log.info("Downloaded Chocolatey package from #{new_resource.download_url} to #{nupkg_path}")
+              end
+
+              ps_code = <<~PS
+                # Pre-steps equivalent to those in Chocolatey's install.ps1
+                [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+                if (-not $env:ChocolateyInstall) {
+                  $env:ChocolateyInstall = Join-Path $env:ALLUSERSPROFILE 'chocolatey'
+                  [Environment]::SetEnvironmentVariable('ChocolateyInstall', $env:ChocolateyInstall, 'Machine')
+                }
+                if (-not (Test-Path $env:ChocolateyInstall)) { New-Item -ItemType Directory -Path $env:ChocolateyInstall -Force | Out-Null }
+
+                $nupkgPath = '#{nupkg_path}'
+                $extractPath = Join-Path $env:TEMP 'chocolatey_nupkg_extract'
+                if (Test-Path $extractPath) { Remove-Item $extractPath -Recurse -Force }
+                $zipPath = "$nupkgPath.zip"
+                Copy-Item $nupkgPath $zipPath
+                Expand-Archive $zipPath $extractPath -Force
+                Remove-Item $zipPath -Force
+                $installScript = Join-Path $extractPath 'tools\\chocolateyInstall.ps1'
+                if (-not (Test-Path $installScript)) { throw "Could not find chocolateyInstall.ps1 in the extracted Chocolatey package at $extractPath" }
+                & $installScript
+              PS
+              powershell_exec(ps_code).error!
             end
           else
             powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))").error!

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -192,7 +192,7 @@ describe Chef::Resource::ChocolateyInstaller do
 
           # Per the download_url property description, ChocolateyDownloadUrl is always set
           # when download_url is provided, regardless of file type.
-          expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value https://some.custom.url/install.ps1")
+          expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value 'https://some.custom.url/install.ps1'")
           expect(commands.any? { |c| c.include?("Invoke-Expression") && c.include?("install.ps1") }).to be true
         end
 
@@ -259,8 +259,8 @@ describe Chef::Resource::ChocolateyInstaller do
 
           resource.run_action(:install)
 
-          expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value https://some.custom.url/packages/chocolatey.2.0.0.nupkg")
-          expect(commands).to include("Invoke-WebRequest 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg' -OutFile '#{expected_destination}'")
+          expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg'")
+          expect(commands).to include("Invoke-WebRequest 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg' -UseBasicParsing -OutFile '#{expected_destination}'")
           expect(commands.any? { |c| c.include?("Expand-Archive") && c.include?("chocolateyInstall.ps1") }).to be true
         end
       end

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -172,12 +172,75 @@ describe Chef::Resource::ChocolateyInstaller do
 
     describe "Installing chocolatey" do
       context "on windows", :windows_only do
-        it "can install Chocolatey with a custom download URL" do
+        it "sets ChocolateyDownloadUrl and executes a custom .ps1 URL directly" do
+          resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom_ps1", run_context)
           resource.download_url = "https://some.custom.url/install.ps1"
-          expect { resource.action :install }.not_to raise_error
+          install_provider = resource.provider_for_action(:install)
+
+          commands = []
+          shell_out = instance_double("Mixlib::ShellOut", error!: nil)
+
+          allow(resource).to receive(:provider_for_action).with(:install).and_return(install_provider)
+          allow(resource).to receive(:is_choco_installed?).and_return(false)
+          allow(install_provider).to receive(:powershell_exec) do |command|
+            commands << command
+            shell_out
+          end
+          allow(Chef::Log).to receive(:info)
+
+          resource.run_action(:install)
+
+          # Per the download_url property description, ChocolateyDownloadUrl is always set
+          # when download_url is provided, regardless of file type.
+          expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value https://some.custom.url/install.ps1")
+          expect(commands.any? { |c| c.include?("Invoke-Expression") && c.include?("install.ps1") }).to be true
         end
 
-        it "downloads non-script URLs to a full path in the chef directory" do
+        it "uses a local drive path directly without downloading, then extracts and installs" do
+          resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_local_path", run_context)
+          resource.download_url = 'C:\packages\chocolatey.2.0.0.nupkg'
+          install_provider = resource.provider_for_action(:install)
+
+          commands = []
+          shell_out = instance_double("Mixlib::ShellOut", error!: nil)
+
+          allow(resource).to receive(:provider_for_action).with(:install).and_return(install_provider)
+          allow(resource).to receive(:is_choco_installed?).and_return(false)
+          allow(install_provider).to receive(:powershell_exec) do |command|
+            commands << command
+            shell_out
+          end
+          allow(Chef::Log).to receive(:info)
+
+          resource.run_action(:install)
+
+          expect(commands.none? { |c| c.include?("Invoke-WebRequest") }).to be true
+          expect(commands.any? { |c| c.include?("Expand-Archive") && c.include?("chocolateyInstall.ps1") && c.include?('C:\packages\chocolatey.2.0.0.nupkg') }).to be true
+        end
+
+        it "uses a UNC path directly without downloading, then extracts and installs" do
+          resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_unc_path", run_context)
+          resource.download_url = '\\\\fileserver\\packages\\chocolatey.2.0.0.nupkg'
+          install_provider = resource.provider_for_action(:install)
+
+          commands = []
+          shell_out = instance_double("Mixlib::ShellOut", error!: nil)
+
+          allow(resource).to receive(:provider_for_action).with(:install).and_return(install_provider)
+          allow(resource).to receive(:is_choco_installed?).and_return(false)
+          allow(install_provider).to receive(:powershell_exec) do |command|
+            commands << command
+            shell_out
+          end
+          allow(Chef::Log).to receive(:info)
+
+          resource.run_action(:install)
+
+          expect(commands.none? { |c| c.include?("Invoke-WebRequest") }).to be true
+          expect(commands.any? { |c| c.include?("Expand-Archive") && c.include?("chocolateyInstall.ps1") && c.include?('\\\\fileserver\\packages\\chocolatey.2.0.0.nupkg') }).to be true
+        end
+
+        it "downloads, extracts, and installs from a nupkg URL for air-gapped environments" do
           resource = Chef::Resource::ChocolateyInstaller.new("fakey_fakerton_custom_download", run_context)
           resource.download_url = "https://some.custom.url/packages/chocolatey.2.0.0.nupkg"
           expected_destination = Chef::Util::PathHelper.join(ChefConfig::Config.etc_chef_dir(windows: true), "chocolatey.2.0.0.nupkg")
@@ -198,6 +261,7 @@ describe Chef::Resource::ChocolateyInstaller do
 
           expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value https://some.custom.url/packages/chocolatey.2.0.0.nupkg")
           expect(commands).to include("Invoke-WebRequest 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg' -OutFile '#{expected_destination}'")
+          expect(commands.any? { |c| c.include?("Expand-Archive") && c.include?("chocolateyInstall.ps1") }).to be true
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We recently corrected an issue with the chocolatey installer where it would not allow for a custom download location. (#15306 ) So users in an air-gapped environment were stuck because the resource installed for chocolatey.org no matter what. 

As side effect of our update that we didn't catch at the time was that our patch didn't allow for the alternate location package to actually install correctly which lead to the new bug. 

This update corrects that. The code below is a substitute for the choco installer only in the scenario where you are downloading choco from an alternate location. Note that the "nupkg_url" can be a file share specified as \\\\server\\share\\foo.nupkg, a local file specified as c:\\local\\foo.nupkg, or a ps1 script as well. Also note that the code assumes the URI gem is installed; on line 3 we call it to parse the URL to see if it is a PS1 file

```powershell
nupkg_url  = node['r101_win_chocolatey']['download_url']
nupkg_dest = "#{Chef::Config[:file_cache_path]}\\chocolatey.nupkg"
is_ps1             = ::File.extname(URI.parse(nupkg_url).path).casecmp(".ps1") == 0 rescue nupkg_url.downcase.end_with?(".ps1")
is_filesystem_path = nupkg_url.match?(%r{^[a-zA-Z]:[\\/]}) || nupkg_url.start_with?("\\\\")

powershell_script 'Install Chocolatey' do
  code(
    if is_ps1
      <<~PS
        # We need to enable TLS 1.2 support so we set the SecurityProtocol property with a "bitwise or" operation.
        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
        Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{nupkg_url}'))
      PS
    else
      <<~PS
        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
        if (-not $env:ChocolateyInstall) {
          $env:ChocolateyInstall = Join-Path $env:ALLUSERSPROFILE 'chocolatey'
          [Environment]::SetEnvironmentVariable('ChocolateyInstall', $env:ChocolateyInstall, 'Machine')
        }
        if (-not (Test-Path $env:ChocolateyInstall)) { New-Item -ItemType Directory -Path $env:ChocolateyInstall -Force | Out-Null }
        #{is_filesystem_path ? "$nupkgPath = '#{nupkg_url}'" : "Invoke-WebRequest '#{nupkg_url}' -OutFile '#{nupkg_dest}'\n      $nupkgPath = '#{nupkg_dest}'"}
        $extractPath = Join-Path $env:TEMP 'chocolatey_nupkg_extract'
        if (Test-Path $extractPath) { Remove-Item $extractPath -Recurse -Force }
        $zipPath = "$nupkgPath.zip"
        Copy-Item $nupkgPath $zipPath
        Expand-Archive $zipPath $extractPath -Force
        Remove-Item $zipPath -Force
        & (Join-Path $extractPath 'tools\\chocolateyInstall.ps1')
      PS
    end
  )
  not_if { ::File.exist?("#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin\\choco.exe") }
end
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
