### PR TITLE
Fix linux-fips CI: clean up stale Habitat studios before build

### DIFF
--- a/.github/workflows/selfhosted-linux-fips.yml
+++ b/.github/workflows/selfhosted-linux-fips.yml
@@ -46,6 +46,20 @@ jobs:
           if [ -d "/home/azureuser/actions-runner/_work/chef/chef" ]; then
             sudo rm -r /home/azureuser/actions-runner/_work/chef/chef/*
           fi
+
+          # Clean up any stale Habitat studios from previous failed runs.
+          # If a prior run failed before its cleanup step, the studio's /src
+          # bind-mount can persist. A new `hab pkg build .` may then interact
+          # with that stale studio, causing popd to fail with
+          # "No such file or directory" for /src/habitat/x86_64-linux.
+          for studio_dir in /hab/studios/*/; do
+            if [ -d "$studio_dir" ]; then
+              mount | grep "$studio_dir" | awk '{print $3}' | sort -r | while read -r mnt; do
+                sudo umount -lf "$mnt" 2>/dev/null || true
+              done
+              sudo rm -rf "$studio_dir" || true
+            fi
+          done
           set -e
 
       - name: Checkout trusted code only


### PR DESCRIPTION
<h2>Summary</h2>
<p>The <code>linux-fips</code> self-hosted CI pipeline was failing with:</p>
<pre>popd: /src/habitat/x86_64-linux: No such file or directory
chef-infra-client: Exiting on error</pre>

<h2>Root Cause</h2>
<p>The initial <em>Clean up any previous installs</em> step only removed the checkout directory contents. It did <strong>not</strong> clean up Habitat studios left behind by previous failed runs.</p>
<p>When a prior run fails before reaching its cleanup step, the studio's <code>/src</code> bind-mount persists on the runner. A subsequent <code>hab pkg build .</code> can interact with that stale studio context — making <code>/src/habitat/x86_64-linux</code> inaccessible by the time <code>hab-plan-build</code> tries to <code>popd</code> back to it, causing the build to exit with an error even though all gem installation steps succeeded.</p>

<h2>Fix</h2>
<p>Mirror the studio unmount + removal logic (already present in the final cleanup step) into the <strong>initial</strong> cleanup step, so every run starts with a clean slate regardless of how the previous run ended.</p>

<hr>
<p><em>This work was completed with AI assistance following Progress AI policies.</em></p>