### PR TITLE
Respect the timeout property in homebrew_package

### DIFF
--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -197,7 +197,7 @@ class Chef
           # the package provider can magically handle that
           shell_out_cmd = options[:allow_failure] ? :shell_out : :shell_out!
 
-          output = send(shell_out_cmd, homebrew_bin_path, *command, user: homebrew_uid, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
+          output = send(shell_out_cmd, homebrew_bin_path, *command, user: homebrew_uid, timeout: new_resource.timeout, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
           output.stdout.chomp
         end
       end

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -307,6 +307,23 @@ describe Chef::Provider::Package::Homebrew do
       expect(provider.brew_cmd_output("info", "opts", "bananas")).to eql("homestarrunner")
     end
 
+    it "hands the resource's timeout to shell_out" do
+      new_resource.timeout(3600)
+      allow(provider).to receive(:homebrew_bin_path).and_return(default_brew_path)
+      expect(provider).to receive(:shell_out!)
+        .with(default_brew_path, "install", hash_including(timeout: 3600))
+        .and_return(OpenStruct.new(stdout: ""))
+      provider.brew_cmd_output("install")
+    end
+
+    it "leaves the timeout unset when the resource does not specify one" do
+      allow(provider).to receive(:homebrew_bin_path).and_return(default_brew_path)
+      expect(provider).to receive(:shell_out!)
+        .with(default_brew_path, "install", hash_including(timeout: nil))
+        .and_return(OpenStruct.new(stdout: ""))
+      provider.brew_cmd_output("install")
+    end
+
     context "when new_resource is Package" do
       let(:new_resource) { Chef::Resource::Package.new("emacs") }
 


### PR DESCRIPTION
## Description

`brew_cmd_output` shells out without ever passing `new_resource.timeout`:

```ruby
output = send(shell_out_cmd, homebrew_bin_path, *command,
              user: homebrew_uid,
              environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
```

So the documented `timeout` property on the package resource is silently ignored, and every `brew` invocation runs under mixlib-shellout's `DEFAULT_READ_TIMEOUT`:

```ruby
homebrew_package "some-slow-formula" do
  timeout 3600   # no effect
end
```

Formulas that build from source routinely take longer than the default, and the run dies mid-install with `Mixlib::ShellOut::CommandTimeout`.

One correction to the original report: the hardcoded `1800` it points at is gone from the provider now, so today the effective cap is mixlib-shellout's 600s default rather than 1800s. The `timeout` property is still ignored either way — the bug is unchanged, just with a smaller number.

## How this was reproduced

Two specs in `spec/unit/provider/package/homebrew_spec.rb`, both failing on `main`:

```ruby
it "hands the resource's timeout to shell_out" do
  new_resource.timeout(3600)
  expect(provider).to receive(:shell_out!)
    .with(default_brew_path, "install", hash_including(timeout: 3600))
    .and_return(OpenStruct.new(stdout: ""))
  provider.brew_cmd_output("install")
end
```

On `main` the options hash has no `:timeout` key at all.

## Fix

Pass `new_resource.timeout` through, matching what the `cab`, `powershell`, `windows/msi` and `windows/exe` package providers already do.

Passing `nil` is safe and needs no guard — `Mixlib::ShellOut#timeout` is:

```ruby
def timeout
  @timeout || DEFAULT_READ_TIMEOUT
end
```

so resources that do not set a timeout keep the existing 600s behavior. The second spec pins that case.

## Tests

```
$ bundle exec rspec spec/unit/provider/package/homebrew_spec.rb spec/unit/resource/homebrew_package_spec.rb
38 examples, 0 failures
```

Closes #13501