### PR TITLE
Fix Security.set_security_descriptor_dacl missing self.

### DIFF
--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -621,7 +621,7 @@ class Chef
         result.read_long
       end
 
-      def set_security_descriptor_dacl(security_descriptor, acl, defaulted = false, present = nil)
+      def self.set_security_descriptor_dacl(security_descriptor, acl, defaulted = false, present = nil)
         security_descriptor = security_descriptor.pointer if security_descriptor.respond_to?(:pointer)
         acl = acl.pointer if acl.respond_to?(:pointer)
         present = !security_descriptor.null? if present.nil?

--- a/spec/unit/win32/security_spec.rb
+++ b/spec/unit/win32/security_spec.rb
@@ -44,6 +44,18 @@ describe "Chef::Win32::Security", :windows_only do
     end
   end
 
+  describe "self.set_security_descriptor_dacl" do
+    it "is callable as a class method, matching set_security_descriptor_sacl/owner/group" do
+      security_descriptor = double("security descriptor", null?: false)
+      acl = double("acl")
+
+      expect(Chef::ReservedNames::Win32::Security).to receive(:SetSecurityDescriptorDacl)
+        .with(security_descriptor, true, acl, false).and_return(true)
+
+      expect { Chef::ReservedNames::Win32::Security.set_security_descriptor_dacl(security_descriptor, acl) }.to_not raise_error
+    end
+  end
+
   describe "self.set_named_security_info" do
     context "when HR result is ERROR_SUCCESS" do
       it "does not raise the exception" do


### PR DESCRIPTION
## Description

`Chef::ReservedNames::Win32::Security.set_security_descriptor_dacl` was defined as an instance method (`def set_security_descriptor_dacl`) while every other method in this class -- including its three closest siblings, `set_security_descriptor_group`, `set_security_descriptor_owner`, and `set_security_descriptor_sacl` -- is defined as a class method (`def self.*`). `Security` is never instantiated anywhere in the codebase; it's always called as `Chef::ReservedNames::Win32::Security.set_security_descriptor_dacl(...)`, matching the calling convention of every sibling. As written, the method was unreachable via that convention and raised `NoMethodError` for any caller.

## Fix

Add the missing `self.`.

## Testing

Added a regression spec (following the existing `:windows_only` pattern in this file) asserting the method is callable as `Chef::ReservedNames::Win32::Security.set_security_descriptor_dacl(...)`. This spec suite is gated to Windows (the file only requires `chef/win32/security` `if ChefUtils.windows?`), so I could not execute it locally on this macOS box -- verified only via `ruby -c` syntax check. It will run on Windows CI.