### PR TITLE
Fix intermittent git hardlink error in unit_specs bundle install

### DIFF
--- a/.github/workflows/unit_specs.yml
+++ b/.github/workflows/unit_specs.yml
@@ -64,7 +64,11 @@ jobs:
       - name: Create unit test node fixtures
         run: mkdir -p spec/data/nodes && touch spec/data/nodes/test.rb spec/data/nodes/default.rb spec/data/nodes/test.example.com.rb
         shell: bash
-      - run: bundle install
+      - name: Bundle install
+        run: |
+          git config --global core.hardlinks false
+          bundle install
+        shell: bash
       - name: Set RUBY_DLL_PATH for chef-powershell (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -135,6 +139,9 @@ jobs:
           echo "$HOME/.rbenv/shims" >> $GITHUB_PATH
       - name: Create unit test node fixtures
         run: mkdir -p spec/data/nodes && touch spec/data/nodes/test.rb spec/data/nodes/default.rb spec/data/nodes/test.example.com.rb
-      - run: bundle install
+      - name: Bundle install
+        run: |
+          git config --global core.hardlinks false
+          bundle install
       - run: bundle exec rake spec:unit
       - run: bundle exec rake component_specs


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes the same intermittent CI failure seen in <code>gem_tests</code> (fixed in #16227), now applied to the <code>unit_specs</code> workflow for the <strong>unit</strong> and <strong>unit-docker</strong> jobs.</p>

<h2>Root Cause</h2>
<p>When Bundler installs git-sourced gems, Git attempts to hardlink files from the Ruby tool cache at <code>/opt/hostedtoolcache/Ruby/...</code> to the runner's working directory. These paths are on different filesystems on GitHub Actions runners, causing:</p>
<pre><code>fatal: hardlink different from source at '...tmp_graph_nyGgw8'
Error: Process completed with exit code 11.</code></pre>

<h2>Fix</h2>
<p>Added <code>git config --global core.hardlinks false</code> before <code>bundle install</code> in both <code>unit</code> and <code>unit-docker</code> jobs to force Git to copy files instead of hardlinking.</p>