### PR TITLE
Add macOS aarch64-darwin tarball export for migration tooling

### DIFF
--- a/.expeditor/macos_universal_package.pipeline.yml
+++ b/.expeditor/macos_universal_package.pipeline.yml
@@ -1,1 +1,33 @@
-# This pipeline is currently under development.
+# Pipeline to export the macOS (aarch64-darwin) Habitat package for chef-infra-client
+# as a self-contained tarball and upload it to S3 for consumption by migration tooling.
+# This mirrors hab-export-pipeline.yml which does the same for x86_64-linux.
+---
+expeditor:
+  secrets:
+    PIPELINE_HAB_AUTH_TOKEN:
+      path: account/static/habitat/chef-ci
+      field: auth_token
+  accounts:
+    - aws/chef-cd
+  defaults:
+    buildkite:
+      timeout_in_minutes: 60
+      env:
+        HAB_ORIGIN: "chef"
+        PIPELINE_HAB_BLDR_URL: "https://bldr.habitat.sh"
+        HAB_STUDIO_SECRET_HAB_PREFER_LOCAL_CHEF_DEPS: "true"
+        HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: "unstable"
+
+steps:
+
+  - label: "[:mac: build hab-pkg-export-tar aarch64-darwin and upload to :amazon-s3:]"
+    command:
+      - echo "--- exporting aarch64-darwin tarball for chef/chef-infra-client"
+      - hab pkg export tar chef/chef-infra-client --channel unstable --target aarch64-darwin
+      - mkdir -p upload && find . -name "chef-chef-infra-client-*.tar.gz" | grep -E 'chef-chef-infra-client-[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.tar\.gz' | xargs -I {} cp {} upload/
+      - cd upload/ && buildkite-agent artifact upload "*.tar.gz" && aws s3 sync . s3://unstable-habitat-tarball/macos/ --exclude "*" --include "*.tar.gz" --region us-west-2 --profile chef-cd
+
+    expeditor:
+      executor:
+        macos:
+          os-version: "14"

--- a/.github/workflows/macos_verify.yml
+++ b/.github/workflows/macos_verify.yml
@@ -112,3 +112,32 @@ jobs:
         run: |
           source ./results/last_build.env
           sudo -E ./habitat/tests/test.darwin.sh "$pkg_ident"
+
+      - name: Export Habitat Package as macOS Tarball
+        run: |
+          source ./results/last_build.env
+          echo "Exporting $pkg_ident as a tarball for aarch64-darwin..."
+          sudo -E hab pkg export tar "$pkg_ident"
+          tarball=$(find . -maxdepth 1 -name "*.tar.gz" | head -1)
+          echo "MACOS_TARBALL=$tarball" >> "$GITHUB_ENV"
+          echo "Exported tarball: $tarball"
+
+      - name: Upload macOS Tarball as GitHub Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chef-infra-client-aarch64-darwin
+          path: "*.tar.gz"
+          retention-days: 30
+
+      - name: Upload macOS Tarball to S3
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          mkdir -p upload
+          find . -maxdepth 1 -name "*.tar.gz" | xargs -I {} cp {} upload/
+          aws s3 sync upload/ s3://unstable-habitat-tarball/macos/ \
+            --exclude "*" --include "*.tar.gz" \
+            --region us-west-2
+          echo "Uploaded tarball to s3://unstable-habitat-tarball/macos/"


### PR DESCRIPTION
<h2>Summary</h2>
<p>Adds the ability to produce a self-contained macOS (aarch64-darwin) tarball of Chef-19 that upstream migration tooling can consume to deploy Chef to macOS machines, without requiring the macOS Habitat client to be production-ready.</p>

<h2>Changes</h2>
<h3>.github/workflows/macos_verify.yml</h3>
<p>Extends the existing <code>habitat-plan</code> job with three new steps added after the test run:</p>
<ul>
  <li><strong>Export:</strong> runs <code>hab pkg export tar</code> on the locally-built package to produce a self-contained <code>.tar.gz</code></li>
  <li><strong>GitHub Artifact upload:</strong> uploads the tarball on every run (30-day retention) for easy download by engineers</li>
  <li><strong>S3 upload:</strong> syncs to <code>s3://unstable-habitat-tarball/macos/</code> on merges to <code>main</code> or manual <code>workflow_dispatch</code> runs, mirroring the Linux pattern</li>
</ul>

<h3>.expeditor/macos_universal_package.pipeline.yml</h3>
<p>Implements the previously stubbed pipeline. Uses <code>hab pkg export tar</code> with <code>--target aarch64-darwin</code> against the <code>unstable</code> channel, then uploads via <code>buildkite-agent artifact upload</code> and <code>aws s3 sync</code> — exactly mirroring <code>hab-export-pipeline.yml</code> for Linux.</p>

<h2>Notes</h2>
<ul>
  <li>AWS credentials for the GHA S3 upload step require <code>AWS_ACCESS_KEY_ID</code> and <code>AWS_SECRET_ACCESS_KEY</code> secrets to be added to the repository if not already present</li>
  <li>The Expeditor macOS executor (<code>macos: os-version: "14"</code>) will need a Buildkite macOS agent registered for that pipeline</li>
</ul>

<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>