### PR TITLE
Fix sysctl resource failing to reload on Debian 13 / trixie

### DIFF
--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -144,7 +144,7 @@ class Chef
           end
 
           execute "Load sysctl values" do
-            command "sysctl #{"-e " if new_resource.ignore_error}-p"
+            command sysctl_reload_command
             default_env true
             action :run
           end
@@ -161,7 +161,7 @@ class Chef
 
             execute "Load sysctl values" do
               default_env true
-              command "sysctl -p"
+              command sysctl_reload_command
               action :run
             end
           end
@@ -177,6 +177,23 @@ class Chef
         #
         def set_sysctl_param(key, value)
           shell_out!("sysctl #{"-e " if new_resource.ignore_error}-w \"#{key}=#{value}\"")
+        end
+
+        #
+        # The command used to reload sysctl settings from disk.
+        #
+        # `sysctl -p` only reads /etc/sysctl.conf (or an explicit file), which
+        # some distros (e.g. Debian 13 "trixie") no longer ship by default, since
+        # they rely entirely on systemd-sysctl loading /etc/sysctl.d/*.conf.
+        # `sysctl --system` reloads from all of the standard locations --
+        # including the conf_dir this resource writes to -- and simply skips
+        # /etc/sysctl.conf if it doesn't exist, so it works whether or not that
+        # file is present.
+        #
+        # @return [String] The sysctl reload command
+        #
+        def sysctl_reload_command
+          "sysctl #{"-e " if new_resource.ignore_error}--system"
         end
 
         #

--- a/spec/unit/resource/sysctl_spec.rb
+++ b/spec/unit/resource/sysctl_spec.rb
@@ -73,4 +73,15 @@ describe Chef::Resource::Sysctl do
       end
     end
   end
+
+  context "#sysctl_reload_command" do
+    it "uses --system instead of -p, so it works on distros without a default /etc/sysctl.conf (e.g. Debian 13)" do
+      expect(provider.sysctl_reload_command).to eql("sysctl --system")
+    end
+
+    it "adds -e when ignore_error is set" do
+      resource.ignore_error true
+      expect(provider.sysctl_reload_command).to eql("sysctl -e --system")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #15263.

## Description

The `sysctl` resource's `:apply` and `:remove` actions both reload settings with `sysctl -p` (or `sysctl -e -p` when `ignore_error` is set), which reads only `/etc/sysctl.conf` (or an explicit file argument passed to `-p`) and fails if that file doesn't exist:

```
# sysctl -p
sysctl: cannot open "/etc/sysctl.conf": No such file or directory
```

Debian 13 ("trixie") no longer ships `/etc/sysctl.conf` by default -- it relies entirely on `systemd-sysctl` loading `/etc/sysctl.d/*.conf`, which is exactly where this resource already writes its own `99-chef-<key>.conf` file (`conf_dir`, default `/etc/sysctl.d`). So the resource writes a config file that's correctly picked up on boot, but its own immediate-reload step fails.

## Fix

Use `sysctl --system` instead of `sysctl -p`. `--system` reloads settings from all of the standard sysctl.d locations -- including `conf_dir` -- and simply skips `/etc/sysctl.conf` if it's absent, rather than failing when it's missing. It behaves the same as `-p` on distros that do ship `/etc/sysctl.conf`, so this isn't a platform-specific branch -- it's a safe drop-in replacement for both actions. Extracted a small `sysctl_reload_command` helper so both `:apply` and `:remove` (which had the identical hardcoded command) share the same fix.

## Testing

Added specs for the new `sysctl_reload_command` helper, covering both the default case and `ignore_error`. Verified they fail on the old code (method doesn't exist yet, confirming the reload command was previously inline and hardcoded to `-p`) and pass with the fix. Full spec file passes (11 examples, 0 failures).