### PR TITLE
Update checkout@v6 to checkout@v7 in macOS kitchen job

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -230,7 +230,7 @@ jobs:
       HAB_LICENSE: accept-no-persist
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false


### PR DESCRIPTION
<h2>Problem</h2>
<p><code>actions/checkout@v6</code> fails on fork PRs when attempting to fetch the <code>GITHUB_TOKEN</code> secret. The <code>mac_arm64</code> job in <code>kitchen.yml</code> was the only job still using <code>checkout@v6</code>; all other jobs in the same workflow already use <code>checkout@v7</code>.</p>

<h2>Fix</h2>
<p>Update the <code>mac_arm64</code> job's checkout step from <code>actions/checkout@v6</code> to <code>actions/checkout@v7</code>, consistent with the rest of the workflow.</p>