### PR TITLE
Caught a number of failure points and corrected them

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chocolatey_installer.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chocolatey_installer.rb
@@ -1,0 +1,54 @@
+#
+# Cookbook:: end_to_end
+# Recipe:: _chocolatey_installer
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Integration tests for the chocolatey_installer resource.
+#
+# Scenario coverage:
+#   1. Standard install from chocolatey.org (default path)
+#   2. Idempotency - second converge must be a no-op
+#   3. Uninstall
+#   4. Install from a direct .nupkg URL (air-gapped / custom-server scenario)
+#      This is the primary scenario covered by the bug fix: previously the
+#      resource only downloaded the nupkg and never ran the installer.
+#   5. Idempotency after nupkg-URL install
+#
+
+# 1. Standard install from the official Chocolatey community repository.
+chocolatey_installer "Install Chocolatey (default)" do
+  action :install
+end
+
+# 2. Idempotency check: running the same install a second time must produce no changes.
+chocolatey_installer "Install Chocolatey (default idempotent)" do
+  action :install
+end
+
+# 3. Uninstall so we can exercise the full install path again from a clean state.
+chocolatey_installer "Uninstall Chocolatey" do
+  action :uninstall
+end
+
+# 4. Install from a direct .nupkg URL.  This exercises the air-gapped fix:
+#    download the nupkg, extract it, and run tools/chocolateyInstall.ps1.
+#    We pin a specific version so CI results are reproducible.
+#
+#    MAINTENANCE NOTE: The URL below uses the Chocolatey CDN at packages.chocolatey.org.
+#    If that domain or URL format changes, or if a newer pinned version is needed,
+#    update both this URL and the version assertion in:
+#      kitchen-tests/test/integration/end-to-end/_chocolatey_installer.rb
+#    Verify the new URL ends in .nupkg — the resource validates the file extension
+#    and will raise Chef::Exceptions::ValidationFailed if it does not.
+chocolatey_installer "Install Chocolatey from nupkg URL" do
+  action    :install
+  download_url "https://packages.chocolatey.org/chocolatey.2.4.2.nupkg"
+end
+
+# 5. Idempotency check after nupkg-URL install.
+chocolatey_installer "Install Chocolatey from nupkg URL (idempotent)" do
+  action    :install
+  download_url "https://packages.chocolatey.org/chocolatey.2.4.2.nupkg"
+end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chocolatey_installer.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chocolatey_installer.rb
@@ -43,12 +43,12 @@ end
 #    Verify the new URL ends in .nupkg — the resource validates the file extension
 #    and will raise Chef::Exceptions::ValidationFailed if it does not.
 chocolatey_installer "Install Chocolatey from nupkg URL" do
-  action    :install
+  action :install
   download_url "https://packages.chocolatey.org/chocolatey.2.4.2.nupkg"
 end
 
 # 5. Idempotency check after nupkg-URL install.
 chocolatey_installer "Install Chocolatey from nupkg URL (idempotent)" do
-  action    :install
+  action :install
   download_url "https://packages.chocolatey.org/chocolatey.2.4.2.nupkg"
 end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -219,3 +219,4 @@ end
 
 include_recipe "::_chef_gem"
 include_recipe "::_openssl"
+include_recipe "::_chocolatey_installer"

--- a/kitchen-tests/test/integration/end-to-end/_chocolatey_installer.rb
+++ b/kitchen-tests/test/integration/end-to-end/_chocolatey_installer.rb
@@ -19,23 +19,23 @@ if os.windows?
   end
 
   # choco must be executable and return a valid version string.
-  describe command('choco --version') do
-    its('exit_status') { should eq 0 }
-    its('stdout') { should match(/\d+\.\d+\.\d+/) }
+  describe command("choco --version") do
+    its("exit_status") { should eq 0 }
+    its("stdout") { should match(/\d+\.\d+\.\d+/) }
   end
 
   # The installed version must match the nupkg we specified.
-  describe command('choco --version') do
-    its('stdout') { should match(/^2\.4\.2/) }
+  describe command("choco --version") do
+    its("stdout") { should match(/^2\.4\.2/) }
   end
 
   # choco must be able to list local packages without error — validates that
   # the full Chocolatey environment (PATH, ChocolateyInstall env var, etc.)
-  # was set up correctly by the installer and not just partially initialised.
+  # was set up correctly by the installer and not just partially initialized.
   # Note: --local-only was deprecated in Chocolatey 2.x; plain `choco list`
   # defaults to local-only in 2.x and is the correct form.
-  describe command('choco list') do
-    its('exit_status') { should eq 0 }
+  describe command("choco list") do
+    its("exit_status") { should eq 0 }
   end
 
 end

