### PR TITLE
Updating FFI for Chef-PowerShell dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,6 +527,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   powerpc-aix-7
+  ruby
   x64-mingw-ucrt
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,6 @@ GEM
       ffi
     ffi-yajl (2.7.7)
       libyajl2 (>= 2.1)
-      yajl
     ffi-yajl (2.7.11-universal-mingw-ucrt)
       libyajl2 (>= 2.1)
     fuzzyurl (0.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
-    ffi-yajl (2.7.7)
+    ffi-yajl (2.7.11)
       libyajl2 (>= 2.1)
     ffi-yajl (2.7.11-universal-mingw-ucrt)
       libyajl2 (>= 2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.1.2)
+    bigdecimal (4.1.1)
     binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
     builder (3.3.0)
@@ -270,9 +270,8 @@ GEM
     ffi-yajl (2.7.7)
       libyajl2 (>= 2.1)
       yajl
-    ffi-yajl (2.7.7-universal-mingw-ucrt)
+    ffi-yajl (2.7.11-universal-mingw-ucrt)
       libyajl2 (>= 2.1)
-      yajl
     fuzzyurl (0.9.0)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
@@ -524,7 +523,6 @@ GEM
       structured_warnings
     wisper (2.0.1)
     wmi-lite (1.0.7)
-    yajl (0.3.4)
     zlib (3.2.3)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 31b00ef92cad7d3d229ae609a87af41574781076
+  revision: cc226beac38274e2da2290ba162aa8c26d58c8e8
   branch: 18-stable
   specs:
-    ohai (18.2.20)
+    ohai (18.2.21)
       chef-config (>= 14.12, < 19)
       chef-utils (>= 16.0, < 19)
       ffi (~> 1.9, <= 1.18.0)
@@ -24,6 +24,7 @@ GIT
   specs:
     rest-client (2.1.0)
       base64
+      ffi (>= 1.15.5, < 1.18.0)
       http-accept (~> 2.1.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -50,9 +51,9 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 2.1.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5, <= 1.16.3)
+      ffi (>= 1.15.5, < 1.18.0)
       ffi-libarchive (~> 1.0, >= 1.0.3)
-      ffi-yajl (>= 2.2, < 4.0)
+      ffi-yajl (>= 2.2, < 4.0, != 3.0.0)
       iniparse (~> 1.4)
       inspec-core (>= 5, < 8)
       license-acceptance (>= 1.0.5, < 3)
@@ -86,9 +87,9 @@ PATH
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 2.1.0, != 1.4.0)
       erubis (~> 2.7)
-      ffi (>= 1.15.5, <= 1.16.3)
+      ffi (>= 1.15.5, < 1.18.0)
       ffi-libarchive (~> 1.0, >= 1.0.3)
-      ffi-yajl (>= 2.2, < 4.0)
+      ffi-yajl (>= 2.2, < 4.0, != 3.0.0)
       iniparse (~> 1.4)
       inspec-core (>= 5, < 8)
       iso8601 (>= 0.12.1, < 0.14)
