### PR TITLE
fix: pass `--clear-sources` when listing available gems

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -387,7 +387,10 @@ class Chef
           end
 
           def candidate_version_from_remote(gem_dependency, *sources)
-            source_args = sources.compact.map { |s| "--source=#{s}" }.join(" ")
+            src = []
+            src << "--clear-sources" if clear_sources?
+            src += sources.compact.map { |s| "--source=#{s}" }
+            source_args = src.join(" ")
             cmd = "#{@gem_binary_location} list #{gem_dependency.name} --remote --all #{source_args}"
             result = shell_out!(cmd)
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
A simple attempt to fix: https://github.com/chef/chef/issues/16266

When querying for the available versions of a gem from a remote source, `--clear-sources` was not being passed even if the attribute `clear_sources true` was set. However `--clear-sources` is provided when installing the gem. This results in the `chef_gem` resource (perhaps other places too?) failing to install when a version of a gem exists in a source that is not the `source` within the `chef_gem` resource.

Note: I have not currently tested this. I tried to adapt the approach in `install_via_gem_command` into `candidate_version_from_remote`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/16266

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco). (obvious fix in this case)
