### PR TITLE
CVE-2026-27820 - Huge upgrade for Zlib 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "18-stable"
 gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt_update1"
 
 gem "ffi", ">= 1.15.5", "<= 1.18.0"
+# CVE-2026-27820 (CVSS 9.8): buffer overflow in Zlib::GzipReader / zstream_buffer_ungets.
+# Versions <= 3.0.0, 3.1.0-3.1.1, and 3.2.0-3.2.1 are affected. Fixed in 3.2.3.
+gem "zlib", ">= 3.2.3"
 gem "chef-utils", path: File.expand_path("chef-utils", __dir__) if File.exist?(File.expand_path("chef-utils", __dir__))
 gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?(File.expand_path("chef-config", __dir__))
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -516,6 +516,7 @@ GEM
       structured_warnings
     wisper (2.0.1)
     wmi-lite (1.0.7)
+    zlib (3.2.3)
 
 PLATFORMS
   arm64-darwin-21
@@ -549,6 +550,7 @@ DEPENDENCIES
   rspec
   ruby-shadow!
   webmock
+  zlib (>= 3.2.3)
 
 BUNDLED WITH
    2.3.27

--- a/post-bundle-install.rb
+++ b/post-bundle-install.rb
@@ -113,6 +113,7 @@ end
 default_gem_list = {
   resolv: "0.2.1",
   uri: "0.12.4",
+  zlib: "2.1.1",
 }
 
 # On AIX, the omnibus toolchain/foundation ships Ruby 3.0.3.  Replacing the


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef-18 was running on the Zlib ruby gem v1.3.1. That version is both stale and subject to CVE. We are updating it here. Oddly, that old version matches a version outside of Ruby that Habitat uses from this repo https://github.com/madler/zlib. We can ignore that version.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
