### PR TITLE
Parameterize apt_update.ignore_failure in the apt_repository resource

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -176,6 +176,10 @@ class Chef
         description: "Determines whether to rebuild the APT package cache.",
         default: true, desired_state: false
 
+      property :cache_rebuild_ignore_failure, [TrueClass, FalseClass],
+        description: "Determines whether to fail the run if rebuilding the APT package cache fails.",
+        default: true, desired_state: false
+
       property :options, [String, Array],
         description: "Additional options to set for the repository",
         default: [], coerce: proc { |x| Array(x) }
@@ -554,7 +558,7 @@ class Chef
         end
 
         apt_update new_resource.name do
-          ignore_failure true
+          ignore_failure new_resource.cache_rebuild_ignore_failure
           action :nothing
         end
 

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -73,6 +73,23 @@ describe Chef::Resource::AptRepository do
     expect(resource.options).to eql(["by-hash=no"])
   end
 
+  it "cache_rebuild defaults to true" do
+    expect(resource.cache_rebuild).to be true
+  end
+
+  it "cache_rebuild_ignore_failure defaults to true" do
+    expect(resource.cache_rebuild_ignore_failure).to be true
+  end
+
+  it "allows setting cache_rebuild_ignore_failure to false" do
+    resource.cache_rebuild_ignore_failure false
+    expect(resource.cache_rebuild_ignore_failure).to be false
+  end
+
+  it "only accepts true or false for cache_rebuild_ignore_failure" do
+    expect { resource.cache_rebuild_ignore_failure "yes" }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
   it "fails if the user provides a repo_name with a forward slash" do
     expect { resource.repo_name "foo/bar" }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
Following [a discussion on
Slack](https://chefcommunity.slack.com/archives/C55FCUGBS/p1786113448358729), I'd like to propose a parameter to be able to turn off the hard-coded `ignore_failure true` on the `apt_update` resource called when adding an `apt_repository`.

This behaviour can make a real problem go unnoticed on the first run when adding a faulty APT repository.

I contemplated changing the default to false, but didn't want to intervene with existing processes too much.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
