### PR TITLE
Re-enable linux-fips check in allchecks workflow

### DIFF
--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -15,5 +15,3 @@ jobs:
           # Retry every minute for 30 minutes...
           retries: 90
           verbose: true
-          # ponytail: fail-after:2026-07-22 — self-hosted FIPS runner is intermittently unavailable; re-enable once runner is stable
-          checks_exclude: ".*linux-fips.*"


### PR DESCRIPTION
<h2>Summary</h2>
<p>Removes the temporary exclusion of the <code>linux-fips</code> check from the allchecks aggregator workflow.</p>

<h2>Background</h2>
<p>The <code>.*linux-fips.*</code> exclusion was added with a ponytail comment (<code>fail-after:2026-07-22</code>) because the self-hosted FIPS runner was intermittently unavailable and the pipeline was failing due to an <code>OPENSSL_CONF</code> misconfiguration.</p>

<h2>Why It's Safe to Remove Now</h2>
<ul>
  <li>PR #16221 fixed the root cause: <code>OPENSSL_CONF</code> is now explicitly set in both Linux hab plans via <code>set_runtime_env -f</code>, ensuring the FIPS provider config is loaded correctly regardless of the system environment.</li>
  <li>The self-hosted runner is stable and the pipeline passes consistently.</li>
</ul>

<h2>Changes</h2>
<ul>
  <li><code>.github/workflows/allchecks.yml</code>: Removed <code>checks_exclude: ".*linux-fips.*"</code> and the associated ponytail comment.</li>
</ul>