### PR TITLE
[Chef-18] backport: Parameterize apt_update.ignore_failure in the apt_repository resource…

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -176,6 +176,10 @@ class Chef
         description: "Determines whether to rebuild the APT package cache.",
         default: true, desired_state: false
 
+      property :cache_rebuild_ignore_failure, [TrueClass, FalseClass],
+        description: "Determines whether to fail the run if rebuilding the APT package cache fails.",
+        default: true, desired_state: false
+
       property :options, [String, Array],
         description: "Additional options to set for the repository.",
         default: [], coerce: proc { |x| Array(x) }
@@ -554,7 +558,7 @@ class Chef
         end
 
         apt_update new_resource.name do
-          ignore_failure true
+          ignore_failure new_resource.cache_rebuild_ignore_failure
           action :nothing
         end
 

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -73,6 +73,23 @@ describe Chef::Resource::AptRepository do
     expect(resource.options).to eql(["by-hash=no"])
   end
 
+  it "cache_rebuild defaults to true" do
+    expect(resource.cache_rebuild).to be true
+  end
+
+  it "cache_rebuild_ignore_failure defaults to true" do
+    expect(resource.cache_rebuild_ignore_failure).to be true
+  end
+
+  it "allows setting cache_rebuild_ignore_failure to false" do
+    resource.cache_rebuild_ignore_failure false
+    expect(resource.cache_rebuild_ignore_failure).to be false
+  end
+
+  it "only accepts true or false for cache_rebuild_ignore_failure" do
+    expect { resource.cache_rebuild_ignore_failure "yes" }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
   it "fails if the user provides a repo_name with a forward slash" do
     expect { resource.repo_name "foo/bar" }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
Backports #16262 to Chef 18.