### PR TITLE
Narrow the bare rescue in the sysctl load_current_value block

### DIFF
--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -124,10 +124,21 @@ class Chef
         end
       end
 
+      # Raised by the current value helpers below when the current value of a key cannot
+      # be determined -- either because Chef has not written a conf file for it yet, or
+      # because the running value no longer agrees with the one Chef wrote. Raising it
+      # signals that the resource needs converging.
+      class CurrentValueUnknown < StandardError; end
+
+      # Only conditions that genuinely mean "the current value cannot be determined" are
+      # rescued here: the two signalled by CurrentValueUnknown, plus a failure to run
+      # sysctl at all. Programming errors such as an undefined constant or a missing
+      # method are deliberately left to surface rather than being reported as a missing
+      # current value, which would silently make the resource non-idempotent.
       load_current_value do
 
         value get_sysctl_value(key)
-      rescue
+      rescue CurrentValueUnknown, Mixlib::ShellOut::ShellCommandFailed, SystemCallError
         current_value_does_not_exist!
 
       end
@@ -208,7 +219,7 @@ class Chef
       #
       def get_sysctl_value(key)
         val = shell_out!("sysctl -n -e #{key}").stdout.tr("\t", " ").strip
-        raise unless val == get_sysctld_value(key)
+        raise CurrentValueUnknown, "The running value of #{key} does not match the value Chef configured" unless val == get_sysctld_value(key)
 
         val
       end
@@ -217,11 +228,15 @@ class Chef
       # return the value. Raise in case this conf file needs to be created
       # or updated
       def get_sysctld_value(key)
-        raise unless ::TargetIO::File.exist?("/etc/sysctl.d/99-chef-#{key.tr("/", ".")}.conf")
+        path = "/etc/sysctl.d/99-chef-#{key.tr("/", ".")}.conf"
+        raise CurrentValueUnknown, "#{path} does not exist" unless ::TargetIO::File.exist?(path)
 
-        k, v = ::TargetIO::File.read("/etc/sysctl.d/99-chef-#{key.tr("/", ".")}.conf").match(/(.*) = (.*)/).captures
-        raise "Unknown sysctl key!" if k.nil?
-        raise "Unknown sysctl value!" if v.nil?
+        matches = ::TargetIO::File.read(path).match(/(.*) = (.*)/)
+        raise CurrentValueUnknown, "#{path} does not contain a 'key = value' pair" if matches.nil?
+
+        k, v = matches.captures
+        raise CurrentValueUnknown, "Unknown sysctl key in #{path}" if k.nil?
+        raise CurrentValueUnknown, "Unknown sysctl value in #{path}" if v.nil?
 
         v
       end

--- a/spec/unit/resource/sysctl_spec.rb
+++ b/spec/unit/resource/sysctl_spec.rb
@@ -53,6 +53,61 @@ describe Chef::Resource::Sysctl do
     expect(resource.value).to eql("1.1")
   end
 
+  context "#load_current_value!" do
+    let(:conf_file) { "/etc/sysctl.d/99-chef-kernel.msgmnb.conf" }
+
+    before do
+      resource.key("kernel.msgmnb")
+      allow(resource).to receive(:shell_out!)
+        .with("sysctl -n -e kernel.msgmnb")
+        .and_return(double(stdout: "65536\n"))
+      allow(::TargetIO::File).to receive(:exist?).with(conf_file).and_return(true)
+      allow(::TargetIO::File).to receive(:read).with(conf_file).and_return("kernel.msgmnb = 65536\n")
+    end
+
+    it "loads the running value when it agrees with the Chef managed conf file" do
+      resource.load_current_value!
+      expect(resource.value).to eql("65536")
+    end
+
+    it "does not exist when Chef has not written a conf file for the key" do
+      allow(::TargetIO::File).to receive(:exist?).with(conf_file).and_return(false)
+      expect { resource.load_current_value! }.to raise_error(Chef::Exceptions::CurrentValueDoesNotExist)
+    end
+
+    it "does not exist when the running value disagrees with the conf file" do
+      allow(::TargetIO::File).to receive(:read).with(conf_file).and_return("kernel.msgmnb = 16384\n")
+      expect { resource.load_current_value! }.to raise_error(Chef::Exceptions::CurrentValueDoesNotExist)
+    end
+
+    it "does not exist when the conf file does not contain a 'key = value' pair" do
+      allow(::TargetIO::File).to receive(:read).with(conf_file).and_return("# hand edited\n")
+      expect { resource.load_current_value! }.to raise_error(Chef::Exceptions::CurrentValueDoesNotExist)
+    end
+
+    it "does not exist when sysctl exits non-zero" do
+      allow(resource).to receive(:shell_out!)
+        .with("sysctl -n -e kernel.msgmnb")
+        .and_raise(Mixlib::ShellOut::ShellCommandFailed)
+      expect { resource.load_current_value! }.to raise_error(Chef::Exceptions::CurrentValueDoesNotExist)
+    end
+
+    it "does not exist when the sysctl binary is missing" do
+      allow(resource).to receive(:shell_out!)
+        .with("sysctl -n -e kernel.msgmnb")
+        .and_raise(Errno::ENOENT)
+      expect { resource.load_current_value! }.to raise_error(Chef::Exceptions::CurrentValueDoesNotExist)
+    end
+
+    # An undefined constant in the current value helpers used to be swallowed by a bare
+    # rescue and silently reported as "the current value does not exist", which made every
+    # sysctl resource non-idempotent without any visible error. See https://github.com/chef/chef/issues/15786
+    it "lets unexpected errors surface rather than reporting the value as missing" do
+      allow(::TargetIO::File).to receive(:read).with(conf_file).and_raise(NameError, "uninitialized constant Target_IO")
+      expect { resource.load_current_value! }.to raise_error(NameError)
+    end
+  end
+
   context "#contruct_sysctl_content" do
     before do
       resource.key("foo")