@@ -155,8 +156,8 @@ GEM
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1234.0)
-    aws-sdk-core (3.244.0)
+    aws-partitions (1.1280.0)
+    aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -164,21 +165,21 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.123.0)
-      aws-sdk-core (~> 3, >= 3.244.0)
+    aws-sdk-kms (1.130.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-s3 (1.218.0)
       aws-sdk-core (~> 3, >= 3.244.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
-    aws-sdk-secretsmanager (1.129.0)
-      aws-sdk-core (~> 3, >= 3.244.0)
+    aws-sdk-secretsmanager (1.134.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
     builder (3.3.0)
@@ -230,16 +231,16 @@ GEM
       logger (< 1.6.0)
       net-ssh
     coderay (1.1.3)
-    concurrent-ruby (1.3.7)
+    concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
-    cookstyle (8.6.10)
-      rubocop (= 1.84.2)
-    corefoundation (0.3.13)
+    cookstyle (8.7.6)
+      rubocop (= 1.86.1)
+    corefoundation (0.3.19)
       ffi (>= 1.15.0)
     crack (1.0.1)
       bigdecimal
       rexml
-    csv (3.3.5)
+    csv (3.3.6)
     date (3.5.1)
     debug_inspector (1.2.0)
     diff-lcs (1.6.2)
@@ -255,20 +256,23 @@ GEM
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     fauxhai-ng (9.3.0)
       net-ssh
-    ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
+    ffi (1.17.4)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x64-mingw-ucrt)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
       ffi
-    ffi-yajl (2.7.11)
+    ffi-yajl (2.7.7)
       libyajl2 (>= 2.1)
-    ffi-yajl (2.7.11-universal-mingw-ucrt)
+      yajl
+    ffi-yajl (2.7.7-universal-mingw-ucrt)
       libyajl2 (>= 2.1)
+      yajl
     fuzzyurl (0.9.0)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
@@ -276,7 +280,7 @@ GEM
     hashie (5.1.0)
       logger
     http-accept (2.1.1)
-    http-cookie (1.1.0)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
@@ -311,8 +315,8 @@ GEM
     ipaddress (0.8.3)
     iso8601 (0.13.0)
     jmespath (1.6.2)
-    json (2.19.9)
-    language_server-protocol (3.17.0.5)
+    json (2.21.2)
+    language_server-protocol (3.17.0.6)
     libyajl2 (2.1.0)
     license-acceptance (2.1.13)
       pastel (~> 0.7)
@@ -329,15 +333,14 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0203)
+    mime-types-data (3.2026.0701)
     mixlib-archive (1.3.3)
       mixlib-log
     mixlib-authentication (3.0.10)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
-    mixlib-log (3.1.2.1)
-      ffi (< 1.17.0)
+    mixlib-log (3.0.9)
     mixlib-shellout (3.4.10)
       chef-utils
     mixlib-shellout (3.4.10-x64-mingw-ucrt)
@@ -361,13 +364,14 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
-    net-ssh (7.3.2)
+    net-ssh (7.3.3)
     netrc (0.11.0)
-    nori (2.7.0)
+    nori (2.9.1)
       bigdecimal
+      stringio
     openssl (3.3.0)
     parallel (1.28.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)
@@ -411,18 +415,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.84.2)
+    rubocop (1.86.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     ruby-progressbar (1.13.0)
@@ -432,6 +436,7 @@ GEM
     semverse (3.0.2)
     socksify (1.8.1)
     sslshake (1.3.1)
+    stringio (3.2.0)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)
@@ -444,7 +449,7 @@ GEM
     thor (1.4.0)
     time (0.4.2)
       date
-    timeout (0.6.0)
+    timeout (0.6.1)
     tomlrb (1.3.0)
     train-core (3.16.5)
       addressable (~> 2.5)
@@ -511,20 +516,20 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.10.0)
       ffi (>= 1.0.0)
-    win32-service (2.3.2)
-      ffi
+    win32-service (2.4.0)
+      ffi (~> 1.17.2)
       ffi-win32-extensions
     win32-taskscheduler (2.0.4)
       ffi
       structured_warnings
     wisper (2.0.1)
     wmi-lite (1.0.7)
+    yajl (0.3.4)
     zlib (3.2.3)
 
 PLATFORMS
   arm64-darwin-21
   powerpc-aix-7
-  ruby
   x64-mingw-ucrt
 
 DEPENDENCIES

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -53,8 +53,11 @@ Gem::Specification.new do |s|
     s.add_dependency "inspec-core", ">= 5", "< 8"
   end
 
-  s.add_dependency "ffi", ">= 1.15.5", "<= 1.16.3"
-  s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"
+  s.add_dependency "ffi", ">= 1.15.5", "< 1.18.0"
+  # ffi-yajl has a stale version in 3.0.0 specifically that is in use. 3.0.1 and higher is ok again
+  s.add_dependency "ffi-yajl", ">= 2.2", "!= 3.0.0", "< 4.0"
+  # s.add_dependency "ffi", ">= 1.15.5", "<= 1.16.3"
+  # s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"
   s.add_dependency "net-sftp", ">= 2.1.2", "< 5.0" # remote_file resource
   s.add_dependency "net-ftp" # remote_file resource
   s.add_dependency "erubis", "~> 2.7" # template resource / cookbook syntax check

--- a/kitchen-tests/kitchen.exec.windows.yml
+++ b/kitchen-tests/kitchen.exec.windows.yml
@@ -14,8 +14,8 @@ lifecycle:
     - remote: $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
     - remote: chef-client -v
     - remote: ohai -v
