### PR TITLE
Fix intermittent git hardlink error during bundle install in gem_tests

### DIFF
--- a/.github/workflows/gem_tests.yml
+++ b/.github/workflows/gem_tests.yml
@@ -39,6 +39,7 @@ jobs:
           bundler-cache: false
       - name: Bundle install Chef
         run: |
+          git config --global core.hardlinks false
           bundle config set --local without packaging
           bundle config set --local path 'vendor/bundle'
           bundle install --jobs=3 --retry=3
@@ -62,6 +63,7 @@ jobs:
           bundler-cache: false
       - name: Bundle install Chef
         run: |
+          git config --global core.hardlinks false
           bundle config set --local without packaging
           bundle config set --local path 'vendor/bundle'
           bundle install --jobs=3 --retry=3
@@ -85,6 +87,7 @@ jobs:
           bundler-cache: false
       - name: Bundle install Chef
         run: |
+          git config --global core.hardlinks false
           bundle config set --local without packaging
           bundle config set --local path 'vendor/bundle'
           bundle install --jobs=3 --retry=3
@@ -108,6 +111,7 @@ jobs:
           bundler-cache: false
       - name: Bundle install Chef
         run: |
+          git config --global core.hardlinks false
           bundle config set --local without packaging
           bundle install --jobs=3 --retry=3
       - name: Run berkshelf tests


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes an intermittent CI failure in the <code>gem_tests</code> workflow affecting <strong>berkshelf</strong>, <strong>cheffish</strong>, <strong>chefspec</strong>, and <strong>chef-zero</strong> jobs.</p>

<h2>Root Cause</h2>
<p>When Bundler installs git-sourced gems (e.g. <code>rest-client</code>), Git internally clones from the Ruby tool cache at <code>/opt/hostedtoolcache/Ruby/3.4.8/x64/...</code> into the runner's working directory. Since these two paths reside on <strong>different filesystems</strong> on GitHub Actions Ubuntu runners, Git's hardlink optimization fails with:</p>
<pre><code>fatal: hardlink different from source at '...tmp_graph_nyGgw8'
Error: Process completed with exit code 11.</code></pre>

<h2>Fix</h2>
<p>Added <code>git config --global core.hardlinks false</code> before <code>bundle install</code> in all four gem_tests jobs. This instructs Git to copy files instead of hardlinking during clone operations, eliminating the cross-filesystem failure.</p>

<h2>Jobs Fixed</h2>
<ul>
  <li>berkshelf</li>
  <li>cheffish</li>
  <li>chefspec</li>
  <li>chef-zero</li>
</ul>

<hr>
<p>This work was completed with AI assistance following Progress AI policies.</p>