### PR TITLE
Remove pinned openssl gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "chef-config", path: File.expand_path("chef-config", __dir__) if File.exist?
 
 # required for FIPS or bundler will pick up default openssl
 install_if -> { !Gem.platforms.any? { |platform| !platform.is_a?(String) && platform.os == "darwin" } } do
-  gem "openssl", "= 3.3.3"
+  gem "openssl"
 end
 
 if File.exist?(File.expand_path("chef-bin", __dir__))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -588,7 +588,7 @@ DEPENDENCIES
   ffi (>= 1.15.5)
   inspec-core-bin (= 7.1.7)
   ohai!
-  openssl (= 3.3.3)
+  openssl
   pry (~> 0.16.0)
   pry-byebug
   pry-stack_explorer

--- a/habitat/x86_64-windows/plan.ps1
+++ b/habitat/x86_64-windows/plan.ps1
@@ -213,7 +213,7 @@ function Invoke-Build {
         $env:_BUNDLER_WINDOWS_DLLS_COPIED = "1"
 
         $openssl_dir = "$(Get-HabPackagePath core/openssl)"
-        gem install openssl:3.3.0 -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
+        gem install openssl -- --with-openssl-dir=$openssl_dir --with-openssl-include="$openssl_dir/include" --with-openssl-lib="$openssl_dir/lib"
 
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
         bundle install --jobs=3 --retry=3


### PR DESCRIPTION
<h2>Summary</h2><p>Removes the hardcoded openssl gem version pin so bundler resolves the latest compatible version instead of a fixed one.</p><ul><li><code>Gemfile</code>: changed <code>gem "openssl", "= 3.3.1"</code> to <code>gem "openssl"</code>.</li><li><code>Gemfile.lock</code>: updated the dependency constraint to match.</li><li><code>habitat/x86_64-windows/plan.ps1</code>: changed <code>gem install openssl:3.3.0</code> to <code>gem install openssl</code>.</li></ul><p>Habitat plans (linux/darwin/windows) already reference <code>core/openssl</code> without a version pin, so no changes were needed there.</p><p>This work was completed with AI assistance following Progress AI policies</p>