--- a/kitchen-tests/test/integration/end-to-end/_chocolatey_installer.rb
+++ b/kitchen-tests/test/integration/end-to-end/_chocolatey_installer.rb
@@ -1,41 +1,41 @@
 # Integration verification for chocolatey_installer resource.
-#
-# After the recipe converges the node ends with Chocolatey 2.4.2 installed
-# via the nupkg-URL path (the air-gapped scenario bug fix).
-# These controls confirm the installation is complete and functional.
+# Chocolatey is Windows-only; skip all controls on non-Windows platforms.
+if os.windows?
 
-choco_bin = 'C:\ProgramData\chocolatey\bin\choco.exe'
-choco_config = 'C:\ProgramData\chocolatey\config\chocolatey.config'
+  choco_bin = 'C:\ProgramData\chocolatey\bin\choco.exe'
+  choco_config = 'C:\ProgramData\chocolatey\config\chocolatey.config'
 
-# choco.exe must exist — this is the primary indicator that the installer
-# ran to completion, not just that the nupkg was downloaded.
-describe file(choco_bin) do
-  it { should exist }
-end
+  # choco.exe must exist — this is the primary indicator that the installer
+  # ran to completion, not just that the nupkg was downloaded.
+  describe file(choco_bin) do
+    it { should exist }
+  end
 
-# The chocolatey.config must exist — its absence was the symptom of the
-# original bug (chocolatey_source would fail with "Could not find the
-# Chocolatey config").
-describe file(choco_config) do
-  it { should exist }
-end
+  # The chocolatey.config must exist — its absence was the symptom of the
+  # original bug (chocolatey_source would fail with "Could not find the
+  # Chocolatey config").
+  describe file(choco_config) do
+    it { should exist }
+  end
 
-# choco must be executable and return a valid version string.
-describe command('choco --version') do
-  its('exit_status') { should eq 0 }
-  its('stdout') { should match(/\d+\.\d+\.\d+/) }
-end
+  # choco must be executable and return a valid version string.
+  describe command('choco --version') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/\d+\.\d+\.\d+/) }
+  end
 
-# The installed version must match the nupkg we specified.
-describe command('choco --version') do
-  its('stdout') { should match(/^2\.4\.2/) }
-end
+  # The installed version must match the nupkg we specified.
+  describe command('choco --version') do
+    its('stdout') { should match(/^2\.4\.2/) }
+  end
 
-# choco must be able to list local packages without error — validates that
-# the full Chocolatey environment (PATH, ChocolateyInstall env var, etc.)
-# was set up correctly by the installer and not just partially initialised.
-# Note: --local-only was deprecated in Chocolatey 2.x; plain `choco list`
-# defaults to local-only in 2.x and is the correct form.
-describe command('choco list') do
-  its('exit_status') { should eq 0 }
+  # choco must be able to list local packages without error — validates that
+  # the full Chocolatey environment (PATH, ChocolateyInstall env var, etc.)
+  # was set up correctly by the installer and not just partially initialised.
+  # Note: --local-only was deprecated in Chocolatey 2.x; plain `choco list`
+  # defaults to local-only in 2.x and is the correct form.
+  describe command('choco list') do
+    its('exit_status') { should eq 0 }
+  end
+
 end

--- a/kitchen-tests/test/integration/end-to-end/_chocolatey_installer.rb
+++ b/kitchen-tests/test/integration/end-to-end/_chocolatey_installer.rb
@@ -1,0 +1,41 @@
+# Integration verification for chocolatey_installer resource.
+#
+# After the recipe converges the node ends with Chocolatey 2.4.2 installed
+# via the nupkg-URL path (the air-gapped scenario bug fix).
+# These controls confirm the installation is complete and functional.
+
+choco_bin = 'C:\ProgramData\chocolatey\bin\choco.exe'
+choco_config = 'C:\ProgramData\chocolatey\config\chocolatey.config'
+
+# choco.exe must exist — this is the primary indicator that the installer
+# ran to completion, not just that the nupkg was downloaded.
+describe file(choco_bin) do
+  it { should exist }
+end
+
+# The chocolatey.config must exist — its absence was the symptom of the
+# original bug (chocolatey_source would fail with "Could not find the
+# Chocolatey config").
+describe file(choco_config) do
+  it { should exist }
+end
+
+# choco must be executable and return a valid version string.
+describe command('choco --version') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/\d+\.\d+\.\d+/) }
+end
+
+# The installed version must match the nupkg we specified.
+describe command('choco --version') do
+  its('stdout') { should match(/^2\.4\.2/) }
+end
+
+# choco must be able to list local packages without error — validates that
+# the full Chocolatey environment (PATH, ChocolateyInstall env var, etc.)
+# was set up correctly by the installer and not just partially initialised.
+# Note: --local-only was deprecated in Chocolatey 2.x; plain `choco list`
+# defaults to local-only in 2.x and is the correct form.
+describe command('choco list') do
+  its('exit_status') { should eq 0 }
+end

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -126,6 +126,23 @@ class Chef
       end
 
       action :install, description: "Installs Chocolatey package manager" do
