### PR TITLE
Add license_id property to chef_gem/gem_package for proprietary gem servers

### DIFF
--- a/lib/chef/licensing.rb
+++ b/lib/chef/licensing.rb
@@ -102,6 +102,15 @@ class Chef
         Chef::Application.exit! "Usage error", 1 # Generic failure
       end
 
+      # Currently persisted license keys, if any. Used as the default
+      # license id for authenticating to a proprietary gem server. Never
+      # raises: no license set/available just means no default.
+      def license_keys
+        ChefLicensing.license_keys
+      rescue ChefLicensing::Error, StandardError
+        []
+      end
+
       private
 
       # Returns true when license validation should be skipped.

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -18,6 +18,7 @@
 #
 
 autoload :URI, "uri"
+require "set"
 require_relative "../package"
 require_relative "../../resource/package"
 require_relative "../../mixin/get_source_from_package"
@@ -561,9 +562,74 @@ class Chef
         end
 
         def gem_sources
-          srcs = [ new_resource.source ]
+          srcs = [ new_resource.source ].flatten.compact.map { |s| with_license_auth(s) }
           srcs << (Chef::Config[:rubygems_url] || "https://rubygems.org") if include_default_source?
-          srcs.flatten.compact
+          srcs.reject { |s| self.class.failed_license_sources.include?(license_source_key(s)) }
+        end
+
+        # Embeds new_resource.license_id as HTTP Basic Auth userinfo on
+        # http(s) source URLs -- the standard rubygems mechanism for
+        # authenticating to a private gem server -- unless the URL already
+        # carries credentials.
+        def with_license_auth(src)
+          return src unless new_resource.license_id && src.is_a?(String)
+
+          uri = URI.parse(src)
+          return src unless %w{http https}.include?(uri.scheme) && uri.user.nil?
+
+          uri.user = new_resource.license_id
+          uri.to_s
+        rescue URI::InvalidURIError
+          # ponytail: non-URL sources (e.g. local .gem paths) are left untouched
+          src
+        end
+
+        # Identity of a source ignoring credentials, used to remember a
+        # licensed source that failed without needing to know its license id.
+        # Returns nil for sources with no embedded credentials (nothing to
+        # remember/exclude) or that aren't URLs.
+        def license_source_key(src)
+          return nil unless src
+
+          uri = URI.parse(src.to_s)
+          return nil unless uri.user
+
+          "#{uri.scheme}://#{uri.host}:#{uri.port}#{uri.path}"
+        rescue URI::InvalidURIError
+          nil
+        end
+
+        def license_source_key_from_error(error)
+          uri = error.respond_to?(:uri) ? error.uri : (error.respond_to?(:source) ? error.source&.uri : nil)
+          license_source_key(uri)
+        end
+
+        ##
+        # Retries once, dropping a proprietary gem source that just failed to
+        # authenticate/fetch from, then remembers it for the remainder of
+        # this chef-client run (ponytail: process-scoped only, resets each
+        # run -- not persisted to disk) so later resources fall straight
+        # through to the remaining gem sources instead of retrying a known-
+        # broken server.
+        def with_license_fallback
+          yield
+        rescue Gem::RemoteFetcher::FetchError, Gem::SourceFetchProblem => e
+          key = license_source_key_from_error(e)
+          raise unless key && !self.class.failed_license_sources.include?(key)
+
+          logger.warn("#{new_resource} failed to fetch from licensed gem source (#{e.message}); falling back to remaining gem sources for the rest of this run.")
+          self.class.failed_license_sources << key
+          yield
+        end
+
+        class << self
+          # ponytail: process-scoped memo (resets every chef-client run,
+          # not persisted to disk) of proprietary gem sources that failed
+          # to authenticate/fetch, so later resources in the same run skip
+          # them instead of retrying.
+          def failed_license_sources
+            @failed_license_sources ||= Set.new
+          end
         end
 
         def load_current_resource
@@ -593,7 +659,7 @@ class Chef
 
         def candidate_version
           @candidate_version ||= if source_is_remote?