-    - remote: rake --version
-    - remote: bundle -v
+    - remote: C:\opscode\chef\embedded\bin\rake --version
+    - remote: C:\opscode\chef\embedded\bin\bundle -v
     - remote: $env:OHAI_VERSION = ( Select-String -Path .\Gemfile.lock -Pattern '(?<=ohai \()\d.*(?=\))' | ForEach-Object { $_.Matches[0].Value } )
     # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
     # This leads to failures during testing. Moving that file to its correct position here.
@@ -30,11 +30,11 @@ lifecycle:
     # if a different version of ffi-yajl is installed, then libyajl2 needs to be reinstalled
     # so that libyajldll.a is present in the intermediate build step. bundler seems to skip
     # libyajl2 build if already present. gem install seems to build anyway.
-    - remote: gem uninstall -I libyajl2
-    - remote: gem install appbundler --no-doc
-    - remote: gem install appbundle-updater -v "~> 1.0.36" --no-doc
+    - remote: C:\opscode\chef\embedded\bin\gem uninstall -I libyajl2
+    - remote: C:\opscode\chef\embedded\bin\gem install appbundler --no-doc
+    - remote: C:\opscode\chef\embedded\bin\gem install appbundle-updater -v "~> 1.0.36" --no-doc
     - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    - remote: appbundle-updater chef chef <%= ENV['GITHUB_SHA']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>
+    - remote: C:\opscode\chef\embedded\bin\appbundle-updater chef chef <%= ENV['GITHUB_SHA']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>
     - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
     - remote: Write-Output "Installed Chef / Ohai release:"
     - remote: chef-client -v
@@ -43,7 +43,7 @@ lifecycle:
     - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
     # htmldiff and ldiff on windows cause a conflict with gems being loaded below. we remove thenm here.
     - remote: if (Test-Path C:\opscode\chef\embedded\bin\htmldiff) { Remove-Item -Path C:\opscode\chef\embedded\bin\htmldiff; Remove-Item -Path C:\opscode\chef\embedded\bin\ldiff }
-    - remote: bundle install --jobs=3 --retry=3
+    - remote: C:\opscode\chef\embedded\bin\bundle install --jobs=3 --retry=3
     - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 platforms:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We are updating dependencies and linting in Chef-18 to bring FFI up to parity with Chef-PowerShell and Chef-19 - Both Chef versions need to be able to use the same version of Chef-PowerShell and this step helps us get there.

