### PR TITLE
Stop windows_update_settings writing unset WSUS values

### DIFF
--- a/lib/chef/resource/windows_update_settings.rb
+++ b/lib/chef/resource/windows_update_settings.rb
@@ -144,38 +144,25 @@ class Chef
       action :set, description: "Set Windows Update settings." do
         actual_day = convert_day(new_resource.scheduled_install_day)
 
+        windows_update_values = [{
+          name: "DisableOSUpgrade",
+          type: :dword,
+          data: new_resource.disable_os_upgrades ? 1 : 0,
+        },
+        {
+          name: "ElevateNonAdmins",
+          type: :dword,
+          data: new_resource.elevate_non_admins ? 1 : 0,
+        },
+        {
+          name: "TargetGroupEnabled",
+          type: :dword,
+          data: new_resource.target_wsus_group_name ? 1 : 0,
+        }] + wsus_registry_values
+
         registry_key "HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WindowsUpdate" do
           recursive true
-          values [{
-            name: "DisableOSUpgrade",
-            type: :dword,
-            data: new_resource.disable_os_upgrades ? 1 : 0,
-          },
-          {
-            name: "ElevateNonAdmins",
-            type: :dword,
-            data: new_resource.elevate_non_admins ? 1 : 0,
-          },
-          {
-            name: "TargetGroupEnabled",
-            type: :dword,
-            data: new_resource.target_wsus_group_name ? 1 : 0,
-          },
-          {
-            name: "TargetGroup",
-            type: :string,
-            data: new_resource.target_wsus_group_name,
-          },
-          {
-            name: "WUServer",
-            type: :string,
-            data: new_resource.wsus_server_url,
-          },
-          {
-            name: "WUStatusServer",
-            type: :string,
-            data: new_resource.wsus_server_url, # status server and server need to be the same. Why? Ask Microsoft
-          }]
+          values windows_update_values
           action :create
         end
 
@@ -248,6 +235,40 @@ class Chef
       action_class do
         def convert_day(day)
           DAYS.index(day)
+        end
+
+        # The WSUS registry values are only meaningful once a WSUS server or
+        # target group has been configured. Emitting them with nil data makes
+        # registry_key rewrite them on every run, so leave them out entirely
+        # when the matching property is unset.
+        #
+        # @return [Array<Hash>]
+        def wsus_registry_values
+          values = []
+
+          if new_resource.target_wsus_group_name
+            values << {
+              name: "TargetGroup",
+              type: :string,
+              data: new_resource.target_wsus_group_name,
+            }
+          end
+
+          if new_resource.wsus_server_url
+            values << {
+              name: "WUServer",
+              type: :string,
+              data: new_resource.wsus_server_url,
+            }
+            values << {
+              name: "WUStatusServer",
+              type: :string,
+              # status server and server need to be the same. Why? Ask Microsoft
+              data: new_resource.wsus_server_url,
+            }
+          end
+
+          values
         end
 
         # support the old name as well

--- a/spec/unit/resource/windows_update_settings_spec.rb
+++ b/spec/unit/resource/windows_update_settings_spec.rb
@@ -61,4 +61,41 @@ describe Chef::Resource::WindowsUpdateSettings do
     expect { resource.custom_detection_frequency 0 }.not_to raise_error
     expect { resource.custom_detection_frequency 23 }.to raise_error(ArgumentError)
   end
+
+  describe "#wsus_registry_values" do
+    let(:node) { Chef::Node.new }
+    let(:events) { Chef::EventDispatch::Dispatcher.new }
+    let(:run_context) { Chef::RunContext.new(node, {}, events) }
+    let(:provider) do
+      resource.run_context = run_context
+      resource.provider_for_action(:set)
+    end
+
+    it "writes nothing when no WSUS server or target group is configured" do
+      expect(provider.wsus_registry_values).to eq([])
+    end
+
+    it "writes TargetGroup only when a target group name is set" do
+      resource.target_wsus_group_name "servers"
+      expect(provider.wsus_registry_values).to eq(
+        [{ name: "TargetGroup", type: :string, data: "servers" }]
+      )
+    end
+
+    it "writes both WSUS server values when a server url is set" do
+      resource.wsus_server_url "https://wsus.example.com"
+      expect(provider.wsus_registry_values).to eq(
+        [
+          { name: "WUServer", type: :string, data: "https://wsus.example.com" },
+          { name: "WUStatusServer", type: :string, data: "https://wsus.example.com" },
+        ]
+      )
+    end
+
+    it "never emits a value with nil data" do
+      resource.target_wsus_group_name "servers"
+      resource.wsus_server_url "https://wsus.example.com"
+      expect(provider.wsus_registry_values.map { |v| v[:data] }).to all(be_a(String))
+    end
+  end
 end


### PR DESCRIPTION
## Description

The `:set` action unconditionally emits `TargetGroup`, `WUServer` and `WUStatusServer`, taking their data straight from properties that are `nil` unless the user actually configured WSUS:

```ruby
{
  name: "WUServer",
  type: :string,
  data: new_resource.wsus_server_url,   # nil when WSUS isn't in use
},
```

`registry_key` is then handed a `:string` value whose data is `nil`, decides it doesn't match what's on disk, and rewrites it. The resource never converges — every run reports the same three updates for a recipe that never mentioned WSUS:

```ruby
windows_update_settings 'Configure Windows Update' do
  automatic_update_option 2
  disable_automatic_updates true
  action :set
end
```

```
  * windows_update_settings[Configure Windows Update] action set
    * registry_key[HKLM\Software\Policies\Microsoft\Windows\WindowsUpdate] action create
      - set value {:name=>"TargetGroup", :type=>:string, :data=>nil}
      - set value {:name=>"WUServer", :type=>:string, :data=>nil}
      - set value {:name=>"WUStatusServer", :type=>:string, :data=>nil}
```

## How this was reproduced

The three offending values are built unconditionally in the action, so the nil case is reachable purely from the resource's own state — no registry needed to demonstrate it. The `:set` action's value list is now built by a `wsus_registry_values` helper, and the specs assert against it directly:

```ruby
it "writes nothing when no WSUS server or target group is configured" do
  expect(provider.wsus_registry_values).to eq([])
end

it "never emits a value with nil data" do
  resource.target_wsus_group_name "servers"
  resource.wsus_server_url "https://wsus.example.com"
  expect(provider.wsus_registry_values.map { |v| v[:data] }).to all(be_a(String))
end
```

On `main` the first returns three hashes with `data: nil`.

## Fix

`wsus_registry_values` emits each value only once its matching property is set — `TargetGroup` when `target_wsus_group_name` is given, `WUServer`/`WUStatusServer` when `wsus_server_url` is given.

`TargetGroupEnabled` and `UseWUServer` already coerce to `0`/`1` and are untouched, so "WSUS is off" is still written explicitly as a dword rather than being left to chance. Only the string values that had no meaningful content are dropped.

## Tests

Four new specs covering the empty case, each property independently, and the invariant that no emitted value ever carries nil data.

```
$ bundle exec rspec spec/unit/resource/windows_update_settings_spec.rb
12 examples, 0 failures
```

Closes #12065