### PR TITLE
use rmdir instead of remove-item for windows plans

### DIFF
--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -354,55 +354,31 @@ function Invoke-After {
     Invoke-DevkitSmokeTests
 
     # Trim the fat before packaging
-
     # We don't need the cache of downloaded .gem files ...
+    Write-BuildLine "Removing vendor cache"
     Remove-Item $pkg_prefix/vendor/cache -Recurse -Force
     # ... or bundler's cache of git-ref'd gems
-    $bundlerPath = "$pkg_prefix/vendor/bundler"
-    $maxRetries = 5
-    for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
-        try {
-            Remove-Item $bundlerPath -Recurse -Force -ErrorAction Stop
-            break
-        } catch {
-            if ($attempt -lt $maxRetries) {
-                Write-BuildLine " ** Removing ${bundlerPath}: attempt $attempt failed (git subdirectories may be locked), retrying..."
-                Start-Sleep -Seconds 2
-            } else {
-                throw "Failed to remove ${bundlerPath} after $maxRetries attempts: $_"
-            }
-        }
-    }
+    Write-BuildLine "Removing bundler cache"
+    cmd.exe /c RMDIR /S /Q "$($pkg_prefix.Replace('/', '\'))\vendor\bundler"
 
     # We don't need the gem docs.
+    Write-BuildLine "Removing vendor doc"
     Remove-Item $pkg_prefix/vendor/doc -Recurse -Force
     # We don't need to ship the test suites for every gem dependency,
     # only Chef's for package verification.
+    Write-BuildLine "Removing vendored gem specs"
     $specDirs = Get-ChildItem $pkg_prefix/vendor/gems -Filter "spec" -Directory -Recurse -Depth 1 `
-        | Where-Object -FilterScript { $_.FullName -notlike "*chef-$pkg_version*" }
-    foreach ($specDir in $specDirs) {
-        $maxRetries = 5
-        for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
-            try {
-                Remove-Item $specDir.FullName -Recurse -Force -ErrorAction Stop
-                break
-            } catch {
-                if ($attempt -lt $maxRetries) {
-                    Write-BuildLine " ** Invoke-After: removing $($specDir.FullName): attempt $attempt failed, retrying..."
-                    Start-Sleep -Seconds 2
-                } else {
-                    throw "Invoke-After: failed to remove $($specDir.FullName) after $maxRetries attempts: $_"
-                }
-            }
-        }
-    }
+        | Where-Object -FilterScript { $_.FullName -notlike "*chef-$pkg_version*" } `
+        | ForEach-Object { cmd.exe /c RMDIR /S /Q "$($_.FullName)" }
     # Remove .github directories from vendored gems so that GitHub Actions workflow
     # files are not shipped and do not trigger grype vulnerability reports.
     # NOTE: this is temporary and can be removed once upstream dependencies
     # fix their file exclusions.
+    Write-BuildLine "Removing .github directories from vendored gems"
     Get-ChildItem $pkg_prefix/vendor/gems -Filter ".github" -Directory -Recurse `
         | Remove-Item -Recurse -Force
     # Remove the byproducts of compiling gems with extensions
+    Write-BuildLine "Removing byproducts of compiling gems with extensions"
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
 


### PR DESCRIPTION
## Description
replace Remove-Item with rmdir to get around the intermittent Remove-Item failures in habitat plan file. 

JIRA: https://progresssoftware.atlassian.net/browse/CHEF-36924 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