-                                   @gem_env.candidate_version_from_remote(gem_dependency, *gem_sources).to_s
+                                   with_license_fallback { @gem_env.candidate_version_from_remote(gem_dependency, *gem_sources).to_s }
                                  else
                                    @gem_env.candidate_version_from_file(gem_dependency, new_resource.source).to_s
                                  end
@@ -614,11 +680,13 @@ class Chef
         def install_package(name, version)
           if source_is_remote? && new_resource.gem_binary.nil?
             if new_resource.options.nil?
-              @gem_env.install(gem_dependency, sources: gem_sources)
+              with_license_fallback { @gem_env.install(gem_dependency, sources: gem_sources) }
             elsif new_resource.options.is_a?(Hash)
-              options = new_resource.options
-              options[:sources] = gem_sources
-              @gem_env.install(gem_dependency, options)
+              with_license_fallback do
+                options = new_resource.options
+                options[:sources] = gem_sources
+                @gem_env.install(gem_dependency, options)
+              end
             else
               install_via_gem_command(name, version)
             end

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -17,6 +17,7 @@
 #
 
 require_relative "package"
+require_relative "../licensing"
 require "chef-utils/dist" unless defined?(ChefUtils::Dist)
 
 class Chef
@@ -96,6 +97,12 @@ class Chef
 
       property :options, [ String, Hash, Array, nil ],
         description: "Options for the gem install, either a Hash or a String. When a hash is given, the options are passed to `Gem::DependencyInstaller.new`, and the gem will be installed via the gems API. When a String is given, the gem will be installed by shelling out to the gem command. Using a Hash of options with an explicit gem_binary will result in undefined behavior.",
+        desired_state: false
+
+      property :license_id, String,
+        description: "The Chef license id used to authenticate against a proprietary #{ChefUtils::Dist::Infra::PRODUCT} gem server. Embedded as HTTP Basic Auth credentials on any `http`/`https` URLs in `source`.",
+        default: lazy { Chef::Licensing.license_keys.first },
+        default_description: "The current node's already-persisted Chef license, if any.",
         desired_state: false
     end
   end

--- a/spec/integration/provider/package/rubygems_license_auth_spec.rb
+++ b/spec/integration/provider/package/rubygems_license_auth_spec.rb
@@ -1,0 +1,93 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "rubygems/remote_fetcher"
+
+# Integration coverage for chef_gem/gem_package's `license_id` property:
+# drives the real rubygems networking code (Gem::RemoteFetcher) against a
+# WebMock-stubbed proprietary gem server to prove the license id is actually
+# sent as HTTP Basic Auth, and that the provider's fallback/memoization
+# kicks in on an auth failure -- not just that a URL string was built.
+describe "gem_package license_id authentication" do
+  let(:new_resource) { Chef::Resource::GemPackage.new("rspec-core") }
+
+  let(:provider) do
+    run_context = Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
+    Chef::Provider::Package::Rubygems.new(new_resource, run_context)
+  end
+
+  let(:license_id) { "my-proprietary-license-id" }
+  let(:private_source) { "https://gems.example.com/private" }
+
+  before do
+    new_resource.source(private_source)
+    new_resource.license_id(license_id)
+    new_resource.include_default_source(false)
+    Chef::Provider::Package::Rubygems.instance_variable_set(:@failed_license_sources, nil)
+  end
+
+  after do
+    Chef::Provider::Package::Rubygems.instance_variable_set(:@failed_license_sources, nil)
+  end
+
+  it "authenticates real requests to the proprietary gem server with the license id" do
+    authed_source = provider.gem_sources.first
+    expect(authed_source).to eq("https://#{license_id}@gems.example.com/private")
+
+    stub_request(:get, "https://gems.example.com/private")
+      .with(basic_auth: [license_id, ""])
+      .to_return(status: 200, body: "OK")
+
+    # exercises the same rubygems HTTP client Gem::DependencyInstaller uses
+    Gem::RemoteFetcher.fetcher.fetch_path(URI.parse(authed_source))
+
+    expect(WebMock).to have_requested(:get, "https://gems.example.com/private")
+      .with(basic_auth: [license_id, ""])
+  end
+
+  it "falls back to the remaining sources and remembers the proprietary server as broken for the rest of the run" do
+    new_resource.include_default_source(true)
+    authed_source = "https://#{license_id}@gems.example.com/private"
+
+    stub_request(:get, "https://gems.example.com/private")
+      .with(basic_auth: [license_id, ""])
+      .to_return(status: 401, body: "Unauthorized")
+
+    attempts = 0
+    remaining_sources = provider.with_license_fallback do
+      attempts += 1
+      Gem::RemoteFetcher.fetcher.fetch_path(URI.parse(authed_source)) if attempts == 1
+      provider.gem_sources
+    end
+
+    expect(attempts).to eq(2)
+    expect(remaining_sources).to eq(["https://rubygems.org"])
+    expect(WebMock).to have_requested(:get, "https://gems.example.com/private").once
+
+    # a later gem_package resource in the same chef-client run should not
+    # retry the known-broken proprietary source at all
+    later_attempts = 0
+    later_sources = provider.with_license_fallback do
+      later_attempts += 1
+      provider.gem_sources
+    end
+    expect(later_attempts).to eq(1)
+    expect(later_sources).to eq(["https://rubygems.org"])
+    expect(WebMock).to have_requested(:get, "https://gems.example.com/private").once
+  end
+end

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -1202,6 +1202,89 @@ describe Chef::Provider::Package::Rubygems, "clear_sources?" do
   end
 end
 
