### PR TITLE
Fix restore_security_context always passing restorecon -R

### DIFF
--- a/lib/chef/util/selinux.rb
+++ b/lib/chef/util/selinux.rb
@@ -48,8 +48,8 @@ class Chef
 
       def restore_security_context(file_path, recursive = false)
         if restorecon_path
-          restorecon_flags = [ "-R" ]
-          restorecon_flags << "-r" if recursive
+          restorecon_flags = []
+          restorecon_flags << "-R" if recursive
           restorecon_flags << file_path
           Chef::Log.trace("Restoring selinux security content with #{restorecon_path}")
           shell_out!(restorecon_path, restorecon_flags)

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -127,21 +127,21 @@ describe Chef::Util::Selinux do
     end
 
     it "should call restorecon non-recursive by default" do
-      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, "-R", path).twice
+      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, path).twice
       @test_instance.restore_security_context(path)
       expect(File).not_to receive(:executable?)
       @test_instance.restore_security_context(path)
     end
 
     it "should call restorecon recursive when recursive is set" do
-      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, "-R", "-r", path).twice
+      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, "-R", path).twice
       @test_instance.restore_security_context(path, true)
       expect(File).not_to receive(:executable?)
       @test_instance.restore_security_context(path, true)
     end
 
     it "should call restorecon non-recursive when recursive is not set" do
-      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, "-R", path).twice
+      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, path).twice
       @test_instance.restore_security_context(path)
       expect(File).not_to receive(:executable?)
       @test_instance.restore_security_context(path)


### PR DESCRIPTION
Fixes #14438.

## Description

`Chef::Util::Selinux#restore_security_context(file_path, recursive)` hardcodes `-R` into `restorecon_flags` unconditionally, then only conditionally appends `-r` when `recursive` is true:

```ruby
restorecon_flags = [ "-R" ]
restorecon_flags << "-r" if recursive
```

This means **every** call passes `-R`, including non-recursive ones -- `Provider::File#do_selinux` defaults `recursive` to `false` for single-file resources, while only `Provider::Directory` passes `true`. So a plain `file` resource's SELinux context restore always runs as `restorecon -R <single-file-path>`, never just `restorecon <single-file-path>`. (One of the existing unit tests even documents this confusion in its own name -- "should call restorecon **non-recursive** by default" -- while asserting `-R` **is** passed.)

The reporter's error, `restorecon: Could not set context for ...: Operation not supported`, occurs specifically when restoring context through an NFS mount point. This matches a known class of Linux/NFS interaction: `-R` forces `restorecon` down an `fts()`-based directory-walk code path even for a single file argument, which can hit operations NFS servers don't support, where a plain non-recursive context restore (a direct syscall on the path) succeeds on the same file. I want to be upfront that the reporter's own manual reproduction compared two different paths rather than isolating the flag directly, so I can't 100% certify this is their exact root cause -- but the flag-handling bug itself is unambiguous by reading the code, independent of the NFS angle: a resource explicitly called non-recursively should never invoke `restorecon -R`.

## Fix

Only add `-R` when `recursive` is actually true, so `file`/`cookbook_file`/`template` resources (non-recursive) and `directory`/`remote_directory` resources (recursive) each get the invocation their case calls for.

## Testing

Corrected the three existing specs to assert the actually-intended flags (no flag for non-recursive, only `-R` for recursive -- dropping the redundant/no-op `-r`). Verified all three fail on the old code (two show `-R` present when it shouldn't be, one shows both `-R -r`) and pass with the fix. Full spec file plus `file_spec.rb`/`directory_spec.rb` pass (111 examples, 0 failures, 4 pre-existing unrelated pending).