### PR TITLE
Restore Windows kitchen recipes after upstream libarchive fix

### DIFF
--- a/.github/workflows/chronoguard.yml
+++ b/.github/workflows/chronoguard.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jaymzh/chronoguard@main
         with:
-          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml, habitat/aarch64-linux/plan.sh, .github/dependabot.yml, kitchen-tests/cookbooks/end_to_end/recipes/windows.rb, kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
+          files: .github/workflows/allchecks.yml, .github/workflows/kitchen.yml, habitat/aarch64-linux/plan.sh, .github/dependabot.yml

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb
@@ -1,9 +1,6 @@
-# TODO: habitat_install Windows kitchen test temporarily commented out while
-# ffi-libarchive/archive.dll loading issue with ruby3_4-plus-devkit/3.4.10
-# is being resolved in https://github.com/chef/chef/pull/16242 - fail-after:2026-08-13
-# habitat_install "default" do
-#   license "accept"
-# end
+habitat_install "default" do
+  license "accept"
+end
 
 habitat_package "chef/splunkforwarder" do
   version "7.0.3/20250714155325"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -189,19 +189,17 @@ end
 include_recipe "::_chef_client_config"
 include_recipe "::_chef_client_trusted_certificate"
 
-# TODO: archive_file Windows kitchen test temporarily commented out while
-# ffi-libarchive/archive.dll loading issue with ruby3_4-plus-devkit/3.4.10
-# is being resolved in https://github.com/chef/chef/pull/16242 - fail-after:2026-08-13
-# %w{tourism.tar.gz tourism.tar.xz tourism.zip}.each do |archive|
-#   cookbook_file File.join(Chef::Config[:file_cache_path], archive) do
-#     source archive
-#   end
-#
-#   archive_file archive do
-#     path File.join(Chef::Config[:file_cache_path], archive)
-#     extract_to File.join(Chef::Config[:file_cache_path], archive.tr(".", "_"))
-#   end
-# end
+# test various archive formats in the archive_file resource
+%w{tourism.tar.gz tourism.tar.xz tourism.zip}.each do |archive|
+  cookbook_file File.join(Chef::Config[:file_cache_path], archive) do
+    source archive
+  end
+
+  archive_file archive do
+    path File.join(Chef::Config[:file_cache_path], archive)
+    extract_to File.join(Chef::Config[:file_cache_path], archive.tr(".", "_"))
+  end
+end
 
 locale "set system locale" do
   lang "en-us"


### PR DESCRIPTION
<h2>Summary</h2>
<p>Reverts the temporary workarounds introduced in #16247 and #16249 that commented out <code>archive_file</code> and <code>habitat_install</code> tests in Windows kitchen recipes.</p>

<h2>Root Cause</h2>
<p>The <code>ffi-libarchive</code> gem was failing to load on Windows Habitat runs due to a missing <code>z.dll</code> dependency in <code>core/libarchive 3.8.1</code> (introduced in the <code>base-2025</code> channel). The <code>archive.dll</code> shipped by libarchive 3.8.1 links against <code>z.dll</code> (previously <code>zlib1.dll</code>), which was not being resolved at runtime.</p>

<h2>Fix</h2>
<p>The <code>core/libarchive</code> and <code>core/zlib</code> packages have been fixed upstream https://github.com/habitat-sh/foundational-packages/pull/275. Windows kitchen tests are now restored and passing.</p>

<h2>Changes</h2>
<ul>
  <li>Restores <code>archive_file</code> test block in <code>kitchen-tests/cookbooks/end_to_end/recipes/windows.rb</code></li>
  <li>Restores <code>habitat_install</code> block in <code>kitchen-tests/cookbooks/end_to_end/recipes/_habitat_win_package.rb</code></li>
  <li>Removes the two kitchen recipe files from <code>.github/workflows/chronoguard.yml</code> watched list (added as part of the workaround in #16249)</li>
</ul>