### PR TITLE
Widen ffi-yajl version constraint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,6 @@ updates:
       # Due to FIPS builds and having to couple the openssl
       # build itself, we don't let dependabot bump openssl
       - dependency-name: "openssl"
-      - dependency-name: "ffi-yajl"
-        # Locking to 2.x until ffi-yajl 3.x gets the allocator fix https://github.com/chef/ffi-yajl/pull/126 fail-after:2026-08-22
-        versions: ["3.x"]
     # don't automatically rebase on every single time we're out of date with
     # base (whith is always) because it kills CI capacity
     rebase-strategy: disabled

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -57,6 +57,7 @@ Gem::Specification.new do |s|
   s.add_dependency "inspec-core", "~> 7.1.7"
 
   s.add_dependency "ffi", ">= 1.15.5", "< 1.18.0"
+  # ffi-yajl has a stale version in 3.0.0 specifically that is in use. 3.0.1 and higher is ok again
   s.add_dependency "ffi-yajl", ">= 2.2", "!= 3.0.0", "< 4.0"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "net-ftp" # remote_file resource

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
   s.add_dependency "inspec-core", "~> 7.1.7"
 
   s.add_dependency "ffi", ">= 1.15.5", "< 1.18.0"
-  s.add_dependency "ffi-yajl", ">= 2.2", "< 3.0"
+  s.add_dependency "ffi-yajl", ">= 2.2", "!= 3.0.0", "< 4.0"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "net-ftp" # remote_file resource
   s.add_dependency "ed25519", "~> 1.2" # ssh-ed25519 support for target mode


### PR DESCRIPTION
<h2>Summary</h2><p>Removes the ffi-yajl dependabot ignore rule and widens the chef.gemspec constraint for ffi-yajl to <code>&gt;= 2.2, != 3.0.0, &lt; 4.0</code>, allowing dependabot/bundler to pick up 3.x releases other than the broken 3.0.0.</p><p>This work was completed with AI assistance following Progress AI policies.</p>