### PR TITLE
Fix with_umask raising NoMethodError when umask is an Integer

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -625,7 +625,7 @@ class Chef
     end
 
     def with_umask
-      old_value = ::File.umask(umask.oct) if umask
+      old_value = ::File.umask(umask.respond_to?(:oct) ? umask.oct : umask.to_i) if umask
       yield
     ensure
       ::File.umask(old_value) if umask

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1461,6 +1461,21 @@ describe Chef::Resource do
 
         expect(actual_value).to eq("0123")
       end
+
+      it "changes the umask in the block to the set value when given as an Integer literal" do
+        resource.umask = 0o123
+
+        block_value = nil
+
+        resource.with_umask do
+          block_value = ::File.umask
+        end
+
+        # Format the returned value so a potential error message is easier to understand.
+        actual_value = block_value.to_s(8).rjust(4, "0")
+
+        expect(actual_value).to eq("0123")
+      end
     end
 
     it "resets the umask afterwards" do


### PR DESCRIPTION
Fixes #13473.

## Description

The `umask` property on `Chef::Resource` has always accepted `[String, Integer]`, but `with_umask` calls `umask.oct` unconditionally:

```ruby
def with_umask
  old_value = ::File.umask(umask.oct) if umask
  ...
```

`String#oct` exists, but `Integer` doesn't define `.oct` at all, so any resource using an Integer umask literal raises:

```
NoMethodError: undefined method 'oct' for an instance of Integer
```

matching the issue exactly: `umask 0o227` breaks, while `umask '0227'` (a String) works fine.

## Fix

`Chef::FileAccessControl`'s `unix.rb`/`windows.rb` already handle this identical String-vs-Integer duality for the analogous `mode` property:

```ruby
mode.respond_to?(:oct) ? mode.oct : mode.to_i
```

Apply the same established pattern to `umask`.

## Testing

Added a spec mirroring the existing String-umask test but with an Integer literal (`0o123`). Verified it fails on the old code with the exact `NoMethodError: undefined method 'oct' for an instance of Integer` from the issue, and passes with the fix. Full spec file passes (164 examples, 0 failures, 1 pre-existing unrelated pending).