### PR TITLE
Temporarily skip habitat_install archive_file in Windows kitchen

### DIFF
--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jaymzh/chronoguard@main
         with:
-          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml, habitat/aarch64-linux/plan.sh, .github/dependabot.yml
+          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml, habitat/aarch64-linux/plan.sh, .github/dependabot.yml, kitchen-tests/cookbooks/end_to_end/recipes/windows.rb, kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
@@ -1,6 +1,9 @@
-habitat_install "default" do
-  license "accept"
-end
+# TODO: habitat_install Windows kitchen test temporarily commented out while
+# ffi-libarchive/archive.dll loading issue with ruby3_4-plus-devkit/3.4.10
+# is being resolved in https://github.com/chef/chef/pull/16242
+# habitat_install "default" do
+#   license "accept"
+# end
 
 habitat_package "chef/splunkforwarder" do
   version "7.0.3/20250714155325"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
@@ -1,6 +1,6 @@
 # TODO: habitat_install Windows kitchen test temporarily commented out while
 # ffi-libarchive/archive.dll loading issue with ruby3_4-plus-devkit/3.4.10
-# is being resolved in https://github.com/chef/chef/pull/16242
+# is being resolved in https://github.com/chef/chef/pull/16242 - fail-after:2026-08-13
 # habitat_install "default" do
 #   license "accept"
 # end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -191,7 +191,7 @@ include_recipe "::_chef_client_trusted_certificate"
 
 # TODO: archive_file Windows kitchen test temporarily commented out while
 # ffi-libarchive/archive.dll loading issue with ruby3_4-plus-devkit/3.4.10
-# is being resolved in https://github.com/chef/chef/pull/16242
+# is being resolved in https://github.com/chef/chef/pull/16242 - fail-after:2026-08-13
 # %w{tourism.tar.gz tourism.tar.xz tourism.zip}.each do |archive|
 #   cookbook_file File.join(Chef::Config[:file_cache_path], archive) do
 #     source archive


### PR DESCRIPTION
<h2>Summary</h2>
<p>PR #16247 disabled the <code>archive_file</code> test block in <code>windows.rb</code>, but the Windows kitchen suite (<code>end_to_end</code>) is still failing on <code>win_x86_64</code> (windows-2022 / windows-2025), per <a href="https://github.com/chef/chef/pull/16235">#16235</a>'s run results:</p>
<pre>FATAL: NameError: habitat_install[default] (end_to_end::_habitat_win_package line 1)
had an error: NameError: archive_file[hab-x86_64-windows.zip]
had an error: NameError: uninitialized constant Chef::Resource::ArchiveFile::Archive
STDERR: ffi-libarchive could not be loaded ...</pre>

<h2>Root cause</h2>
<p><code>lib/chef/resource/habitat_install.rb</code>'s <code>:install</code> action has its own internal <code>archive_file</code> call (used to extract <code>hab-x86_64-windows.zip</code> on Windows) that #16247 didn't touch, that PR only disabled the test recipe's own separate <code>archive_file</code> block in <code>windows.rb</code>.</p>
<p>This is triggered specifically by <code>kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb</code>, which calls <code>habitat_install "default"</code> directly with no <code>hab_version</code> set, forcing an unconditional version-mismatch reinstall/extract every run. Every other <code>_habitat_win_*</code> recipe goes through <code>habitat_sup</code>'s wrapped <code>habitat_install</code> call, which is guarded by <code>not_if { File.exist?("c:/habitat/hab.exe") }</code>, since hab is already pre-baked into the AMI, those all skip the reinstall/extract step and never hit <code>archive_file</code>. Confirmed via repo-wide grep that no other recipe/resource in the Windows run list reaches <code>archive_file</code>.</p>

<h2>Fix</h2>
<p>Comment out the <code>habitat_install "default"</code> block in <code>_habitat_win_package.rb</code>, matching the same disable pattern and tracking reference (#16242) used in #16247. <code>habitat_package "chef/splunkforwarder"</code> is left active since hab is already installed on the test image.</p>

<h2>Testing</h2>
<ul>
<li>Ruby syntax validated with <code>ruby -c</code> on the changed file.</li>
<li>Repo-wide grep confirms no other reachable <code>archive_file</code> call sites remain in the Windows <code>end_to_end</code> kitchen run list.</li>
<li>No spec/unit tests affected, this is a kitchen integration test recipe only.</li>
</ul>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>
