### PR TITLE
Stop the dscl group provider mutating new_resource.gid

### DIFF
--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -111,6 +111,11 @@ class Chef
       end
 
       def group_gid_match?
+        # No gid requested means no desired gid, so whatever the group already
+        # has is a match. Providers must not backfill new_resource.gid from the
+        # current state to make this comparison work.
+        return true if new_resource.gid.nil?
+
         new_resource.gid.to_s == current_resource.gid.to_s
       end
 

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -61,7 +61,6 @@ class Chef
               val.strip! if val
               case key.downcase
               when "primarygroupid"
-                new_resource.gid(val) unless new_resource.gid
                 current_resource.gid(val)
               when "groupmembership"
                 current_resource.members(val.split(" "))
@@ -99,10 +98,15 @@ class Chef
         end
 
         def set_gid
-          new_resource.gid(get_free_gid) if [nil, ""].include? new_resource.gid
-          raise(Chef::Exceptions::Group, "gid is already in use") if gid_used?(new_resource.gid)
+          # Resolve the gid into a local so that the desired state on the new
+          # resource is left alone. Memoizing a free gid back onto the resource
+          # would mean a reused resource object gets the same gid every time
+          # rather than a fresh free one.
+          gid = new_resource.gid
+          gid = get_free_gid if [nil, ""].include?(gid)
+          raise(Chef::Exceptions::Group, "gid is already in use") if gid_used?(gid)
 
-          safe_dscl("create", "/Groups/#{new_resource.group_name}", "PrimaryGroupID", new_resource.gid)
+          safe_dscl("create", "/Groups/#{new_resource.group_name}", "PrimaryGroupID", gid)
         end
 
         def set_members

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -184,6 +184,28 @@ describe Chef::Provider::Group::Dscl do
         @provider.set_gid
       end
     end
+
+    describe "when no gid was requested on the new resource" do
+      before do
+        @new_resource.instance_variable_set(:@gid, nil)
+        allow(@provider).to receive(:gid_used?).and_return(false)
+        allow(@provider).to receive(:safe_dscl).and_return("")
+      end
+
+      it "does not memoize the free gid onto the new resource" do
+        allow(@provider).to receive(:get_free_gid).and_return(501)
+        @provider.set_gid
+        expect(@new_resource.gid).to be_nil
+      end
+
+      it "asks for a free gid on every run so the resource can be reused" do
+        expect(@provider).to receive(:get_free_gid).twice.and_return(501, 502)
+        expect(@provider).to receive(:safe_dscl).with("create", "/Groups/aj", "PrimaryGroupID", 501)
+        expect(@provider).to receive(:safe_dscl).with("create", "/Groups/aj", "PrimaryGroupID", 502)
+        @provider.set_gid
+        @provider.set_gid
+      end
+    end
   end
 
   describe "set_members" do
@@ -332,8 +354,17 @@ describe "Test DSCL loading" do
     allow(File).to receive(:exist?).and_return(true)
     expect(@current_resource.gid).to eq("999")
   end
+  it "should not copy the discovered gid onto the new resource" do
+    allow(File).to receive(:exist?).and_return(true)
+    expect(@new_resource.gid).to be_nil
+  end
   it "should parse members properly" do
     allow(File).to receive(:exist?).and_return(true)
     expect(@current_resource.members).to eq(%w{waka bar})
+  end
+  it "does not report a gid change when the resource did not request a gid" do
+    allow(File).to receive(:exist?).and_return(true)
+    @new_resource.members(%w{waka bar})
+    expect(@provider.compare_group).to be false
   end
 end


### PR DESCRIPTION
## Description

The dscl group provider wrote to the new resource's *desired* state in two places:

```ruby
# load_current_resource
new_resource.gid(val) unless new_resource.gid

# set_gid
new_resource.gid(get_free_gid) if [nil, ""].include? new_resource.gid
```

Both clobber what the caller asked for. The second is the more damaging one: because the free gid is memoized back onto the resource, a reused resource object can never pick up a fresh gid. Running the `:add` action twice reuses the first gid instead of asking `get_free_gid` for the next free one — exactly the case called out in #11928.

## How this was reproduced

Two specs in `spec/unit/provider/group/dscl_spec.rb`, both failing on `main`:

```ruby
it "does not memoize the free gid onto the new resource" do
  allow(@provider).to receive(:get_free_gid).and_return(501)
  @provider.set_gid
  expect(@new_resource.gid).to be_nil          # main: 501
end

it "asks for a free gid on every run so the resource can be reused" do
  expect(@provider).to receive(:get_free_gid).twice.and_return(501, 502)
  expect(@provider).to receive(:safe_dscl).with("create", "/Groups/aj", "PrimaryGroupID", 501)
  expect(@provider).to receive(:safe_dscl).with("create", "/Groups/aj", "PrimaryGroupID", 502)
  @provider.set_gid
  @provider.set_gid                             # main: get_free_gid called once, 501 written twice
end
```

plus one against `load_current_resource`, which on `main` copies the discovered `PrimaryGroupID: 999` onto the new resource.

## Fix

`set_gid` resolves the gid into a local; `load_current_resource` only populates `current_resource`.

Removing the backfill exposes a latent bug in the shared `group_gid_match?`:

```ruby
new_resource.gid.to_s == current_resource.gid.to_s
```

With the backfill gone, an unspecified gid is `nil`, which stringifies to `""` and never matches `"999"` — so every run would report a spurious `change gid 999 to ` and the resource would never converge. A nil gid means *no desired gid*, so it now matches whatever the group already has.

## Tests

Four new specs, all red on `main`. The idempotency one is the load-bearing check on the second half of the fix — reverting just the `group_gid_match?` change makes it fail:

```
$ git stash -- lib/chef/provider/group.rb
$ bundle exec rspec spec/unit/provider/group/dscl_spec.rb -e "does not report a gid change"
1 example, 1 failure
```

Full group suite green:

```
$ bundle exec rspec spec/unit/provider/group/ spec/unit/provider/group_spec.rb spec/unit/resource/group_spec.rb
165 examples, 0 failures
```

Note: `Chef::Provider::Group#load_current_resource` still backfills `new_resource.gid` for the non-dscl providers. That is the same anti-pattern and is now safe to remove given the `group_gid_match?` guard, but I have left it alone here to keep this change scoped to the reported provider.

Closes #11928