### PR TITLE
Update Ruby to 3.4.10 and openssl to 3.5.7 in all Habitat plans

### DIFF
--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -262,11 +262,32 @@ jobs:
           # Remove the installed Chef Infra Client package(s) from /hab/pkgs
           sudo rm -rf /hab/pkgs/$HAB_ORIGIN/chef-infra-client || true
 
-          # Clean up Habitat build artifacts
+          # Clean up Habitat build artifacts (gha origin only)
           sudo rm -rf /hab/cache/artifacts/$HAB_ORIGIN-chef-infra-client-*.hart || true
 
           # Remove origin keys
           sudo rm -f /hab/cache/keys/$HAB_ORIGIN-*.* || true
+
+          # Clean up the Habitat build studio to avoid stale build environments.
+          # The studio mounts /dev/pts and other filesystems inside itself — these
+          # must be unmounted before the directory can be removed, otherwise rm -rf
+          # fails with "Device or resource busy".
+          for studio_dir in /hab/studios/*/; do
+            if [ -d "$studio_dir" ]; then
+              # Unmount any lingering bind mounts inside the studio (reverse order)
+              mount | grep "$studio_dir" | awk '{print $3}' | sort -r | while read -r mnt; do
+                sudo umount -lf "$mnt" 2>/dev/null || true
+              done
+              sudo rm -rf "$studio_dir" || true
+            fi
+          done
+
+          # Remove stale core dependency packages that accumulate across runs
+          # (ruby, openssl and their transitive deps) to force fresh resolution from builder
+          sudo rm -rf /hab/pkgs/core/ruby3_4 || true
+          sudo rm -rf /hab/pkgs/core/openssl || true
+          sudo rm -rf /hab/cache/artifacts/core-ruby3_4-*.hart || true
+          sudo rm -rf /hab/cache/artifacts/core-openssl-*.hart || true
 
           # Clean up any Chef local-mode cache
           sudo rm -rf /root/.chef/local-mode-cache || true

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?
 
 # required for FIPS or bundler will pick up default openssl
 install_if -> { !Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" } } do
-  gem "openssl", "= 3.3.1"
+  gem "openssl", "= 3.3.3"
 end
 
 if File.exist?(File.expand_path("chef-bin", __dir__))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,7 @@ GEM
     nori (2.9.1)
       bigdecimal
       stringio
-    openssl (3.3.1)
+    openssl (3.3.3)
     ostruct (0.6.3)
     parallel (1.28.0)
     parser (3.3.11.1)
@@ -588,7 +588,7 @@ DEPENDENCIES
   ffi (>= 1.15.5)
   inspec-core-bin (= 7.1.7)
   ohai!
-  openssl (= 3.3.1)
+  openssl (= 3.3.3)
   pry (~> 0.16.0)
   pry-byebug
   pry-stack_explorer

--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -1,6 +1,6 @@
 export HAB_BLDR_CHANNEL="base-2025"
 SRC_PATH="$(dirname "$(dirname "$PLAN_CONTEXT")")"
-_chef_client_ruby="core/ruby3_4/3.4.8"
+_chef_client_ruby="core/ruby3_4/3.4.10"
 pkg_name="chef-infra-client"
 pkg_origin="chef"
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,6 +1,6 @@
 export HAB_BLDR_CHANNEL="base-2025"
 SRC_PATH="$(dirname "$(dirname "$PLAN_CONTEXT")")"
-_chef_client_ruby="core/ruby3_4/3.4.8"
+_chef_client_ruby="core/ruby3_4/3.4.10"
 pkg_name="chef-infra-client"
 pkg_origin="chef"
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"

--- a/habitat/x86_64-linux/plan.sh
+++ b/habitat/x86_64-linux/plan.sh
@@ -1,6 +1,6 @@
 export HAB_BLDR_CHANNEL="base-2025"
 SRC_PATH="$(dirname "$(dirname "$PLAN_CONTEXT")")"
-_chef_client_ruby="core/ruby3_4/3.4.8"
+_chef_client_ruby="core/ruby3_4/3.4.10"
 pkg_name="chef-infra-client"
 pkg_origin="chef"
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -18,7 +18,7 @@ $pkg_deps=@(
   "core/zlib"
   "core/xz"
   "core/libarchive"
-  "core/ruby3_4-plus-devkit/3.4.8"
+  "core/ruby3_4-plus-devkit/3.4.10"
   "core/visual-cpp-redist-2022"
 )
 

--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -37,11 +37,17 @@ begin
   # This code dynamically determines the path to archive.dll using the Habitat CLI (`hab pkg path core/libarchive`) and explicitly
   # loads the library using FFI::DynamicLibrary.open. This ensures that the library is correctly loaded in the Habitat environment.
   #
-  # Note: This logic is gated by a check for Habitat-specific environment variables (HAB_CACHE_SRC_PATH or HAB_PKG_PATH) to ensure
-  # that it is only applied in Habitat runs. For other environments (e.g., Omnibus, plain gem installations, or git checkouts),
-  # the default behavior of FFI is sufficient, as the libraries are installed in standard locations or embedded paths that are
-  # included in the default search paths.
-  if RUBY_PLATFORM.match?(/mswin|mingw|windows/) && (ENV["HAB_CACHE_SRC_PATH"] || ENV["HAB_PKG_PATH"])
+  # Note: This logic is gated by a check that we are running from a Habitat package
+  # path to ensure it is only applied in Habitat runs. For other environments
+  # (e.g., Omnibus, plain gem installations, or git checkouts), the default behavior
+  # of FFI is sufficient, as the libraries are installed in standard locations or
+  # embedded paths that are included in the default search paths.
+  # Detect Habitat runtime environment reliably. HAB_CACHE_SRC_PATH is only set
+  # during `hab pkg build` (studio), not at runtime. HAB_PKG_PATH is also not
+  # guaranteed at runtime. Checking __FILE__ is reliable: when chef-client runs
+  # from a Hab package via `hab pkg exec`, this file's path always contains
+  # "hab/pkgs".
+  if RUBY_PLATFORM.match?(/mswin|mingw|windows/) && __FILE__.match?(%r{hab[/\\]pkgs})
     require "ffi" unless defined?(FFI)
     require "open3" unless defined?(Open3)
     # Dynamically determine the path to the core/libarchive package


### PR DESCRIPTION
<h2>Summary</h2>
<p>Updates Ruby from <code>3.4.8</code> to <code>3.4.10</code> across all four Habitat plans. Ruby 3.4.10 is now available in the <code>base-2025</code> channel.</p>

<h2>Changes</h2>
<ul>
  <li><code>habitat/aarch64-linux/plan.sh</code> — <code>core/ruby3_4/3.4.8</code> → <code>core/ruby3_4/3.4.10</code></li>
  <li><code>habitat/x86_64-linux/plan.sh</code> — <code>core/ruby3_4/3.4.8</code> → <code>core/ruby3_4/3.4.10</code></li>
  <li><code>habitat/aarch64-darwin/plan.sh</code> — <code>core/ruby3_4/3.4.8</code> → <code>core/ruby3_4/3.4.10</code></li>
  <li><code>habitat/x86_64-windows/plan.ps1</code> — <code>core/ruby3_4-plus-devkit/3.4.8</code> → <code>core/ruby3_4-plus-devkit/3.4.10</code></li>
</ul>
<p>Note: The <code>$ruby_version = "3.4.0"</code> references in the Windows plan are intentionally unchanged — they refer to the Ruby ABI/gems path version, not the package version.</p>

<h2>Pipeline Issues Fixed</h2>

<h3>1. Linux Hab build — duplicate openssl in dependency graph</h3>
<p><code>ruby3_4/3.4.8</code> depends on <code>core/openssl/3.5.6</code>, while the new <code>core/libarchive/3.8.1</code> (pulled in via base-2025) depends on <code>core/openssl/3.5.7</code>. Habitat refuses to build when two versions of the same package appear in the runtime dependency graph. Upgrading to <code>ruby3_4/3.4.10</code> (which was built against <code>openssl/3.5.7</code>) resolves the conflict.</p>

<h3>2. Windows + Linux kitchen — openssl gem version conflict</h3>
<p><code>ruby3_4/3.4.10</code> and <code>ruby3_4-plus-devkit/3.4.10</code> ship with the <code>openssl</code> gem at version <code>3.3.3</code>, but the Gemfile pinned <code>openssl = 3.3.1</code>. This caused a <code>Gem::LoadError: can't activate openssl-3.3.1, already activated openssl-3.3.3</code> at runtime. Fixed by updating <code>Gemfile</code> and <code>Gemfile.lock</code> to pin <code>openssl = 3.3.3</code>.</p>

<h3>3. Self-hosted Linux runner — stale hab packages across runs</h3>
<p>The cleanup step was not removing old <code>core/ruby3_4</code> and <code>core/openssl</code> packages or the Habitat build studio, causing stale dependency versions to be resolved locally on subsequent runs. Added cleanup of <code>/hab/studios/</code>, <code>/hab/pkgs/core/ruby3_4</code>, <code>/hab/pkgs/core/openssl</code> and their cached <code>.hart</code> files.</p>

<h3>4. Windows kitchen — <code>NameError: uninitialized constant Archive::EXTRACT_OWNER</code></h3>
<p>The existing Hab detection condition for pre-loading <code>archive.dll</code> checked <code>HAB_CACHE_SRC_PATH || HAB_PKG_PATH</code>. <code>HAB_CACHE_SRC_PATH</code> is only set during <code>hab pkg build</code> (studio), not at runtime. <code>HAB_PKG_PATH</code> was set by older Hab versions but is no longer exported into the <code>hab pkg exec</code> environment. With neither variable set, the <code>archive.dll</code> pre-load was silently skipped, causing <code>ffi-libarchive</code> to fail with a <code>LoadError</code> and <code>Archive::EXTRACT_OWNER</code> to be undefined at convergence. Fixed by detecting Hab via <code>__FILE__.match?(/hab[\/\]pkgs/)</code> which is always reliable when running from a packaged chef.</p>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>