### PR TITLE
Lower 'No key detected' log level from puts to Chef::Log.debug

### DIFF
--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -151,7 +151,7 @@ class Chef
         if !!results
           @raw_key = results
         elsif key_file.nil? && raw_key.nil?
-          puts "\nNo key detected\n"
+          Chef::Log.debug("No key detected")
           return
         elsif !!key_file
           @raw_key = IO.read(key_file).strip


### PR DESCRIPTION
<h2>Problem</h2>
<p>The <code>No key detected</code> message in <code>lib/chef/http/authenticator.rb</code> was emitted via <code>puts</code>, causing it to print unconditionally to stdout on every chef-client run where no signing key is present (e.g. local-mode / <code>-z</code> runs). This is noisy and not actionable for end users.</p>

<h2>Fix</h2>
<p>Replace <code>puts "\nNo key detected\n"</code> with <code>Chef::Log.debug("No key detected")</code> so the message is only visible at debug log level (<code>--log-level debug</code>).</p>