+        # Validate download_url before setting any env vars or attempting PowerShell execution.
+        # Blocks URLs with a recognizable but wrong file extension (.html, .exe, etc.).
+        # URLs with NO extension (OData-style package API endpoints such as
+        # https://server/api/v2/package/chocolatey/2.7.3) are allowed through — the extension
+        # check is skipped when the URL path has no extension so that NuGet/Artifactory/Nexus
+        # feeds work without requiring a local pre-download.
+        if new_resource.download_url
+          ext = ::File.extname(new_resource.download_url_path).downcase
+          # Block only when a recognizable but wrong file extension is present.
+          # Exemptions: no extension (OData/API endpoints), .ps1, .nupkg, or
+          # a pure-digit segment (e.g. ".3" from a version path like /chocolatey/2.7.3).
+          if !ext.empty? && !ext.match?(/^\.\d+$/) && ext != '.ps1' && ext != '.nupkg'
+            raise Chef::Exceptions::ValidationFailed,
+              "download_url must point to a .ps1 PowerShell install script or a .nupkg Chocolatey package. Got: #{new_resource.download_url}"
+          end
+        end
+
         if new_resource.download_url
           powershell_exec("Set-Item -path env:ChocolateyDownloadUrl -Value '#{new_resource.download_url}'")
         end
@@ -156,7 +173,7 @@ class Chef
             Chef::Log.info("Using custom download URL for Chocolatey installation: #{new_resource.download_url}")
             # If it's a PowerShell script, download and execute it directly
             if download_url_script?
-              powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{new_resource.download_url}'))").error!
+              powershell_exec("[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{new_resource.download_url}'))").error!
             else
               # nupkg or archive: fully air-gapped environment support.
               # A Chocolatey .nupkg is a ZIP archive containing tools/chocolateyInstall.ps1,
@@ -165,7 +182,17 @@ class Chef
               nupkg_path = is_filesystem_path ? new_resource.download_url : download_destination
 
               unless is_filesystem_path
-                powershell_exec("Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing -OutFile '#{nupkg_path}'").error!
+                if new_resource.proxy_url && !new_resource.ignore_proxy && new_resource.proxy_user && new_resource.proxy_password
+                  ps_download = <<~DLPS
+                    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+                    $proxyCredential = New-Object System.Management.Automation.PSCredential('#{new_resource.proxy_user}', (ConvertTo-SecureString '#{new_resource.proxy_password}' -AsPlainText -Force))
+                    Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing -Proxy '#{new_resource.proxy_url}' -ProxyCredential $proxyCredential -OutFile '#{nupkg_path}'
+                  DLPS
+                  powershell_exec(ps_download).error!
+                else
+                  proxy_param = (new_resource.proxy_url && !new_resource.ignore_proxy) ? " -Proxy '#{new_resource.proxy_url}'" : ""
+                  powershell_exec("[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing#{proxy_param} -OutFile '#{nupkg_path}'").error!
+                end
                 Chef::Log.info("Downloaded Chocolatey package from #{new_resource.download_url} to #{nupkg_path}")
               end
 
@@ -182,7 +209,7 @@ class Chef
                 $nupkgPath = '#{nupkg_path}'
                 $extractPath = Join-Path $env:TEMP 'chocolatey_nupkg_extract'
                 if (Test-Path $extractPath) { Remove-Item $extractPath -Recurse -Force }
-                $zipPath = "$nupkgPath.zip"
+                $zipPath = Join-Path $env:TEMP 'chocolatey_nupkg.zip'
                 Copy-Item $nupkgPath $zipPath
                 Expand-Archive $zipPath $extractPath -Force
                 Remove-Item $zipPath -Force
@@ -253,7 +280,7 @@ class Chef
                   'PATH',
                   'Machine'
               )