bundle install            
Using rake 13.4.2
Using public_suffix 6.0.2
Using addressable 2.9.0
Using mixlib-cli 2.1.8
Using concurrent-ruby 1.3.8
Using chef-utils 18.11.17 from source at `chef-utils`
Using ffi 1.17.4 (x64-mingw-ucrt)
Using ffi-win32-extensions 1.0.4
Using win32-process 0.10.0
Using wmi-lite 1.0.7
Using mixlib-shellout 3.4.10 (x64-mingw-ucrt)
Using appbundler 0.13.4
Using ast 2.4.3
Using aws-eventstream 1.4.0
Using aws-partitions 1.1280.0
Using aws-sigv4 1.12.1
Using base64 0.3.0
Using bigdecimal 4.1.2
Using jmespath 1.6.2
Using logger 1.5.3
Using aws-sdk-core 3.254.1
Using aws-sdk-kms 1.130.0
Using aws-sdk-s3 1.218.0
Using aws-sdk-secretsmanager 1.134.0
Using benchmark 0.5.0
Using debug_inspector 1.2.0
Using binding_of_caller 2.0.0
Using builder 3.3.0
Using bundler 2.3.27
Using byebug 12.0.0
Using cgi 0.5.2
Using fuzzyurl 0.9.0
Using tomlrb 1.3.0
Using mixlib-config 3.0.27
Using chef-config 18.11.17 from source at `chef-config`
Using libyajl2 2.1.0
Using yajl 0.3.4
Using ffi-yajl 2.7.7 (universal-mingw-ucrt)
Using chef-powershell 18.6.6
Using syslog 0.4.0
Using chef-vault 4.2.12
Using hashie 5.1.0
Using mixlib-log 3.0.9
Using rack 3.2.6
Using rackup 2.3.1
Using uuidtools 3.0.0
Using webrick 1.9.2
Using chef-zero 15.1.11
Using corefoundation 0.3.19
Using diff-lcs 1.6.2
Using erubis 2.7.0
Using ffi-libarchive 1.1.14
Using iniparse 1.5.0
Using chef-telemetry 1.1.1
Using json 2.21.2
Using language_server-protocol 3.17.0.6
Using lint_roller 1.1.0
Using parallel 1.28.0
Using racc 1.8.1
Using parser 3.3.12.0
Using rainbow 3.1.1
Using regexp_parser 2.12.0
Using prism 1.9.0
Using rubocop-ast 1.50.0
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.6.0
Using rubocop 1.86.1
Using cookstyle 8.7.6
Using uri 1.1.1
Using net-http 0.9.1
Using faraday-net_http 3.4.4
Using faraday 2.14.3
Using faraday-follow_redirects 0.5.0
Using tty-color 0.6.0
Using pastel 0.8.0
Using strings-ansi 0.2.0
Using unicode_utils 1.4.0
Using strings 0.2.1
Using tty-cursor 0.7.1
Using tty-box 0.7.0
Using tty-screen 0.8.2
Using wisper 2.0.1
Using tty-reader 0.9.0
Using tty-prompt 0.23.1
Using license-acceptance 2.1.13
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 2.0.0
Using coderay 1.1.3
Using pry 0.15.2
Using rspec-support 3.13.7
Using rspec-core 3.13.6
Using rspec-expectations 3.13.5
Using rspec-mocks 3.13.8
Using rspec 3.13.2
Using rspec-its 2.0.0
Using rubyzip 2.4.1
Using semverse 3.0.2
Using sslshake 1.3.1
Using thor 1.4.0
Using net-ssh 7.3.3
Using net-scp 4.1.0
Using train-core 3.16.5
Using tty-table 0.12.0
Using inspec-core 5.24.24
Using iso8601 0.13.0
Using mixlib-archive 1.3.3
Using mixlib-authentication 3.0.10
Using timeout 0.6.1
Using net-protocol 0.2.2
Using date 3.5.1
Using time 0.4.2
Using net-ftp 0.3.9
Using net-sftp 4.0.0
Using ipaddress 0.8.3
Using plist 3.7.2
Using ohai 18.2.21 from https://github.com/chef/ohai.git (at 18-stable@cc226be)
Using proxifier2 1.1.0
Using syslog-logger 1.6.8
Using http-accept 2.1.1
Using domain_name 0.6.20240107
Using http-cookie 1.1.6
Using mime-types-data 3.2026.0701
Using mime-types 3.7.0
Using netrc 0.11.0
Using rest-client 2.1.0 from https://github.com/chef/rest-client (at jfm/ucrt_update1@4725c8b)
Using train-rest 0.5.0
Using rexml 3.4.4
Using chef-gyoku 1.5.0
Using erubi 1.13.1
Using gssapi 1.3.1
Using mutex_m 0.3.0
Using httpclient 2.9.0
Using little-plugger 1.1.4
Using multi_json 1.19.1
Using logging 2.4.0
Using stringio 3.2.0
Using nori 2.9.1
Using rubyntlm 0.6.5
Using chef-winrm 2.5.0
Using csv 3.3.6
Using chef-winrm-fs 1.4.2
Using chef-winrm-elevated 1.2.5
Using socksify 1.8.1
Using train-winrm 0.4.3
Using unf_ext 0.0.9.1 (x64-mingw-ucrt)
Using connection_pool 2.5.5
Using net-http-persistent 4.0.8
Using vault 0.20.1
Using win32-api 1.10.1 (universal-mingw32)
Using win32-certstore 0.6.16
Using win32-ipc 0.7.0
Using win32-event 0.6.3
Using win32-eventlog 0.6.7
Using win32-mmap 0.4.2
Using win32-mutex 0.4.3
Using win32-service 2.4.0
Using structured_warnings 0.4.0
Using win32-taskscheduler 2.0.4
Using chef 18.11.17 (universal-mingw-ucrt) from source at `.`
Using chef-bin 18.11.17 from source at `chef-bin` and installing its executables
Using cheffish 17.1.8
Using crack 1.0.1
Using ed25519 1.4.0
Using erb 4.0.4.1
Using fauxhai-ng 9.3.0
Using hashdiff 1.2.1
Using inspec-core-bin 5.24.24
Using openssl 3.3.0
Using pry-byebug 3.11.0
Using pry-stack_explorer 0.6.3
Using rb-readline 0.5.5
Using webmock 3.26.2
Using zlib 3.2.3
Bundle complete! 27 Gemfile dependencies, 174 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
