### PR TITLE
Add allow-unsafe-pr-checkout to macOS kitchen job

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -235,6 +235,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           clean: true
+          allow-unsafe-pr-checkout: true
 
       - name: Install Habitat CLI
         run: |


### PR DESCRIPTION
<h2>Summary</h2>
<p>Adds <code>allow-unsafe-pr-checkout: true</code> to the <code>actions/checkout@v7</code> step in the macOS kitchen job.</p>

<h2>Why</h2>
<p><code>actions/checkout@v7</code> requires <code>allow-unsafe-pr-checkout: true</code> when checking out a PR head SHA from a fork in a <code>pull_request_target</code> workflow. Without this flag, the action refuses to fetch fork code into the privileged runner context, which causes the checkout to fail and prevents the <code>GITHUB_TOKEN</code> secret from being accessible.</p>

<p>Other jobs in this workflow and other workflows (<code>selfhosted-linux-fips.yml</code>, <code>macos_verify.yml</code>, <code>windows-fips.yml</code>, <code>workflow-change-guard.yml</code>) already set this flag on their checkout steps.</p>

<h2>Changes</h2>
<ul>
  <li><code>.github/workflows/kitchen.yml</code>: Added <code>allow-unsafe-pr-checkout: true</code> to the <code>mac_arm64</code> job checkout step.</li>
</ul>