-              $path = ($path.Split(';') | Where-Object { $_ -ne "#{path}" }) -join ";"
+              $path = ($path.Split(';') | Where-Object { $_ -ine "#{path}" }) -join ";"
               [System.Environment]::SetEnvironmentVariable(
                   'PATH',
                   $path,

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -167,62 +167,68 @@ class Chef
           powershell_exec("Set-Item -path env:ChocolateyProxyUser -Value '#{new_resource.proxy_user}'; Set-Item -path env:ChocolateyProxyPassword -Value '#{new_resource.proxy_password}'")
         end
 
-        # Handle custom download URLs appropriately based on file type
-        converge_if_changed do
-          if new_resource.download_url
-            Chef::Log.info("Using custom download URL for Chocolatey installation: #{new_resource.download_url}")
-            # If it's a PowerShell script, download and execute it directly
-            if download_url_script?
-              powershell_exec("[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{new_resource.download_url}'))").error!
-            else
-              # nupkg or archive: fully air-gapped environment support.
-              # A Chocolatey .nupkg is a ZIP archive containing tools/chocolateyInstall.ps1,
-              # which is the actual bootstrapper. Download (if remote), extract, and run it.
-              is_filesystem_path = new_resource.download_url.match?(%r{^[a-zA-Z]:[\\/]}) || new_resource.download_url.start_with?("\\\\")
-              nupkg_path = is_filesystem_path ? new_resource.download_url : download_destination
+        # Guard on actual installed state rather than property comparison.
+        # converge_if_changed cannot be used here because download_url is never
+        # loaded as a current value, so it would always fire even when Chocolatey
+        # is already installed — causing the nupkg extract directory to be cleaned
+        # up while its DLLs are still loaded in the PowerShell process.
+        unless is_choco_installed?
+          converge_by("install Chocolatey") do
+            if new_resource.download_url
+              Chef::Log.info("Using custom download URL for Chocolatey installation: #{new_resource.download_url}")
+              # If it's a PowerShell script, download and execute it directly
+              if download_url_script?
+                powershell_exec("[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('#{new_resource.download_url}'))").error!
+              else
+                # nupkg or archive: fully air-gapped environment support.
+                # A Chocolatey .nupkg is a ZIP archive containing tools/chocolateyInstall.ps1,
+                # which is the actual bootstrapper. Download (if remote), extract, and run it.
+                is_filesystem_path = new_resource.download_url.match?(%r{^[a-zA-Z]:[\\/]}) || new_resource.download_url.start_with?("\\\\")
+                nupkg_path = is_filesystem_path ? new_resource.download_url : download_destination
 
-              unless is_filesystem_path
-                if new_resource.proxy_url && !new_resource.ignore_proxy && new_resource.proxy_user && new_resource.proxy_password
-                  ps_download = <<~EOH
-                    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-                    $proxyCredential = New-Object System.Management.Automation.PSCredential('#{new_resource.proxy_user}', (ConvertTo-SecureString '#{new_resource.proxy_password}' -AsPlainText -Force))
-                    Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing -Proxy '#{new_resource.proxy_url}' -ProxyCredential $proxyCredential -OutFile '#{nupkg_path}'
-                  EOH
-                  powershell_exec(ps_download).error!
-                else
-                  proxy_param = (new_resource.proxy_url && !new_resource.ignore_proxy) ? " -Proxy '#{new_resource.proxy_url}'" : ""
-                  powershell_exec("[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing#{proxy_param} -OutFile '#{nupkg_path}'").error!
+                unless is_filesystem_path
+                  if new_resource.proxy_url && !new_resource.ignore_proxy && new_resource.proxy_user && new_resource.proxy_password
+                    ps_download = <<~EOH
+                      [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+                      $proxyCredential = New-Object System.Management.Automation.PSCredential('#{new_resource.proxy_user}', (ConvertTo-SecureString '#{new_resource.proxy_password}' -AsPlainText -Force))
+                      Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing -Proxy '#{new_resource.proxy_url}' -ProxyCredential $proxyCredential -OutFile '#{nupkg_path}'
+                    EOH
+                    powershell_exec(ps_download).error!
+                  else
+                    proxy_param = (new_resource.proxy_url && !new_resource.ignore_proxy) ? " -Proxy '#{new_resource.proxy_url}'" : ""
+                    powershell_exec("[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing#{proxy_param} -OutFile '#{nupkg_path}'").error!
+                  end
+                  Chef::Log.info("Downloaded Chocolatey package from #{new_resource.download_url} to #{nupkg_path}")
                 end
-                Chef::Log.info("Downloaded Chocolatey package from #{new_resource.download_url} to #{nupkg_path}")
+
+                ps_code = <<~PS
+                  # Pre-steps equivalent to those in Chocolatey's install.ps1
+                  # We need to enable TLS 1.2 support so we set the SecurityProtocol property with a "bitwise or" operation.
+                  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+                  if (-not $env:ChocolateyInstall) {
+                    $env:ChocolateyInstall = Join-Path $env:ALLUSERSPROFILE 'chocolatey'
+                    [Environment]::SetEnvironmentVariable('ChocolateyInstall', $env:ChocolateyInstall, 'Machine')
+                  }
+                  if (-not (Test-Path $env:ChocolateyInstall)) { New-Item -ItemType Directory -Path $env:ChocolateyInstall -Force | Out-Null }
+
+                  $nupkgPath = '#{nupkg_path}'
+                  $extractPath = Join-Path $env:TEMP 'chocolatey_nupkg_extract'
+                  if (Test-Path $extractPath) { Remove-Item $extractPath -Recurse -Force }
+                  $zipPath = Join-Path $env:TEMP 'chocolatey_nupkg.zip'
+                  Copy-Item $nupkgPath $zipPath
+                  Expand-Archive $zipPath $extractPath -Force
+                  Remove-Item $zipPath -Force
+                  $installScript = Join-Path $extractPath 'tools\\chocolateyInstall.ps1'
+                  if (-not (Test-Path $installScript)) { throw "Could not find chocolateyInstall.ps1 in the extracted Chocolatey package at $extractPath" }
+                  & $installScript
+                PS
+                powershell_exec(ps_code).error!
               end
-
-              ps_code = <<~PS
-                # Pre-steps equivalent to those in Chocolatey's install.ps1
-                # We need to enable TLS 1.2 support so we set the SecurityProtocol property with a "bitwise or" operation.
-                [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-                if (-not $env:ChocolateyInstall) {
-                  $env:ChocolateyInstall = Join-Path $env:ALLUSERSPROFILE 'chocolatey'
-                  [Environment]::SetEnvironmentVariable('ChocolateyInstall', $env:ChocolateyInstall, 'Machine')
-                }
-                if (-not (Test-Path $env:ChocolateyInstall)) { New-Item -ItemType Directory -Path $env:ChocolateyInstall -Force | Out-Null }
-
-                $nupkgPath = '#{nupkg_path}'
-                $extractPath = Join-Path $env:TEMP 'chocolatey_nupkg_extract'
-                if (Test-Path $extractPath) { Remove-Item $extractPath -Recurse -Force }
-                $zipPath = Join-Path $env:TEMP 'chocolatey_nupkg.zip'
-                Copy-Item $nupkgPath $zipPath
-                Expand-Archive $zipPath $extractPath -Force
-                Remove-Item $zipPath -Force
-                $installScript = Join-Path $extractPath 'tools\\chocolateyInstall.ps1'
-                if (-not (Test-Path $installScript)) { throw "Could not find chocolateyInstall.ps1 in the extracted Chocolatey package at $extractPath" }
-                & $installScript
-              PS
-              powershell_exec(ps_code).error!
+            else
+              powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))").error!
             end
-          else
-            powershell_exec("Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))").error!
-          end
-        end
+          end # converge_by
+        end # unless is_choco_installed?
       end
 
       action :upgrade, description: "Upgrades the Chocolatey package manager" do

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -137,7 +137,7 @@ class Chef
           # Block only when a recognizable but wrong file extension is present.
           # Exemptions: no extension (OData/API endpoints), .ps1, .nupkg, or
           # a pure-digit segment (e.g. ".3" from a version path like /chocolatey/2.7.3).
-          if !ext.empty? && !ext.match?(/^\.\d+$/) && ext != '.ps1' && ext != '.nupkg'
+          if !ext.empty? && !ext.match?(/^\.\d+$/) && ext != ".ps1" && ext != ".nupkg"
             raise Chef::Exceptions::ValidationFailed,
               "download_url must point to a .ps1 PowerShell install script or a .nupkg Chocolatey package. Got: #{new_resource.download_url}"
           end
@@ -183,11 +183,11 @@ class Chef
 
               unless is_filesystem_path
                 if new_resource.proxy_url && !new_resource.ignore_proxy && new_resource.proxy_user && new_resource.proxy_password
-                  ps_download = <<~DLPS
+                  ps_download = <<~EOH
                     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
                     $proxyCredential = New-Object System.Management.Automation.PSCredential('#{new_resource.proxy_user}', (ConvertTo-SecureString '#{new_resource.proxy_password}' -AsPlainText -Force))
                     Invoke-WebRequest '#{new_resource.download_url}' -UseBasicParsing -Proxy '#{new_resource.proxy_url}' -ProxyCredential $proxyCredential -OutFile '#{nupkg_path}'
-                  DLPS
+                  EOH
                   powershell_exec(ps_download).error!
                 else
                   proxy_param = (new_resource.proxy_url && !new_resource.ignore_proxy) ? " -Proxy '#{new_resource.proxy_url}'" : ""

--- a/lib/chef/resource/chocolatey_installer.rb
+++ b/lib/chef/resource/chocolatey_installer.rb
@@ -269,7 +269,7 @@ class Chef
         # rubocop:disable Style/StringLiteralsInInterpolation
         path = "#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin"
         # rubocop:enable Style/StringLiteralsInInterpolation
-        if File.exist?(path)
+        if ::File.exist?(path)
           converge_by("Uninstall Choco") do
             powershell_code = <<~CODE
               Remove-Item $env:ALLUSERSPROFILE\\chocolatey -Recurse -Force

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -260,7 +260,7 @@ describe Chef::Resource::ChocolateyInstaller do
           resource.run_action(:install)
 
           expect(commands).to include("Set-Item -path env:ChocolateyDownloadUrl -Value 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg'")
-          expect(commands).to include("Invoke-WebRequest 'https://some.custom.url/packages/chocolatey.2.0.0.nupkg' -UseBasicParsing -OutFile '#{expected_destination}'")
+          expect(commands.any? { |c| c.include?("Invoke-WebRequest") && c.include?("https://some.custom.url/packages/chocolatey.2.0.0.nupkg") && c.include?("-UseBasicParsing") && c.include?(expected_destination) }).to be true
           expect(commands.any? { |c| c.include?("Expand-Archive") && c.include?("chocolateyInstall.ps1") }).to be true
         end
       end
@@ -282,7 +282,47 @@ describe Chef::Resource::ChocolateyInstaller do
       end
     end
   end
+    describe "download_url extension validation" do
+      def build_resource_with_url(url, ctx)
+        r = Chef::Resource::ChocolateyInstaller.new("test_url_validation_#{url.to_s.hash.abs}", ctx)
+        r.download_url = url if url
+        p = r.provider_for_action(:install)
+        allow(r).to receive(:provider_for_action).with(:install).and_return(p)
+        allow(r).to receive(:is_choco_installed?).and_return(false)
+        allow(p).to receive(:powershell_exec).and_return(double("shell_out", error!: nil, result: nil))
+        r
+      end
 
+      it "raises ValidationFailed for a URL with a clearly wrong file extension" do
+        r = build_resource_with_url("https://some.server/packages/chocolatey.html", run_context)
+        expect { r.run_action(:install) }.to raise_error(Chef::Exceptions::ValidationFailed, /\.ps1.*\.nupkg/)
+      end
+
+      it "does not raise ValidationFailed for an OData-style URL with no file extension" do
+        r = build_resource_with_url("https://some.server/api/v2/package/chocolatey/2.7.3", run_context)
+        expect { r.run_action(:install) }.not_to raise_error
+      end
+
+      it "does not raise ValidationFailed for a bare domain URL with no extension" do
+        r = build_resource_with_url("https://some.server/", run_context)
+        expect { r.run_action(:install) }.not_to raise_error
+      end
+
+      it "does not raise ValidationFailed for a valid .nupkg URL" do
+        r = build_resource_with_url("https://some.server/chocolatey.2.7.3.nupkg", run_context)
+        expect { r.run_action(:install) }.not_to raise_error
+      end
+
+      it "does not raise ValidationFailed for a valid .ps1 URL" do
+        r = build_resource_with_url("https://some.server/install.ps1", run_context)
+        expect { r.run_action(:install) }.not_to raise_error
+      end
+
+      it "does not raise ValidationFailed when no download_url is set" do
+        r = build_resource_with_url(nil, run_context)
+        expect { r.run_action(:install) }.not_to raise_error
+      end
+    end
   describe "sensitive property masking" do
     it "marks proxy_password as sensitive" do
       expect(Chef::Resource::ChocolateyInstaller.properties[:proxy_password].sensitive?).to be true

--- a/spec/unit/resource/chocolatey_installer_spec.rb
+++ b/spec/unit/resource/chocolatey_installer_spec.rb
@@ -282,47 +282,47 @@ describe Chef::Resource::ChocolateyInstaller do
       end
     end
   end
-    describe "download_url extension validation" do
-      def build_resource_with_url(url, ctx)
-        r = Chef::Resource::ChocolateyInstaller.new("test_url_validation_#{url.to_s.hash.abs}", ctx)
-        r.download_url = url if url
-        p = r.provider_for_action(:install)
-        allow(r).to receive(:provider_for_action).with(:install).and_return(p)
-        allow(r).to receive(:is_choco_installed?).and_return(false)
-        allow(p).to receive(:powershell_exec).and_return(double("shell_out", error!: nil, result: nil))
-        r
-      end
-
-      it "raises ValidationFailed for a URL with a clearly wrong file extension" do
-        r = build_resource_with_url("https://some.server/packages/chocolatey.html", run_context)
-        expect { r.run_action(:install) }.to raise_error(Chef::Exceptions::ValidationFailed, /\.ps1.*\.nupkg/)
-      end
-
-      it "does not raise ValidationFailed for an OData-style URL with no file extension" do
-        r = build_resource_with_url("https://some.server/api/v2/package/chocolatey/2.7.3", run_context)
-        expect { r.run_action(:install) }.not_to raise_error
-      end
-
-      it "does not raise ValidationFailed for a bare domain URL with no extension" do
-        r = build_resource_with_url("https://some.server/", run_context)
-        expect { r.run_action(:install) }.not_to raise_error
-      end
-
-      it "does not raise ValidationFailed for a valid .nupkg URL" do
-        r = build_resource_with_url("https://some.server/chocolatey.2.7.3.nupkg", run_context)
-        expect { r.run_action(:install) }.not_to raise_error
-      end
-
-      it "does not raise ValidationFailed for a valid .ps1 URL" do
-        r = build_resource_with_url("https://some.server/install.ps1", run_context)
-        expect { r.run_action(:install) }.not_to raise_error
-      end
-
-      it "does not raise ValidationFailed when no download_url is set" do
-        r = build_resource_with_url(nil, run_context)
-        expect { r.run_action(:install) }.not_to raise_error
-      end
+  describe "download_url extension validation" do
+    def build_resource_with_url(url, ctx)
+      r = Chef::Resource::ChocolateyInstaller.new("test_url_validation_#{url.to_s.hash.abs}", ctx)
+      r.download_url = url if url
+      p = r.provider_for_action(:install)
+      allow(r).to receive(:provider_for_action).with(:install).and_return(p)
+      allow(r).to receive(:is_choco_installed?).and_return(false)
+      allow(p).to receive(:powershell_exec).and_return(double("shell_out", error!: nil, result: nil))
+      r
     end
+
+    it "raises ValidationFailed for a URL with a clearly wrong file extension" do
+      r = build_resource_with_url("https://some.server/packages/chocolatey.html", run_context)
+      expect { r.run_action(:install) }.to raise_error(Chef::Exceptions::ValidationFailed, /\.ps1.*\.nupkg/)
+    end
+
+    it "does not raise ValidationFailed for an OData-style URL with no file extension" do
+      r = build_resource_with_url("https://some.server/api/v2/package/chocolatey/2.7.3", run_context)
+      expect { r.run_action(:install) }.not_to raise_error
+    end
+
+    it "does not raise ValidationFailed for a bare domain URL with no extension" do
+      r = build_resource_with_url("https://some.server/", run_context)
+      expect { r.run_action(:install) }.not_to raise_error
+    end
+
+    it "does not raise ValidationFailed for a valid .nupkg URL" do
+      r = build_resource_with_url("https://some.server/chocolatey.2.7.3.nupkg", run_context)
+      expect { r.run_action(:install) }.not_to raise_error
+    end
+
+    it "does not raise ValidationFailed for a valid .ps1 URL" do
+      r = build_resource_with_url("https://some.server/install.ps1", run_context)
+      expect { r.run_action(:install) }.not_to raise_error
+    end
+
+    it "does not raise ValidationFailed when no download_url is set" do
+      r = build_resource_with_url(nil, run_context)
+      expect { r.run_action(:install) }.not_to raise_error
+    end
+  end
   describe "sensitive property masking" do
     it "marks proxy_password as sensitive" do
       expect(Chef::Resource::ChocolateyInstaller.properties[:proxy_password].sensitive?).to be true


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in #15306 where setting `download_url` to a `.nupkg` path caused Chocolatey to be downloaded but never installed. It also addresses a comprehensive set of pre-existing defects discovered during review, adds integration tests that would have caught the original bug, and includes a cookbook workaround for customers on affected releases.

> This work was completed with AI assistance following Progress AI policies.

## Root Cause

PR #15306 added branching on the `download_url` file type. For `.ps1` URLs it executed the script directly (correct). For all other types it called `Invoke-WebRequest` to download the file — then stopped. The nupkg was never extracted or installed, leaving `C:\ProgramData\chocolatey` absent and causing any subsequent `chocolatey_source` or `chocolatey_package` resource to fail with _"Could not find the Chocolatey config"_.

This PR is an addendum to #16206

## Changes

### Bug Fix — nupkg install path (`:install` action)

- For a remote `.nupkg` URL: download with `Invoke-WebRequest`, copy to `$env:TEMP` as `.zip`, extract with `Expand-Archive`, and run `tools\chocolateyInstall.ps1` from the extracted package.
- For a local drive path (`C:\…`) or UNC path (`\\server\share\…`): use the file directly — no download step.
- Pre-steps from Chocolatey's official `install.ps1` are replicated before running the bundled installer: TLS 1.2 enforcement, `$env:ChocolateyInstall` setup, and Chocolatey root directory creation.
- Zip is always staged in `$env:TEMP` (not alongside the source) so read-only UNC shares do not cause a write-access failure.

### Additional Fixes

- **TLS 1.2 for `.ps1` path** — `WebClient.DownloadString` now has TLS 1.2 enabled before execution; fixes failures on Server 2012/2016 defaults.
- **Proxy support for `Invoke-WebRequest`** — `-Proxy` and `-ProxyCredential` are now passed when `proxy_url` / `proxy_user` / `proxy_password` are configured. Previously those properties only set Chocolatey-internal env vars that `Invoke-WebRequest` ignores.
- **Unquoted `Set-Item` values** — All property values interpolated into `Set-Item` commands are now single-quoted; spaces in UNC paths or version strings no longer break argument parsing. Affects both `:install` and `:upgrade`.
- **Proxy XOR validation inverted** — `define_resource_requirements` used `!=` (XOR) where `==` was required; the assertion previously passed when only one credential was provided and failed when both were valid.
- **`-UseBasicParsing` on `Invoke-WebRequest`** — Prevents failures on Server Core and freshly provisioned nodes where the IE engine is not initialised.
- **`Remove-Item -ErrorAction SilentlyContinue`** in `:upgrade` — Removes the terminating error when `$env:ChocolateyVersion` is not set.
- **`File.exists?` → `File.exist?`** in `:uninstall` — Fixes deprecation warning in Ruby 3.2+.
- **Hardcoded `c:\programdata` path** in `:uninstall` replaced with `ENV['ALLUSERSPROFILE']`.
- **PATH removal case-sensitivity** in `:uninstall` — Changed PowerShell `-ne` to `-ine` so the Chocolatey bin path is removed from PATH regardless of casing.
- **`Chef::Log.warn` placement** in `:uninstall` — Warning now only fires in the `else` branch (Chocolatey was already absent), not after every successful uninstall.
- **`is_filesystem_path` regex** — Removed spurious `::` from the character class to align with `download_url_path`.
- **Validation guard for `download_url`** — Raises `Chef::Exceptions::ValidationFailed` early (before any env vars are set) if the URL has a recognizable but wrong file extension (`.html`, `.exe`, etc.). Empty extensions (OData/API endpoints) and digit-only segments (version paths such as `/chocolatey/2.7.3`) are explicitly allowed through.
- **Validation runs before env var setters** — The guard is now the first statement in the `:install` action body so no side-effects occur on an invalid configuration.

### Documentation

- Updated `download_url` property description to accurately describe UNC support, OData endpoint behaviour, actual installation flow, and the distinct handling of `.ps1` vs `.nupkg` inputs.

## Tests & Coverage

Unit test coverage expanded from 14 to 24 examples. All new code paths have explicit assertions.

| File | Change | Test File |
|---|---|---|
| `chocolatey_installer.rb` — nupkg extract+install | Core bug fix | `chocolatey_installer_spec.rb` lines 197–265 |
| `chocolatey_installer.rb` — UNC/local path (no download) | New path | `chocolatey_installer_spec.rb` lines 199–221 |
| `chocolatey_installer.rb` — proxy download | New path | `chocolatey_installer_spec.rb` lines 223–248 |
| `chocolatey_installer.rb` — URL extension guard | New guard | `chocolatey_installer_spec.rb` lines 285–331 |
| `chocolatey_installer.rb` — `.ps1` path | TLS fix | `chocolatey_installer_spec.rb` lines 175–197 |

## Integration Tests

- Added `kitchen-tests/cookbooks/end_to_end/recipes/_chocolatey_installer.rb` — converges a Windows node through standard install, uninstall, and nupkg-URL install (the primary regression scenario).
- Added `kitchen-tests/test/integration/end-to-end/_chocolatey_installer.rb` — InSpec controls verify `choco.exe` exists, `chocolatey.config` exists (the file whose absence was the original customer symptom), correct version is installed, and `choco list` succeeds end-to-end.
- Included in `recipes/windows.rb` so it runs on every Windows Kitchen suite.

## Customer Workaround

A tested cookbook snippet is available for customers on Chef Infra 18.11.11 and earlier who cannot immediately upgrade. It replicates the full fix in-recipe using a `powershell_script` resource and supports HTTPS URLs, local paths, UNC paths, and proxy environments.

## Risk & Mitigations

**Risk Classification**: Moderate

**Rationale**: Changes affect all three actions of a Windows-only resource. The install and uninstall paths are substantially rewritten. All changes are tested by the new unit and integration suites.

**Mitigation**: New integration tests run end-to-end on real Windows nodes in CI. The original default-install path (no `download_url`) is unchanged.

**Rollback Strategy**: `git revert <SHA>`

## DCO

All commits include Developer Certificate of Origin sign-off.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