### PR DESCRIPTION
## Description

Follow-up to #16035, which fixed the `::Target_IO` typo in `get_sysctld_value` but left the mechanism that hid it in place.

The `sysctl` resource loads its current value inside a bare `rescue`:

```ruby
load_current_value do
  value get_sysctl_value(key)
rescue
  current_value_does_not_exist!
end
```

Because `NameError < StandardError`, that bare rescue swallowed the undefined-constant error and reported "the current value does not exist" on every converge instead. The symptom was silent non-idempotency — every `sysctl` resource using `action :apply` logged `- create <key>`, never "up to date", and reran `execute[Load sysctl values]` — with nothing in the output pointing at the cause. That shipped in every release from 19.0.20 (Sept 2024) through 19.3.21, about 20 months.

The one-character fix is already merged. This PR addresses the two things that let it go unnoticed for that long.

### 1. Narrow the rescue

Add a `CurrentValueUnknown` error raised by the two conditions that genuinely mean "this resource needs converging":

- Chef has not written a `99-chef-<key>.conf` file for the key yet
- the running value no longer agrees with the one Chef wrote

The rescue then catches only that, plus `Mixlib::ShellOut::ShellCommandFailed` and `SystemCallError`. Programming errors — an undefined constant, a missing method — now surface instead of being reported as a missing current value.

The two shell-out error classes are there deliberately to preserve existing behaviour, and are the main judgment call worth reviewing. `shell_out!` raises `ShellCommandFailed` when sysctl exits non-zero, but `Errno::ENOENT` when the binary is missing entirely:

```
$ Mixlib::ShellOut.new("definitely-not-a-real-binary-xyz -n").run_command
raised: Errno::ENOENT  (SystemCallError? true)
```

The old bare rescue absorbed both. Rescuing only `CurrentValueUnknown` would turn a missing `sysctl` binary into a hard converge failure, including for `action :remove`, which otherwise doesn't need to read anything. `SystemCallError` keeps that behaviour. The line drawn is environment failures → current value unknown; programming errors → surface. Happy to adjust if maintainers prefer a different boundary.

One related change is required rather than optional: a conf file with no `key = value` pair made `.match(...)` return `nil`, and `nil.captures` raised `NoMethodError`, which the bare rescue also absorbed. Under a narrowed rescue that would crash, so it is now checked explicitly and keeps reporting a missing current value.

### 2. Add the missing test coverage

`spec/unit/resource/sysctl_spec.rb` had no coverage of `load_current_value!` at all, which is why a `NameError` on every converge passed CI for 20 months. Six examples added, covering the happy path, each "does not exist" condition, and — most importantly — that an unexpected error propagates rather than being reported as a missing value.

Verified the tests fail against the actual historical bug, not just a synthetic one:

| Code under test | Result |
| --- | --- |
| This branch | 16 examples, 0 failures |
| Current `main` (bare rescue, `TargetIO` correct) | **1 failure** — `lets unexpected errors surface...` |
| Pre-#16035 (`Target_IO` typo + bare rescue) | **2 failures** — that one, plus `loads the running value...` |

## Related Issue

Refs #15786, #16035

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor / test coverage

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/chef/chef/blob/main/CONTRIBUTING.md) document
- [x] I have signed off all my commits as required by [DCO](https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco)
- [x] My code follows the project style (`cookstyle --chefstyle` clean on both files)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Noted but not addressed

The `/(.*) = (.*)/` regex matches the first line containing ` = `, so a comment such as `# foo = bar` above the setting would be parsed as the key/value pair and cause non-idempotency. Pre-existing and out of scope here — happy to open a separate issue if useful.
