### PR TITLE
Fix NoMethodError in data collector http output locations

### DIFF
--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -66,6 +66,7 @@ class Chef
         @events = events
         @expanded_run_list = {}
         @deprecations = Set.new
+        @http_output_locations_clients = {}
       end
 
       # Hook to grab the run_status.  We also make the decision to run or not run here (our

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -895,6 +895,20 @@ describe Chef::DataCollector do
     end
   end
 
+  describe "#send_to_http_location(http_url, message)" do
+    let(:message) { "message" }
+    let(:http_client) { instance_double(Chef::ServerAPI) }
+
+    it "posts the message using a memoized http client per URL rather than raising NoMethodError on a nil cache" do
+      expect(data_collector).to receive(:setup_http_client).once.with("https://automate.example.com").and_return(http_client)
+      expect(http_client).to receive(:post).twice.with(nil, message, data_collector.send(:headers))
+
+      expect { data_collector.send(:send_to_http_location, "https://automate.example.com", message) }.not_to raise_error
+      # a second call for the same URL should reuse the cached client instead of creating a new one
+      data_collector.send(:send_to_http_location, "https://automate.example.com", message)
+    end
+  end
+
   describe "#send_to_datacollector" do
     def stub_http_client(exception = nil)
       if exception.nil?


### PR DESCRIPTION
## Description

`Chef::DataCollector::Reporter#send_to_http_location` references `@http_output_locations_clients` as a cache of HTTP clients keyed by URL, but the ivar is never initialized in `#initialize`. Every call raises `NoMethodError` on `nil`, which is silently swallowed by the method's bare `rescue` and only logged as a generic warning ("Data collector failed to send to URL location..."). As a result, the `data_collector.output_locations[:urls]` feature has never actually worked -- messages are never posted to any configured URL output location.

## Fix

Initialize `@http_output_locations_clients = {}` in the constructor, matching the memoization pattern the method already assumes.

## Testing

Added a regression test asserting the client is set up and reused across calls for the same URL. Verified the new test fails on the old code (NoMethodError, `setup_http_client` never invoked) and passes with the fix. Full `spec/unit/data_collector_spec.rb` suite passes (398 examples, 0 failures).