### PR TITLE
Enable Grype source scan on push/merge to main

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -55,6 +55,9 @@ jobs:
       # scc-output-filename: 'scc-output.txt'
       perform-language-linting: false    # Perform language-specific linting and pre-compilation checks
 
+      # grype vulnerability scan on source code (runs on push/merge to main, not on PRs)
+      perform-grype-scan: ${{ github.event_name == 'push' }}
+
       # trufflehog secret scanning
       perform-trufflehog-scan: true
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>Enables the Grype vulnerability scan on the source code in the CI pipeline, triggered only on <code>push</code> events (i.e., PR merges to <code>main</code>).</p>

<h2>Changes</h2>
<ul>
  <li>Added <code>perform-grype-scan: ${{ github.event_name == 'push' }}</code> to <code>ci-main-pull-request-stub.yml</code></li>
  <li>Consistent with existing BlackDuck Polaris and SCA scan conditions — skipped on PRs, runs on merge</li>
</ul>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>