### PR TITLE
only use major.minor for version in blackduck

### DIFF
--- a/.github/workflows/generate-habitat-sbom.yml
+++ b/.github/workflows/generate-habitat-sbom.yml
@@ -36,8 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set BD version from VERSION file
-        run: echo "BD_VERSION_NAME=$(cat VERSION)" >> "$GITHUB_ENV"
+      - name: Set BD version from VERSION file (major.minor)
+        run: echo "BD_VERSION_NAME=$(cut -d. -f1,2 VERSION)" >> "$GITHUB_ENV"
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating the habitat sbom generation workflow to use `major.minor` version and exlude patch version for blackduck reports.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
