### PR TITLE
docs: update win32-api repo link to chef-win32-api

### DIFF
--- a/docs/dev/how_to/community_pr_review_checklist.md
+++ b/docs/dev/how_to/community_pr_review_checklist.md
@@ -33,7 +33,7 @@ From there you should see a zoom link that links you to the meeting.
 - [Win32-TaskScheduler](https://github.com/chef/win32-taskscheduler) ![Open PRs](https://img.shields.io/github/issues-pr/chef/win32-taskscheduler) [Win32-TaskScheduler pull requests](https://github.com/chef/win32-taskscheduler/pulls)
 - [Win32-Process](https://github.com/chef/win32-process) ![Open PRs](https://img.shields.io/github/issues-pr/chef/win32-process) [Win32-Process pull requests](https://github.com/chef/win32-process/pulls)
 - [Win32-Event](https://github.com/chef/win32-event) ![Open PRs](https://img.shields.io/github/issues-pr/chef/win32-event) [Win32-Event pull requests](https://github.com/chef/win32-event/pulls)
-- [Win32-Api](https://github.com/chef/win32-api) ![Open PRs](https://img.shields.io/github/issues-pr/chef/win32-api) [Win32-Api pull requests](https://github.com/chef/win32-api/pulls)
+- [Chef-Win32-Api](https://github.com/chef/chef-win32-api) ![Open PRs](https://img.shields.io/github/issues-pr/chef/chef-win32-api) [Chef-Win32-Api pull requests](https://github.com/chef/chef-win32-api/pulls)
 - [Win32-Eventlog](https://github.com/chef/win32-eventlog) ![Open PRs](https://img.shields.io/github/issues-pr/chef/win32-eventlog) [Win32-Eventlog pull requests](https://github.com/chef/win32-eventlog/pulls)
 - [Ffi-Win32-Extensions](https://github.com/chef/ffi-win32-extensions) ![Open PRs](https://img.shields.io/github/issues-pr/chef/ffi-win32-extensions) [Ffi-Win32-Extensions pull requests](https://github.com/chef/ffi-win32-extensions/pulls)
 


### PR DESCRIPTION
<h2>Summary</h2><p>Updates the community PR review checklist to reference the correct repository name <code>chef/chef-win32-api</code> instead of the outdated <code>chef/win32-api</code>, consistent with the actual repo name.</p><p>This work was completed with AI assistance following Progress AI policies</p>