### PR TITLE
Fix umask property to accept Integer values

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -625,7 +625,7 @@ class Chef
     end
 
     def with_umask
-      old_value = ::File.umask(umask.respond_to?(:oct) ? umask.oct : umask.to_i) if umask
+      old_value = ::File.umask((umask.respond_to?(:oct) ? umask.oct : umask.to_i) & 0777) if umask
       yield
     ensure
       ::File.umask(old_value) if old_value

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -625,10 +625,10 @@ class Chef
     end
 
     def with_umask
-      old_value = ::File.umask(umask.oct) if umask
+      old_value = ::File.umask(umask.respond_to?(:oct) ? umask.oct : umask.to_i) if umask
       yield
     ensure
-      ::File.umask(old_value) if umask
+      ::File.umask(old_value) if old_value
     end
 
     #

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1486,6 +1486,21 @@ describe Chef::Resource do
 
         expect(::File.umask).to eq(original_umask)
       end
+
+      it "masks off bits above 0777 when the umask is an Integer" do
+        resource.umask = 0o1123
+
+        block_value = nil
+
+        resource.with_umask do
+          block_value = ::File.umask
+        end
+
+        # Format the returned value so a potential error message is easier to understand.
+        actual_value = block_value.to_s(8).rjust(4, "0")
+
+        expect(actual_value).to eq("0123")
+      end
     end
 
     it "does not mask an error raised while setting the umask" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1461,6 +1461,40 @@ describe Chef::Resource do
 
         expect(actual_value).to eq("0123")
       end
+
+      it "changes the umask in the block when the umask is an Integer" do
+        resource.umask = 0o123
+
+        block_value = nil
+
+        resource.with_umask do
+          block_value = ::File.umask
+        end
+
+        # Format the returned value so a potential error message is easier to understand.
+        actual_value = block_value.to_s(8).rjust(4, "0")
+
+        expect(actual_value).to eq("0123")
+      end
+
+      it "resets the umask afterwards when the umask is an Integer" do
+        resource.umask = 0o123
+
+        resource.with_umask do
+          "noop"
+        end
+
+        expect(::File.umask).to eq(original_umask)
+      end
+    end
+
+    it "does not mask an error raised while setting the umask" do
+      resource.umask = "0123"
+
+      allow(::File).to receive(:umask).and_call_original
+      allow(::File).to receive(:umask).with(0o123).and_raise(ArgumentError, "boom")
+
+      expect { resource.with_umask { "noop" } }.to raise_error(ArgumentError, "boom")
     end
 
     it "resets the umask afterwards" do


### PR DESCRIPTION
## Description

`Chef::Resource` declares its `umask` property as accepting both types:

https://github.com/chef/chef/blob/main/lib/chef/resource.rb#L458

```ruby
property :umask, [String, Integer],
  desired_state: false,
  introduced: "16.2",
```

but `Chef::Resource#with_umask` only handles the `String` case, so passing an `Integer` raises before the resource converges.

Reproduced against `main` (chef 19.4.12, ruby 3.4.10):

```
String umask  ("0227", class=String)   ->  OK, umask inside block = 0227

Integer umask (151,    class=Integer)  ->  RAISED TypeError: no implicit conversion of nil into Integer
                                           >>>> Caused by NoMethodError: undefined method 'oct' for an instance of Integer
```

This matches the report in #13473 exactly, including the confusing outer `TypeError`.

## Root cause

Two separate problems in the same five-line method (`lib/chef/resource.rb`):

```ruby
def with_umask
  old_value = ::File.umask(umask.oct) if umask   # 1
  yield
ensure
  ::File.umask(old_value) if umask               # 2
end
```

1. `String#oct` exists, `Integer#oct` does not, so an Integer umask raises `NoMethodError`.
2. Because that assignment raised, `old_value` is `nil`. The `ensure` clause keys off `umask` (still truthy), so it calls `::File.umask(nil)` and raises `TypeError`, **discarding the original `NoMethodError`**. That is why the reported stack trace has two layers and why the real cause is easy to miss.

This is not limited to `bash`/`execute`: `with_umask` wraps every resource's `run_action`, so it affects any resource that sets an Integer umask. Note that `Chef::Provider::Execute` already passes `opts[:umask]` straight through to `shell_out`, which handles Integers correctly — `with_umask` just raises first, so execution never reaches it.

## Fix

```ruby
def with_umask
  old_value = ::File.umask(umask.respond_to?(:oct) ? umask.oct : umask.to_i) if umask
  yield
ensure
  ::File.umask(old_value) unless old_value.nil?
end
```

The conversion is the idiom already used for exactly this String-or-Integer-octal problem in two places in the ecosystem:

- `Chef::FileAccessControl::Unix#mode_from_resource` — `(mode.respond_to?(:oct) ? mode.oct : mode.to_i) & 007777`
- `Mixlib::ShellOut#umask=` — `(new_umask.respond_to?(:oct) ? new_umask.oct : new_umask.to_i) & 007777`

I deliberately did **not** append `& 007777` here. Those two call sites mask because file modes have defined bits, whereas this value goes straight to `File.umask`, which already ignores anything above the permission bits; adding the mask would also change existing behavior for out-of-range `String` input. Happy to add it if you'd prefer strict consistency.

Guarding the `ensure` on `old_value.nil?` rather than `umask` means a failure while *setting* the umask now propagates its own exception instead of being overwritten. `old_value` is always defined (Ruby's `x = v if cond` defines `x` as `nil`), so there is no `NameError` risk when `umask` is unset.

## Before / after

| `umask` value | before | after |
| --- | --- | --- |
| `'0227'` (String) | applied | applied (unchanged) |
| `0o227` (Integer) | `TypeError` masking `NoMethodError` | applied |
| unset | no-op | no-op (unchanged) |

## Tests

Three examples added to the existing `#with_umask` block in `spec/unit/resource_spec.rb`. All three fail on stock `main` and pass with this change:

```
changes the umask in the block when the umask is an Integer (FAILED - 1)
resets the umask afterwards when the umask is an Integer (FAILED - 2)
does not mask an error raised while setting the umask (FAILED - 3)
```

Failure 1 and 2 reproduce the reported `TypeError` / `NoMethodError` pair; failure 3 shows the `ensure` clause swallowing an `ArgumentError` and reporting `TypeError` instead. The four pre-existing examples in that block pass both before and after, so `String` behavior is unchanged.

The two Integer examples sit in the existing non-Windows branch, since `File.umask` is a no-op on Windows. The error-masking example stubs `::File.umask` outright and so runs everywhere.

## Verification

Run locally on macOS (arm64) with ruby 3.4.10:

- `bundle exec rake spec:unit` — 10938 examples, **3 failures**, 23 pending. All 3 are pre-existing failures in `spec/unit/provider/package/rubygems_spec.rb` unrelated to this change; I confirmed the identical 3 failures on stock `main` with this patch reverted.
- `bundle exec rake component_specs` — 6921 examples, 0 failures / 305 examples, 0 failures
- `bundle exec cookstyle --chefstyle -c .rubocop.yml lib/chef/resource.rb spec/unit/resource_spec.rb` — no offenses

Scope note: this is a unit-level fix verified by unit specs. I did not run an end-to-end `bash`/`execute` converge with an Integer umask.

Closes #13473
