### PR TITLE
Load stringio only when file_open reads through a train transport

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/train_helpers.rb
+++ b/chef-utils/lib/chef-utils/dsl/train_helpers.rb
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "stringio" unless defined?(StringIO)
 require_relative "../internal"
 
 module ChefUtils
@@ -54,6 +53,8 @@ module ChefUtils
       #
       def file_open(*args, &block)
         if __transport_connection
+          require "stringio" unless defined?(StringIO)
+
           content = __transport_connection.file(args[0]).content
           string_io = StringIO.new content
           yield string_io if block_given?


### PR DESCRIPTION
### Description

`chef-utils` requires `stringio` at the top of `lib/chef-utils/dsl/train_helpers.rb`, so every consumer of the gem pays for the extension load on `require "chef-utils"`.

`StringIO` is referenced in exactly one place — the `__transport_connection` branch of `file_open`, which only runs in target mode:

```ruby
def file_open(*args, &block)
  if __transport_connection
    content = __transport_connection.file(args[0]).content
    string_io = StringIO.new content
    ...
```

Local-mode Chef Infra Client, `mixlib-shellout` and Test Kitchen never reach that branch, yet all of them load the extension. This moves the require into the branch that uses it.

### Measurements

Interleaved A/B, 30 process launches per arm, Ruby 4.0.6 on arm64-darwin:

| | min | p50 | p90 |
|---|---|---|---|
| `require "chef-utils"` before | 5.843 ms | 6.509 ms | 7.138 ms |
| `require "chef-utils"` after | 3.514 ms | 3.731 ms | 4.049 ms |

2.8 ms off the median — about **43% of the gem's load time** — paid back by every process that loads `chef-utils`.

### Notes

- The guard stays as `unless defined?(StringIO)`, so the require is a no-op when something else already pulled it in.
- `file_read` calls straight through to `file_open`, so it is covered by the same path.

### Verification

- Stubbed a transport connection and exercised `file_open` / `file_read`: `StringIO` is undefined until the first target-mode call, and content reads back correctly.
- `chef-utils` spec suite: **6888 examples, 0 failures**.

### Types of changes
- [x] Performance

### Checklist
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes — existing suite covers `file_open`/`file_read`; no behavior change.
- [x] All new and existing tests passed.