+describe Chef::Provider::Package::Rubygems, "license_id auth on gem_sources" do
+  let(:new_resource) do
+    Chef::Resource::GemPackage.new("foo")
+  end
+
+  let(:provider) do
+    run_context = Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
+    Chef::Provider::Package::Rubygems.new(new_resource, run_context)
+  end
+
+  # the memo is process-scoped (class-level) so reset it around every spec
+  before { described_class.instance_variable_set(:@failed_license_sources, nil) }
+  after { described_class.instance_variable_set(:@failed_license_sources, nil) }
+
+  context "when license_id is set and source is an http(s) URL" do
+    before do
+      new_resource.source("https://gems.chef.io/private")
+      new_resource.license_id("my-license-id")
+    end
+
+    it "embeds the license id as HTTP Basic Auth userinfo" do
+      expect(provider.gem_sources).to include("https://my-license-id@gems.chef.io/private")
+    end
+
+    it "does not embed the license id in the default rubygems.org source" do
+      expect(provider.gem_sources).to include("https://rubygems.org")
+    end
+
+    it "does not clobber a source that already carries credentials" do
+      new_resource.source("https://user:pass@gems.chef.io/private")
+      expect(provider.gem_sources).to include("https://user:pass@gems.chef.io/private")
+    end
+
+    it "leaves a local gem file path untouched" do
+      new_resource.source("/tmp/foo.gem")
+      expect(provider.gem_sources).to include("/tmp/foo.gem")
+    end
+  end
+
+  context "when license_id is not set" do
+    before { new_resource.source("https://gems.chef.io/private") }
+
+    it "leaves the source untouched" do
+      expect(provider.gem_sources).to include("https://gems.chef.io/private")
+    end
+  end
+
+  context "when a licensed source previously failed to fetch/authenticate" do
+    before do
+      new_resource.source("https://gems.chef.io/private")
+      new_resource.license_id("my-license-id")
+    end
+
+    it "falls back to the remaining sources and remembers the failure for the rest of this run" do
+      attempts = 0
+      result = provider.with_license_fallback do
+        attempts += 1
+        raise Gem::RemoteFetcher::FetchError.new("401 Unauthorized", "https://my-license-id@gems.chef.io/private") if attempts == 1
+
+        provider.gem_sources
+      end
+
+      expect(attempts).to eq(2)
+      expect(result).to eq(["https://rubygems.org"])
+
+      # a later resource in the same process run skips the known-bad source immediately
+      later_attempts = 0
+      later_result = provider.with_license_fallback do
+        later_attempts += 1
+        provider.gem_sources
+      end
+      expect(later_attempts).to eq(1)
+      expect(later_result).to eq(["https://rubygems.org"])
+    end
+
+    it "re-raises when the fetch error is unrelated to a licensed source" do
+      expect do
+        provider.with_license_fallback { raise Gem::RemoteFetcher::FetchError.new("boom", "https://rubygems.org") }
+      end.to raise_error(Gem::RemoteFetcher::FetchError)
+    end
+  end
+end
+
 describe Chef::Provider::Package::Rubygems, "include_default_source?" do
   let(:new_resource) do
     Chef::Resource::GemPackage.new("foo")

