### PR TITLE
Temporarily skip archive_file test in Windows kitchen

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -189,17 +189,19 @@ end
 include_recipe "::_chef_client_config"
 include_recipe "::_chef_client_trusted_certificate"
 
-# test various archive formats in the archive_file resource
-%w{tourism.tar.gz tourism.tar.xz tourism.zip}.each do |archive|
-  cookbook_file File.join(Chef::Config[:file_cache_path], archive) do
-    source archive
-  end
-
-  archive_file archive do
-    path File.join(Chef::Config[:file_cache_path], archive)
-    extract_to File.join(Chef::Config[:file_cache_path], archive.tr(".", "_"))
-  end
-end
+# TODO: archive_file Windows kitchen test temporarily commented out while
+# ffi-libarchive/archive.dll loading issue with ruby3_4-plus-devkit/3.4.10
+# is being resolved in https://github.com/chef/chef/pull/16242
+# %w{tourism.tar.gz tourism.tar.xz tourism.zip}.each do |archive|
+#   cookbook_file File.join(Chef::Config[:file_cache_path], archive) do
+#     source archive
+#   end
+#
+#   archive_file archive do
+#     path File.join(Chef::Config[:file_cache_path], archive)
+#     extract_to File.join(Chef::Config[:file_cache_path], archive.tr(".", "_"))
+#   end
+# end
 
 locale "set system locale" do
   lang "en-us"


### PR DESCRIPTION
<h2>Summary</h2>
<p>Temporarily comments out the <code>archive_file</code> resource test in the Windows end-to-end kitchen recipe while the <code>ffi-libarchive</code>/<code>archive.dll</code> pre-load issue with <code>ruby3_4-plus-devkit/3.4.10</code> is being resolved.</p>

<h2>Context</h2>
<p>The Windows kitchen run fails with:</p>
<pre><code>NameError: uninitialized constant Archive::EXTRACT_OWNER</code></pre>
<p>...because <code>ffi-libarchive</code> raises a <code>LoadError</code> at startup (archive.dll not found), leaving <code>Archive</code> constants undefined when the resource attempts to converge.</p>
<p>Root cause and fix are tracked in <a href="https://github.com/chef/chef/pull/16242">#16242</a> (Ruby 3.4.10 Habitat upgrade). This PR unblocks the kitchen pipeline in the meantime.</p>

<h2>To Revert</h2>
<p>Once #16242 is merged and verified, uncomment the block in <code>kitchen-tests/cookbooks/end_to_end/recipes/windows.rb</code>.</p>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>