### PR TITLE
Add chef-partners/azure-chef-extension to community PR review list

### DIFF
--- a/docs/dev/how_to/community_pr_review_checklist.md
+++ b/docs/dev/how_to/community_pr_review_checklist.md
@@ -43,3 +43,4 @@ From there you should see a zoom link that links you to the meeting.
 - [Fauxhai](https://github.com/chef/fauxhai) ![Open PRs](https://img.shields.io/github/issues-pr/chef/fauxhai) [Fauxhai pull requests](https://github.com/chef/fauxhai/pulls)
 - [Chefspec](https://github.com/chef/chefspec) ![Open PRs](https://img.shields.io/github/issues-pr/chef/chefspec) [Chefspec pull requests](https://github.com/chef/chefspec/pulls)
 - [Shared Github Workflows](https://github.com/chef/github-workflows) ![Open PRs](https://img.shields.io/github/issues-pr/chef/github-workflows) [Shared Github Workflows pull requests](https://github.com/chef/github-workflows/pulls)
+- [Azure-Chef-Extension](https://github.com/chef-partners/azure-chef-extension) ![Open PRs](https://img.shields.io/github/issues-pr/chef-partners/azure-chef-extension) [Azure-Chef-Extension pull requests](https://github.com/chef-partners/azure-chef-extension/pulls)


### PR DESCRIPTION
<h2>Summary</h2><p>Adds <a href="https://github.com/chef-partners/azure-chef-extension">chef-partners/azure-chef-extension</a> to the weekly Community PR Review list under Peripheral projects.</p><p>This work was completed with AI assistance following Progress AI policies</p>