--- a/spec/unit/resource/gem_package_spec.rb
+++ b/spec/unit/resource/gem_package_spec.rb
@@ -65,3 +65,23 @@ describe Chef::Resource::GemPackage, "clear_sources" do
     expect(resource.clear_sources).to be true
   end
 end
+
+describe Chef::Resource::GemPackage, "license_id" do
+  let(:resource) { Chef::Resource::GemPackage.new("foo") }
+
+  it "defaults to the node's already-persisted Chef license, if any" do
+    allow(Chef::Licensing).to receive(:license_keys).and_return(%w{persisted-license-id})
+    expect(resource.license_id).to eq("persisted-license-id")
+  end
+
+  it "defaults to nil when no license is persisted" do
+    allow(Chef::Licensing).to receive(:license_keys).and_return([])
+    expect(resource.license_id).to be_nil
+  end
+
+  it "can be set explicitly, overriding the persisted license" do
+    allow(Chef::Licensing).to receive(:license_keys).and_return(%w{persisted-license-id})
+    resource.license_id("explicit-license-id")
+    expect(resource.license_id).to eq("explicit-license-id")
+  end
+end


### PR DESCRIPTION
<h2>Summary</h2>
<p>This work was completed with AI assistance following Progress AI policies.</p>
<p>Adds a <code>license_id</code> property to <code>gem_package</code> (inherited by <code>chef_gem</code>) so gems can be installed from a proprietary Chef gem server that authenticates via the Chef license id.</p>
<ul>
<li><code>license_id</code> defaults to the node&#39;s already-persisted Chef license (<code>Chef::Licensing.license_keys.first</code>), but can be set explicitly.</li>
<li>When set, <code>Chef::Provider::Package::Rubygems#gem_sources</code> embeds it as HTTP Basic Auth userinfo on the resource&#39;s own <code>http</code>/<code>https</code> <code>source</code> URL(s) &mdash; the standard rubygems mechanism for authenticating to a private gem server. The default <code>rubygems.org</code> fallback source and any URL that already carries credentials are left untouched.</li>
<li>If the proprietary source fails to authenticate/fetch, the provider retries with the remaining gem sources and remembers the failure (in-memory, for the rest of the chef-client run) via a process-scoped memo, so later <code>gem_package</code>/<code>chef_gem</code> resources in the same run skip straight to the remaining sources instead of retrying a known-broken server.</li>
</ul>
<h2>Testing</h2>
<ul>
<li>Unit specs added to <code>spec/unit/resource/gem_package_spec.rb</code> and <code>spec/unit/provider/package/rubygems_spec.rb</code> for the property default/override, URL auth-embedding, and fallback/memoization behavior.</li>
<li>New integration spec <code>spec/integration/provider/package/rubygems_license_auth_spec.rb</code> uses WebMock to stand up a fake proprietary gem server and drives real rubygems networking code (<code>Gem::RemoteFetcher</code>) to prove the license id is sent as a real HTTP Basic Auth header, and that a 401 triggers the fallback/memoization path end-to-end.</li>
</ul>
<h2>Out of scope</h2>
<ul>
<li>Shell-out (<code>gem install</code> CLI string options) fallback/memoization path.</li>
<li>Persisting the failure memo to disk across separate chef-client process runs (in-memory/process-scoped only, per design discussion).</li>
</ul>