### PR TITLE
Fix selfhosted-linux-fips to checkout PR head instead of base

### DIFF
--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           allow-unsafe-pr-checkout: true
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           clean: false
 


### PR DESCRIPTION
<h2>Problem</h2>
<p>The <code>selfhosted-linux-fips</code> workflow was checking out <code>base.sha</code> (tip of <code>main</code>) instead of the PR's <code>head.sha</code>, meaning it always built and tested <strong>main's code</strong> rather than the actual PR branch being reviewed.</p>

<h2>Root Cause</h2>
<p>When the workflow was created from the <a href="https://github.com/chef/chef/blob/02fb94d5cdc2d7055052984fcf6bbf57766db0e8/.github/workflows/selfhosted-linux-fips.yml.disabled#L52">original disabled predecessor</a>, the checkout ref was changed from the correct <code>head.sha</code> to <code>base.sha</code>. The original file had the correct behaviour:</p>
<pre><code>ref: ${{ github.event.pull_request.head.sha }}</code></pre>

<h2>Fix</h2>
<p>Restore the checkout ref to <code>head.sha</code>, consistent with both <code>windows-fips.yml</code> and <code>kitchen.yml</code> which already correctly use <code>head.sha</code>.</p>

<h2>Change</h2>
<pre><code>- ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+ ref: ${{ github.event.pull_request.head.sha }}</code></pre>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>