### PR TITLE
Correcting the Kitchen windows tests

### DIFF
--- a/kitchen-tests/kitchen.exec.windows.yml
+++ b/kitchen-tests/kitchen.exec.windows.yml
@@ -10,41 +10,73 @@ transport:
 
 lifecycle:
   pre_converge:
-    - remote: . { Invoke-WebRequest -useb https://omnitruck.chef.io/install.ps1 } | Invoke-Expression; Install-Project -project chef -channel current
-    - remote: $env:PATH = "C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;" + $env:PATH
-    - remote: chef-client -v
-    - remote: ohai -v
-    - remote: rake --version
-    - remote: bundle -v
-    - remote: $env:OHAI_VERSION = ( Select-String -Path .\Gemfile.lock -Pattern '(?<=ohai \()\d.*(?=\))' | ForEach-Object { $_.Matches[0].Value } )
-    # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
-    # This leads to failures during testing. Moving that file to its correct position here.
-    # Another example of 'bad' that needs to be corrected
-    - remote: $output = gci -path C:\opscode\ -file ansidecl.h -Recurse
-    # As of Ruby 3.1, there are 3 ansidecl.h files found in the opscode path
-    # Grabbing the first (and shortest) path found is a bit of a :fingers-crossed: but
-    # making the leap that ansidecl.h isn't going to vary in a way that will fail subtly.
-    - remote: if ($output -is [Array]) { $output = $output[0] }
-    - remote: $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-    - remote: Move-Item -Path $output.FullName -Destination $target_path
-    # if a different version of ffi-yajl is installed, then libyajl2 needs to be reinstalled
-    # so that libyajldll.a is present in the intermediate build step. bundler seems to skip
-    # libyajl2 build if already present. gem install seems to build anyway.
-    - remote: gem uninstall -I libyajl2
-    - remote: gem install appbundler --no-doc
-    - remote: gem install appbundle-updater -v "~> 1.0.36" --no-doc
-    - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    - remote: appbundle-updater chef chef <%= ENV['GITHUB_SHA']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>
-    - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    - remote: Write-Output "Installed Chef / Ohai release:"
-    - remote: chef-client -v
-    - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    - remote: ohai -v
-    - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
-    # htmldiff and ldiff on windows cause a conflict with gems being loaded below. we remove thenm here.
-    - remote: if (Test-Path C:\opscode\chef\embedded\bin\htmldiff) { Remove-Item -Path C:\opscode\chef\embedded\bin\htmldiff; Remove-Item -Path C:\opscode\chef\embedded\bin\ldiff }
-    - remote: bundle install --jobs=3 --retry=3
-    - remote: If ($lastexitcode -ne 0) { Exit $lastexitcode }
+    - remote: |
+        $ErrorActionPreference = "Stop"
+
+        . { Invoke-WebRequest -useb https://omnitruck.chef.io/install.ps1 } | Invoke-Expression
+        Install-Project -project chef -channel current
+
+        # What we're doing here is deriving the top-level Chef parent directory to the chef-client executable. We'll prepend it below.
+        # This is necessary because chef-workstation is installed as well and it has a different ruby version. 
+        $chef_command = (Get-Command chef-client -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+        $chef_root_match = [regex]::Match($chef_command, '^[A-Za-z]:\\[^\\]+')
+        $chef_root = if ($chef_root_match.Success) { $chef_root_match.Value } else { throw "Could not derive the Chef parent directory from '$chef_command'" }
+        $chef_bin = "$chef_root\chef\bin"
+        $embedded_bin = "$chef_root\chef\embedded\bin"
+        $chef_ruby = "$embedded_bin\ruby.exe"
+        $chef_gem = "$embedded_bin\gem.bat"
+        $chef_bundle = "$embedded_bin\bundle.bat"
+
+        $env:PATH = "$chef_bin;$embedded_bin;" + $env:PATH
+        chef-client -v
+        ohai -v
+        & "$embedded_bin\rake.bat" --version
+        & $chef_bundle -v
+        $env:OHAI_VERSION = ( Select-String -Path ..\Gemfile.lock -Pattern '(?<=ohai \()\d.*(?=\))' | ForEach-Object { $_.Matches[0].Value } )
+
+        # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
+        # This leads to failures during testing. Moving that file to its correct position here.
+        # Another example of 'bad' that needs to be corrected
+        $output = gci -path $chef_root -file ansidecl.h -Recurse
+
+        # As of Ruby 3.1, there are 3 ansidecl.h files found in the opscode path
+        # Grabbing the first (and shortest) path found is a bit of a :fingers-crossed: but
+        # making the leap that ansidecl.h isn't going to vary in a way that will fail subtly.
+        if ($output -is [Array]) { $output = $output[0] }
+        $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
+        Move-Item -Path $output.FullName -Destination $target_path
+
+        # if a different version of ffi-yajl is installed, then libyajl2 needs to be reinstalled
+        # so that libyajldll.a is present in the intermediate build step. bundler seems to skip
+        # libyajl2 build if already present. gem install seems to build anyway.
+        & $chef_gem uninstall -I libyajl2
+        If ($lastexitcode -ne 0) { throw "Failed to uninstall libyajl2 (exit code $lastexitcode)" }
+
+        & $chef_gem install appbundler --no-doc
+        If ($lastexitcode -ne 0) { throw "Failed to install appbundler (exit code $lastexitcode)" }
+        Write-Host "Installing appbundle-updater gem..."
+        & $chef_gem install appbundle-updater -v "~> 1.0.36" --no-doc
+        If ($lastexitcode -ne 0) { throw "Failed to install appbundle-updater (exit code $lastexitcode)" }
+        $appbundle_updater_version = & $chef_gem list appbundle-updater
+        Write-Host "Installed appbundle-updater gem version: $appbundle_updater_version"
+
+        $appbundle_updater = & $chef_ruby -e "spec = Gem::Specification.find_all_by_name('appbundle-updater').first; abort 'appbundle-updater is not installed' unless spec; print spec.bin_file('appbundle-updater')"
+        If ($lastexitcode -ne 0) { throw "Failed to locate appbundle-updater (exit code $lastexitcode)" }
+        if (-not (Test-Path $appbundle_updater)) { throw "appbundle-updater was installed, but '$appbundle_updater' does not exist" }
+
+        & $chef_ruby $appbundle_updater chef chef <%= ENV['GITHUB_SHA']  || %x(git rev-parse HEAD).chomp %> --tarball --github <%= ENV['GITHUB_REPOSITORY']  || "chef/chef" %>
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+        Write-Output "Installed Chef / Ohai release:"
+        chef-client -v
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
+        ohai -v
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+        # htmldiff and ldiff on windows cause a conflict with gems being loaded below. we remove thenm here.
+        if (Test-Path "$embedded_bin\htmldiff") { Remove-Item -Path "$embedded_bin\htmldiff"; Remove-Item -Path "$embedded_bin\ldiff" }
+        & $chef_bundle install --jobs=3 --retry=3
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 platforms:
   - name: windows-2025

--- a/kitchen-tests/kitchen.exec.windows.yml
+++ b/kitchen-tests/kitchen.exec.windows.yml
@@ -37,14 +37,14 @@ lifecycle:
         # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
         # This leads to failures during testing. Moving that file to its correct position here.
         # Another example of 'bad' that needs to be corrected
-        $output = gci -path $chef_root -file ansidecl.h -Recurse
+        # $output = gci -path $chef_root -file ansidecl.h -Recurse
 
         # As of Ruby 3.1, there are 3 ansidecl.h files found in the opscode path
         # Grabbing the first (and shortest) path found is a bit of a :fingers-crossed: but
         # making the leap that ansidecl.h isn't going to vary in a way that will fail subtly.
-        if ($output -is [Array]) { $output = $output[0] }
-        $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-        Move-Item -Path $output.FullName -Destination $target_path
+        # if ($output -is [Array]) { $output = $output[0] }
+        # $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
+        # Move-Item -Path $output.FullName -Destination $target_path
 
         # if a different version of ffi-yajl is installed, then libyajl2 needs to be reinstalled
         # so that libyajldll.a is present in the intermediate build step. bundler seems to skip

--- a/kitchen-tests/kitchen.exec.windows.yml
+++ b/kitchen-tests/kitchen.exec.windows.yml
@@ -34,18 +34,6 @@ lifecycle:
         & $chef_bundle -v
         $env:OHAI_VERSION = ( Select-String -Path ..\Gemfile.lock -Pattern '(?<=ohai \()\d.*(?=\))' | ForEach-Object { $_.Matches[0].Value } )
 
-        # The chef-client installer does not put the file 'ansidecl.h' down in the correct location
-        # This leads to failures during testing. Moving that file to its correct position here.
-        # Another example of 'bad' that needs to be corrected
-        # $output = gci -path $chef_root -file ansidecl.h -Recurse
-
-        # As of Ruby 3.1, there are 3 ansidecl.h files found in the opscode path
-        # Grabbing the first (and shortest) path found is a bit of a :fingers-crossed: but
-        # making the leap that ansidecl.h isn't going to vary in a way that will fail subtly.
-        # if ($output -is [Array]) { $output = $output[0] }
-        # $target_path = $($output.Directory.Parent.FullName + "\x86_64-w64-mingw32\include")
-        # Move-Item -Path $output.FullName -Destination $target_path
-
         # if a different version of ffi-yajl is installed, then libyajl2 needs to be reinstalled
         # so that libyajldll.a is present in the intermediate build step. bundler seems to skip
         # libyajl2 build if already present. gem install seems to build anyway.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef 18 Windows Kitchen tests were failing because command resolution could select Chef Workstation executables, which use Ruby 3.3.12, instead of Chef Infra Client’s Ruby 3.1.7.

This change derives the Chef Infra Client install root at runtime, explicitly invokes its Windows batch launchers for Ruby tooling, and locates `appbundle-updater` through the embedded RubyGems specification. This prevents Chef Workstation, rbenv, and user gem paths from affecting the test environment.

The Windows lifecycle now follows the same install, updater, and post-update verification flow as the existing macOS and Linux Kitchen configurations, while retaining required Windows-specific remediation.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
